### PR TITLE
fix(omo-ai): resolve Claude native binary from the engine tree under hoisted global installs

### DIFF
--- a/.omo/evidence/20260824-hoisted-install-binary-path/QA.md
+++ b/.omo/evidence/20260824-hoisted-install-binary-path/QA.md
@@ -1,0 +1,75 @@
+# QA evidence: hoisted-install Claude native binary resolution (#7063)
+
+Date: 2026-08-24
+Branch: issue/7063-hoisted-install-binary-path (base: dev @ 8833800ae)
+Scope: packages/omo-native (npm omo-ai launcher: package-paths.js resolver + doctor.js check)
+
+## WHAT WAS TESTED
+
+1. Unit/regression tests (`bun test packages/omo-native/test/package-paths.test.ts`):
+   synthetic tempdir installs driven through `resolveClaudeNativeBinary()`:
+   - hoisted layout: binary present ONLY at the parent node_modules, senpi has no private
+     node_modules -> resolver returns the parent-level path
+   - nested layout (bun global): binary under senpi/node_modules -> still resolves first
+   - CLAUDE_CODE_EXECUTABLE set to an existing file -> override wins over the engine tree
+   - CLAUDE_CODE_EXECUTABLE set to a missing file -> error names the variable and the path
+   - binary absent everywhere -> actionable error naming `omo-ai@beta` reinstall and the override
+   - linux with only the -musl platform package -> musl candidate reached after glibc misses
+2. Doctor integration tests (`bun test packages/omo-native/test/doctor.test.ts`): real launcher
+   spawned via `node bin/omo.js doctor` against fixture installs:
+   - complete install gains `PASS claude native binary: <path>`
+   - missing platform package -> `FAIL claude native binary` + exit 1 + actionable message
+   - CLAUDE_CODE_EXECUTABLE env -> PASS reports the override path
+3. setup-detect.test.ts launcher fixtures updated with the platform package so the new fail-closed
+   check does not flip unrelated exit-code assertions.
+4. End-to-end reproduction of the issue layout on the REAL launcher (hermetic prefix under /tmp,
+   isolated OMO_CODING_AGENT_DIR + HOME; fixture binaries are dummy files, never executed):
+   - Scenario A (e2e-A-hoisted-doctor.txt): npm-hoisted global shape, deps next to omo-ai,
+     binary only at `<prefix>/lib/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude`
+     -> doctor PASS with exactly that parent-level path, exit 0.
+   - Scenario B (e2e-B-missing-fail-closed.txt): same tree without the platform package
+     -> `FAIL claude native binary: ... reinstall with: npm i -g omo-ai@beta, or set
+     CLAUDE_CODE_EXECUTABLE ...`, exit 1 (fail closed).
+   - Scenario C (e2e-C-override-wins.txt): CLAUDE_CODE_EXECUTABLE points at an existing file
+     -> PASS reports the override path, exit 0.
+
+## WHAT WAS OBSERVED
+
+- Failing-first: before implementation the new suite failed with
+  `SyntaxError: Export named 'resolveClaudeNativeBinary' not found`, and doctor.test.ts failed
+  3 cases (no claude line emitted by the old doctor). After implementation: all green.
+- Scoped suites: package-paths + doctor + setup-detect = 24 pass / 0 fail.
+- Full `bun test packages/omo-native/test`: 133 pass / 6 skip / 1 fail. The single failure is
+  `payload.test.ts` ("build:omo-native staged payload") which invokes `build:senpi-plugin` ->
+  `materialize-shared-upstreams.mjs --strict` and dies on `git submodule update --init` for
+  `packages/shared-skills/upstreams/*`. Proven pre-existing: `git stash -u` on the clean base
+  commit reproduces the identical failure (missing submodule objects in this worktree); CI builds
+  submodules out-of-band before `bun test`.
+- Typecheck: `bunx tsc -p packages/omo-native/tsconfig.json --noEmit` clean.
+- Entry smoke: `node packages/omo-native/bin/omo.js --version` ->
+  `omo 5.0.0-0.beta.18 (engine: senpi 2026.8.23)`.
+- An earlier non-hermetic E2E attempt symlinked the worktree's real senpi into the prefix; Node's
+  realpath-based ancestor walk then escaped into the bun store and resolved a real 0.3.238 binary.
+  That run was discarded and redone with a fully synthetic senpi copy so Scenario A proves
+  parent-level resolution and Scenario B proves fail-closed hermetically.
+
+## WHY IT IS ENOUGH
+
+- The unit suite pins the resolver contract (hoisted parent hit, nested precedence unchanged,
+  override precedence, both failure messages) on synthetic trees, so it cannot drift with whatever
+  the developer machine has installed.
+- The doctor integration tests pin the user-visible surface (PASS line, FAIL + exit code, override).
+- The hermetic E2E drives the real `bin/omo.js doctor` entrypoint against the exact directory shape
+  from the issue report (npm hoisted global prefix), closing the loop from unit to product surface.
+- Remaining risk: platforms/architectures other than linux-x64/darwin-arm64 are covered by the
+  shared candidate builder (mirrors senpi's `claudeCodeExecutableCandidates`, including win32 `.exe`
+  and musl ordering) but only linux-x64 was exercised live here.
+
+## WHAT WAS OMITTED
+
+- Fixture binary contents are placeholder bytes (`fixture-mach-o`); no binary was executed and no
+  Claude SDK network/OAuth flow was driven (requires real credentials; out of scope for a path-
+  resolution fix).
+- Real macOS hoisted-install verification (the maintainer's outstanding ask on the issue) cannot be
+  performed from this Linux environment; the E2E reproduces the layout, not the OS.
+- No secrets, tokens, or host paths beyond the local worktree appear in the captured outputs.

--- a/.omo/evidence/20260824-hoisted-install-binary-path/e2e-A-hoisted-doctor.txt
+++ b/.omo/evidence/20260824-hoisted-install-binary-path/e2e-A-hoisted-doctor.txt
@@ -1,0 +1,9 @@
+PASS plugin manifest: plugin/package.json
+PASS extension: plugin/extensions/omo.js
+PASS lsp-daemon runtime: plugin/runtime/lsp-daemon/dist/cli.js
+PASS agent-toolkit runtime: plugin/runtime/agent-toolkit/cli.js
+PASS senpi CLI: /tmp/opencode/omo7063-e2e/hoisted-prefix/lib/node_modules/@code-yeongyu/senpi/dist/cli.js
+PASS senpi version 2026.8.23
+PASS claude native binary: /tmp/opencode/omo7063-e2e/hoisted-prefix/lib/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude
+INFO omo 5.0.0-0.beta.18 (engine: senpi 2026.8.23)
+exit=0

--- a/.omo/evidence/20260824-hoisted-install-binary-path/e2e-B-missing-fail-closed.txt
+++ b/.omo/evidence/20260824-hoisted-install-binary-path/e2e-B-missing-fail-closed.txt
@@ -1,0 +1,9 @@
+PASS plugin manifest: plugin/package.json
+PASS extension: plugin/extensions/omo.js
+PASS lsp-daemon runtime: plugin/runtime/lsp-daemon/dist/cli.js
+PASS agent-toolkit runtime: plugin/runtime/agent-toolkit/cli.js
+PASS senpi CLI: /tmp/opencode/omo7063-e2e/hoisted-prefix/lib/node_modules/@code-yeongyu/senpi/dist/cli.js
+PASS senpi version 2026.8.23
+FAIL claude native binary: Claude native binary not found for linux-x64 under the pinned engine at /tmp/opencode/omo7063-e2e/hoisted-prefix/lib/node_modules/@code-yeongyu/senpi; reinstall with: npm i -g omo-ai@beta, or set CLAUDE_CODE_EXECUTABLE to the claude binary inside @anthropic-ai/claude-agent-sdk-linux-x64
+INFO omo 5.0.0-0.beta.18 (engine: senpi 2026.8.23)
+exit=1

--- a/.omo/evidence/20260824-hoisted-install-binary-path/e2e-C-override-wins.txt
+++ b/.omo/evidence/20260824-hoisted-install-binary-path/e2e-C-override-wins.txt
@@ -1,0 +1,9 @@
+PASS plugin manifest: plugin/package.json
+PASS extension: plugin/extensions/omo.js
+PASS lsp-daemon runtime: plugin/runtime/lsp-daemon/dist/cli.js
+PASS agent-toolkit runtime: plugin/runtime/agent-toolkit/cli.js
+PASS senpi CLI: /tmp/opencode/omo7063-e2e/hoisted-prefix/lib/node_modules/@code-yeongyu/senpi/dist/cli.js
+PASS senpi version 2026.8.23
+PASS claude native binary: /tmp/opencode/omo7063-e2e/override-claude
+INFO omo 5.0.0-0.beta.18 (engine: senpi 2026.8.23)
+exit=0

--- a/packages/omo-native/bin/lib/doctor.js
+++ b/packages/omo-native/bin/lib/doctor.js
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 import { canonicalAgentDir } from "./agent-dir.js"
-import { packageManifest, packageRoot, readJson, resolveSenpi } from "./package-paths.js"
+import { packageManifest, packageRoot, readJson, resolveClaudeNativeBinary, resolveSenpi } from "./package-paths.js"
 import { needsSetupSuggestion } from "./setup-detect.js"
 
 const artifacts = [
@@ -85,6 +85,16 @@ export function runDoctor(inventory) {
       }
     } catch (error) {
       fail(lines, `senpi version: ${error.message}`)
+      failed = true
+    }
+
+    // A turn that picks a Claude model spawns exactly this executable; a missing one must fail
+    // diagnostics instead of surfacing as a broken session later.
+    try {
+      const claude = resolveClaudeNativeBinary({ senpiRoot: senpi.packageRoot })
+      pass(lines, `claude native binary: ${claude.path}`)
+    } catch (error) {
+      fail(lines, `claude native binary: ${error.message}`)
       failed = true
     }
   }

