### PR TITLE
chore(omo-codex): clean every plugin component check

### DIFF
--- a/.omo/evidence/20260824-ulw-loop-check-cleanup/README.md
+++ b/.omo/evidence/20260824-ulw-loop-check-cleanup/README.md
@@ -1,0 +1,25 @@
+# ulw-loop component check cleanup evidence
+
+## What was tested
+
+- Exact full component RED→GREEN check.
+- Focused affected tests.
+- Changed-file LSP diagnostics and diff hygiene.
+- Mandatory repository Codex gate.
+- Isolated real-Codex install and app-server QA.
+
+## What was observed
+
+- RED: 3 errors, 1 warning, and 2 configuration infos.
+- GREEN: all 82 Biome files clean; typecheck/build pass.
+- Focused tests: 75/75.
+- Mandatory Codex final Node stage: 493/493.
+- Isolated Codex hooks fired and the real user config remained unchanged.
+
+## Why it is enough
+
+The exact failing command is now clean, every affected executable/test surface passed, and the repository's mandatory Codex integration gate independently remained green.
+
+## What was omitted
+
+No secret-bearing logs, tokens, credentials, or unrelated generated bundle drift were retained.

--- a/.omo/evidence/20260824-ulw-loop-check-cleanup/expanded-checks.txt
+++ b/.omo/evidence/20260824-ulw-loop-check-cleanup/expanded-checks.txt
@@ -1,0 +1,30 @@
+EXPANDED SCOPE — ALL CODEX PLUGIN COMPONENTS
+Trigger: user directive to fix all same-class check debt; context review proved identical Biome 2.5 debt beyond ulw-loop.
+
+RED (before expanded edits), npm run check per component:
+- comment-checker: exit 1 — 4 errors (3x assist/source/organizeImports, 1x format) + 2 config infos
+- lazycodex-executor-verify: exit 1 — 2 format errors + 2 config infos
+- lsp: exit 1 — TypeScript TS2339 startup_timeout_sec gone from typed McpServer fixture
+- rules: exit 1 — 21 errors (useOptionalChain, organizeImports, format) + 1 warning + 2 config infos
+- start-work-continuation: exit 0 but 2 config infos
+- telemetry: exit 1 — 7 errors (useImportType, organizeImports, format) + 2 config infos
+- ultrawork: exit 1 — 1 format error + 2 config infos
+- ulw-loop: exit 0 (fixed in first increment 46aacea73)
+
+GREEN (after expanded edits), same commands:
+- All 8 components: exit 0, zero errors, zero warnings, zero config infos.
+- Per-component tests: comment-checker 29, lazycodex-executor-verify 25, lsp 24+8, rules 165, start-work-continuation 42, telemetry 15, ultrawork 24 — all passed.
+
+ROOT GATES ON EXPANDED TREE
+- bun run test:codex: PASS — final Node stage 493/493, 0 failed, 0 skipped.
+- Isolated real-Codex QA: common.sh self-check PASS; install-verify PASS (cache/config/bins/agents in sandbox, real ~/.codex/config.toml unchanged); app-server-drive --plugin PASS (turn completed, sessionStart/userPromptSubmit hooks fired).
+
+BEHAVIOR-AUDIT OF NON-FORMATTING EDITS
+- lsp test/package-smoke.test.ts: startup_timeout_sec now asserted via literal comparison of shipped .mcp.json document (timeout 10 still locked; cwd assertion added); typed command/args checks kept; no lying casts.
+- rules src/static-injection.ts: transcriptText !== null && .includes() -> transcriptText?.includes() — equivalent for string|null.
+- rules test pin picomatch ^4.0.5 matches shipped package.json exactly.
+- All other edits: import organization, formatter wrapping, biome.json schema 2.5.9 + preset:"recommended" (CLI-previewed, no policy change).
+
+CLEANUP
+- Gate/setup regenerated codegraph dist + install-local.mjs drift restored to committed bytes (git restore).
+- Codex QA sandboxes removed by their drivers.

--- a/.omo/evidence/20260824-ulw-loop-check-cleanup/green-check.txt
+++ b/.omo/evidence/20260824-ulw-loop-check-cleanup/green-check.txt
@@ -1,0 +1,18 @@
+WHAT WAS TESTED
+npm --prefix packages/omo-codex/plugin/components/ulw-loop run check
+
+OBSERVED GREEN
+Exit code: 0.
+TypeScript `tsc --noEmit`: passed.
+Biome: checked 82 files, no fixes or diagnostics.
+Build: `tsc -p tsconfig.build.json` passed.
+
+RED TO GREEN
+Before the patch, the same command exited 1 with three errors, one warning, and two configuration infos.
+After the patch, it exits 0 with no Biome findings.
+
+WHY IT IS ENOUGH
+This is the exact component quality gate that previously failed. It exercises the migrated Biome configuration, formatter output, lint rules, type checker, and build in one command.
+
+WHAT WAS OMITTED
+No credentials, tokens, or secret-bearing logs were captured.

--- a/.omo/evidence/20260824-ulw-loop-check-cleanup/red-check.txt
+++ b/.omo/evidence/20260824-ulw-loop-check-cleanup/red-check.txt
@@ -1,0 +1,20 @@
+WHAT WAS TESTED
+npm --prefix packages/omo-codex/plugin/components/ulw-loop run check
+
+OBSERVED RED
+Exit code: 1.
+Biome checked 82 files and reported:
+- error: src/codex-hook.ts formatter output differs.
+- error: test/package-smoke.test.ts uses unsafe optional chaining at the nested hooks command lookup.
+- error: test/steering.test.ts formatter output differs.
+- warning: test/package-smoke.test.ts unnecessarily escapes double quotes inside a template literal.
+
+The command also prints two non-failing configuration infos:
+- biome.json schema URL is 2.4.16 while the installed CLI is 2.5.9.
+- the current linter configuration shape includes a deprecated key.
+
+WHY THIS IS THE RIGHT RED
+These are exactly the three previously disclosed failing files. The full component check reaches TypeScript successfully, then fails only in Biome before build.
+
+WHAT WAS OMITTED
+No credentials, auth headers, or secret-bearing output was captured.

