### PR TITLE
fix(omo-senpi): accept canonical debug log casing

### DIFF
--- a/docs/reference/omo-ai-publishing.md
+++ b/docs/reference/omo-ai-publishing.md
@@ -74,12 +74,18 @@ identity instead of impersonating the product.
 
 | field | value | effect |
 | --- | --- | --- |
-| `name` | `omo` | welcome header, terminal titles, help, tips, first-run, system-prompt identity |
+| `name` | `OmO` | welcome header, terminal titles, help, tips, first-run, system-prompt identity |
 | `displayVersion` | the omo-ai version | `omo --version` and the TUI header; the engine version stays internal for update comparisons |
 | `configDir` + `flatLayout` | `.omo`, nested | agent state lives at `~/.omo/agent` - the one directory every omo entry point resolves through `bin/lib/agent-dir.js`; the launcher pins it for the engine with `OMO_CODING_AGENT_DIR` plus the legacy `SENPI_CODING_AGENT_DIR` |
 | `envPrefix` | `OMO` | `OMO_*` variables are read first, then the legacy `SENPI_*` and `PI_*` names |
 | `userAgent` / `originator` | `omo` | outgoing request identity |
 | `update` | `omo-ai`, `beta`, `npm i -g omo-ai@beta` | the update banner checks the beta dist-tag of omo-ai and prints the product's own command |
+
+The display name also becomes Senpi's `APP_NAME`, so process titles, exported
+session filenames, debug-log filenames, and opt-in provider attribution headers
+use `OmO`. Machine contracts remain explicitly pinned by the other fields:
+`.omo`, `OMO_*`, the `omo` User-Agent/originator, and the lowercase `omo`
+command/package names do not derive from the display spelling.
 
 The update channel matters: omo-ai's `latest` tag is pinned to the deprecated bootstrap
 placeholder forever, so a `latest` lookup would never see a release. The engine therefore reads

--- a/packages/omo-senpi/scripts/qa/facts-backlog-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/facts-backlog-e2e.mjs
@@ -49,7 +49,20 @@ function findOnPath(bin) {
 
 /** Digest of a real user directory: the isolation proof. Volatile session/log paths a live host
  * rewrites on its own are excluded, exactly as memory-e2e.mjs does. */
-const VOLATILE = new Set(["sessions", "senpi-debug.log", "mcp-cache.json", "mcp-auth", "settings.json", "telemetry.log", "goals", "logs", "omo-debug.log", "last-payloads.json"])
+const VOLATILE = new Set([
+  "sessions",
+  "senpi-debug.log",
+  "mcp-cache.json",
+  "mcp-auth",
+  "settings.json",
+  "telemetry.log",
+  "goals",
+  "logs",
+  "omo-debug.log",
+  "OmO-debug.log",
+  "OmO-crash.log",
+  "last-payloads.json",
+])
 function hashFiles(root, excludePrefix = undefined) {
   const files = new Map()
   if (!existsSync(root)) return files

--- a/packages/omo-senpi/scripts/qa/task-lane-spill-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/task-lane-spill-e2e.mjs
@@ -39,7 +39,12 @@ function snapshotRealAgentDirs() {
 // senpi-* names, but this file is the same thing: a machine-global append-only journal every
 // concurrent omo process on the host writes (17MB and growing during any live TUI session), so it
 // can no more identify QA pollution than senpi-debug.log can.
-const SHARED_OMO_DIAGNOSTICS = new Set(["omo-debug.log", "omo-crash.log"])
+const SHARED_OMO_DIAGNOSTICS = new Set([
+  "omo-debug.log",
+  "omo-crash.log",
+  "OmO-debug.log",
+  "OmO-crash.log",
+])
 
 function classifyRealAgentChanges(before, after, sandboxTokens) {
   const qaAttributedPaths = []


### PR DESCRIPTION
## Summary

Follow-up to #7148. The merged brand change makes Senpi derive the new
`OmO-debug.log` diagnostic filename from `APP_NAME`, while two isolated live-QA
drivers recognized only the legacy lowercase filename.

This update accepts both legacy and canonical diagnostic filenames so upgrades
cannot create false-positive user-directory pollution reports. It also updates
the publishing contract to document which values derive from the display name
and which lowercase machine contracts remain fixed.

## Changes

- Ignore both `omo-debug.log` / `omo-crash.log` and
  `OmO-debug.log` / `OmO-crash.log` in task-lane spill QA.
- Ignore both legacy and canonical debug/crash filenames in facts backlog QA.
- Document the canonical `SENPI_BRAND.name = "OmO"` and its `APP_NAME`-derived
  process/export/debug/provider-title effects.

## RED → GREEN

- RED:
  `.omo/evidence/20260823-omo-brand-casing/red-qa-diagnostic-filter.txt`
  failed because the task-lane QA filter did not recognize `OmO-debug.log`.
- GREEN:
  `.omo/evidence/20260823-omo-brand-casing/green-qa-diagnostic-filter.txt`
  verifies both QA scripts accept legacy and canonical filenames.

## Verification

- `node packages/omo-senpi/scripts/qa/task-lane-spill-e2e.mjs --self-test`
- `node --check` on both changed QA scripts
- `bun run --cwd packages/omo-senpi typecheck`
- `node packages/omo-senpi/plugin/scripts/build-extension.mjs --check`
- Focused launcher, local-launcher, and schema tests
- `git diff --check`

All passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts canonical debug/crash log casing introduced by the `APP_NAME` brand change. Previously QA ignored only `omo-debug.log`/`omo-crash.log`; now it also ignores `OmO-debug.log`/`OmO-crash.log` to prevent false-positive user-directory pollution. Updates publishing docs to clarify which fields derive from the display name.

- `packages/omo-senpi/scripts/qa/task-lane-spill-e2e.mjs` and `packages/omo-senpi/scripts/qa/facts-backlog-e2e.mjs` treat both casings as shared diagnostics.
- Docs define canonical `SENPI_BRAND.name = "OmO"` and note that `APP_NAME`-derived outputs use `OmO` while machine contracts remain `.omo`, `OMO_*`, `omo` UA/command/package.
- No runtime behavior change; QA filters and docs only.

<sup>Written for commit ca4f101e400562271ccaf787b9339ec375443b35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