--- a/packages/omo-native/bin/lib/package-paths.js
+++ b/packages/omo-native/bin/lib/package-paths.js
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs"
+import { createRequire } from "node:module"
 import { basename, dirname, join, parse } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -44,6 +45,59 @@ export function resolveSenpi() {
     throw new Error(`senpi CLI is missing at ${cliPath}; reinstall with: ${updateTarget().command}`)
   }
   return { cliPath, packageRoot: dirname(dirname(indexPath)) }
+}
+
+function isMuslLinuxRuntime(platform) {
+  if (platform !== "linux" || typeof process.report?.getReport !== "function") return false
+  const report = process.report.getReport()
+  if (report === null || typeof report !== "object" || !("header" in report)) return false
+  const header = report.header
+  return typeof header !== "object" || header === null || header.glibcVersionRuntime === undefined
+}
+
+// Mirrors the engine's claudeCodeExecutableCandidates so diagnostics name exactly the binary a
+// turn would spawn.
+function claudeNativeBinaryCandidates(platform, arch, preferMusl) {
+  const ext = platform === "win32" ? ".exe" : ""
+  if (platform === "linux") {
+    const glibc = `@anthropic-ai/claude-agent-sdk-linux-${arch}/claude${ext}`
+    const musl = `@anthropic-ai/claude-agent-sdk-linux-${arch}-musl/claude${ext}`
+    return preferMusl ? [musl, glibc] : [glibc, musl]
+  }
+  return [`@anthropic-ai/claude-agent-sdk-${platform}-${arch}/claude${ext}`]
+}
+
+export function resolveClaudeNativeBinary(options = {}) {
+  const {
+    senpiRoot = resolveSenpi().packageRoot,
+    env = process.env,
+    platform = process.platform,
+    arch = process.arch,
+    preferMusl = isMuslLinuxRuntime(platform),
+  } = options
+
+  const override = env.CLAUDE_CODE_EXECUTABLE
+  if (override) {
+    if (!existsSync(override)) {
+      throw new Error(`CLAUDE_CODE_EXECUTABLE points at ${override}, which does not exist; fix the path or unset it to fall back to the engine tree`)
+    }
+    return { path: override, source: "override" }
+  }
+
+  // Rooting resolution at the engine package lets Node's own ancestor walk cover hoisted global
+  // layouts, where platform packages land in the parent node_modules instead of omo-ai/node_modules.
+  const engineRequire = createRequire(join(senpiRoot, "package.json"))
+  for (const candidate of claudeNativeBinaryCandidates(platform, arch, preferMusl)) {
+    try {
+      return { path: engineRequire.resolve(candidate), source: "engine-tree" }
+    } catch {
+      // try next candidate
+    }
+  }
+  throw new Error(
+    `Claude native binary not found for ${platform}-${arch} under the pinned engine at ${senpiRoot}; `
+    + `reinstall with: ${updateTarget().command}, or set CLAUDE_CODE_EXECUTABLE to the claude binary inside @anthropic-ai/claude-agent-sdk-${platform}-${arch}`,
+  )
 }
 
 export function nearestNodeBin(startPath) {

--- a/packages/omo-native/test/doctor.test.ts
+++ b/packages/omo-native/test/doctor.test.ts
@@ -42,6 +42,18 @@ function createFixture(): Fixture {
   }))
   writeFile(join(senpiRoot, "dist", "index.js"), "export const fixture = true\n")
   writeFile(join(senpiRoot, "dist", "cli.js"), "process.exit(0)\n")