--- a/.omo/evidence/20260824-ulw-loop-check-cleanup/validation.txt
+++ b/.omo/evidence/20260824-ulw-loop-check-cleanup/validation.txt
@@ -1,0 +1,36 @@
+FOCUSED TESTS
+- test/codex-hook.test.ts
+- test/package-smoke.test.ts
+- test/steering.test.ts
+- Result: 3 files passed, 75 tests passed.
+
+CHANGED-FILE DIAGNOSTICS
+- src/codex-hook.ts: no LSP diagnostics.
+- test/package-smoke.test.ts: no LSP diagnostics.
+- test/steering.test.ts: no LSP diagnostics.
+- git diff --check: passed.
+
+FULL COMPONENT CHECK
+- TypeScript: passed.
+- Biome: 82 files clean, no findings.
+- Build: passed.
+
+MANDATORY CODEX GATE
+- `bun run test:codex`: passed.
+- Final Node test stage: 493 passed, 0 failed, 0 skipped.
+
+ISOLATED REAL-CODEX QA
+- common self-check: passed; sandbox home removed; real config unchanged.
+- install verification: passed; plugin cache, config, bins, and agent TOMLs present in sandbox.
+- app-server plugin drive: passed; turn completed and sessionStart/stop/userPromptSubmit hooks fired.
+- Real `~/.codex/config.toml` hash remained c5f0992836d5be1988c09454d66521dcb6ff6321.
+
+DIFF REVIEW
+- `codex-hook.ts` and `steering.test.ts` are formatter-only.
+- `package-smoke.test.ts` replaces unsafe optional indexing with a fully optional chain plus an explicit string assertion, and removes unnecessary template-literal escapes.
+- `biome.json` applies the exact CLI migration preview: schema 2.5.9 and the equivalent recommended preset.
+- No shipped behavior or lint-policy change.
+
+CLEANUP
+- Setup-generated unrelated codegraph/install bundles were restored to origin/dev bytes and executable modes.
+- Codex QA sandboxes and mock-model processes were removed by their drivers.

--- a/packages/omo-codex/plugin/components/comment-checker/biome.json
+++ b/packages/omo-codex/plugin/components/comment-checker/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noDefaultExport": "error",
 				"noEnum": "error",

--- a/packages/omo-codex/plugin/components/comment-checker/src/apply-patch.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/src/apply-patch.ts
@@ -1,8 +1,5 @@
-import {
-	extractApplyPatchEdits,
-	getApplyPatchMetadataFiles,
-} from "@oh-my-opencode/comment-checker-core";
 import type { CheckerEdit as CoreApplyPatchEdit } from "@oh-my-opencode/comment-checker-core";
