### PR TITLE
fix(model-core): let GPT-5.6-Luna run reasoning effort max

### DIFF
--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -454,7 +454,7 @@ describe("resolveCompatibleModelSettings", () => {
     ])
   })
 
-  test("GPT-5 downgrades unsupported max variant to xhigh", () => {
+  test("GPT-5 translates an unsupported max variant into the reasoningEffort channel (#7100)", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "openai",
       modelID: "gpt-5.4",
@@ -462,17 +462,51 @@ describe("resolveCompatibleModelSettings", () => {
     })
 
     expect(result).toEqual({
-      variant: "xhigh",
-      reasoningEffort: undefined,
+      variant: undefined,
+      reasoningEffort: "max",
       changes: [
         {
           field: "variant",
           from: "max",
-          to: "xhigh",
-          reason: "unsupported-by-model-family",
+          to: undefined,
+          reason: "translated-to-reasoning-effort",
         },
       ],
     })
+  })
+
+  test("GPT-5.6-Luna keeps a configured max effort instead of downgrading it (#7100)", () => {
+    // given - user configures variant "max" without an explicit effort option
+    const withoutExplicitEffort = resolveCompatibleModelSettings({
+      providerID: "newapi-openai",
+      modelID: "gpt-5.6-luna",
+      desired: { variant: "max" },
+    })
+
+    // then - the max level rides the reasoningEffort channel instead of being clamped
+    expect(withoutExplicitEffort).toEqual({
+      variant: undefined,
+      reasoningEffort: "max",
+      changes: [
+        {
+          field: "variant",
+          from: "max",
+          to: undefined,
+          reason: "translated-to-reasoning-effort",
+        },
+      ],
+    })
+
+    // given - user configures both variant "max" and an explicit reasoningEffort
+    const withExplicitEffort = resolveCompatibleModelSettings({
+      providerID: "newapi-openai",
+      modelID: "gpt-5.6-luna",
+      desired: { variant: "max", reasoningEffort: "max" },
+    })
+
+    // then - the explicit effort wins and stays max
+    expect(withExplicitEffort.reasoningEffort).toBe("max")
+    expect(withExplicitEffort.changes.map((change) => change.field)).toEqual(["variant"])
   })
 
   test("GPT-5 keeps none reasoningEffort", () => {

--- a/packages/model-core/src/model-settings-compatibility.ts
+++ b/packages/model-core/src/model-settings-compatibility.ts
@@ -1,6 +1,6 @@
 import { detectHeuristicModelFamily } from "./model-capability-heuristics"
 import { isClaudeOpus47OrLaterModel } from "./model-family-detectors"
-import { clampReasoningLevel, REASONING_LEVELS } from "./reasoning-level"
+import { clampReasoningLevel, isReasoningLevel, REASONING_LEVELS } from "./reasoning-level"
 
 type CompatibilityField = "variant" | "reasoningEffort" | "temperature" | "topP" | "maxTokens" | "thinking"
 
@@ -37,6 +37,7 @@ export type ModelSettingsCompatibilityChange = {
   | "unsupported-by-model-family"
   | "unknown-model-family"
   | "unsupported-by-model-metadata"
+  | "translated-to-reasoning-effort"
   | "max-output-limit"
 }
 
@@ -116,13 +117,28 @@ export function resolveCompatibleModelSettings(
   const metadataReasoningEfforts = normalizeCapabilitiesReasoningEfforts(input.capabilities)
 
   let variant = input.desired.variant
+  let translatedReasoningEffort: string | undefined
   if (variant !== undefined) {
     const normalized = variant.toLowerCase()
     const resolved = resolveField(normalized, family?.variants, REASONING_LEVELS as unknown as string[], familyKnown, metadataVariants)
     if (resolved.value !== normalized && resolved.reason) {
-      changes.push({ field: "variant", from: variant, to: resolved.value, reason: resolved.reason })
+      const effortCaps = metadataReasoningEfforts ?? family?.reasoningEfforts
+      if (isReasoningLevel(normalized) && effortCaps?.includes(normalized)) {
+        changes.push({
+          field: "variant",
+          from: variant,
+          to: undefined,
+          reason: "translated-to-reasoning-effort",
+        })
+        variant = undefined
+        translatedReasoningEffort = normalized
+      } else {
+        changes.push({ field: "variant", from: variant, to: resolved.value, reason: resolved.reason })
+        variant = resolved.value
+      }
+    } else {
+      variant = resolved.value
     }
-    variant = resolved.value
   }
 
   let reasoningEffort = input.desired.reasoningEffort
@@ -140,6 +156,8 @@ export function resolveCompatibleModelSettings(
       changes.push({ field: "reasoningEffort", from: reasoningEffort, to: resolved.value, reason: resolved.reason })
     }
     reasoningEffort = resolved.value
+  } else if (translatedReasoningEffort !== undefined) {
+    reasoningEffort = translatedReasoningEffort
   }
 
   let temperature = input.desired.temperature

--- a/packages/omo-opencode/src/plugin-interface.test.ts
+++ b/packages/omo-opencode/src/plugin-interface.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { randomUUID } from "node:crypto"
+import * as connectedProvidersCache from "./shared/connected-providers-cache"
 import { createPluginInterface } from "./plugin-interface"
 import { createAutoSlashCommandHook } from "./hooks/auto-slash-command"
 import { createStartWorkHook } from "./hooks/start-work"
@@ -366,5 +367,46 @@ describe("createPluginInterface - chat.params variant injection", () => {
 
     // then
     expect(input.message.variant).toBe("high")
+  })
+
+  test("routes agent max variant to reasoningEffort when the model has no max preset (#7100)", async () => {
+    // given - hephaestus on a custom-provider luna model with no cached variant metadata
+    const providerMetadataSpy = spyOn(connectedProvidersCache, "findProviderModelMetadata").mockReturnValue(undefined)
+    const pluginInterface = createPluginInterface({
+      ctx: { client: {} } as never,
+      pluginConfig: {
+        agents: {
+          hephaestus: { variant: "max" },
+        },
+      } as never,
+      firstMessageVariantGate: {
+        shouldOverride: () => false,
+        markApplied: () => {},
+        markSessionCreated: () => {},
+        clear: () => {},
+      },
+      managers: {} as never,
+      hooks: {} as never,
+      tools: {},
+    })
+    const input = {
+      sessionID: "ses-luna-max",
+      agent: "hephaestus",
+      model: { providerID: "newapi-openai", modelID: "gpt-5.6-luna" },
+      provider: { id: "newapi-openai" },
+      message: {} as { variant?: string; reasoningEffort?: string },
+    }
+    const output = { options: {} }
+
+    // when
+    try {
+      await pluginInterface["chat.params"]?.(input as never, output as never)
+    } finally {
+      providerMetadataSpy.mockRestore()
+    }
+
+    // then - max survives to the outgoing options instead of being dropped or clamped
+    expect(output.options).toEqual({ reasoningEffort: "max" })
+    expect(input.message.variant).not.toBe("high")
   })
 })

--- a/packages/omo-opencode/src/plugin-interface.ts
+++ b/packages/omo-opencode/src/plugin-interface.ts
@@ -1,7 +1,9 @@
 import type { PluginContext, PluginInterface, ToolsRecord } from "./plugin/types"
 import type { OhMyOpenCodeConfig } from "./config"
+import { isRecord } from "@oh-my-opencode/utils"
 
 import { applyAgentVariant } from "./shared/agent-variant"
+import type { LoweredReasoning } from "./shared/agent-variant"
 import { createChatParamsHandler } from "./plugin/chat-params"
 import { createChatHeadersHandler } from "./plugin/chat-headers"
 import { createChatMessageHandler } from "./plugin/chat-message"
@@ -49,8 +51,17 @@ export function createPluginInterface(args: {
       const providerID = chatParamsInput.model?.providerID
       const rawModelID = chatParamsInput.model?.modelID ?? chatParamsInput.model?.id
       const modelID = typeof rawModelID === "string" ? rawModelID : undefined
+      let loweredReasoning: LoweredReasoning = {}
       if (chatParamsInput.message && typeof providerID === "string" && modelID !== undefined) {
-        applyAgentVariant(pluginConfig, agentName, chatParamsInput.message, { providerID, modelID })
+        loweredReasoning = applyAgentVariant(pluginConfig, agentName, chatParamsInput.message, { providerID, modelID })
+      }
+      if (
+        loweredReasoning.reasoningEffort !== undefined
+        && isRecord(output)
+        && isRecord(output.options)
+        && output.options.reasoningEffort === undefined
+      ) {
+        output.options.reasoningEffort = loweredReasoning.reasoningEffort
       }
       const handler = createChatParamsHandler({
         client: ctx.client,

--- a/packages/omo-opencode/src/shared/agent-variant.test.ts
+++ b/packages/omo-opencode/src/shared/agent-variant.test.ts
@@ -182,6 +182,27 @@ describe("applyAgentVariant", () => {
     // then
     expect(message.variant).toBe("max")
   })
+
+  test("returns the lowered reasoning so callers can route the effort channel (#7100)", () => {
+    // given - luna exposes no max preset, so the requested level lowers to an effort
+    const config = {
+      agents: {
+        hephaestus: { variant: "max" },
+      },
+    } as OhMyOpenCodeConfig
+    const message: { variant?: string; reasoningEffort?: string } = {}
+
+    // when
+    const lowered = applyAgentVariant(config, "hephaestus", message, {
+      providerID: "newapi-openai",
+      modelID: "gpt-5.6-luna",
+      runtimeModel: { variants: { low: {}, medium: {}, high: {}, xhigh: {} } },
+    } as { providerID: string; modelID: string; runtimeModel?: { variants?: Record<string, unknown> } })
+
+    // then
+    expect(lowered).toEqual({ reasoningEffort: "max" })
+    expect(message).toEqual({ reasoningEffort: "max" })
+  })
 })
 
 describe("resolveVariantForModel", () => {

--- a/packages/omo-opencode/src/shared/agent-variant.ts
+++ b/packages/omo-opencode/src/shared/agent-variant.ts
@@ -131,9 +131,11 @@ export function applyAgentVariant(
   agentName: string | undefined,
   message: { variant?: string },
   currentModel: { providerID: string; modelID: string },
-): void {
+): LoweredReasoning {
   const variant = resolveAgentVariant(config, agentName)
-  if (variant === undefined || message.variant !== undefined) return
+  if (variant === undefined || message.variant !== undefined) return {}
 
-  Object.assign(message, lowerReasoningForModel(variant, currentModel))
+  const lowered = lowerReasoningForModel(variant, currentModel)
+  Object.assign(message, lowered)
+  return lowered
 }


### PR DESCRIPTION
## What

A user-configured `variant: "max"` (or equivalent reasoning level) on a gpt-5-family model such as `gpt-5.6-luna` now reaches the outgoing request as `reasoningEffort: "max"` instead of being silently dropped or clamped to a lower preset.

Two changes:

1. `packages/model-core`: `resolveCompatibleModelSettings()` no longer downgrades a canonical reasoning level that is unsupported as a variant but supported as a reasoningEffort. It translates the value into the effort channel and records the change with a new reason, `translated-to-reasoning-effort`. Families that do not declare efforts keep today's downgrade behavior.
2. `packages/omo-opencode`: `applyAgentVariant()` returns the lowered reasoning, and the `chat.params` handler seeds `output.options.reasoningEffort` from it when options do not already carry one, so the effort-channel fallback lands on the field OpenCode actually consumes.

## Why

The heuristic `gpt-5` family (matches `gpt-5.6-luna`) declares `max` as a legal reasoningEffort but not as a variant preset. Two defects broke the reported config (`hephaestus` + `newapi-openai/gpt-5.6-luna` + `variant: "max"`):

- When runtime variant metadata was missing (custom providers are often absent from the connected-providers cache), `lowerReasoningForModel` correctly fell back to `{ reasoningEffort: "max" }`, but `applyAgentVariant` assigned it onto the chat.params message, a field OpenCode never reads. The value died there.
- When `message.variant = "max"` did arrive, `resolveCompatibleModelSettings` clamped it down the variant ladder (to xhigh/high) even though the same model declares `max` as a supported effort.

Net effect: the reasoning effort for GPT-5.6-Luna could not be fixed to max.

## Verified

Failing-first regression tests, then green after the fix:

- `model-settings-compatibility.test.ts`: luna keeps a configured max effort (translated channel), explicit effort wins when both are set, updated GPT-5 pin for the new translation behavior.
- `plugin-interface.test.ts`: hephaestus + `newapi-openai/gpt-5.6-luna` + `variant: "max"` with empty provider cache produces `output.options.reasoningEffort === "max"`.
- `agent-variant.test.ts`: `applyAgentVariant` returns the lowered reasoning for the effort channel.

Scoped suites: 117 pass (4 files), full `packages/model-core` 357 pass, `packages/omo-opencode/src/{shared,plugin,cli}` 2377 pass / 0 fail, `bun run typecheck:packages` clean, LSP diagnostics clean on changed files. Existing pins (GitHub Copilot GPT-5 downgrades, GLM/DeepSeek alias maps, Claude caps) remain green. QA evidence captured under `.omo/evidence/20260824-luna-reasoning-max/`.

## Risk

Behavior changes only for canonical-level variant tokens that a model supports as an effort but not as a variant; today that is exactly the gpt-5 family's `max`. Providers supporting neither keep the previous downgrade path. The new change reason is additive; no consumer outside model-core reads `changes[].reason`.

## Coordination

#6614 covers stale provider options overriding a configured level; this fix is orthogonal (channel translation plus clamp correctness) and touches none of that path.

Fixes #7100

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures a user-configured variant "max" on `gpt-5` family models (e.g., `gpt-5.6-luna`) is sent as `reasoningEffort: "max"` instead of being downgraded or dropped. Previously, "max" was clamped to xhigh/high or lost without provider metadata; now it translates to the effort channel and propagates to the outgoing request. Fixes #7100.

- `packages/model-core`: `resolveCompatibleModelSettings` translates an unsupported canonical-level variant into `reasoningEffort` when the model supports that effort; records change reason `translated-to-reasoning-effort`; keeps downgrade behavior for families without effort support.
- `packages/omo-opencode`: `applyAgentVariant` returns lowered reasoning; `chat.params` seeds `output.options.reasoningEffort` from it when unset, so the request carries "max" even without cached provider variants.

<sup>Written for commit c47df5ea38dfec881bd351df221a6c0218d95875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