+  const claudeExt = process.platform === "win32" ? ".exe" : ""
+  const claudePkgDir = join(
+    packageRoot,
+    "node_modules",
+    "@anthropic-ai",
+    `claude-agent-sdk-${process.platform}-${process.arch}`,
+  )
+  writeFile(join(claudePkgDir, "package.json"), JSON.stringify({
+    name: `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`,
+    version: "0.3.220",
+  }))
+  writeFile(join(claudePkgDir, `claude${claudeExt}`))
   for (const [, artifact] of artifacts) writeFile(join(packageRoot, artifact))
   const agentDir = join(root, "agent")
   mkdirSync(agentDir, { recursive: true })
@@ -69,8 +81,32 @@ describe("omo doctor", () => {
         for (const [label] of artifacts) expect(result.stdout).toContain(`PASS ${label}`)
         expect(result.stdout).toContain("PASS senpi CLI")
         expect(result.stdout).toContain("PASS senpi version 2026.8.9")
+        expect(result.stdout).toContain("PASS claude native binary: ")
         expect(result.stdout).not.toContain("FAIL")
       })
+    })
+  })
+
+  describe("#given the Claude native binary is missing from the engine tree", () => {
+    test("#then diagnostics fail closed and name the override and reinstall command", () => {
+      const fixture = createFixture()
+      rmSync(join(fixture.packageRoot, "node_modules", "@anthropic-ai"), { recursive: true, force: true })
+      const result = run(fixture)
+      expect(result.status).toBe(1)
+      expect(result.stdout).toContain("FAIL claude native binary")
+      expect(result.stdout).toContain("CLAUDE_CODE_EXECUTABLE")
+      expect(result.stdout).toContain("omo-ai@beta")
+    })
+  })
+
+  describe("#given CLAUDE_CODE_EXECUTABLE points at an existing binary", () => {
+    test("#then diagnostics report the override path as the one a turn would spawn", () => {
+      const fixture = createFixture()
+      const overridePath = join(fixture.root, "override", "claude")
+      writeFile(overridePath)
+      const result = run(fixture, { CLAUDE_CODE_EXECUTABLE: overridePath })
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain(`PASS claude native binary: ${overridePath}`)
     })
   })
 