+import { extractApplyPatchEdits, getApplyPatchMetadataFiles } from "@oh-my-opencode/comment-checker-core";
 import type { CommentCheckRequest } from "./types.js";
 
 export function extractApplyPatchRequests(event: {
@@ -27,10 +24,7 @@ function extractApplyPatchMetadataRequests(details: unknown, sourceToolName: str
 	return toCommentCheckRequests(edits, sourceToolName);
 }
 
-function toCommentCheckRequests(
-	edits: readonly CoreApplyPatchEdit[],
-	sourceToolName: string,
-): CommentCheckRequest[] {
+function toCommentCheckRequests(edits: readonly CoreApplyPatchEdit[], sourceToolName: string): CommentCheckRequest[] {
 	const requests: CommentCheckRequest[] = [];
 	for (const edit of edits) {
 		if (edit.before.length === 0) {

--- a/packages/omo-codex/plugin/components/comment-checker/src/core.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/src/core.ts
@@ -1,6 +1,5 @@
-export { parseApplyPatchRequests } from "@oh-my-opencode/comment-checker-core";
+export { isRecord, parseApplyPatchRequests } from "@oh-my-opencode/comment-checker-core";
 export { toHookInput } from "./hook-input.js";
-export { isRecord } from "@oh-my-opencode/comment-checker-core";
 export { extractCommentCheckRequests, isToolFailureOutput } from "./request-extractor.js";
 export type {
 	CheckerEdit,

--- a/packages/omo-codex/plugin/components/comment-checker/src/request-extractor.ts
+++ b/packages/omo-codex/plugin/components/comment-checker/src/request-extractor.ts
@@ -1,5 +1,5 @@
-import { extractApplyPatchRequests } from "./apply-patch.js";
 import { getString, isRecord } from "@oh-my-opencode/comment-checker-core";
+import { extractApplyPatchRequests } from "./apply-patch.js";
 import type { CheckerEdit, CommentCheckRequest, TextContent, ToolResultContent, ToolResultLike } from "./types.js";
 
 export function extractCommentCheckRequests(event: ToolResultLike): CommentCheckRequest[] {

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/biome.json
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noDefaultExport": "error",
 				"noEnum": "error",

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/src/codex-hook.ts
@@ -6,11 +6,7 @@ import { clearAttemptState, MAX_ATTEMPTS, readAttemptState, writeAttemptState } 
 import type { HookFileSystem, StopHookOutput, SubagentStopInput } from "./types.js";
 import { SUBAGENT_STOP_EVENT } from "./types.js";
 
-const RECEIPT_ENFORCED_AGENTS = new Set([
-	"lazycodex-worker-low",
-	"lazycodex-worker-medium",
-	"lazycodex-worker-high",
-]);
+const RECEIPT_ENFORCED_AGENTS = new Set(["lazycodex-worker-low", "lazycodex-worker-medium", "lazycodex-worker-high"]);
 
 export function runSubagentStopHook(input: unknown, fs: HookFileSystem): string {
 	if (!isSubagentStopInput(input)) return "";

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/test/codex-hook.test.ts
@@ -374,9 +374,7 @@ describe("tier worker receipt enforcement", () => {
 
 	it("#given both hook manifests #when their matchers are applied #then enforced agents match and read-only roles do not", () => {
 		// given
-		const componentManifest = JSON.parse(
-			readFileSync(new URL("../hooks/hooks.json", import.meta.url), "utf8"),
-		);
+		const componentManifest = JSON.parse(readFileSync(new URL("../hooks/hooks.json", import.meta.url), "utf8"));
 		const rootManifest = JSON.parse(
 			readFileSync(
 				new URL("../../../hooks/subagent-stop-verifying-lazycodex-executor-evidence.json", import.meta.url),
@@ -394,4 +392,3 @@ describe("tier worker receipt enforcement", () => {
 		}
 	});
 });
-

--- a/packages/omo-codex/plugin/components/lsp/biome.json
+++ b/packages/omo-codex/plugin/components/lsp/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noDefaultExport": "error",
 				"noEnum": "error",

--- a/packages/omo-codex/plugin/components/lsp/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/lsp/src/codex-hook.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 
 import { callDiagnosticsViaDaemon } from "@code-yeongyu/lsp-daemon/client";
 import { collectPostEditDiagnostics, type PostEditDiagnosticsOutcome } from "@oh-my-opencode/lsp-core/post-edit";
-import { parseLspRequestContext, type LspRequestContext } from "@oh-my-opencode/lsp-core/request-context";
+import { type LspRequestContext, parseLspRequestContext } from "@oh-my-opencode/lsp-core/request-context";
 
 import { ensureLspDaemonCliEnv } from "./daemon-cli-path.js";
 import {

--- a/packages/omo-codex/plugin/components/lsp/src/daemon-cli-path.ts
+++ b/packages/omo-codex/plugin/components/lsp/src/daemon-cli-path.ts
@@ -3,11 +3,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import {
-	OMO_LSP_DAEMON_CLI,
-	OMO_LSP_DAEMON_VERSION,
-	resolveDaemonRuntime,
-} from "@code-yeongyu/lsp-daemon/client";
+import { OMO_LSP_DAEMON_CLI, OMO_LSP_DAEMON_VERSION, resolveDaemonRuntime } from "@code-yeongyu/lsp-daemon/client";
 
 const requireFromHere = createRequire(import.meta.url);
 

--- a/packages/omo-codex/plugin/components/lsp/test/codex-hook-unavailable.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/codex-hook-unavailable.test.ts
@@ -1,9 +1,8 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-
-import { afterEach, describe, expect, it } from "vitest";
 import type { PostEditDiagnosticsOutcome } from "@oh-my-opencode/lsp-core/post-edit";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { runLspPostCompactHook, runLspPostToolUseHook } from "../src/codex-hook.js";
 
@@ -149,11 +148,11 @@ describe("codex PostToolUse unavailable LSP suppression", () => {
 		const input = postToolUseInput("session-daemon-down-probe", ".omo/ulw-loop/evidence/note.md");
 		let calls = 0;
 
-			await withPluginData(pluginData, async () => {
-				await runLspPostToolUseHook(input, async () => {
-					calls += 1;
-					return markdownNotConfigured();
-				});
+		await withPluginData(pluginData, async () => {
+			await runLspPostToolUseHook(input, async () => {
+				calls += 1;
+				return markdownNotConfigured();
+			});
 			await runLspPostToolUseHook(input, async () => {
 				calls += 1;
 				return "error[markdown] (1000) at 1:1: cached call should have been skipped.";

--- a/packages/omo-codex/plugin/components/lsp/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/codex-hook.test.ts
@@ -1,9 +1,8 @@
 import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-
-import { afterEach, describe, expect, it } from "vitest";
 import type { PostEditDiagnosticsOutcome } from "@oh-my-opencode/lsp-core/post-edit";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { codexLspRequestContext, extractMutatedFilePaths, runLspPostToolUseHook } from "../src/codex-hook.js";
 

--- a/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/lsp/test/package-smoke.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	listDirectoryEntries,
 	readHooksJson,
+	readJsonFile,
 	readMcpJson,
 	readPackageJson,
 	readTextFile,
@@ -44,7 +45,16 @@ describe("plugin package metadata", () => {
 		expect(postCompactCommand).toBe(`node "${pluginRoot}/dist/cli.js" hook post-compact`);
 		expect(lspServer?.command).toBe("node");
 		expect(lspServer?.args).toEqual(["../../../../lsp-daemon/dist/cli.js", "mcp"]);
-		expect(lspServer?.startup_timeout_sec).toBe(10);
+		expect(readJsonFile(".mcp.json")).toEqual({
+			mcpServers: {
+				lsp: {
+					command: "node",
+					args: ["../../../../lsp-daemon/dist/cli.js", "mcp"],
+					cwd: ".",
+					startup_timeout_sec: 10,
+				},
+			},
+		});
 		expect(cliSource).not.toContain("./lazy-lsp-mcp.js");
 		expect(cliSource).toContain("resolveLspDaemonCliPath");
 		expect(daemonCliPathSource).toContain("@code-yeongyu/lsp-daemon/cli");

--- a/packages/omo-codex/plugin/components/rules/biome.json
+++ b/packages/omo-codex/plugin/components/rules/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noDefaultExport": "error",
 				"noEnum": "error",

--- a/packages/omo-codex/plugin/components/rules/src/config.ts
+++ b/packages/omo-codex/plugin/components/rules/src/config.ts
@@ -1,6 +1,5 @@
-import { SOURCE_PRIORITY } from "@oh-my-opencode/rules-engine/engine";
-import { defaultConfig } from "@oh-my-opencode/rules-engine/engine";
 import type { PiRulesConfig, RuleSource } from "@oh-my-opencode/rules-engine/engine";
+import { defaultConfig, SOURCE_PRIORITY } from "@oh-my-opencode/rules-engine/engine";
 
 export function configFromEnvironment(env: NodeJS.ProcessEnv = process.env): PiRulesConfig {
 	const config = defaultConfig();

--- a/packages/omo-codex/plugin/components/rules/src/persistent-cache.ts
+++ b/packages/omo-codex/plugin/components/rules/src/persistent-cache.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-
+import type { Engine } from "@oh-my-opencode/rules-engine/engine";
 import {
 	type PostCompactPendingKind,
 	type PostCompactPendingState,
@@ -9,7 +9,6 @@ import {
 	postCompactPendingKinds,
 	postCompactRecoveringKinds,
 } from "./post-compact-state.js";
-import type { Engine } from "@oh-my-opencode/rules-engine/engine";
 import { SESSION_STATE_LOCK_CONTENDED, withSessionStateLock } from "./session-state-lock.js";
 
 export type PostCompactClaimResult = "claimed" | "not-pending" | "contended";

--- a/packages/omo-codex/plugin/components/rules/src/post-compact-budget.ts
+++ b/packages/omo-codex/plugin/components/rules/src/post-compact-budget.ts
@@ -1,5 +1,5 @@
-import { hasContextPressureMarker } from "./context-pressure.js";
 import type { PiRulesConfig } from "@oh-my-opencode/rules-engine/engine";
+import { hasContextPressureMarker } from "./context-pressure.js";
 import { readTranscriptSearchText } from "./transcript-search.js";
 
 export interface PostCompactBudgetContext {
@@ -33,7 +33,11 @@ const MODEL_CONTEXT_BUDGETS: readonly ModelContextBudget[] = [
 		effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
 	},
 	{ slug: "gpt-5.5", contextWindowTokens: 272_000, effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT },
-	{ slug: "gpt-5.6-luna-fast", contextWindowTokens: 272_000, effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT },
+	{
+		slug: "gpt-5.6-luna-fast",
+		contextWindowTokens: 272_000,
+		effectivePercent: DEFAULT_EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+	},
 	{
 		slug: "codex-auto-review",
 		contextWindowTokens: 272_000,

--- a/packages/omo-codex/plugin/components/rules/src/rules-engine-factory.ts
+++ b/packages/omo-codex/plugin/components/rules/src/rules-engine-factory.ts
@@ -1,11 +1,8 @@
 import { readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-
+import { createEngine, findProjectRoot, findRuleCandidates } from "@oh-my-opencode/rules-engine/engine";
 import { configFromEnvironment } from "./config.js";
-import { createEngine } from "@oh-my-opencode/rules-engine/engine";
-import { findRuleCandidates } from "@oh-my-opencode/rules-engine/engine";
-import { findProjectRoot } from "@oh-my-opencode/rules-engine/engine";
 
 interface RulesEngineFactoryOptions {
 	env?: NodeJS.ProcessEnv;

--- a/packages/omo-codex/plugin/components/rules/src/static-injection.ts
+++ b/packages/omo-codex/plugin/components/rules/src/static-injection.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
-
+import type { Engine, LoadedRule, PiRulesConfig } from "@oh-my-opencode/rules-engine/engine";
+import { isNeverTruncatedRule } from "@oh-my-opencode/rules-engine/engine";
 import type { CodexRulesHookOptions } from "./codex-hook-options.js";
 import { configFromEnvironment } from "./config.js";
 import { withPromptBudget } from "./event-budget.js";
@@ -7,9 +8,6 @@ import { formatAdditionalContextOutput } from "./hook-output.js";
 import { completePostCompactRecovery, hydrateEngineState, persistEngineState } from "./persistent-cache.js";
 import { withPostCompactBudget } from "./post-compact-budget.js";
 import { buildPostCompactReadDirective } from "./post-compact-directive.js";
-import type { Engine } from "@oh-my-opencode/rules-engine/engine";
-import { isNeverTruncatedRule } from "@oh-my-opencode/rules-engine/engine";
-import type { LoadedRule, PiRulesConfig } from "@oh-my-opencode/rules-engine/engine";
 import { createRulesEngine } from "./rules-engine-factory.js";
 import { filterRulesAlreadyInTranscript, filterRulesNotInTranscriptText } from "./transcript-rule-filter.js";
 import type { TranscriptSearchOptions } from "./transcript-search.js";
@@ -120,10 +118,7 @@ function runPostCompactRecovery(input: PostCompactRecoveryInput): string {
 		engine.markStaticInjected(rule);
 	}
 	persistEngineState(engine, input.cachePath, input.channel);
-	return formatAdditionalContextOutput(
-		input.eventName,
-		combineStaticContext(bodyBlock, directive),
-	);
+	return formatAdditionalContextOutput(input.eventName, combineStaticContext(bodyBlock, directive));
 }
 
 function readRecoveryTranscriptText(transcriptPath: string | null): string | null {
@@ -153,7 +148,7 @@ function recoverDynamicRulePaths(
 			if (staticRulePaths.has(rulePath)) {
 				continue;
 			}
-			if (transcriptText !== null && transcriptText.includes(rulePath)) {
+			if (transcriptText?.includes(rulePath)) {
 				continue;
 			}
 			if (!existsSync(rulePath)) {

--- a/packages/omo-codex/plugin/components/rules/test/bundled-rules.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/bundled-rules.test.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createRuleDiscoveryCache, findRuleCandidates } from "@oh-my-opencode/rules-engine/engine";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
 import {
 	type CodexPostCompactInput,
 	type CodexSessionStartInput,
@@ -10,7 +10,6 @@ import {
 	runSessionStartHook,
 	runUserPromptSubmitHook,
 } from "../src/codex-hook.js";
-import { createRuleDiscoveryCache, findRuleCandidates } from "@oh-my-opencode/rules-engine/engine";
 
 interface FixtureOptions {
 	readonly writeProjectDuplicate?: boolean;

--- a/packages/omo-codex/plugin/components/rules/test/dynamic-target-fingerprints.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/dynamic-target-fingerprints.test.ts
@@ -1,10 +1,9 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-
-import { fingerprintDynamicTargets } from "../src/dynamic-target-fingerprints.js";
 import { defaultConfig } from "@oh-my-opencode/rules-engine/engine";
+import { afterEach, describe, expect, it } from "vitest";
+import { fingerprintDynamicTargets } from "../src/dynamic-target-fingerprints.js";
 
 const tempDirectories: string[] = [];
 

--- a/packages/omo-codex/plugin/components/rules/test/engine.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/engine.test.ts
@@ -1,10 +1,13 @@
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-
-import { configFromEnvironment } from "../src/config.js";
-import { createEngine, defaultConfig, type EngineDeps } from "@oh-my-opencode/rules-engine/engine";
-import { matchRule as defaultMatchRule } from "@oh-my-opencode/rules-engine/engine";
 import type { RuleCandidate } from "@oh-my-opencode/rules-engine/engine";
+import {
+	createEngine,
+	defaultConfig,
+	matchRule as defaultMatchRule,
+	type EngineDeps,
+} from "@oh-my-opencode/rules-engine/engine";
+import { describe, expect, it } from "vitest";
+import { configFromEnvironment } from "../src/config.js";
 
 const projectRoot = "/tmp/codex-rules-engine";
 

--- a/packages/omo-codex/plugin/components/rules/test/finder.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/finder.test.ts
@@ -1,10 +1,9 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-
-import { findRuleCandidates } from "@oh-my-opencode/rules-engine/engine";
 import type { RuleCandidate } from "@oh-my-opencode/rules-engine/engine";
+import { findRuleCandidates } from "@oh-my-opencode/rules-engine/engine";
+import { afterEach, describe, expect, it } from "vitest";
 
 const tempDirectories: string[] = [];
 

--- a/packages/omo-codex/plugin/components/rules/test/formatter.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/formatter.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it } from "vitest";
-
-import { formatDynamicBlock, formatStaticBlock } from "@oh-my-opencode/rules-engine/engine";
 import type { LoadedRule, MatchReason, RuleSource } from "@oh-my-opencode/rules-engine/engine";
+import { formatDynamicBlock, formatStaticBlock } from "@oh-my-opencode/rules-engine/engine";
+import { describe, expect, it } from "vitest";
 
 const FORMAT_OPTIONS = {
 	maxRuleChars: 10_000,

--- a/packages/omo-codex/plugin/components/rules/test/hephaestus-model-variant.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/hephaestus-model-variant.test.ts
@@ -1,10 +1,9 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-
-import { type CodexSessionStartInput, runSessionStartHook } from "../src/codex-hook.js";
 import { findPluginBundledCandidates } from "@oh-my-opencode/rules-engine/engine";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CodexSessionStartInput, runSessionStartHook } from "../src/codex-hook.js";
 
 const GPT_55_VARIANT_PATH = "bundled-rules/hephaestus/gpt-5.5.md";
 const GPT_56_VARIANT_PATH = "bundled-rules/hephaestus/gpt-5.6.md";

--- a/packages/omo-codex/plugin/components/rules/test/matcher.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/matcher.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it } from "vitest";
-
-import { matchRule, normalizeGlobs } from "@oh-my-opencode/rules-engine/engine";
 import type { RuleFrontmatter } from "@oh-my-opencode/rules-engine/engine";
+import { matchRule, normalizeGlobs } from "@oh-my-opencode/rules-engine/engine";
+import { describe, expect, it } from "vitest";
 
 function matchFrontmatter(
 	frontmatter: RuleFrontmatter,

--- a/packages/omo-codex/plugin/components/rules/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/package-smoke.test.ts
@@ -32,7 +32,7 @@ describe("plugin package metadata", () => {
 		// then
 		expect(packageJson.type).toBe("module");
 		expect(packageJson.packageManager).toBe("npm@11.12.1");
-		expect(packageJson.dependencies ?? {}).toEqual({ picomatch: "^4.0.3" });
+		expect(packageJson.dependencies ?? {}).toEqual({ picomatch: "^4.0.5" });
 		expect(packageJson.bin["omo-rules"]).toBe("./dist/cli.js");
 		expect(packageFiles).toContain("bundled-rules");
 		expect(bundledRules).toContain("windows-git-bash.md");

--- a/packages/omo-codex/plugin/components/rules/test/parser.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/parser.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from "vitest";
-
 import { parseRule } from "@oh-my-opencode/rules-engine/engine";
+import { describe, expect, it } from "vitest";
 
 describe("parseRule", () => {
 	it("#given content without frontmatter #when parsing #then body is preserved", () => {

--- a/packages/omo-codex/plugin/components/rules/test/post-compact-budget.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/post-compact-budget.test.ts
@@ -1,10 +1,9 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-
-import { withPostCompactBudget } from "../src/post-compact-budget.js";
 import type { PiRulesConfig } from "@oh-my-opencode/rules-engine/engine";
+import { afterEach, describe, expect, it } from "vitest";
+import { withPostCompactBudget } from "../src/post-compact-budget.js";
 
 const tempDirectories: string[] = [];
 const CONFIG: PiRulesConfig = {

--- a/packages/omo-codex/plugin/components/rules/test/rules-engine-consumption.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/rules-engine-consumption.test.ts
@@ -1,15 +1,14 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-
 import {
 	findPluginBundledCandidates,
 	matchRule,
 	parseRule,
-	scanRuleFiles,
 	SOURCE_PRIORITY,
+	scanRuleFiles,
 } from "@oh-my-opencode/rules-engine/engine";
+import { afterEach, describe, expect, it } from "vitest";
 
 const tempDirectories: string[] = [];
 
@@ -37,9 +36,7 @@ describe("rules-engine package consumption", () => {
 
 		// then
 		expect(SOURCE_PRIORITY.get("plugin-bundled")).toBe(200);
-		expect(nonWindowsCandidates.map((candidate) => candidate.relativePath)).toEqual([
-			"bundled-rules/hephaestus.md",
-		]);
+		expect(nonWindowsCandidates.map((candidate) => candidate.relativePath)).toEqual(["bundled-rules/hephaestus.md"]);
 		expect(windowsCandidates.map((candidate) => candidate.relativePath)).toEqual([
 			"bundled-rules/hephaestus.md",
 			"bundled-rules/windows-git-bash.md",

--- a/packages/omo-codex/plugin/components/rules/test/scanner.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/scanner.test.ts
@@ -1,9 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-
 import { scanRuleFiles } from "@oh-my-opencode/rules-engine/engine";
+import { afterEach, describe, expect, it } from "vitest";
 
 const tempDirectories: string[] = [];
 

--- a/packages/omo-codex/plugin/components/rules/test/sources.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/sources.test.ts
@@ -1,9 +1,6 @@
-import { describe, expect, it } from "vitest";
-
-import { SOURCE_PRIORITY } from "@oh-my-opencode/rules-engine/engine";
-import { defaultConfig } from "@oh-my-opencode/rules-engine/engine";
-import { disabledSourcesFromConfig } from "@oh-my-opencode/rules-engine/engine";
 import type { PiRulesConfig } from "@oh-my-opencode/rules-engine/engine";
+import { defaultConfig, disabledSourcesFromConfig, SOURCE_PRIORITY } from "@oh-my-opencode/rules-engine/engine";
+import { describe, expect, it } from "vitest";
 
 describe("rules source selection", () => {
 	it("#given default config #when disabled sources are derived #then opt-out sources stay disabled", () => {

--- a/packages/omo-codex/plugin/components/rules/test/windows-git-bash-bundled-rule.test.ts
+++ b/packages/omo-codex/plugin/components/rules/test/windows-git-bash-bundled-rule.test.ts
@@ -1,10 +1,9 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-
-import { type CodexSessionStartInput, runSessionStartHook } from "../src/codex-hook.js";
 import { findPluginBundledCandidates } from "@oh-my-opencode/rules-engine/engine";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CodexSessionStartInput, runSessionStartHook } from "../src/codex-hook.js";
 
 const WINDOWS_RULE_DESCRIPTION = "Windows Git Bash guidance for Codex";
 const WINDOWS_RULE_PATH = "bundled-rules/windows-git-bash.md";

--- a/packages/omo-codex/plugin/components/start-work-continuation/biome.json
+++ b/packages/omo-codex/plugin/components/start-work-continuation/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noDefaultExport": "error",
 				"noEnum": "error",

--- a/packages/omo-codex/plugin/components/telemetry/biome.json
+++ b/packages/omo-codex/plugin/components/telemetry/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noDefaultExport": "error",
 				"noEnum": "error",

--- a/packages/omo-codex/plugin/components/telemetry/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/telemetry/src/codex-hook.ts
@@ -1,7 +1,4 @@
-import {
-	type TelemetryDiagnosticErrorKind,
-	type TelemetryDiagnosticEvent,
-} from "@oh-my-opencode/telemetry-core";
+import type { TelemetryDiagnosticErrorKind, TelemetryDiagnosticEvent } from "@oh-my-opencode/telemetry-core";
 import {
 	createPluginPostHog,
 	getPostHogDistinctId,

--- a/packages/omo-codex/plugin/components/telemetry/src/posthog.ts
+++ b/packages/omo-codex/plugin/components/telemetry/src/posthog.ts
@@ -9,10 +9,10 @@ import {
 } from "@oh-my-opencode/telemetry-core";
 
 import {
-	MACHINE_ID_PREFIX,
 	createComponentTelemetryProductConfig,
 	getComponentTelemetryStateDir,
 	getComponentVersion,
+	MACHINE_ID_PREFIX,
 	writeComponentTelemetryDiagnostic,
 } from "./product-identity.js";
 
@@ -53,24 +53,14 @@ function resolveActivityStateProvider(options: CreatePluginPostHogOptions): Acti
 
 	if (options.stateDir === undefined) {
 		return () =>
-			getDailyActiveCaptureState(createDailyActiveCaptureStateInput(
-				getComponentTelemetryStateDir(),
-				options.now,
-			));
+			getDailyActiveCaptureState(createDailyActiveCaptureStateInput(getComponentTelemetryStateDir(), options.now));
 	}
 
 	const stateDir = options.stateDir;
-	return () =>
-		getDailyActiveCaptureState(createDailyActiveCaptureStateInput(
-			stateDir,
-			options.now,
-		));
+	return () => getDailyActiveCaptureState(createDailyActiveCaptureStateInput(stateDir, options.now));
 }
 
-function createDailyActiveCaptureStateInput(
-	stateDir: string,
-	now: Date | undefined,
-) {
+function createDailyActiveCaptureStateInput(stateDir: string, now: Date | undefined) {
 	if (now === undefined) {
 		return {
 			diagnostics: writeComponentTelemetryDiagnostic,

--- a/packages/omo-codex/plugin/components/telemetry/src/product-identity.ts
+++ b/packages/omo-codex/plugin/components/telemetry/src/product-identity.ts
@@ -5,9 +5,9 @@ import {
 	DEFAULT_POSTHOG_HOST,
 	getTelemetryDiagnosticsFilePath,
 	resolveTelemetryStateDir,
-	writeTelemetryDiagnostic,
 	type TelemetryDiagnosticInput,
 	type TelemetryProductConfig,
+	writeTelemetryDiagnostic,
 } from "@oh-my-opencode/telemetry-core";
 
 export { DEFAULT_POSTHOG_API_KEY, DEFAULT_POSTHOG_HOST };

--- a/packages/omo-codex/plugin/components/telemetry/test/diagnostics.test.ts
+++ b/packages/omo-codex/plugin/components/telemetry/test/diagnostics.test.ts
@@ -1,17 +1,14 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { cleanupTelemetryDiagnostics } from "@oh-my-opencode/telemetry-core";
 import { afterEach, describe, expect, it } from "vitest";
-
 import {
-	cleanupTelemetryDiagnostics,
-} from "@oh-my-opencode/telemetry-core";
-import {
+	CACHE_DIR_NAME,
 	getComponentTelemetryDiagnosticsFilePath,
 	getComponentTelemetryStateDir,
 	writeComponentTelemetryDiagnostic,
 } from "../src/product-identity.js";
-import { CACHE_DIR_NAME } from "../src/product-identity.js";
 
 const originalXdgDataHome = process.env["XDG_DATA_HOME"];
 const tempDirectories: string[] = [];

--- a/packages/omo-codex/plugin/components/ultrawork/biome.json
+++ b/packages/omo-codex/plugin/components/ultrawork/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noDefaultExport": "error",
 				"noEnum": "error",

--- a/packages/omo-codex/plugin/components/ultrawork/test/codex-hook-trigger-policy.test.ts
+++ b/packages/omo-codex/plugin/components/ultrawork/test/codex-hook-trigger-policy.test.ts
@@ -105,7 +105,15 @@ describe("codex ultrawork trigger policy", () => {
 
 		// then
 		expect(outputs).toEqual(["", "", "", "", "", "", ""]);
-		expect(prompts.map((prompt) => isUltraworkPrompt(prompt))).toEqual([false, false, false, false, false, false, false]);
+		expect(prompts.map((prompt) => isUltraworkPrompt(prompt))).toEqual([
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+			false,
+		]);
 	});
 
 	it("#given prompt contains ultrawork or standalone ulw #when hook runs #then emits directive", () => {

--- a/packages/omo-codex/plugin/components/ulw-loop/biome.json
+++ b/packages/omo-codex/plugin/components/ulw-loop/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"style": {
 				"noDefaultExport": "error",
 				"noEnum": "error",

--- a/packages/omo-codex/plugin/components/ulw-loop/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/codex-hook.ts
@@ -95,7 +95,9 @@ export async function applyUserPromptUlwLoopSteering(
 }
 
 function hasSteeringDirectiveMarker(prompt: string): boolean {
-	return /(?:^|\s)(?:OMO_ULW_LOOP_STEER|omo\.ulw-loop\.steer|omo ulw-loop steer|omo-agent-toolkit ulw-loop steer):/u.test(prompt);
+	return /(?:^|\s)(?:OMO_ULW_LOOP_STEER|omo\.ulw-loop\.steer|omo ulw-loop steer|omo-agent-toolkit ulw-loop steer):/u.test(
+		prompt,
+	);
 }
 
 function payloadScope(payload: UserPromptSubmitPayload): UlwLoopScope {

--- a/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/package-smoke.test.ts
@@ -88,7 +88,8 @@ describe("hooks/hooks.json", () => {
 		const hooks = await readJson("hooks/hooks.json") as Record<string, unknown>;
 		const events = (hooks["hooks"] as Record<string, unknown>)["UserPromptSubmit"] as readonly Record<string, unknown>[];
 		expect(events.length).toBeGreaterThan(0);
-		const command = ((events[0]?.["hooks"] as readonly Record<string, unknown>[])[0]?.["command"]) as string;
+		const command = (events[0]?.["hooks"] as readonly Record<string, unknown>[] | undefined)?.[0]?.["command"];
+		expect(command).toEqual(expect.any(String));
 		expect(command).toContain(`$${"{PLUGIN_ROOT}"}`);
 		expect(command).toContain("dist/cli.js");
 		expect(command).toContain("hook user-prompt-submit");
@@ -168,7 +169,7 @@ describe("skills/ulw-loop/SKILL.md", () => {
 				].join("\n"),
 			);
 
-			const result = await runShell(`${bootstrap}\n\"$ULW_LOOP_NODE\" \"$ULW_LOOP_CLI\" ulw-loop status --json`, {
+			const result = await runShell(`${bootstrap}\n"$ULW_LOOP_NODE" "$ULW_LOOP_CLI" ulw-loop status --json`, {
 				...process.env,
 				CODEX_HOME: codexHome,
 				HOME: home,

--- a/packages/omo-codex/plugin/components/ulw-loop/test/steering.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/steering.test.ts
@@ -422,11 +422,14 @@ describe("steerUlwLoop", () => {
 });
 
 describe("parseUlwLoopSteeringDirective", () => {
-	it.each(["OMO_ULW_LOOP_STEER", "omo.ulw-loop.steer", "omo ulw-loop steer", "omo-agent-toolkit ulw-loop steer"])("parses %s pattern", (marker) => {
-		expect(parseUlwLoopSteeringDirective(`${marker}: ${JSON.stringify(steering())}`)).toMatchObject({
-			kind: "add_subgoal",
-		});
-	});
+	it.each(["OMO_ULW_LOOP_STEER", "omo.ulw-loop.steer", "omo ulw-loop steer", "omo-agent-toolkit ulw-loop steer"])(
+		"parses %s pattern",
+		(marker) => {
+			expect(parseUlwLoopSteeringDirective(`${marker}: ${JSON.stringify(steering())}`)).toMatchObject({
+				kind: "add_subgoal",
+			});
+		},
+	);
 
 	it("returns null when no marker", () => {
 		expect(parseUlwLoopSteeringDirective(JSON.stringify(steering()))).toBeNull();


### PR DESCRIPTION
## Summary

- clear every Codex plugin component `npm run check` failure and configuration notice
- migrate all 8 component `biome.json` files to the CLI-previewed 2.5.9 schema + `preset: "recommended"`
- apply formatter/import-organization output and safe lint repairs across `comment-checker`, `lazycodex-executor-verify`, `lsp`, `rules`, `start-work-continuation`, `telemetry`, `ultrawork`, and `ulw-loop`

## Root cause

`d4e56dbad` (2026-08-21) upgraded `@biomejs/biome` to 2.5.9 across the 8 components without migrating their configs or reformatting sources. Biome 2.5's changed wrapping and new rules then failed `check` in 6 components; `lsp` additionally hit TypeScript drift (`startup_timeout_sec` removed from the typed `McpServer` fixture while the shipped `.mcp.json` still carries it). No aggregate gate runs per-component `check`, so the debt sat undetected.

## Behavior-audit of the only non-formatting edits

- `lsp/test/package-smoke.test.ts`: the timeout assertion moved to a whole-document `toEqual` on the shipped `.mcp.json` (timeout `10` still locked, `cwd` newly pinned, typed structural guard retained) — strictly stronger than before
- `rules/src/static-injection.ts`: `transcriptText !== null && transcriptText.includes(...)` → `transcriptText?.includes(...)` — branch-equivalent for `string | null`
- `rules/test/package-smoke.test.ts`: stale `picomatch ^4.0.3` expectation corrected to the shipped `^4.0.5` (no dependency change)
- `ulw-loop/test/package-smoke.test.ts`: unsafe optional-indexing cast replaced by a full optional chain plus `expect.any(String)`

Everything else is formatter output, import organization, `useImportType`, or the exact `biome migrate` preview.

## Verification

- RED: 6 components exited `check` with errors/warnings; 2 more carried config notices — exact transcripts in evidence
- GREEN: all 8 components exit `check` 0 with zero errors, warnings, and configuration infos
- per-component tests: 29 + 25 + (24+8) + 165 + 42 + 15 + 24 + 423 all passed
- `bun run test:codex`: 493/493, 0 failed, 0 skipped
- isolated real-Codex QA: self-check, install-verify, and app-server plugin drive all passed; real `~/.codex/config.toml` unchanged
- five-lane review on the final commit: goal, QA, code quality, security, and context all PASS

## Evidence

- `.omo/evidence/20260824-ulw-loop-check-cleanup/red-check.txt`
- `.omo/evidence/20260824-ulw-loop-check-cleanup/green-check.txt`
- `.omo/evidence/20260824-ulw-loop-check-cleanup/validation.txt`
- `.omo/evidence/20260824-ulw-loop-check-cleanup/expanded-checks.txt`
- `.omo/evidence/20260824-ulw-loop-check-cleanup/README.md`

## Follow-up (not in this PR)

The context review flagged that no CI gate runs per-component `check`, which is how this debt accumulated silently for three days. Worth a separate `chore(ci)` PR if you want it enforced.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans Biome check failures across all Codex plugin components and migrates each `biome.json` to the 2.5.9 schema with `preset: "recommended"`. Previously multiple components failed `npm run check` due to formatter/import rules and config drift; now all eight pass with zero diagnostics, and runtime behavior is unchanged.

**Review focus**
- Non-formatting edits:
  - `lsp/test/package-smoke.test.ts`: assert the shipped `.mcp.json` as a whole (adds `cwd`), keeps typed guards; no runtime change.
  - `rules/src/static-injection.ts`: `transcriptText?.includes(...)` replaces a null-check; equivalent for `string | null`.
  - `rules/test/package-smoke.test.ts`: expect `picomatch` `^4.0.5` to match the package.
  - `ulw-loop/test/package-smoke.test.ts`: replace unsafe optional indexing with optional chaining and `expect.any(String)`.
- Widespread formatter, import organization, and `useImportType` updates only.
- Updated `biome.json` in `comment-checker`, `lazycodex-executor-verify`, `lsp`, `rules`, `start-work-continuation`, `telemetry`, `ultrawork`, and `ulw-loop`. No lint-policy change beyond Biome 2.5.9 defaults. No consumer or API migrations required.

**Verification**
- Each component `npm run check`: exit 0, no diagnostics.
- Per-component tests all pass; repo gate `bun run test:codex` passes (493/493).
- Isolated Codex plugin QA passes; no changes to user config.

<sup>Written for commit 66de4fc153080d06819b84954c8d338d684f6f91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

