### PR TITLE
feat(skills): bind mass-ulw runs to a goal carrying result verification

### DIFF
--- a/packages/omo-senpi/skills/mass-ulw/SKILL.md
+++ b/packages/omo-senpi/skills/mass-ulw/SKILL.md
@@ -19,6 +19,10 @@ A run is a declarative definition: a stable `key` (idempotency: re-starting the 
 
 Route every node by `category` using the routing table in `references/planning.md`; the run executes nodes in parallel waves as their dependencies clear.
 
+## Goal before start
+
+Every run is goal-bound. Before `start`, register the run's goal (`create_goal`, or a `# Goal` block where no goal tool exists): the objective names the deliverable the graph produces, and the success criteria carry RESULT VERIFICATION - node and run completion claims are false until proven against captured evidence, the same contract the dag completion directive injects (TREAT AS FALSE UNTIL YOU PROVE IT). The verification wave (references/planning.md) produces the evidence those criteria name; the run ends when the criteria pass, never when the last node reports completion.
+
 ## Running a dag - eval is the default
 
 Build and run every dag INSIDE an eval cell. The eval kernel installs the `tool.dag` proxy and the extension publishes a small JS SDK at `OMO_DAG_SDK_ROOT`; driving runs from a cell is what unlocks the orchestration patterns in `references/planning.md` (data-driven graph construction, multi-run composition, concurrent runs, adaptive retries).


### PR DESCRIPTION
## What

Adds a **Goal before start** section to the mass-ulw skill (`packages/omo-senpi/skills/mass-ulw/SKILL.md`): every dag run is goal-bound, and the goal's success criteria must carry RESULT VERIFICATION — node and run completion claims are false until proven against captured evidence, matching the `DAG_VERIFICATION_DIRECTIVE` contract (#7080). The section ties the goal's criteria to the existing verification wave in `references/planning.md` instead of duplicating it.

## Why

The skill never told the orchestrator to register a goal or to put result verification inside the goal's criteria — runs could be treated as done when the last node reported completion. Defect class: missing context; fixed at the point of use (immediately before `start`), +4 lines, no other section touched.

## Verification

- QA-by-read of the shipped section (diff is the whole change: +4/-0, prose-only).
- `bun test script/package-layout.test.ts script/verify-omo-ai-payload.test.ts packages/omo-senpi/src/components/task/mass-ulw-protocol-doc.test.ts` — 15 pass / 0 fail, identical to pristine `dev` baseline.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds mass-ulw runs to an explicit goal that carries result verification. Previously, a run could be marked complete when the last node finished; now it completes only when the goal’s verification criteria pass using captured evidence.

- Before `start`, register a run goal with RESULT VERIFICATION criteria (via `create_goal` or a `# Goal` block); treat node/run completion claims as false until verified, and end the run only when criteria pass.
- Doc-only change in `packages/omo-senpi/skills/mass-ulw/SKILL.md`; aligns the skill with the existing verification wave in `references/planning.md`.

<sup>Written for commit 76daf86b92ed8600290882c70c6b8d96f95c60ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

