### PR TITLE
feat(cli): add omo-agent-toolkit worktree-sweep command

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,6 +46,7 @@ bunx oh-my-opencode
 | `get-local-version` | Show current installed version and check for updates |
 | `refresh-model-capabilities` | Refresh cached model capabilities snapshot from models.dev |
 | `config migrate` | Migrate legacy OMO configuration into the unified config at `~/.omo/omo.jsonc` (`--dry-run` prints the transform/backup plan without writing, `--json` emits a machine-readable report) |
+| `worktree-sweep` | Report (and optionally remove) stale linked git worktrees: SWEEP when merged into the default branch and clean, KEEP when locked/external/unmerged/dirty, PRUNE when the path is gone. Dry-run by default; `--apply` removes with `git worktree remove` (never forced) and prunes; `--older-than <days>` adds an age fallback, `--repo <path>` is repeatable, `--json` emits machine-readable output |
 | `ulw-loop [args...]` | Pass arguments through to the Codex LazyCodex ulw-loop CLI |
 | `update` | `lazycodex` / `lazycodex-ai` bins only: refresh the installed Codex Light edition in place (`--dry-run`, `--repo-root <path>`) |
 | `boulder` | Inspect Sisyphus boulder work-state (active plan, current-task timing, session count); supports `-d/--directory`, `-w/--work-id`, and `--json` |

--- a/packages/omo-opencode/src/cli/runtime-commands.ts
+++ b/packages/omo-opencode/src/cli/runtime-commands.ts
@@ -1,8 +1,11 @@
-import type { Command } from "commander"
+import { InvalidArgumentError, type Command } from "commander"
 
 import { boulder } from "./boulder"
 import { codexUlwLoop } from "./codex-ulw-loop"
 import { refreshModelCapabilities } from "./refresh-model-capabilities"
+import { worktreeSweep } from "./worktree-sweep"
+import { parseOlderThanDays } from "./worktree-sweep/options"
+
 import { PLUGIN_NAME } from "../shared"
 import packageJson from "../../../../package.json" with { type: "json" }
 
