### PR TITLE
fix(cli): normalize worktree-sweep porcelain paths at the parse boundary

### DIFF
--- a/.omo/evidence/20260823-worktree-sweep-path-normalize/README.md
+++ b/.omo/evidence/20260823-worktree-sweep-path-normalize/README.md
@@ -1,0 +1,45 @@
+# Evidence: worktree-sweep path normalization (Windows CI blocker)
+
+Date: 2026-08-23. Branch `fix/worktree-sweep-path-normalize` off `origin/dev` (d5b8f1df7).
+
+## What changed
+
+`packages/omo-opencode/src/cli/worktree-sweep/parse-worktree-list.ts` now runs the
+porcelain-emitted worktree path through `path.normalize()` in `finalize()`.
+
+## Why
+
+`git worktree list --porcelain` emits forward separators even on Windows (`C:/Users/...`),
+while every Node-side consumer (tests via `path.join`, `isExcludedPath` prefix matching
+against `os.homedir()`, removal bookkeeping) works in platform-native separators
+(`C:\Users\...`). The sweep feature (f447933bc) compared these raw, so on Windows:
+
+- `decisionFor` in the test suite never found a classification (7 deterministic failures,
+  both original run and rerun on the release-state PR #7154 — not a flake);
+- in production, `isExcludedPath(record.path, prefixes, home)` compared a forward-slash
+  record path against a backslash home/prefix, silently breaking the protected-prefix
+  exclusion on Windows.
+
+Normalizing at the parse boundary is the parse-don't-validate fix: one canonical form
+for every downstream comparison, POSIX behavior unchanged (git already emits `/`).
+
+## Gates
+
+| Gate | Command | Result |
+|---|---|---|
+| Failing-first unit contract | `parseWorktreeList("worktree /tmp/sweep/./wt-x …")` must equal `path.normalize("/tmp/sweep/wt-x")` | red before fix (`/tmp/sweep/./wt-x` returned raw), green after |
+| Module suite | `bun test ./packages/omo-opencode/src/cli/worktree-sweep/` | 20 pass / 0 fail |
+| Typecheck | `bun x tsgo --noEmit -p packages/omo-opencode` | exit 0 |
+| Real-surface drive | `cli-drive.json`: temp repo, worktree added at `<base>/dot/../wt-linked`, `worktreeSweep({json:true, repos:[repo]})` | exit 0, `apply:false` (dry-run), classification path has the dot segment collapsed to `…/wt-linked` |
+| Windows CI | PR check `test (windows-latest, 1/2)` | the decisive gate — this fix exists because that job fails deterministically on dev HEAD |
+
+## Blast radius
+
+Parse layer only; POSIX paths normalize to themselves. The macOS evidence run and the
+20/20 module suite cover non-Windows regression; Windows CI on the PR is the platform
+proof.
+
+## Residual risk
+
+Symlinked tmpdirs (macOS `/var` vs `/private/var`) remain distinct strings — pre-existing,
+unchanged by this fix, and not a separator problem.

--- a/.omo/evidence/20260823-worktree-sweep-path-normalize/cli-drive.json
+++ b/.omo/evidence/20260823-worktree-sweep-path-normalize/cli-drive.json
@@ -1,0 +1,12 @@
+[exit 0]
+{
+  "exit": 0,
+  "apply": false,
+  "classifications": [
+    {
+      "path": "/private/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/wt-evidence-o7cgOu/wt-linked",
+      "decision": "SWEEP"
+    }
+  ],
+  "linkedReal": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/wt-evidence-o7cgOu/wt-linked"
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/parse-worktree-list.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/parse-worktree-list.ts
@@ -1,3 +1,5 @@
+import { normalize } from "node:path"
+
 import type { WorktreeRecord } from "./types"
 
 interface MutableRecord {
@@ -17,7 +19,10 @@ function emptyRecord(): MutableRecord {
 function finalize(record: MutableRecord): WorktreeRecord | undefined {
   if (record.path === undefined || record.path.length === 0) return undefined
   return {
-    path: record.path,
+    // git emits forward separators even on Windows while Node-side callers
+    // build platform-native paths; normalize at the boundary so one record
+    // path matches every consumer comparison.
+    path: normalize(record.path),
     ...(record.head === undefined ? {} : { head: record.head }),
     ...(record.branch === undefined ? {} : { branch: record.branch }),
     detached: record.detached,

--- a/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
@@ -157,6 +157,13 @@ describe("parseWorktreeList", () => {
     expect(records).toHaveLength(1)
     expect(records[0]?.path).toBe("/a")
   })
+
+  test("normalizes worktree paths so separator and dot segments cannot split identity", () => {
+    const records = parseWorktreeList(
+      ["worktree /tmp/sweep/./wt-x", "HEAD 1", "branch refs/heads/main"].join("\n"),
+    )
+    expect(records[0]?.path).toBe(path.normalize("/tmp/sweep/wt-x"))
+  })
 })
 
 describe("isExcludedPath", () => {


### PR DESCRIPTION
## Summary

`git worktree list --porcelain` emits forward separators even on Windows (`C:/Users/...`), but every Node-side consumer of the new worktree-sweep feature compares platform-native paths: the test suite builds expectations with `path.join` (backslashes on Windows), and `isExcludedPath` matches protected prefixes against `os.homedir()`. The feature (f447933bc) compared these strings raw, so on Windows:

- `test (windows-latest, 1/2)` fails deterministically — 7 sweep tests, reproduced on both the original run and the rerun of release-state PR #7154 (this is currently blocking the v5.0.0-beta.18 release);
- in production, `isExcludedPath(record.path, prefixes, home)` compared a forward-slash record path against a backslash home, silently disabling the codex-managed worktree protection on Windows.

## Fix

`parse-worktree-list.ts` runs `record.path` through `path.normalize()` in `finalize()` — one canonical form at the parse boundary, matching every downstream comparison. POSIX behavior is unchanged (git already emits `/` there); on Windows the record converts to backslashes, aligning with `path.join` and `os.homedir`.

## Evidence (`.omo/evidence/20260823-worktree-sweep-path-normalize/`)

- Failing-first parser contract: `parseWorktreeList("worktree /tmp/sweep/./wt-x …")` must equal `path.normalize("/tmp/sweep/wt-x")` — red before, green after.
- Module suite: `bun test ./packages/omo-opencode/src/cli/worktree-sweep/` — 20 pass / 0 fail.
- Typecheck: `bun x tsgo --noEmit -p packages/omo-opencode` — exit 0.
- Real CLI drive (`cli-drive.json`): temp repo, worktree added at `<base>/dot/../wt-linked`, `worktreeSweep({ json: true, repos: [repo] })` — exit 0, dry-run (`apply: false`), classification path collapses the dot segment. The CLI entry itself is this module's real surface.
- The decisive platform gate is this PR's `test (windows-latest, 1/2)`.

## Residual risk

Parse layer only; POSIX no-op. Symlinked tmpdirs (`/var` vs `/private/var`) remain distinct strings — pre-existing, not a separator problem.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes `git worktree list --porcelain` paths at parse time so worktree-sweep compares canonical, OS-native paths. Previously we compared Git’s forward-slash paths to platform-native paths, which broke Windows tests and disabled protected-prefix checks; now `record.path` uses `path.normalize`, leaving POSIX behavior unchanged.

- Review notes
  - Change is limited to `packages/omo-opencode/src/cli/worktree-sweep/parse-worktree-list.ts`: normalize `record.path` in `finalize()`.
  - Adds a unit test that asserts separator and dot-segment normalization.
  - Evidence: module tests pass, typecheck clean, CLI dry-run collapses dot segments; Windows CI should now pass and protected-prefix exclusion works on Windows.

<sup>Written for commit 550fd5e1dbde4e1900bf8d6676551d37461d5215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