--- a/packages/omo-native/test/package-paths.test.ts
+++ b/packages/omo-native/test/package-paths.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { resolveClaudeNativeBinary } from "../bin/lib/package-paths.js"
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function writeFile(path: string, content = "binary\n"): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+}
+
+function platformPackageDirName(platform: string, arch: string, variant = ""): string {
+  return `claude-agent-sdk-${platform}-${arch}${variant}`
+}
+
+function installClaudeBinary(modulesRoot: string, platform: string, arch: string, variant = ""): string {
+  const pkgDir = join(modulesRoot, "@anthropic-ai", platformPackageDirName(platform, arch, variant))
+  const ext = platform === "win32" ? ".exe" : ""
+  const binaryPath = join(pkgDir, `claude${ext}`)
+  writeFile(join(pkgDir, "package.json"), JSON.stringify({
+    name: `@anthropic-ai/${platformPackageDirName(platform, arch, variant)}`,
+    version: "0.3.220",
+  }))
+  writeFile(binaryPath)
+  return binaryPath
+}
+
+// npm's default global shape: every dependency lands in ONE shared node_modules next to omo-ai,
+// so the engine package has no private node_modules of its own.
+function hoistedEngineTree(): { modulesRoot: string; senpiRoot: string } {
+  const root = mkdtempSync(join(tmpdir(), "omo-package-paths-hoisted-"))
+  roots.push(root)
+  const modulesRoot = join(root, "lib", "node_modules")
+  const senpiRoot = join(modulesRoot, "@code-yeongyu", "senpi")
+  writeFile(join(senpiRoot, "package.json"), JSON.stringify({
+    name: "@code-yeongyu/senpi",
+    version: "2026.8.23",
+  }))
+  return { modulesRoot, senpiRoot }
+}
+
+// bun's global shape: dependencies nest inside omo-ai/node_modules, giving the engine package a
+// private node_modules that holds the optional platform packages.
+function nestedEngineTree(): { modulesRoot: string; senpiRoot: string } {
+  const root = mkdtempSync(join(tmpdir(), "omo-package-paths-nested-"))
+  roots.push(root)
+  const modulesRoot = join(root, "global", "node_modules", "omo-ai", "node_modules")
+  const senpiRoot = join(modulesRoot, "@code-yeongyu", "senpi")
+  writeFile(join(senpiRoot, "package.json"), JSON.stringify({
+    name: "@code-yeongyu/senpi",
+    version: "2026.8.23",
+  }))
+  return { modulesRoot, senpiRoot }
+}
+
+describe("resolveClaudeNativeBinary", () => {
+  describe("#given a hoisted global install with the binary in the parent node_modules", () => {
+    describe("#when the resolver runs from the engine package root", () => {
+      test("#then it finds the parent-level binary without any package-local node_modules", () => {
+        const { modulesRoot, senpiRoot } = hoistedEngineTree()
+        const binaryPath = installClaudeBinary(modulesRoot, "darwin", "arm64")
+
+        const resolved = resolveClaudeNativeBinary({ senpiRoot, env: {}, platform: "darwin", arch: "arm64" })
+
+        expect(resolved).toEqual({ path: binaryPath, source: "engine-tree" })
+      })
+    })
+  })
+
+  describe("#given a nested global install with the binary under the engine's private node_modules", () => {
+    describe("#when the resolver runs", () => {
+      test("#then it still resolves the nested binary first", () => {
+        const { modulesRoot, senpiRoot } = nestedEngineTree()
+        const binaryPath = installClaudeBinary(join(senpiRoot, "node_modules"), "darwin", "arm64")
+
+        const resolved = resolveClaudeNativeBinary({ senpiRoot, env: {}, platform: "darwin", arch: "arm64" })
+
+        expect(resolved).toEqual({ path: binaryPath, source: "engine-tree" })
+      })
+    })
+  })
+
+  describe("#given CLAUDE_CODE_EXECUTABLE points at an existing binary", () => {
+    describe("#when the resolver runs against a tree that also ships the binary", () => {
+      test("#then the explicit override wins over the engine tree", () => {
+        const { modulesRoot, senpiRoot } = hoistedEngineTree()
+        installClaudeBinary(modulesRoot, "darwin", "arm64")
+        const overridePath = installClaudeBinary(join(dirname(modulesRoot), "override"), "darwin", "arm64")
+
+        const resolved = resolveClaudeNativeBinary({
+          senpiRoot,
+          env: { CLAUDE_CODE_EXECUTABLE: overridePath },
+          platform: "darwin",
+          arch: "arm64",
+        })
+
+        expect(resolved).toEqual({ path: overridePath, source: "override" })
+      })
+    })
+  })
+
+  describe("#given CLAUDE_CODE_EXECUTABLE points at a missing file", () => {
+    describe("#when the resolver runs", () => {
+      test("#then it fails and names both the variable and the broken path", () => {
+        const { senpiRoot } = hoistedEngineTree()
+
+        expect(() => resolveClaudeNativeBinary({
+          senpiRoot,
+          env: { CLAUDE_CODE_EXECUTABLE: "/no/such/claude" },
+          platform: "darwin",
+          arch: "arm64",
+        })).toThrow(/CLAUDE_CODE_EXECUTABLE.*\/no\/such\/claude/)
+      })
+    })
+  })
+
+  describe("#given the binary is absent from every node_modules level", () => {
+    describe("#when the resolver runs", () => {
+      test("#then it throws an actionable error naming the reinstall command and the override", () => {
+        const { senpiRoot } = hoistedEngineTree()
+
+        expect(() => resolveClaudeNativeBinary({ senpiRoot, env: {}, platform: "darwin", arch: "arm64" }))
+          .toThrow(/CLAUDE_CODE_EXECUTABLE/)
+        expect(() => resolveClaudeNativeBinary({ senpiRoot, env: {}, platform: "darwin", arch: "arm64" }))
+          .toThrow(/omo-ai@beta/)
+      })
+    })
+  })
+
+  describe("#given linux with only the musl platform package installed", () => {
+    describe("#when the resolver runs", () => {
+      test("#then the musl candidate is reached after glibc misses", () => {
+        const { modulesRoot, senpiRoot } = hoistedEngineTree()
+        const binaryPath = installClaudeBinary(modulesRoot, "linux", "x64", "-musl")
+
+        const resolved = resolveClaudeNativeBinary({ senpiRoot, env: {}, platform: "linux", arch: "x64" })
+
+        expect(resolved).toEqual({ path: binaryPath, source: "engine-tree" })
+      })
+    })
+  })
+})

