### PR TITLE
fix(omo-codex): accept title-based goal snapshots

### DIFF
--- a/.omo/evidence/20260824-ulw-checkpoint-snapshot/README.md
+++ b/.omo/evidence/20260824-ulw-checkpoint-snapshot/README.md
@@ -1,0 +1,29 @@
+# Checkpoint snapshot compatibility QA
+
+## What was tested
+
+- Focused Vitest RED to GREEN for the title-bearing snapshot parser contract.
+- Built local `omo-agent-toolkit ulw-loop` CLI against isolated persisted plan state.
+- Valid title-bearing snapshot acceptance.
+- Invalid objective-free snapshot rejection.
+
+## What was observed
+
+- RED: one focused assertion failed because `snapshot.objective` was undefined.
+- GREEN: all 13 focused parser/reconciliation tests passed.
+- Real CLI valid scenario returned `ok: true` and completed G001.
+- Real CLI invalid scenario returned `ulw_loop_codex_snapshot_mismatch` with `Codex goal snapshot is missing objective text.`
+
+## Why it is enough
+
+The evidence covers the parser seam, the complete CLI checkpoint path, persistence into the ledger, next-goal activation, and the malformed-input guard.
+
+## What was omitted
+
+No secret-bearing logs, credentials, tokens, or auth headers were captured.
+
+## Cleanup receipt
+
+- Removed accidental task-owned QA state from `/Users/yeongyu/sisyphuslabs/.omo/ulw-loop/01a032fc-4113-7557-af51-e9bbb71a383c`.
+- Removed isolated QA directory `/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/ulw-checkpoint-qa.XXXXXX.bG7jIhYVsb`.
+- Both paths were verified absent.

--- a/.omo/evidence/20260824-ulw-checkpoint-snapshot/cli-invalid.txt
+++ b/.omo/evidence/20260824-ulw-checkpoint-snapshot/cli-invalid.txt
@@ -1,0 +1,21 @@
+WHAT WAS TESTED
+After all G002 criteria were marked pass, the built local CLI received a snapshot with a complete status but no objective or title:
+
+node dist/cli.js ulw-loop checkpoint \
+  --goal-id G002-goal-b \
+  --status complete \
+  --evidence "done" \
+  --codex-goal-json '{"status":"complete"}' \
+  --json
+
+OBSERVED
+Exit code: 1.
+JSON: ok=false.
+Error code: ulw_loop_codex_snapshot_mismatch.
+Error message: Codex goal snapshot is missing objective text.
+
+WHY IT IS ENOUGH
+The new title compatibility does not weaken the missing-objective guard. A malformed snapshot still fails closed with the existing precise error.
+
+WHAT WAS OMITTED
+No credentials, auth headers, or secret-bearing logs were captured.

--- a/.omo/evidence/20260824-ulw-checkpoint-snapshot/cli-valid.txt
+++ b/.omo/evidence/20260824-ulw-checkpoint-snapshot/cli-valid.txt
@@ -1,0 +1,23 @@
+WHAT WAS TESTED
+The built local CLI was driven in an isolated directory with two per-story goals.
+All three G001 criteria were marked pass, then:
+
+node dist/cli.js ulw-loop checkpoint \
+  --goal-id G001-goal-a \
+  --status complete \
+  --evidence "done" \
+  --codex-goal-json '{"id":"G001-goal-a","title":"Goal A","status":"complete","successCriteria":[]}' \
+  --json
+
+OBSERVED
+Exit code: 0.
+JSON: ok=true.
+Goal G001-goal-a status became complete.
+The ledger stored the original title-bearing codexGoal object.
+The next goal G002-goal-b became in_progress.
+
+WHY IT IS ENOUGH
+This is the real checkpoint CLI path against persisted .omo/ulw-loop state, not a parser-only unit test. It proves the title alias survives argument parsing, file-state loading, reconciliation, ledger persistence, and next-goal activation.
+
+WHAT WAS OMITTED
+The full successful JSON response was summarized because it contains repetitive plan state. No secrets were present.