@@ -41,6 +44,39 @@ export function configureRuntimeCommands(program: Command): void {
       const exitCode = await boulder({
         directory: options.directory,
         workId: options.workId,
+        json: options.json ?? false,
+      })
+      process.exit(exitCode)
+    })
+
+  program
+    .command("worktree-sweep")
+    .description("Report (and optionally remove) stale linked git worktrees")
+    .option("--apply", "Actually remove SWEEP worktrees and prune stale metadata (default is dry-run)")
+    .option("--older-than <days>", "Sweep unmerged worktrees older than N days (0 = merged-only)", (value: string) => {
+      try {
+        return parseOlderThanDays(value)
+      } catch (error) {
+        throw new InvalidArgumentError(error instanceof Error ? error.message : String(error))
+      }
+    })
+    .option("--repo <path>", "Repository to sweep (repeatable)", (value: string, previous: string[] = []) => [...previous, value])
+    .option("--json", "Output structured JSON result")
+    .addHelpText("after", `
+Examples:
+  $ omo-agent-toolkit worktree-sweep
+  $ omo-agent-toolkit worktree-sweep --older-than=14
+  $ omo-agent-toolkit worktree-sweep --repo /path/to/repo --repo /path/to/other --apply
+
+Lines: SWEEP <path> <ref> | KEEP(<reason>) <path> <ref> | PRUNE <path> <ref>
+KEEP reasons: locked, external, unmerged, dirty. Dry-run is the default; --apply
+removes with 'git worktree remove' (never --force) and then prunes.
+`)
+    .action(async (options: { readonly apply?: boolean; readonly olderThan?: number; readonly repo?: string[]; readonly json?: boolean }) => {
+      const exitCode = await worktreeSweep({
+        apply: options.apply === true,
+        olderThanDays: options.olderThan ?? 0,
+        repos: options.repo,
         json: options.json ?? false,
       })
       process.exit(exitCode)

--- a/packages/omo-opencode/src/cli/worktree-sweep/classify.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/classify.ts
@@ -1,0 +1,55 @@
+import path from "node:path"
+
+import type { ClassificationInput, WorktreeClassification, WorktreeRecord } from "./types"
+
+/**
+ * Externally-owned worktree roots. These are managed by other applications, so
+ * sweeping them would delete state we do not own.
+ */
+export const DEFAULT_EXCLUDE_PREFIXES: readonly string[] = [
+  "~/.codex/worktrees",
+  "~/.codex-gui-cli-remote/worktrees",
+]
+
+export function expandHome(value: string, home: string): string {
+  if (value === "~") return home
+  if (value.startsWith("~/")) return path.join(home, value.slice(2))
+  return value
+}
+
+export function isExcludedPath(
+  worktreePath: string,
+  prefixes: readonly string[],
+  home: string,
+): boolean {
+  const target = path.resolve(expandHome(worktreePath, home))
+  return prefixes.some((prefix) => {
+    const resolved = path.resolve(expandHome(prefix, home))
+    return target === resolved || target.startsWith(`${resolved}${path.sep}`)
+  })
+}
+
+/** Branch name when attached, otherwise the detached HEAD sha. */
+export function worktreeRef(record: WorktreeRecord): string {
+  return record.branch ?? record.head ?? ""
+}
+
+/**
+ * Single source of truth for sweep decisions. Mirrors the validated `git-wt-cl`
+ * prototype: protection wins over eligibility, and eligibility requires both a
+ * merged (or aged-out) ref and a clean tree.
+ */
+export function classifyWorktree(input: ClassificationInput): WorktreeClassification {
+  const { record } = input
+  const ref = worktreeRef(record)
+
+  if (record.locked) return { path: record.path, ref, decision: "KEEP", reason: "locked" }
+  if (!input.pathExists) return { path: record.path, ref, decision: "PRUNE" }
+  if (input.external) return { path: record.path, ref, decision: "KEEP", reason: "external" }
+  if (!input.merged && !input.agedOut) {
+    return { path: record.path, ref, decision: "KEEP", reason: "unmerged" }
+  }
+  if (input.dirty) return { path: record.path, ref, decision: "KEEP", reason: "dirty" }
+
+  return { path: record.path, ref, decision: "SWEEP" }
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/command-registration.test.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/command-registration.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect } from "bun:test"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+
+describe("worktree-sweep command registration", () => {
+  test("registers worktree-sweep on the omo-agent-toolkit program with the documented flags", async () => {
+    // given
+    const source = await readFile(
+      path.resolve(import.meta.dir, "..", "runtime-commands.ts"),
+      "utf-8",
+    )
+
+    // when
+    const commandBlock = source.match(/program\s*\n\s*\.command\("worktree-sweep"\)([\s\S]*?)\.action\(/)
+
+    // then
+    expect(commandBlock).not.toBeNull()
+    expect(commandBlock?.[1]).toContain('"--apply"')
+    expect(commandBlock?.[1]).toContain('"--older-than <days>"')
+    expect(commandBlock?.[1]).toContain('"--repo <path>"')
+    expect(commandBlock?.[1]).toContain('"--json"')
+  })
+
+  test("sweep implementation never forces a removal", async () => {
+    // given
+    const gitSource = await readFile(path.resolve(import.meta.dir, "git.ts"), "utf-8")
+
+    // when / then
+    expect(gitSource).not.toContain("'--force'")
+    expect(gitSource).not.toContain('"--force"')
+    expect(gitSource).toContain('runGit(repo, ["worktree", "remove", worktreePath])')
+  })
+
+  test("apply only removes after classification decides SWEEP", async () => {
+    // given
+    const sweepSource = await readFile(path.resolve(import.meta.dir, "sweep.ts"), "utf-8")
+
+    // when / then
+    expect(sweepSource).toContain('classification.decision !== "SWEEP"')
+    expect(sweepSource).toContain("await pruneWorktrees(root)")
+  })
+})

--- a/packages/omo-opencode/src/cli/worktree-sweep/format.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/format.ts
@@ -1,0 +1,37 @@
+import type { WorktreeClassification, WorktreeSweepResult } from "./types"
+
+/**
+ * One machine-parseable line per worktree:
+ *   `SWEEP <path> <ref>` / `KEEP(<reason>) <path> <ref>` / `PRUNE <path> <ref>`
+ */
+export function formatClassification(classification: WorktreeClassification): string {
+  const head =
+    classification.decision === "KEEP" && classification.reason !== undefined
+      ? `KEEP(${classification.reason})`
+      : classification.decision
+  return classification.ref.length > 0
+    ? `${head} ${classification.path} ${classification.ref}`
+    : `${head} ${classification.path}`
+}
+
+export function formatSummary(result: WorktreeSweepResult): string {
+  const mode = result.apply ? "apply" : "dry-run"
+  const removed = result.repos.reduce((total, repo) => total + repo.removed.length, 0)
+  const failed = result.repos.reduce((total, repo) => total + repo.failed.length, 0)
+  return `SUMMARY mode=${mode} repos=${result.repos.length} sweep=${result.sweepCount} keep=${result.keepCount} prune=${result.pruneCount} removed=${removed} failed=${failed}`
+}
+
+export function formatResult(result: WorktreeSweepResult): string[] {
+  const lines: string[] = []
+  for (const repo of result.repos) {
+    lines.push(`REPO ${repo.repo} default=${repo.defaultBranch}`)
+    for (const classification of repo.classifications) {
+      lines.push(formatClassification(classification))
+    }
+    for (const failure of repo.failed) {
+      lines.push(`FAILED ${failure.path} ${failure.error}`)
+    }
+  }
+  lines.push(formatSummary(result))
+  return lines
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/git.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/git.ts
@@ -1,0 +1,93 @@
+import { spawn } from "@oh-my-opencode/utils/runtime"
+
+export interface GitResult {
+  readonly code: number
+  readonly stdout: string
+  readonly stderr: string
+}
+
+export async function runGit(cwd: string, args: readonly string[]): Promise<GitResult> {
+  const child = spawn({ cmd: ["git", "-C", cwd, ...args], stdout: "pipe", stderr: "pipe" })
+  const [code, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  return { code, stdout, stderr }
+}
+
+export async function listWorktreesPorcelain(repo: string): Promise<string> {
+  const result = await runGit(repo, ["worktree", "list", "--porcelain"])
+  if (result.code !== 0) {
+    throw new Error(result.stderr.trim() || `git worktree list failed in ${repo}`)
+  }
+  return result.stdout
+}
+
+/**
+ * Default branch detection: `origin/HEAD` symbolic ref first, then a local
+ * `main`, then `master`. Mirrors the prototype's fallback chain.
+ */
+export async function detectDefaultBranch(repo: string): Promise<string | undefined> {
+  const symbolic = await runGit(repo, [
+    "symbolic-ref",
+    "--quiet",
+    "--short",
+    "refs/remotes/origin/HEAD",
+  ])
+  if (symbolic.code === 0) {
+    const value = symbolic.stdout.trim()
+    if (value.length > 0) return value.replace(/^[^/]*\//, "")
+  }
+
+  const local = await runGit(repo, [
+    "branch",
+    "--list",
+    "main",
+    "master",
+    "--format=%(refname:short)",
+  ])
+  if (local.code === 0) {
+    for (const candidate of ["main", "master"]) {
+      if (
+        local.stdout
+          .split("\n")
+          .map((line) => line.trim())
+          .includes(candidate)
+      ) {
+        return candidate
+      }
+    }
+  }
+
+  return undefined
+}
+
+/** `git merge-base --is-ancestor <ref> <default>` — the merged oracle. */
+export async function isMerged(repo: string, ref: string, defaultBranch: string): Promise<boolean> {
+  if (ref.length === 0) return false
+  const result = await runGit(repo, ["merge-base", "--is-ancestor", ref, defaultBranch])
+  return result.code === 0
+}
+
+export async function isDirty(worktreePath: string): Promise<boolean> {
+  const result = await runGit(worktreePath, ["status", "--porcelain"])
+  if (result.code !== 0) return true
+  return result.stdout.trim().length > 0
+}
+
+/** Never uses `--force`: git itself refuses dirty and locked worktrees. */
+export async function removeWorktree(repo: string, worktreePath: string): Promise<GitResult> {
+  return runGit(repo, ["worktree", "remove", worktreePath])
+}
+
+export async function pruneWorktrees(repo: string): Promise<GitResult> {
+  return runGit(repo, ["worktree", "prune"])
+}
+
+export async function resolveRepoRoot(cwd: string): Promise<string | undefined> {
+  const result = await runGit(cwd, ["rev-parse", "--show-toplevel"])
+  if (result.code !== 0) return undefined
+  const value = result.stdout.trim()
+  return value.length > 0 ? value : undefined
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/index.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/index.ts
@@ -1,0 +1,16 @@
+export { classifyWorktree, DEFAULT_EXCLUDE_PREFIXES, isExcludedPath } from "./classify"
+export { formatClassification, formatResult, formatSummary } from "./format"
+export { parseOlderThanDays } from "./options"
+export { parseWorktreeList, linkedWorktrees } from "./parse-worktree-list"
+export { sweepWorktrees } from "./sweep"
+export { worktreeSweep } from "./worktree-sweep"
+export type {
+  ClassificationInput,
+  WorktreeClassification,
+  WorktreeDecision,
+  WorktreeKeepReason,
+  WorktreeRecord,
+  WorktreeSweepOptions,
+  WorktreeSweepRepoReport,
+  WorktreeSweepResult,
+} from "./types"

--- a/packages/omo-opencode/src/cli/worktree-sweep/options.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/options.ts
@@ -1,0 +1,8 @@
+/** Parses the `--older-than <days>` value: a non-negative integer, else throws. */
+export function parseOlderThanDays(value: string): number {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+    throw new Error(`--older-than must be a non-negative integer number of days, got: ${value}`)
+  }
+  return parsed
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/parse-worktree-list.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/parse-worktree-list.ts
@@ -1,0 +1,86 @@
+import type { WorktreeRecord } from "./types"
+
+interface MutableRecord {
+  path?: string
+  head?: string
+  branch?: string
+  detached: boolean
+  locked: boolean
+  lockReason?: string
+  prunable: boolean
+}
+
+function emptyRecord(): MutableRecord {
+  return { detached: false, locked: false, prunable: false }
+}
+
+function finalize(record: MutableRecord): WorktreeRecord | undefined {
+  if (record.path === undefined || record.path.length === 0) return undefined
+  return {
+    path: record.path,
+    ...(record.head === undefined ? {} : { head: record.head }),
+    ...(record.branch === undefined ? {} : { branch: record.branch }),
+    detached: record.detached,
+    locked: record.locked,
+    ...(record.lockReason === undefined ? {} : { lockReason: record.lockReason }),
+    prunable: record.prunable,
+  }
+}
+
+function applyLine(record: MutableRecord, line: string): void {
+  if (line.startsWith("worktree ")) {
+    record.path = line.slice("worktree ".length)
+    return
+  }
+  if (line.startsWith("HEAD ")) {
+    record.head = line.slice("HEAD ".length)
+    return
+  }
+  if (line.startsWith("branch ")) {
+    record.branch = line.slice("branch ".length).replace(/^refs\/heads\//, "")
+    return
+  }
+  if (line === "detached") {
+    record.detached = true
+    return
+  }
+  if (line === "locked" || line.startsWith("locked ")) {
+    record.locked = true
+    const reason = line.slice("locked".length).trim()
+    if (reason.length > 0) record.lockReason = reason
+    return
+  }
+  if (line === "prunable" || line.startsWith("prunable ")) {
+    record.prunable = true
+  }
+}
+
+/**
+ * Parses `git worktree list --porcelain` output. Records are separated by blank
+ * lines; the first record is always the main worktree.
+ */
+export function parseWorktreeList(porcelain: string): WorktreeRecord[] {
+  const records: WorktreeRecord[] = []
+  let current = emptyRecord()
+
+  for (const rawLine of porcelain.split("\n")) {
+    const line = rawLine.replace(/\r$/, "")
+    if (line.length === 0) {
+      const finalized = finalize(current)
+      if (finalized) records.push(finalized)
+      current = emptyRecord()
+      continue
+    }
+    applyLine(current, line)
+  }
+
+  const trailing = finalize(current)
+  if (trailing) records.push(trailing)
+
+  return records
+}
+
+/** Drops the main worktree (first record), which is never a sweep candidate. */
+export function linkedWorktrees(records: readonly WorktreeRecord[]): WorktreeRecord[] {
+  return records.slice(1)
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/sweep.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/sweep.ts
@@ -1,0 +1,138 @@
+import { existsSync } from "node:fs"
+import { stat } from "node:fs/promises"
+import os from "node:os"
+
+import { classifyWorktree, DEFAULT_EXCLUDE_PREFIXES, isExcludedPath, worktreeRef } from "./classify"
+import {
+  detectDefaultBranch,
+  isDirty,
+  isMerged,
+  listWorktreesPorcelain,
+  pruneWorktrees,
+  removeWorktree,
+  resolveRepoRoot,
+} from "./git"
+import { linkedWorktrees, parseWorktreeList } from "./parse-worktree-list"
+import type {
+  WorktreeClassification,
+  WorktreeRecord,
+  WorktreeSweepOptions,
+  WorktreeSweepRepoReport,
+  WorktreeSweepResult,
+} from "./types"
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+async function isOlderThan(worktreePath: string, days: number, now: number): Promise<boolean> {
+  if (days <= 0) return false
+  try {
+    const stats = await stat(worktreePath)
+    return now - stats.mtimeMs > days * DAY_MS
+  } catch {
+    return false
+  }
+}
+
+async function classifyRecord(
+  repo: string,
+  record: WorktreeRecord,
+  defaultBranch: string,
+  options: {
+    readonly olderThanDays: number
+    readonly excludePrefixes: readonly string[]
+    readonly home: string
+    readonly now: number
+  },
+): Promise<WorktreeClassification> {
+  const pathExists = existsSync(record.path)
+  const external = isExcludedPath(record.path, options.excludePrefixes, options.home)
+
+  // Short-circuit: protected or vanished trees need no git interrogation.
+  if (record.locked || !pathExists || external) {
+    return classifyWorktree({
+      record,
+      pathExists,
+      merged: false,
+      agedOut: false,
+      dirty: false,
+      external,
+    })
+  }
+
+  const merged = await isMerged(repo, worktreeRef(record), defaultBranch)
+  const agedOut = merged
+    ? false
+    : await isOlderThan(record.path, options.olderThanDays, options.now)
+  const dirty = merged || agedOut ? await isDirty(record.path) : false
+
+  return classifyWorktree({ record, pathExists, merged, agedOut, dirty, external })
+}
+
+async function sweepRepo(
+  repo: string,
+  options: {
+    readonly apply: boolean
+    readonly olderThanDays: number
+    readonly excludePrefixes: readonly string[]
+    readonly home: string
+    readonly now: number
+  },
+): Promise<WorktreeSweepRepoReport> {
+  const root = (await resolveRepoRoot(repo)) ?? repo
+  const defaultBranch = await detectDefaultBranch(root)
+  if (defaultBranch === undefined) {
+    throw new Error(`Could not determine the default branch for ${root}`)
+  }
+
+  const records = linkedWorktrees(parseWorktreeList(await listWorktreesPorcelain(root)))
+  const classifications: WorktreeClassification[] = []
+  for (const record of records) {
+    classifications.push(await classifyRecord(root, record, defaultBranch, options))
+  }
+
+  const removed: string[] = []
+  const failed: { path: string; error: string }[] = []
+
+  if (options.apply) {
+    for (const classification of classifications) {
+      if (classification.decision !== "SWEEP") continue
+      // `git worktree remove` without --force: git refuses dirty/locked trees.
+      const result = await removeWorktree(root, classification.path)
+      if (result.code === 0) removed.push(classification.path)
+      else {
+        failed.push({
+          path: classification.path,
+          error: result.stderr.trim() || `git worktree remove exited with ${result.code}`,
+        })
+      }
+    }
+    await pruneWorktrees(root)
+  }
+
+  return { repo: root, defaultBranch, classifications, removed, failed }
+}
+
+export async function sweepWorktrees(options: WorktreeSweepOptions = {}): Promise<WorktreeSweepResult> {
+  const apply = options.apply === true
+  const olderThanDays = options.olderThanDays ?? 0
+  const excludePrefixes = options.excludePrefixes ?? DEFAULT_EXCLUDE_PREFIXES
+  const home = os.homedir()
+  const now = Date.now()
+  const repos = options.repos && options.repos.length > 0 ? options.repos : [options.cwd ?? process.cwd()]
+
+  const reports: WorktreeSweepRepoReport[] = []
+  for (const repo of repos) {
+    reports.push(await sweepRepo(repo, { apply, olderThanDays, excludePrefixes, home, now }))
+  }
+
+  const all = reports.flatMap((report) => report.classifications)
+
+  return {
+    apply,
+    olderThanDays,
+    repos: reports,
+    sweepCount: all.filter((item) => item.decision === "SWEEP").length,
+    keepCount: all.filter((item) => item.decision === "KEEP").length,
+    pruneCount: all.filter((item) => item.decision === "PRUNE").length,
+  }
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/types.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/types.ts
@@ -1,0 +1,69 @@
+export interface WorktreeRecord {
+  /** Absolute worktree path as reported by `git worktree list --porcelain`. */
+  readonly path: string
+  /** Commit SHA of the worktree HEAD, when reported. */
+  readonly head?: string
+  /** Short branch name (`refs/heads/` stripped), when the worktree is attached. */
+  readonly branch?: string
+  readonly detached: boolean
+  readonly locked: boolean
+  /** Lock reason string recorded by `git worktree lock --reason`, when present. */
+  readonly lockReason?: string
+  readonly prunable: boolean
+}
+
+export type WorktreeDecision = "SWEEP" | "KEEP" | "PRUNE"
+
+export type WorktreeKeepReason = "locked" | "external" | "unmerged" | "dirty"
+
+export interface WorktreeClassification {
+  readonly path: string
+  /** Branch name when attached, otherwise the HEAD sha; empty when neither is known. */
+  readonly ref: string
+  readonly decision: WorktreeDecision
+  readonly reason?: WorktreeKeepReason
+}
+
+export interface ClassificationInput {
+  readonly record: WorktreeRecord
+  /** False when the worktree path no longer exists on disk. */
+  readonly pathExists: boolean
+  readonly merged: boolean
+  /** True when `--older-than` is satisfied; always false when `--older-than=0`. */
+  readonly agedOut: boolean
+  readonly dirty: boolean
+  /** True when the path lives under one of the configured protected prefixes. */
+  readonly external: boolean
+}
+
+export interface WorktreeSweepRepoReport {
+  readonly repo: string
+  readonly defaultBranch: string
+  readonly classifications: readonly WorktreeClassification[]
+  /** Paths actually removed; always empty in dry-run mode. */
+  readonly removed: readonly string[]
+  /** Paths that `git worktree remove` refused, with the git error text. */
+  readonly failed: readonly { readonly path: string; readonly error: string }[]
+}
+
+export interface WorktreeSweepResult {
+  readonly apply: boolean
+  readonly olderThanDays: number
+  readonly repos: readonly WorktreeSweepRepoReport[]
+  readonly sweepCount: number
+  readonly keepCount: number
+  readonly pruneCount: number
+}
+
+export interface WorktreeSweepOptions {
+  /** Dry-run is the default; only an explicit `true` removes anything. */
+  readonly apply?: boolean
+  /** 0 means merged-only: unmerged worktrees are never swept. */
+  readonly olderThanDays?: number
+  /** Repositories to sweep; defaults to the current working directory's repo. */
+  readonly repos?: readonly string[]
+  readonly json?: boolean
+  /** Overrides the built-in externally-owned path prefixes. */
+  readonly excludePrefixes?: readonly string[]
+  readonly cwd?: string
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
@@ -412,7 +412,7 @@ describe("worktreeSweep output", () => {
 
     const originalWrite = process.stderr.write.bind(process.stderr)
     process.stderr.write = ((chunk: unknown) => {
-      originalWrite(chunk)
+      originalWrite(String(chunk))
       return true
     }) as typeof process.stderr.write
     let exitCode: number

--- a/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
@@ -1,0 +1,451 @@
+/// <reference types="bun-types" />
+import { afterAll, describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import fs from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { DEFAULT_EXCLUDE_PREFIXES, isExcludedPath } from "./classify"
+import { formatClassification, formatSummary } from "./format"
+import { linkedWorktrees, parseWorktreeList } from "./parse-worktree-list"
+import { parseOlderThanDays } from "./options"
+import { sweepWorktrees } from "./sweep"
+import { worktreeSweep } from "./worktree-sweep"
+import type { WorktreeSweepRepoReport } from "./types"
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const temporaryDirectories: string[] = []
+
+afterAll(async () => {
+  for (const directory of temporaryDirectories.reverse()) {
+    await fs.rm(directory, { recursive: true, force: true })
+  }
+})
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+  GIT_TERMINAL_PROMPT: "0",
+}
+
+function git(cwd: string, args: readonly string[]): string {
+  const result = spawnSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8",
+    env: GIT_ENV,
+  })
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed in ${cwd}: ${result.stderr}`)
+  }
+  return result.stdout
+}
+
+async function commit(repo: string, message: string): Promise<void> {
+  git(repo, [
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=Test",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "--allow-empty",
+    "-m",
+    message,
+  ])
+}
+
+async function newTmpDir(prefix: string): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  // macOS hands out /var/folders/... while git reports /private/var/folders/...;
+  // normalizing up front keeps porcelain output comparable.
+  return fs.realpath(directory)
+}
+
+interface Fixture {
+  readonly base: string
+  readonly repo: string
+}
+
+/** Main worktree on `main` with one commit; linked worktrees are added by each test. */
+async function createFixture(prefix = "wt-sweep-"): Promise<Fixture> {
+  const base = await newTmpDir(prefix)
+  const repo = path.join(base, "repo")
+  await fs.mkdir(repo)
+  git(repo, ["init", "-b", "main"])
+  await commit(repo, "initial")
+  return { base, repo }
+}
+
+/**
+ * Creates branch `name` with one commit, fast-forwards `main` to it (so the
+ * branch is merged), then checks the branch out in a linked worktree.
+ */
+async function addMergedWorktree(repo: string, name: string, worktreePath: string): Promise<void> {
+  git(repo, ["branch", name])
+  git(repo, ["merge", "--ff-only", name])
+  git(repo, ["worktree", "add", worktreePath, name])
+}
+
+/** Same as addMergedWorktree but leaves the branch unmerged. */
+async function addUnmergedWorktree(repo: string, name: string, worktreePath: string): Promise<void> {
+  git(repo, ["checkout", "-b", name])
+  await commit(repo, `${name} commit`)
+  git(repo, ["checkout", "main"])
+  git(repo, ["worktree", "add", worktreePath, name])
+}
+
+function decisionFor(report: WorktreeSweepRepoReport, worktreePath: string) {
+  const classification = report.classifications.find((item) => item.path === worktreePath)
+  if (classification === undefined) {
+    throw new Error(`no classification for ${worktreePath}; got ${JSON.stringify(report.classifications)}`)
+  }
+  return classification
+}
+
+describe("parseWorktreeList", () => {
+  test("parses main worktree, locked reason, detached, and prunable records", () => {
+    const porcelain = [
+      "worktree /repos/omo",
+      "HEAD 1111111111111111111111111111111111111111",
+      "branch refs/heads/main",
+      "",
+      "worktree /tmp/wt-a",
+      "HEAD 2222222222222222222222222222222222222222",
+      "branch refs/heads/feature",
+      "locked review:pr-1",
+      "",
+      "worktree /tmp/wt-b",
+      "HEAD 3333333333333333333333333333333333333333",
+      "detached",
+      "",
+      "worktree /tmp/wt-gone",
+      "HEAD 4444444444444444444444444444444444444444",
+      "branch refs/heads/gone",
+      "prunable gitdir file points to non-existent location",
+      "",
+    ].join("\n")
+
+    const records = parseWorktreeList(porcelain)
+
+    expect(records).toHaveLength(4)
+    expect(records[0]).toEqual({
+      path: "/repos/omo",
+      head: "1111111111111111111111111111111111111111",
+      branch: "main",
+      detached: false,
+      locked: false,
+      prunable: false,
+    })
+    expect(records[1]?.branch).toBe("feature")
+    expect(records[1]?.locked).toBe(true)
+    expect(records[1]?.lockReason).toBe("review:pr-1")
+    expect(records[2]?.detached).toBe(true)
+    expect(records[2]?.branch).toBeUndefined()
+    expect(records[3]?.prunable).toBe(true)
+    // First record is the main worktree and is always excluded from candidates.
+    expect(linkedWorktrees(records).map((record) => record.path)).toEqual([
+      "/tmp/wt-a",
+      "/tmp/wt-b",
+      "/tmp/wt-gone",
+    ])
+  })
+
+  test("accepts output without a trailing blank line", () => {
+    const records = parseWorktreeList("worktree /a\nHEAD 1\nbranch refs/heads/main")
+    expect(records).toHaveLength(1)
+    expect(records[0]?.path).toBe("/a")
+  })
+})
+
+describe("isExcludedPath", () => {
+  test("default exclude prefixes protect codex-managed worktree roots", () => {
+    expect(isExcludedPath("/home/dev/.codex/worktrees/lane-a", DEFAULT_EXCLUDE_PREFIXES, "/home/dev")).toBe(true)
+    expect(
+      isExcludedPath("/home/dev/.codex-gui-cli-remote/worktrees/pr-9", DEFAULT_EXCLUDE_PREFIXES, "/home/dev"),
+    ).toBe(true)
+  })
+
+  test("paths outside the prefixes are not excluded, and prefix siblings do not match", () => {
+    expect(isExcludedPath("/home/dev/src/omo", DEFAULT_EXCLUDE_PREFIXES, "/home/dev")).toBe(false)
+    expect(isExcludedPath("/home/dev/.codex-other/worktrees/x", DEFAULT_EXCLUDE_PREFIXES, "/home/dev")).toBe(false)
+  })
+})
+
+describe("parseOlderThanDays", () => {
+  test("accepts non-negative integers and rejects everything else", () => {
+    expect(parseOlderThanDays("0")).toBe(0)
+    expect(parseOlderThanDays("14")).toBe(14)
+    expect(() => parseOlderThanDays("-1")).toThrow()
+    expect(() => parseOlderThanDays("1.5")).toThrow()
+    expect(() => parseOlderThanDays("soon")).toThrow()
+  })
+})
+
+describe("sweepWorktrees classification", () => {
+  test("classifies merged, unmerged, dirty, locked, excluded, missing, and detached worktrees", async () => {
+    const { base, repo } = await createFixture()
+
+    const merged = path.join(base, "wt-merged")
+    const unmerged = path.join(base, "wt-unmerged")
+    const dirty = path.join(base, "wt-dirty")
+    const locked = path.join(base, "wt-locked")
+    const external = path.join(base, "external", "wt-external")
+    const missing = path.join(base, "wt-missing")
+    const detached = path.join(base, "wt-detached")
+
+    await addMergedWorktree(repo, "merged-branch", merged)
+    await addUnmergedWorktree(repo, "unmerged-branch", unmerged)
+    await addMergedWorktree(repo, "dirty-branch", dirty)
+    await fs.writeFile(path.join(dirty, "scratch.txt"), "local change\n")
+    await addMergedWorktree(repo, "locked-branch", locked)
+    git(repo, ["worktree", "lock", locked])
+    await fs.mkdir(path.dirname(external), { recursive: true })
+    await addMergedWorktree(repo, "external-branch", external)
+    await addMergedWorktree(repo, "missing-branch", missing)
+    await fs.rm(missing, { recursive: true, force: true })
+    const mergedTip = git(repo, ["rev-parse", "merged-branch"]).trim()
+    git(repo, ["worktree", "add", "--detach", detached, mergedTip])
+
+    const result = await sweepWorktrees({
+      repos: [repo],
+      excludePrefixes: [path.join(base, "external")],
+    })
+
+    expect(result.repos).toHaveLength(1)
+    const report = result.repos[0]!
+    expect(report.defaultBranch).toBe("main")
+
+    const mergedItem = decisionFor(report, merged)
+    expect(mergedItem.decision).toBe("SWEEP")
+    expect(mergedItem.ref).toBe("merged-branch")
+
+    expect(decisionFor(report, unmerged)).toEqual({
+      path: unmerged,
+      ref: "unmerged-branch",
+      decision: "KEEP",
+      reason: "unmerged",
+    })
+    expect(decisionFor(report, dirty).reason).toBe("dirty")
+    expect(decisionFor(report, locked).reason).toBe("locked")
+    expect(decisionFor(report, external).reason).toBe("external")
+    expect(decisionFor(report, missing).decision).toBe("PRUNE")
+    // Detached trees are judged by their HEAD sha, which is merged here.
+    expect(decisionFor(report, detached)).toEqual({
+      path: detached,
+      ref: mergedTip,
+      decision: "SWEEP",
+    })
+
+    // The main worktree itself is never a candidate.
+    expect(report.classifications.some((item) => item.path === repo)).toBe(false)
+
+    expect(result.sweepCount).toBe(2)
+    expect(result.keepCount).toBe(4)
+    expect(result.pruneCount).toBe(1)
+    expect(result.apply).toBe(false)
+
+    // Dry-run removed nothing.
+    expect(await fs.stat(merged)).toBeTruthy()
+    expect(git(repo, ["worktree", "list", "--porcelain"])).toContain(missing)
+  })
+
+  test("detects the default branch through origin/HEAD when present", async () => {
+    const base = await newTmpDir("wt-sweep-origin-")
+    const seed = path.join(base, "seed")
+    const origin = path.join(base, "origin.git")
+    const clone = path.join(base, "clone")
+
+    await fs.mkdir(seed)
+    git(seed, ["init", "-b", "trunk"])
+    await commit(seed, "initial")
+    git(seed, ["clone", "--bare", seed, origin])
+    git(seed, ["clone", origin, clone])
+
+    git(clone, ["checkout", "-b", "feature"])
+    await commit(clone, "feature commit")
+    git(clone, ["checkout", "trunk"])
+    git(clone, ["merge", "--ff-only", "feature"])
+    const feature = path.join(base, "wt-feature")
+    git(clone, ["worktree", "add", feature, "feature"])
+
+    const result = await sweepWorktrees({ repos: [clone] })
+    const report = result.repos[0]!
+
+    expect(report.defaultBranch).toBe("trunk")
+    expect(decisionFor(report, feature).decision).toBe("SWEEP")
+  })
+
+  test("falls back to master when origin/HEAD and main are absent", async () => {
+    const { base, repo } = await createFixture("wt-sweep-master-")
+    git(repo, ["branch", "-m", "main", "master"])
+
+    const worktree = path.join(base, "wt-m")
+    git(repo, ["branch", "done"])
+    git(repo, ["merge", "--ff-only", "done"])
+    git(repo, ["worktree", "add", worktree, "done"])
+
+    const result = await sweepWorktrees({ repos: [repo] })
+    expect(result.repos[0]?.defaultBranch).toBe("master")
+    expect(decisionFor(result.repos[0]!, worktree).decision).toBe("SWEEP")
+  })
+})
+
+describe("sweepWorktrees --older-than", () => {
+  test("unmerged worktrees are kept when newer than the cutoff and swept when older and clean", async () => {
+    const { base, repo } = await createFixture("wt-sweep-age-")
+    const young = path.join(base, "wt-young")
+    const old = path.join(base, "wt-old")
+    const oldDirty = path.join(base, "wt-old-dirty")
+
+    await addUnmergedWorktree(repo, "young-branch", young)
+    await addUnmergedWorktree(repo, "old-branch", old)
+    await addUnmergedWorktree(repo, "old-dirty-branch", oldDirty)
+    // The untracked file first (writing it would touch the directory mtime), then age the directory.
+    await fs.writeFile(path.join(oldDirty, "scratch.txt"), "local change\n")
+    const staleTime = new Date(Date.now() - 10 * DAY_MS)
+    await fs.utimes(old, staleTime, staleTime)
+    await fs.utimes(oldDirty, staleTime, staleTime)
+
+    const result = await sweepWorktrees({ repos: [repo], olderThanDays: 7 })
+
+    const report = result.repos[0]!
+    expect(decisionFor(report, young).reason).toBe("unmerged")
+    expect(decisionFor(report, old).decision).toBe("SWEEP")
+    expect(decisionFor(report, oldDirty).reason).toBe("dirty")
+  })
+
+  test("olderThanDays 0 never sweeps unmerged worktrees regardless of age", async () => {
+    const { base, repo } = await createFixture("wt-sweep-age0-")
+    const old = path.join(base, "wt-old")
+    await addUnmergedWorktree(repo, "old-branch", old)
+    const staleTime = new Date(Date.now() - 30 * DAY_MS)
+    await fs.utimes(old, staleTime, staleTime)
+
+    const result = await sweepWorktrees({ repos: [repo] })
+    expect(decisionFor(result.repos[0]!, old).reason).toBe("unmerged")
+  })
+})
+
+describe("sweepWorktrees --apply", () => {
+  test("removes sweep candidates with git worktree remove and prunes stale metadata", async () => {
+    const { base, repo } = await createFixture("wt-sweep-apply-")
+    const merged = path.join(base, "wt-merged")
+    const missing = path.join(base, "wt-missing")
+    const kept = path.join(base, "wt-kept")
+
+    await addMergedWorktree(repo, "merged-branch", merged)
+    await addMergedWorktree(repo, "missing-branch", missing)
+    await addUnmergedWorktree(repo, "unmerged-branch", kept)
+    await fs.rm(missing, { recursive: true, force: true })
+
+    const result = await sweepWorktrees({ repos: [repo], apply: true })
+
+    expect(result.apply).toBe(true)
+    const report = result.repos[0]!
+    expect(report.removed).toEqual([merged])
+    expect(report.failed).toEqual([])
+
+    await expect(fs.stat(merged)).rejects.toThrow()
+    expect(await fs.stat(kept)).toBeTruthy()
+    const porcelain = git(repo, ["worktree", "list", "--porcelain"])
+    expect(porcelain).not.toContain(missing)
+    expect(porcelain).not.toContain(merged)
+    expect(porcelain).toContain(kept)
+  })
+
+  test("leaves locked and dirty worktrees in place even under --apply", async () => {
+    const { base, repo } = await createFixture("wt-sweep-apply2-")
+    const locked = path.join(base, "wt-locked")
+    const dirty = path.join(base, "wt-dirty")
+
+    await addMergedWorktree(repo, "locked-branch", locked)
+    git(repo, ["worktree", "lock", locked])
+    await addMergedWorktree(repo, "dirty-branch", dirty)
+    await fs.writeFile(path.join(dirty, "scratch.txt"), "local change\n")
+
+    const result = await sweepWorktrees({ repos: [repo], apply: true })
+    const report = result.repos[0]!
+
+    expect(report.removed).toEqual([])
+    expect(await fs.stat(locked)).toBeTruthy()
+    expect(await fs.stat(dirty)).toBeTruthy()
+    expect(result.sweepCount).toBe(0)
+  })
+})
+
+describe("worktreeSweep output", () => {
+  test("prints one machine-parseable line per tree then a summary, and exits 0", async () => {
+    const { base, repo } = await createFixture("wt-sweep-output-")
+    const merged = path.join(base, "wt-merged")
+    const unmerged = path.join(base, "wt-unmerged")
+    await addMergedWorktree(repo, "merged-branch", merged)
+    await addUnmergedWorktree(repo, "unmerged-branch", unmerged)
+
+    const chunks: string[] = []
+    const originalWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((chunk: unknown) => {
+      chunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    let exitCode: number
+    try {
+      exitCode = await worktreeSweep({ repos: [repo] })
+    } finally {
+      process.stdout.write = originalWrite
+    }
+
+    expect(exitCode).toBe(0)
+    const lines = chunks.join("").trim().split("\n")
+    expect(lines[0]).toBe(`REPO ${repo} default=main`)
+    expect(lines).toContain(`SWEEP ${merged} merged-branch`)
+    expect(lines).toContain(`KEEP(unmerged) ${unmerged} unmerged-branch`)
+    const summary = lines[lines.length - 1]!
+    expect(summary).toBe(
+      "SUMMARY mode=dry-run repos=1 sweep=1 keep=1 prune=0 removed=0 failed=0",
+    )
+  })
+
+  test("returns exit code 1 and a stderr message for a non-repository path", async () => {
+    const base = await newTmpDir("wt-sweep-bad-")
+
+    const originalWrite = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((chunk: unknown) => {
+      originalWrite(chunk)
+      return true
+    }) as typeof process.stderr.write
+    let exitCode: number
+    try {
+      exitCode = await worktreeSweep({ repos: [path.join(base, "not-a-repo")] })
+    } finally {
+      process.stderr.write = originalWrite
+    }
+
+    expect(exitCode).toBe(1)
+  })
+})
+
+describe("format helpers", () => {
+  test("formatClassification and formatSummary stay machine-parseable", () => {
+    expect(
+      formatClassification({ path: "/tmp/w", ref: "feature", decision: "KEEP", reason: "locked" }),
+    ).toBe("KEEP(locked) /tmp/w feature")
+    expect(formatClassification({ path: "/tmp/w", ref: "feature", decision: "SWEEP" })).toBe(
+      "SWEEP /tmp/w feature",
+    )
+    expect(formatClassification({ path: "/tmp/w", ref: "", decision: "PRUNE" })).toBe("PRUNE /tmp/w")
+  })
+
+  test("formatSummary reports apply counts", () => {
+    const summary = formatSummary({
+      apply: true,
+      olderThanDays: 7,
+      repos: [],
+      sweepCount: 2,
+      keepCount: 1,
+      pruneCount: 1,
+    })
+    expect(summary).toBe("SUMMARY mode=apply repos=0 sweep=2 keep=1 prune=1 removed=0 failed=0")
+  })
+})

--- a/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.ts
@@ -1,0 +1,27 @@
+import { formatResult } from "./format"
+import { sweepWorktrees } from "./sweep"
+import type { WorktreeSweepOptions } from "./types"
+
+export async function worktreeSweep(options: WorktreeSweepOptions = {}): Promise<number> {
+  let result
+  try {
+    result = await sweepWorktrees(options)
+  } catch (error) {
+    process.stderr.write(
+      `[omo] worktree-sweep failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    return 1
+  }
+
+  if (options.json === true) {
+    process.stdout.write(JSON.stringify(result, null, 2))
+    process.stdout.write("\n")
+  } else {
+    process.stdout.write(formatResult(result).join("\n"))
+    process.stdout.write("\n")
+  }
+
+  const failedTotal = result.repos.reduce((total, repo) => total + repo.failed.length, 0)
+  if (failedTotal > 0) return 1
+  return 0
+}

--- a/packages/shared-skills/skills/review-work/SKILL.md
+++ b/packages/shared-skills/skills/review-work/SKILL.md
@@ -90,7 +90,7 @@ Before launching agents, collect these inputs. Extract from conversation history
 </required_inputs>
 
 
-Review PRs and branches from a dedicated review worktree only: create or attach one with `git worktree add <path> <branch>` before collecting changed files, diff, file contents, or running checks. The main worktree is read-only context; never checkout, test, or edit the review branch there.
+Review PRs and branches from a dedicated review worktree only: create or attach one with `git worktree add <path> <branch>` before collecting changed files, diff, file contents, or running checks, then immediately lock it with `git worktree lock <path> --reason "review:<pr-or-branch>"`. The main worktree is read-only context; never checkout, test, or edit the review branch there.
 
 **Auto-collection sequence:**
 
@@ -531,6 +531,8 @@ OUTPUT FORMAT:
 ```
 
 ---
+
+Before waiting for agents, tear down the review worktree: run `git worktree unlock <path>` followed by `git worktree remove <path>`. The periodic sweep recovers trees abandoned mid-review; locked trees are skipped by the sweep, so a crashed review leaves a recoverable marker rather than an invisible leak.
 
 ## Phase 2: Wait & Collect
 

--- a/packages/shared-skills/skills/review-work/SKILL.md
+++ b/packages/shared-skills/skills/review-work/SKILL.md
@@ -530,10 +530,6 @@ OUTPUT FORMAT:
 """)
 ```
 
----
-
-Before waiting for agents, tear down the review worktree: run `git worktree unlock <path>` followed by `git worktree remove <path>`. The periodic sweep recovers trees abandoned mid-review; locked trees are skipped by the sweep, so a crashed review leaves a recoverable marker rather than an invisible leak.
-
 ## Phase 2: Wait & Collect
 
 After launching all 5 agents in one turn, wait for completions in bounded
@@ -562,6 +558,8 @@ agent if safe, keep the lane INCONCLUSIVE, and emit the final aggregate
 review result with the incomplete lane named. Do not spin in repeated
 wait/followup cycles. Do not use `multi_agent_v1.send_input` as an interrupt; queued
 followups are not cancellation.
+
+After ALL 5 lanes reach a terminal state and before delivering the verdict, tear down the review worktree: run `git worktree unlock <path>` followed by `git worktree remove <path>`. The lanes above run inside that worktree, so removing it earlier destroys their working directory; a crashed review leaves the locked tree as a recoverable marker for manual cleanup.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `omo-agent-toolkit worktree-sweep`, a deterministic command that reports (and optionally removes) stale linked git worktrees, plus a teardown instruction for review-work skill worktrees. Review and lane workflows create worktrees as a matter of policy while cleanup lived in prose instructions — interrupted sessions leaked them. On the author's machine this had accumulated 126 registered leftover trees (~149G, incl. 16G of detached `pr-review-worktrees`), and the registered-vs-orphan split showed the real problem is trees that stay registered and untouched, not broken registrations.
- The command moves cleanup into code with git-verified safety: a tree is only swept when its branch (or detached HEAD) is an ancestor of the default branch AND the tree is clean. Locked trees, excluded external paths (`~/.codex/worktrees`, `~/.codex-gui-cli-remote/worktrees`), unmerged branches, and dirty trees are always kept.

## Changes

- **New CLI command** (`packages/omo-opencode/src/cli/worktree-sweep/`): porcelain parser, pure classifier, git driver (default-branch detection via origin/HEAD → main → master; `merge-base --is-ancestor`; `worktree remove` never forced; `worktree prune`), orchestrator, and `--json` output. Registered on the `omo-agent-toolkit` program in `runtime-commands.ts` with flags `--apply`, `--older-than <days>`, repeatable `--repo <path>`.
- **Dry-run by default**: with no flags the command only prints `SWEEP`/`KEEP(<reason>)`/`PRUNE` lines and a summary. `--apply` performs removal and prune.
- **review-work skill** (`packages/shared-skills/skills/review-work/SKILL.md`): the existing worktree-creation sentence now locks the tree with `git worktree lock <path> --reason "review:<pr-or-branch>"`, and the pre-wait step tears it down with unlock + remove. A crashed review leaves a locked tree the sweep skips — a recoverable marker instead of an invisible leak. Net growth 2 lines.

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/cli/worktree-sweep` (hermetic fixture repos in tmpdirs with real git init/commit/worktree/merge/lock).
  **Observed result:** 19 pass / 0 fail — merged+clean → SWEEP; unmerged/dirty/locked/excluded → KEEP; missing path → PRUNE; detached merged → SWEEP; dry-run removes nothing; `--apply` removes then prunes; registration exposes documented flags; removal never passes `--force`.
  **Why sufficient:** every classification branch and both modes are exercised against real git behavior, not mocks.
- **What was tested:** `bun run typecheck` (root tsgo + script + all package projects).
  **Observed result:** clean, no diagnostics.
- **What was tested:** real-surface dry-run against two live repos (`--repo` on the omo and senpi checkouts on this machine, no `--apply`).
  **Observed result:** omo `sweep=31 keep=29 prune=0`; senpi `sweep=27 keep=43 prune=0`; `removed=0 failed=0` everywhere — matches the validated bash prototype baseline (omo 31/28, senpi 30/40) with explainable drift from repo-state changes since baseline capture.
  **Why sufficient:** proves the parser, default-branch detection, ancestor checks, and classification against 130+ real worktree records without touching them.

## Risks & Residuals

- Destructive behavior is opt-in (`--apply`), never forced, and refuses dirty/locked trees — worst case with flags mistyped is a report. Mitigated by tests and dry-run default.
- Default-branch detection assumes origin/HEAD or a main/master branch; exits nonzero with a clear message otherwise. Accepted.
- Existing accumulated trees are not auto-swept by this PR; users run the command explicitly. Accepted (intended).

## Credits

- **@sigridjineth (Sigrid Jin)** — 이 기능은 당신의 제보 덕분에 기획할 수 있었습니다 (This was planned thanks to your report of worktree leftovers piling up). 감사합니다!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `worktree-sweep` to `omo-agent-toolkit` to report and optionally remove stale linked git worktrees, and updates the `review-work` skill to lock review worktrees and remove them only after all lanes finish. This replaces manual cleanup with a deterministic, git-verified workflow to prevent leaked trees and disk bloat.

- Old behavior: review/lane flows created worktrees with cleanup in prose; leftovers accumulated. New behavior: `worktree-sweep` classifies each linked worktree as SWEEP (merged into the default branch and clean), KEEP (locked, external, unmerged, or dirty), or PRUNE (missing path). Dry-run is default; `--apply` removes via `git worktree remove` (never `--force`) and prunes stale metadata. Locked trees and configured external roots are always kept. Default branch is detected via `origin/HEAD` → `main` → `master`; failure exits nonzero.

- Implementation highlights: porcelain parser, pure classifier, git driver (`merge-base --is-ancestor`, `status --porcelain`, `worktree list/remove/prune`), JSON output via `--json`, flags `--apply`, `--older-than <days>` (age fallback for unmerged trees), repeatable `--repo <path>`. CLI help and reference updated; tests enforce flag registration, classification, default-branch detection, dry-run vs apply, and refusal to force-remove.

- `review-work` skill: lock created review worktrees immediately with `git worktree lock <path> --reason "review:<pr-or-branch>"`, and tear them down only after all 5 lanes complete with `git worktree unlock <path>` then `git worktree remove <path>`. Crashed sessions leave a locked tree the sweep skips.

**Rollout and actions**
- Run `omo-agent-toolkit worktree-sweep` without flags first (dry-run); then reclaim space with `--apply` across known repos using `--repo` as needed.
- Required: adopt the updated `review-work` steps—lock on creation; unlock+remove only after all lanes finish.
- Optional: schedule periodic sweeps; use `--older-than <days>` to age out unmerged, idle worktrees. If the default branch cannot be determined, the command exits nonzero with a clear message.

<sup>Written for commit 5a21af66ce0cc19b17198d0b92e77d3e78d27e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

