### PR TITLE
fix(cli): finish worktree-sweep separator parity for Windows

### DIFF
--- a/.omo/evidence/20260823-worktree-sweep-path-normalize/README.md
+++ b/.omo/evidence/20260823-worktree-sweep-path-normalize/README.md
@@ -43,3 +43,13 @@ proof.
 
 Symlinked tmpdirs (macOS `/var` vs `/private/var`) remain distinct strings — pre-existing,
 unchanged by this fix, and not a separator problem.
+
+
+## Follow-up (same branch lineage, PR 7155's successor)
+
+Windows CI after the parse-boundary fix exposed two sibling separator gaps, both in the same feature:
+
+- `sweepRepo` reported `resolveRepoRoot()`'s git output verbatim — git emits forward separators on Windows, so `REPO <root>` never matched native-path expectations. Fixed: `normalize()` at the use site (`repo-root-drive.json`: reported root is in native normalized form).
+- Test assertions compared raw porcelain strings (always forward-slashed) with `path.join` paths, and parse fixtures asserted POSIX literals verbatim. Fixed with a `toPosix` helper for porcelain comparisons and `path.normalize`-wrapped fixture expectations.
+
+Module suite 20/20 and `tsgo --noEmit` exit 0 after the follow-up. The platform gate remains this PR's `test (windows-latest, 1/2)`.

--- a/.omo/evidence/20260823-worktree-sweep-path-normalize/repo-root-drive.json
+++ b/.omo/evidence/20260823-worktree-sweep-path-normalize/repo-root-drive.json
@@ -1,0 +1,6 @@
+[exit 0]
+{
+  "repoReported": "/private/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/wt-evidence2-T5rlmT/repo",
+  "repoNative": "/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/wt-evidence2-T5rlmT/repo",
+  "matchesNativeForm": true
+}

--- a/packages/omo-opencode/src/cli/worktree-sweep/sweep.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/sweep.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs"
 import { stat } from "node:fs/promises"
 import os from "node:os"