--- a/.omo/evidence/20260824-ulw-checkpoint-snapshot/green-test.txt
+++ b/.omo/evidence/20260824-ulw-checkpoint-snapshot/green-test.txt
@@ -1,0 +1,16 @@
+WHAT WAS TESTED
+npm --prefix packages/omo-codex/plugin/components/ulw-loop test -- test/codex-goal-snapshot.test.ts
+
+WHAT IT PROVES
+The checkpoint snapshot parser accepts the title-bearing ulw-loop status/TUI goal shape while preserving every existing parser and reconciliation case.
+
+OBSERVED GREEN
+Test files: 1 passed.
+Tests: 13 passed.
+Exit code: 0.
+
+WHY IT IS ENOUGH FOR THE UNIT CONTRACT
+The exact assertion that failed before the production change now passes, and the existing direct get_goal, file-input, malformed-input, objective mismatch, and status mismatch cases remain green.
+
+WHAT WAS OMITTED
+No credentials, auth headers, or secret-bearing logs were captured.

--- a/.omo/evidence/20260824-ulw-checkpoint-snapshot/red-test.txt
+++ b/.omo/evidence/20260824-ulw-checkpoint-snapshot/red-test.txt
@@ -1,0 +1,19 @@
+WHAT WAS TESTED
+npm --prefix packages/omo-codex/plugin/components/ulw-loop test -- test/codex-goal-snapshot.test.ts
+
+WHAT IT PROVES
+A goal snapshot shaped like the ulw-loop status/TUI payload:
+{"id":"G002-goal-2-senpi-repo-audit-determine-wh","title":"Audit the Senpi repository","status":"in_progress","successCriteria":[]}
+must preserve its title as the goal objective.
+
+OBSERVED RED
+Test file: test/codex-goal-snapshot.test.ts
+Result: 1 failed, 12 passed.
+Failure: expected snapshot.objective to equal "Audit the Senpi repository", received undefined.
+Exit code: 1.
+
+WHY THIS IS THE RIGHT FAILURE
+The parser recognizes in_progress as an active status, so the snapshot is available, but it ignores title and reaches the exact missing-objective reconciliation branch seen by the user.
+
+WHAT WAS OMITTED
+No credentials, auth headers, or secret-bearing logs were captured.

--- a/.omo/evidence/20260824-ulw-checkpoint-snapshot/validation.txt
+++ b/.omo/evidence/20260824-ulw-checkpoint-snapshot/validation.txt
@@ -1,0 +1,32 @@
+CHANGED-FILE DIAGNOSTICS
+- lsp_diagnostics src/codex-goal-snapshot.ts: no diagnostics.
+- lsp_diagnostics test/codex-goal-snapshot.test.ts: no diagnostics.
+- npx biome check src/codex-goal-snapshot.ts test/codex-goal-snapshot.test.ts: checked 2 files, no fixes, exit 0.
+- git diff --check: exit 0.
+
+COMPONENT VALIDATION
+- Focused test: 13/13 passed.
+- Full ulw-loop suite: 40 files passed, 423 tests passed.
+- npm run typecheck: exit 0.
+- npm run build: exit 0.
+
+CODEX GATE
+- bun run test:codex: exit 0.
+- Final Node test stage: 493 tests passed, 0 failed, 0 skipped.
+
+ISOLATED REAL-CODEX QA
+- common.sh --self-check: dependencies present, local mock Responses endpoint passed, isolated CODEX_HOME auto-removed, real ~/.codex/config.toml unchanged.
+- install-verify.sh --self-test: plugin cache present, omo@sisyphuslabs enabled in sandbox config, 10 component bins linked, agent TOMLs linked, real ~/.codex/config.toml unchanged.
+- app-server-drive.sh --plugin: turn completed with mock model, sessionStart and userPromptSubmit hook/started + hook/completed notifications present, missingHooks=[], failedHooks=[].
+
+PRE-EXISTING COMPONENT-WIDE CHECK FAILURE
+`npm run check` reaches Biome and fails on unrelated pre-existing files:
+- src/codex-hook.ts formatting.
+- test/package-smoke.test.ts unsafe optional chaining and one unnecessary escape warning.
+- test/steering.test.ts formatting.
+The changed files pass Biome, TypeScript, tests, build, LSP diagnostics, and the mandatory full Codex gate.
+
+CLEANUP
+- Every codex-qa script used its own isolated CODEX_HOME and removed it on exit.
+- Mock model and PTY/process resources were terminated by the scripts.
+- Real ~/.codex/config.toml hash remained c5f0992836d5be1988c09454d66521dcb6ff6321.

--- a/packages/omo-codex/plugin/components/ulw-loop/src/codex-goal-snapshot.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/codex-goal-snapshot.ts
@@ -56,7 +56,9 @@ export function parseCodexGoalSnapshot(value: unknown): CodexGoalSnapshot {
 	}
 
 	const goal = safeObject(goalValue);
