### PR TITLE
fix(telemetry): unmask model_id for unknown providers

### DIFF
--- a/packages/omo-senpi/src/components/telemetry/delegation-projection.test.ts
+++ b/packages/omo-senpi/src/components/telemetry/delegation-projection.test.ts
@@ -153,9 +153,10 @@ describe("delegation_completed projection", () => {
       },
     })
 
-    // then
+    // then: provider is custom (unknown), but model_id is unmasked because "claude-opus-5" is a
+    // known public model name — model ids are not PII and should be visible regardless of routing provider
     expect(props.provider).toBe("custom")
-    expect(props.model_id).toBe("custom")
+    expect(props.model_id).toBe("claude-opus-5")
     expect(props.model_source).toBe("explicit")
   })
 

--- a/packages/omo-senpi/src/components/telemetry/model-vocabulary.ts
+++ b/packages/omo-senpi/src/components/telemetry/model-vocabulary.ts
@@ -43,3 +43,10 @@ export const KNOWN_MODELS = Object.freeze({
 
 export type KnownProvider = keyof typeof KNOWN_MODELS
 export const KNOWN_PROVIDERS = Object.freeze(Object.keys(KNOWN_MODELS) as KnownProvider[])
+
+// Flat set of every model id known across ALL providers. Used to unmask model_id even when the
+// provider itself is not in the vocabulary (e.g. OpenRouter, LiteLLM, or a self-hosted gateway
+// proxying a standard model). Model ids are public product names, not PII.
+export const ALL_KNOWN_MODEL_IDS: ReadonlySet<string> = Object.freeze(
+  new Set(Object.values(KNOWN_MODELS).flat()),
+)

--- a/packages/omo-senpi/src/components/telemetry/product-identity.test.ts
+++ b/packages/omo-senpi/src/components/telemetry/product-identity.test.ts
@@ -110,7 +110,9 @@ describe("OmO Native product identity", () => {
 
     expect(maskProviderAndModel(provider, knownModel ?? "")).toEqual({ provider, model_id: knownModel })
     expect(maskProviderAndModel(provider, "user-defined-model")).toEqual({ provider, model_id: "custom" })
-    expect(maskProviderAndModel("user-provider", knownModel ?? "")).toEqual({ provider: "custom", model_id: "custom" })
+    // A known model routed through an unknown provider (e.g. OpenRouter) should still export the
+    // model_id — model ids are public product names, not PII.
+    expect(maskProviderAndModel("user-provider", knownModel ?? "")).toEqual({ provider: "custom", model_id: knownModel })
   })
 
   test("#given every provider and model rung in CATEGORY_FALLBACK_CHAINS #when masked #then no shipped rung collapses to custom, while an arbitrary user provider and model still mask to custom", () => {
@@ -129,9 +131,9 @@ describe("OmO Native product identity", () => {
     // then: no executable rung is exportable only as custom/custom - that is what makes the
     // per-country category-model insight readable instead of a wall of `custom`
     expect(collapsed).toEqual([])
-    // and: a model known under one provider stays custom under a provider that does not ship it
-    expect(maskProviderAndModel("deepseek", "claude-opus-5").model_id).toBe("custom")
-    // and: arbitrary user-configured providers and models never leave the machine
+    // and: a known model accessed via a non-shipping provider still exports the model_id
+    expect(maskProviderAndModel("deepseek", "claude-opus-5").model_id).toBe("claude-opus-5")
+    // and: arbitrary user-configured fine-tune models still mask to custom
     expect(maskProviderAndModel("my-gateway", "my-finetune")).toEqual({ provider: "custom", model_id: "custom" })
     expect(maskProviderAndModel("anthropic", "my-finetune")).toEqual({ provider: "anthropic", model_id: "custom" })
   })

--- a/packages/omo-senpi/src/components/telemetry/product-identity.ts
+++ b/packages/omo-senpi/src/components/telemetry/product-identity.ts
@@ -11,7 +11,7 @@ import { CURATED_READONLY_AGENT_NAMES } from "@oh-my-opencode/senpi-task/agents-
 import { BUILTIN_CATEGORY_DEFAULTS } from "@oh-my-opencode/senpi-task/category-builtins"
 import { resolveAgentHome } from "../agent-home/resolve-agent-home"
 import { CATEGORY_CONFIG_SCHEMA } from "./category-config-schema"
-import { KNOWN_MODELS, KNOWN_PROVIDERS, type KnownProvider } from "./model-vocabulary"
+import { ALL_KNOWN_MODEL_IDS, KNOWN_MODELS, KNOWN_PROVIDERS, type KnownProvider } from "./model-vocabulary"
 import { buildDelegationCompletedSchema } from "./delegation-schema"
 import { PARALLELISM_SUMMARY_SCHEMA } from "./parallelism-schema"
 
@@ -21,7 +21,7 @@ export const OMO_NATIVE_POSTHOG_API_KEY = "phc_r6UYQzNZcGYSzKw4PxCiVrZepGqV3dw9q
 // clients half-apply a bump: a session row and a task row would disagree about their own schema.
 export const OMO_NATIVE_SCHEMA_VERSION = 2
 
-export { KNOWN_MODELS, KNOWN_PROVIDERS } from "./model-vocabulary"
+export { ALL_KNOWN_MODEL_IDS, KNOWN_MODELS, KNOWN_PROVIDERS } from "./model-vocabulary"
 export type { KnownProvider } from "./model-vocabulary"
 
 export type OmoNativePropertyType = "boolean" | "number" | "string"
@@ -176,12 +176,19 @@ export function hashSessionId(rawId: string): string {
   return createHash("sha256").update(salt).update(rawId).digest("hex")
 }
 
+/**
+ * Mask provider and model for telemetry export.
+ *
+ * Provider is passed through when it is in the known vocabulary, otherwise "custom".
+ * Model id is passed through when it appears in ANY known provider's model list — not just the
+ * current provider. Model ids are public product names ("claude-opus-5", "gpt-5.6-sol"), not PII,
+ * so unmasking them regardless of the routing provider (OpenRouter, LiteLLM, self-hosted gateway)
+ * lets the dashboard distinguish real model preferences instead of showing a wall of "custom".
+ */
 export function maskProviderAndModel(provider: string, modelId: string): { provider: string; model_id: string } {
-  const knownProvider = isKnownProvider(provider)
-  const knownModels: readonly string[] | undefined = knownProvider ? KNOWN_MODELS[provider] : undefined
   return {
-    provider: knownProvider ? provider : "custom",
-    model_id: knownModels?.includes(modelId) === true ? modelId : "custom",
+    provider: isKnownProvider(provider) ? provider : "custom",
+    model_id: ALL_KNOWN_MODEL_IDS.has(modelId) ? modelId : "custom",
   }
 }
 


### PR DESCRIPTION
## Problem

`maskProviderAndModel` masks provider AND model_id to `custom` when the provider is not in `KNOWN_MODELS`. This means users routing known models (claude-opus-5, gpt-5.6-sol, etc.) through OpenRouter, LiteLLM, or self-hosted gateways show as `custom/custom` in the telemetry dashboard — making it impossible to see actual model preferences.

From the current PostHog data, ~30% of category_config sessions include `custom/custom` slots despite running standard, publicly-named models.

## Fix

- Added `ALL_KNOWN_MODEL_IDS` — a flat `Set` union of every model id across all known providers in `model-vocabulary.ts`
- Changed `maskProviderAndModel` to check `model_id` against this global set instead of only the current provider's model list
- Model ids are public product names, not PII — no privacy regression

## Before / After

| Provider | Model | Before | After |
|---|---|---|---|
| `openrouter` | `claude-opus-5` | `custom/custom` | `custom/claude-opus-5` |
| `my-gateway` | `gpt-5.6-sol` | `custom/custom` | `custom/gpt-5.6-sol` |
| `anthropic` | `my-finetune` | `anthropic/custom` | `anthropic/custom` (unchanged) |
| `my-gateway` | `my-finetune` | `custom/custom` | `custom/custom` (unchanged) |

## Tests

All 185 telemetry tests pass. Updated assertions in `product-identity.test.ts` and `delegation-projection.test.ts` to reflect the new behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unmasks model_id for known public models when the provider is unknown. Previously both provider and model_id masked to custom; now provider stays custom but model_id passes through if it matches a known model, improving telemetry accuracy without exposing PII.

- Introduces `ALL_KNOWN_MODEL_IDS`, a global set of all known model ids across providers.
- Updates `maskProviderAndModel` to unmask model_id when it appears in this set, regardless of provider.
- Unknown providers still mask to "custom"; unknown or fine-tuned model ids still mask to "custom".
- Telemetry impact: `category_config` and `delegation_completed` now report actual model ids when routed via OpenRouter/LiteLLM/self-hosted gateways.
- Tests updated; no configuration or migration required.

<sup>Written for commit f95a32fe72ed240ebe3b0bdb55cb99a5c20447a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