+import { normalize } from "node:path"
 
 import { classifyWorktree, DEFAULT_EXCLUDE_PREFIXES, isExcludedPath, worktreeRef } from "./classify"
 import {
@@ -78,7 +79,9 @@ async function sweepRepo(
     readonly now: number
   },
 ): Promise<WorktreeSweepRepoReport> {
-  const root = (await resolveRepoRoot(repo)) ?? repo
+  // git reports forward-separator roots even on Windows; normalize so the
+  // report's repo identity matches platform-native consumer paths.
+  const root = normalize((await resolveRepoRoot(repo)) ?? repo)
   const defaultBranch = await detectDefaultBranch(root)
   if (defaultBranch === undefined) {
     throw new Error(`Could not determine the default branch for ${root}`)

--- a/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
@@ -104,6 +104,9 @@ function decisionFor(report: WorktreeSweepRepoReport, worktreePath: string) {
   return classification
 }
 
+/** git porcelain output always uses forward separators, even on Windows. */
+const toPosix = (value: string): string => value.split(path.sep).join("/")
+
 describe("parseWorktreeList", () => {
   test("parses main worktree, locked reason, detached, and prunable records", () => {
     const porcelain = [
@@ -131,7 +134,7 @@ describe("parseWorktreeList", () => {
 
     expect(records).toHaveLength(4)
     expect(records[0]).toEqual({
-      path: "/repos/omo",
+      path: path.normalize("/repos/omo"),
       head: "1111111111111111111111111111111111111111",
       branch: "main",
       detached: false,
@@ -145,17 +148,15 @@ describe("parseWorktreeList", () => {
     expect(records[2]?.branch).toBeUndefined()
     expect(records[3]?.prunable).toBe(true)
     // First record is the main worktree and is always excluded from candidates.
-    expect(linkedWorktrees(records).map((record) => record.path)).toEqual([
-      "/tmp/wt-a",
-      "/tmp/wt-b",
-      "/tmp/wt-gone",
-    ])
+    expect(linkedWorktrees(records).map((record) => record.path)).toEqual(
+      ["/tmp/wt-a", "/tmp/wt-b", "/tmp/wt-gone"].map(path.normalize),
+    )
   })
 
   test("accepts output without a trailing blank line", () => {
     const records = parseWorktreeList("worktree /a\nHEAD 1\nbranch refs/heads/main")
     expect(records).toHaveLength(1)
-    expect(records[0]?.path).toBe("/a")
+    expect(records[0]?.path).toBe(path.normalize("/a"))
   })
 
   test("normalizes worktree paths so separator and dot segments cannot split identity", () => {
@@ -255,7 +256,7 @@ describe("sweepWorktrees classification", () => {
 
     // Dry-run removed nothing.
     expect(await fs.stat(merged)).toBeTruthy()
-    expect(git(repo, ["worktree", "list", "--porcelain"])).toContain(missing)
+    expect(git(repo, ["worktree", "list", "--porcelain"])).toContain(toPosix(missing))
   })
 
   test("detects the default branch through origin/HEAD when present", async () => {
@@ -357,9 +358,9 @@ describe("sweepWorktrees --apply", () => {
     await expect(fs.stat(merged)).rejects.toThrow()
     expect(await fs.stat(kept)).toBeTruthy()
     const porcelain = git(repo, ["worktree", "list", "--porcelain"])
-    expect(porcelain).not.toContain(missing)
-    expect(porcelain).not.toContain(merged)
-    expect(porcelain).toContain(kept)
+    expect(porcelain).not.toContain(toPosix(missing))
+    expect(porcelain).not.toContain(toPosix(merged))
+    expect(porcelain).toContain(toPosix(kept))
   })
 
   test("leaves locked and dirty worktrees in place even under --apply", async () => {


### PR DESCRIPTION
## Summary

Completes the Windows separator parity started in #7155. The parse-boundary `path.normalize()` fixed the classification lookups (the `--older-than` pair now passes on Windows), but the updated release-state PR run exposed two sibling gaps in the same feature:

1. **`sweepRepo` reported git output verbatim** — `resolveRepoRoot()` returns forward-separator roots on Windows (`C:/Users/...`), so the formatted `REPO <root>` line never matched the native-path expectation in `worktreeSweep output`. Fix: `normalize()` at the use site in `sweep.ts`.
2. **Test assertions were separator-blind** — raw porcelain strings (git always emits `/`) compared against `path.join` paths (2 assertion sites), and the parser fixture tests asserted POSIX literals verbatim (`/repos/omo`, `/a`). Fix: `toPosix` helper for porcelain comparisons, `path.normalize`-wrapped fixture expectations.

## Evidence

`.omo/evidence/20260823-worktree-sweep-path-normalize/` (follow-up section):
- `repo-root-drive.json` — live `sweepWorktrees` drive: reported repo root is in native normalized form.
- Module suite 20/20; `tsgo --noEmit -p packages/omo-opencode` exit 0.
- Platform gate: this PR's `test (windows-latest, 1/2)` — the exact job that failed on release-state PR #7154 after #7155 landed.

## Why urgent

This is the last blocker for the v5.0.0-beta.18 release (release-state PR #7154, which carries the senpi 2026.8.23 bump).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Windows path-separator parity in worktree sweep. Previously the REPO line echoed git’s forward-slashed root on Windows and tests compared mixed separators; now we normalize the repo root to native form and compare porcelain via POSIX strings.

- Normalize the repo root at use in `packages/omo-opencode/src/cli/worktree-sweep/sweep.ts` so REPO paths match native consumers.
- Test updates: add a `toPosix` helper for git porcelain comparisons and wrap fixture expectations with `path.normalize`.
- Evidence updated under `.omo/evidence/20260823-worktree-sweep-path-normalize/`. This unblocks the v5.0.0-beta.18 release on Windows CI.

<sup>Written for commit 0201f67445c664f31bc1874c4353cc8f8e827c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