-	const objective = safeString(goal["objective"] ?? goal["goal"] ?? goal["description"] ?? root["objective"]);
+	const objective = safeString(
+		goal["objective"] ?? goal["goal"] ?? goal["description"] ?? goal["title"] ?? root["objective"] ?? root["title"],
+	);
 	const status = normalizeStatus(goal["status"] ?? root["status"]);
 
 	return {

--- a/packages/omo-codex/plugin/components/ulw-loop/test/codex-goal-snapshot.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/codex-goal-snapshot.test.ts
@@ -24,6 +24,24 @@ describe("parseCodexGoalSnapshot", () => {
 		expect(snapshot.status).toBe("active");
 	});
 
+	it("reads the objective from a title-bearing ulw-loop status goal", () => {
+		// given
+		const payload = {
+			id: "G002-goal-2-senpi-repo-audit-determine-wh",
+			title: "Audit the Senpi repository",
+			status: "in_progress",
+			successCriteria: [],
+		};
+
+		// when
+		const snapshot = parseCodexGoalSnapshot(payload);
+
+		// then
+		expect(snapshot.available).toBe(true);
+		expect(snapshot.objective).toBe("Audit the Senpi repository");
+		expect(snapshot.status).toBe("active");
+	});
+
 	it("ignores remaining token budget fields from goal snapshots", () => {
 		// given
 		const payload = { goal: { objective: "X", status: "active" }, remainingTokens: 123 };


### PR DESCRIPTION
## Summary

- accept the title-bearing ulw-loop status/TUI goal shape as a Codex goal snapshot objective
- preserve the existing objective/goal/description precedence and strict plan-objective reconciliation
- keep objective-free snapshots failing closed with the existing precise error
- include RED→GREEN and real CLI evidence in `.omo/evidence/20260824-ulw-checkpoint-snapshot/`

## Root cause

The checkpoint parser recognized `status: "in_progress"` as active, but it ignored the `title` field used by the ulw-loop status/TUI goal payload. That produced an available snapshot with no objective and triggered:

```text
Codex goal snapshot is missing objective text.
```

## Verification

- RED: focused title-bearing snapshot assertion failed with `objective === undefined`
- GREEN: focused parser/reconciliation suite `13/13`
- full ulw-loop component suite: `40` files, `423/423` tests
- changed-file LSP diagnostics: clean
- changed-file Biome: clean
- component typecheck and build: pass
- mandatory `bun run test:codex`: pass; final Node stage `493/493`
- isolated Codex install verification: pass; real `~/.codex/config.toml` unchanged
- real Codex app-server plugin drive: pass; required hooks completed
- real CLI valid scenario: title-bearing snapshot returns `ok: true`
- real CLI invalid scenario: objective-free snapshot returns exit `1` and the exact existing missing-objective error
- five-lane post-implementation review: goal, QA, code quality, security, and context all PASS

## Evidence

- `.omo/evidence/20260824-ulw-checkpoint-snapshot/README.md`
- `.omo/evidence/20260824-ulw-checkpoint-snapshot/red-test.txt`
- `.omo/evidence/20260824-ulw-checkpoint-snapshot/green-test.txt`
- `.omo/evidence/20260824-ulw-checkpoint-snapshot/cli-valid.txt`
- `.omo/evidence/20260824-ulw-checkpoint-snapshot/cli-invalid.txt`
- `.omo/evidence/20260824-ulw-checkpoint-snapshot/validation.txt`

## Pre-existing issue left unchanged

The component-wide `npm run check` reaches Biome and reports unrelated existing findings in `src/codex-hook.ts`, `test/package-smoke.test.ts`, and `test/steering.test.ts`. The changed files pass Biome, TypeScript, tests, build, LSP diagnostics, and the repository's mandatory Codex gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts title-based `ulw-loop` goal snapshots in `omo-codex` so checkpoint reconciliation no longer fails on missing objectives. Previously, title-bearing snapshots were available but lacked an objective and errored; now the parser uses title as a fallback objective.

- Parser change: extend objective resolution to include `goal.title` then `root.title`, preserving existing precedence (`objective` > `goal` > `description` > `title` fallbacks).
- Behavior: objective-free snapshots still fail closed with the same error message.
- Tests: add a focused unit test; component and Codex gates remain green.
- Review focus: one-line fallback change in `parseCodexGoalSnapshot`; remaining changes are QA evidence only.
- Rollout: no config changes or migrations; CLI now accepts valid title-bearing snapshots.

<sup>Written for commit 7222b21aa23c28fdef232ddd005c3ddd4cd9c788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