--- a/packages/omo-native/test/package-paths.test.ts
+++ b/packages/omo-native/test/package-paths.test.ts
@@ -76,7 +76,7 @@ describe("resolveClaudeNativeBinary", () => {
   describe("#given a nested global install with the binary under the engine's private node_modules", () => {
     describe("#when the resolver runs", () => {
       test("#then it still resolves the nested binary first", () => {
-        const { modulesRoot, senpiRoot } = nestedEngineTree()
+        const { senpiRoot } = nestedEngineTree()
         const binaryPath = installClaudeBinary(join(senpiRoot, "node_modules"), "darwin", "arm64")
 
         const resolved = resolveClaudeNativeBinary({ senpiRoot, env: {}, platform: "darwin", arch: "arm64" })

--- a/packages/omo-native/test/setup-detect.test.ts
+++ b/packages/omo-native/test/setup-detect.test.ts
@@ -136,6 +136,14 @@ function createLauncherFixture(fixture: Fixture): string {
   }))
   write(join(senpiRoot, "dist", "index.js"), "export const fixture = true\n")
   write(join(senpiRoot, "dist", "cli.js"), "process.exit(0)\n")
+  const claudeExt = process.platform === "win32" ? ".exe" : ""
+  const claudePkgDir = join(
+    packageRoot, "node_modules", "@anthropic-ai", `claude-agent-sdk-${process.platform}-${process.arch}`,
+  )
+  write(join(claudePkgDir, "package.json"), JSON.stringify({
+    name: `@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}`, version: "0.3.220",
+  }))
+  write(join(claudePkgDir, `claude${claudeExt}`), "fixture\n")
   for (const artifact of [
     "plugin/package.json", "plugin/extensions/omo.js", "plugin/runtime/lsp-daemon/dist/cli.js",
     "plugin/runtime/agent-toolkit/cli.js",


### PR DESCRIPTION
## What

- Add `resolveClaudeNativeBinary()` to `packages/omo-native/bin/lib/package-paths.js`. It resolves the Claude Agent SDK native binary (`@anthropic-ai/claude-agent-sdk-<platform>-<arch>/claude`, `.exe` on win32, glibc/musl ordering on linux) via `createRequire` rooted at the pinned `@code-yeongyu/senpi` package, so Node's own ancestor node_modules walk covers hoisted global layouts. An explicit `CLAUDE_CODE_EXECUTABLE` still wins; a broken override or a missing binary produces an actionable error naming the reinstall command (`npm i -g omo-ai@beta`) and the override variable.
- Wire the resolver into `omo doctor` as a fail-closed check: a missing executable now prints `FAIL claude native binary: ...` and exits 1 instead of reporting PASS on an install that cannot spawn Claude.

## Why

Under npm's default hoisted global install strategy, `@code-yeongyu/senpi` and its optional `@anthropic-ai` platform packages land **next to** `omo-ai` in the parent node_modules, not inside `omo-ai/node_modules`. The Claude native binary therefore exists only under the senpi tree, while resolution rooted at the omo-ai prefix finds nothing and every Claude-model turn fails with "Claude Code native binary not found at .../omo-ai/node_modules/@anthropic-ai/..." (#7063). The engine itself resolves the executable correctly since senpi 2026.8.22 (`resolveClaudeCodeExecutable()`), but nothing on the omo side could answer where that binary lives, and `omo doctor` kept reporting PASS on installs that could not run Claude at all - exactly the blind spot reported in the issue.

This mirrors the resolution strategy of #6848 (walk the ancestor node_modules chain / honor the env override) for the Claude binary, and implements the issue's suggested fix items 1-3 on the omo side: resolve from the senpi tree, never construct `join(omoAiRoot, "node_modules/@anthropic-ai/...")`, and make doctor verify the executable it would spawn.

## Verified

- Failing-first: new tests failed before the fix (`Export 'resolveClaudeNativeBinary' not found`; 3 doctor cases red), pass after.
- `bun test packages/omo-native/test/package-paths.test.ts packages/omo-native/test/doctor.test.ts packages/omo-native/test/setup-detect.test.ts`: 24 pass / 0 fail. New coverage: hoisted parent-level hit, nested-layout precedence unchanged, override wins, broken override error, missing-everywhere actionable error, linux musl fallback.
- Full `bun test packages/omo-native/test`: 133 pass / 6 skip / 1 fail; the single failure (`payload.test.ts`) is pre-existing on the clean base commit in this worktree (`git stash` A/B) and stems from missing git submodule objects for `packages/shared-skills/upstreams/*`, which CI builds out-of-band.
- `bunx tsc -p packages/omo-native/tsconfig.json --noEmit`: clean. `node bin/omo.js --version`: OK.
- End-to-end on the real launcher against a hermetic npm-hoisted global prefix reproducing the issue's layout: doctor PASS with the parent-level binary path (exit 0); with the binary removed everywhere, FAIL + exit 1 + actionable message; with `CLAUDE_CODE_EXECUTABLE` set, PASS reports the override path. Evidence: `.omo/evidence/20260824-hoisted-install-binary-path/`.

## Risk

Low and scoped to `packages/omo-native`. The doctor check is additive; existing checks and their exit-code contract are unchanged (launcher fixtures updated so the new check has a binary to find). Resolution order for the spawn path itself is untouched - the launcher change is diagnostics-only, and the resolver mirrors the engine's own candidate ordering rather than replacing it. Not verified live on macOS (the maintainer's outstanding retest ask); the E2E reproduces the directory layout on Linux.

Fixes #7063

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the Claude Agent SDK native binary from the pinned engine tree under hoisted global installs and makes `omo doctor` fail closed when it’s missing. Previously `omo-ai` searched its own `node_modules` and `omo doctor` reported PASS; now resolution anchors at `@code-yeongyu/senpi`, honors `CLAUDE_CODE_EXECUTABLE`, and surfaces actionable errors. Fixes #7063.

- Review notes
  - Adds `resolveClaudeNativeBinary()` in `packages/omo-native/bin/lib/package-paths.js`; uses `createRequire` from the `@code-yeongyu/senpi` root to resolve `@anthropic-ai/claude-agent-sdk-<platform>-<arch>/claude` (win `.exe`; linux glibc/musl ordering).
  - Integrates into `omo doctor`: prints `PASS claude native binary: <path>` on success; prints `FAIL ...` and exits 1 on missing or invalid paths.
  - Diagnostics-only; runtime spawn resolution is unchanged and mirrors the engine’s candidates.

- Rollout
  - No migrations. If `omo doctor` now fails for Claude, reinstall globally (`npm i -g omo-ai@beta`) or set `CLAUDE_CODE_EXECUTABLE` to the `claude` binary inside the appropriate `@anthropic-ai/claude-agent-sdk-<platform>-<arch>` package.

<sup>Written for commit 871e6c2166b52e17ef237fb922d044a3f7f826ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

