### PR TITLE
feat(skills): route dependency-ordered start-work lanes through a dag run

### DIFF
--- a/packages/shared-skills/skills/start-work/SKILL.md
+++ b/packages/shared-skills/skills/start-work/SKILL.md
@@ -102,6 +102,7 @@ For PR/branch work, a task-owned worktree is mandatory before implementation sta
 Solo orchestration with parallel background workers is the default topology. Decide once, when the wave's lanes are known, and record the verdict in the ledger:
 
 - **Independent lanes -> parallel workers.** Separate files, no shared contract: one parallel spawn burst; no team.
+- **Dependency-ordered lanes -> a dag run.** Sub-tasks with real ordering between them (C needs A and B finished first) and a harness with a native `dag` tool: dispatch the wave as ONE dag run — one producer node per lane plus a verification node — instead of a spawn burst, and watch the run's lifecycle instead of arming per-lane watchers. Read the `mass-ulw` skill's `SKILL.md` and `references/planning.md` IN FULL before defining any graph.
 - **Overlapping lanes -> a team.** The lanes touch the same module or contract AND running them concurrently actually finishes sooner: stand up a team (where the harness has one) so one lane's discoveries relay through you mid-flight.
 - **PR-mode independent lanes -> a worktree per lane.** Under `--make-pr`/`--ship`, when a wave holds independent checkboxes, give each lane its own branch and task-owned worktree, delivered as its own PR.
 
@@ -118,7 +119,7 @@ Landing rules, regardless of topology:
 3. Ignore nested checkboxes under acceptance criteria, evidence, and definition-of-done sections.
 4. Classify the checkbox tier and record it in its ledger entry. Default is LIGHT — a narrow change inside existing layers. Take HEAVY only on a fact you can point to: a new module / abstraction / domain model; auth, security, or session; an external integration; a DB schema or migration; concurrency or transaction boundaries; a cross-domain refactor; or the plan or user signals care. When unsure, take HEAVY; upgrade and redo skipped gates the moment a HEAVY fact surfaces; never downgrade.
 5. Decompose that checkbox into atomic sub-tasks sized for ONE worker in ONE run — a sub-task that would need mid-flight steering is two sub-tasks. Collect every other unchecked checkbox in the same plan wave whose dependencies are met — their lanes execute concurrently. A wave that could split further but holds fewer than 3 independent sub-tasks is under-split.
-6. **DELEGATE EVERYTHING. YOU NEVER IMPLEMENT.** Route every sub-task through the delegation router below, then dispatch ALL independent sub-tasks across those checkboxes in one parallel worker-spawn burst (a single batched spawn call where the harness supports it); serialize only named dependencies. Verification and checkbox marking stay per-checkbox.
+6. **DELEGATE EVERYTHING. YOU NEVER IMPLEMENT.** Route every sub-task through the delegation router below, then dispatch ALL independent sub-tasks across those checkboxes in one parallel worker-spawn burst (a single batched spawn call where the harness supports it); route named dependencies per the lane-topology decision above. Verification and checkbox marking stay per-checkbox.
 7. Give every dispatched sub-task its completion condition and watch for it per the section below. A dispatch whose completion nobody watches is an unfinished dispatch.
 
 ### Monitor every dispatched subagent to its completion condition


### PR DESCRIPTION
## Summary

start-work's parallel-lane topology section gains a fourth option: **dependency-ordered lanes -> a dag run**, pointing at the `mass-ulw` skill instead of duplicating its doctrine.

- New bullet in "Parallel delivery lanes (teams and worktrees)": when sub-tasks carry real ordering (C needs A and B first) and the harness exposes a native `dag` tool, dispatch the wave as ONE dag run — one producer node per lane plus a verification node — and watch the run's lifecycle instead of arming per-lane watchers. The bullet mandates reading `mass-ulw`'s `SKILL.md` and `references/planning.md` IN FULL before defining any graph.
- Phase 3 step 6 contradiction fixed at the source: "serialize only named dependencies" -> "route named dependencies per the lane-topology decision above", so the dispatch step no longer conflicts with the new topology.

Design rules applied (prompt-engineering): pointer only, zero doctrine duplication — `mass-ulw/references/planning.md` stays the single home for graph-planning doctrine; the entry sits at the existing topology decision point; phrasing is harness-conditional ("a harness with a native `dag` tool") so the omo-codex copy of start-work (no dag tool, no mass-ulw skill) stays inert. Net +2 lines.

## Verification

- `bun test packages/omo-senpi/src/skills-sync.test.ts` — 11/11 pass (forbidden-token, banner, and roster invariants hold with the new text)
- `bun test packages/omo-codex/plugin/test/sync-skills.test.mjs` — 12/12 pass
- `bun test packages/shared-skills` — 80/80 pass
- `bun test packages/omo-opencode/src/shared-skills-package.test.ts` — 3/3 pass
- Both syncs rerun (`omo-senpi` + `omo-codex` `sync-skills.mjs`); regenerated copies verified to carry the pointer (synced copies are gitignored build outputs; only the shared source is committed)
- QA-by-read of the final diff: bullet placed between Independent and Overlapping lanes; no forbidden tokens (`multi_agent`/`spawn_agent`/`lazycodex`/`wait_agent`/`codex:<session_id>`); no wording pinned by any test (prose skill content ships on review per shared-skills AGENTS.md)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route dependency-ordered start-work lanes through a single DAG run via `mass-ulw`. Previously we spawned lanes and serialized named dependencies with per-lane watchers; now, when the harness has a native `dag` tool, we dispatch one DAG run (producer node per lane plus a verification node) and watch the run lifecycle. Align dispatch guidance to route named dependencies per the chosen topology.

- Applies only when a native `dag` tool is available; otherwise behavior is unchanged.
- Required: read `mass-ulw`’s `SKILL.md` and `references/planning.md` before defining any graph.

<sup>Written for commit cabecc5885d16c0c154070d39aa2a00ff2c33458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

