### PR TITLE
fix(model-core): add claude-opus-5 to GA 1M context allowlist

### DIFF
--- a/.omo/evidence/20260824-6640-ga1m-context-gap/evidence.md
+++ b/.omo/evidence/20260824-6640-ga1m-context-gap/evidence.md
@@ -1,0 +1,77 @@
+# Evidence: Issue #6640 - hasGA1MContext regex gap (claude-opus-5 falls back to 200K)
+
+Date: 2026-08-24
+Worktree: /home/viprix/projects/oom-wt-6640
+Branch: issue/6640-ga1m-context-gap (base: dev @8833800ae)
+
+## Root cause
+
+`packages/model-core/src/context-limit-resolver.ts` `hasGA1MContext()`:
+
+- Before: `/^claude-(?:fable|mythos|sonnet)-5$/` for the 5-family alternation.
+  `claude-opus-5` matches neither the opus/sonnet-4 pattern nor the 5-family
+  pattern, so `resolveActualContextLimit("anthropic", "claude-opus-5", ...)`
+  returns `DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000` even though the model has a
+  1M context window. The same gap also discards a cached provider limit because
+  the cache branch is gated on `cachedLimit && hasGA1MContext(modelID)`.
+- Consumer: `packages/omo-opencode/src/hooks/preemptive-compaction-trigger.ts`
+  compacts when usage >= `PREEMPTIVE_COMPACTION_THRESHOLD = 0.78` of the resolved
+  limit -> opus-5 sessions compacted at ~156K tokens (15.6% of the real 1M
+  window), producing premature/duplicate auto-compactions as reported in #6640.
+- Fix: add `opus` to the 5-family alternation:
+  `/^claude-(?:fable|mythos|sonnet|opus)-5$/` (issue suggested fix #1).
+  Bug 2 of the issue (compactedSessions latch set after the awaited summarize)
+  is intentionally out of scope for this PR; it is an independent defect in
+  packages/omo-opencode/src/hooks/preemptive-compaction-trigger.ts.
+
+## WHAT WAS TESTED
+
+1. Failing-first regression tests added to the co-located
+   `packages/model-core/src/context-limit-resolver.test.ts` (given/when/then):
+   - "returns GA 1M for claude-opus-5 without explicit 1M mode"
+   - "uses cached limit for claude-opus-5 when cache exists" (proves the cached
+     limit is no longer discarded by the regex gate)
+   - "keeps 200K default for Anthropic models outside the GA 1M allowlist"
+     (guard: allowlist must not become allow-all; green before and after)
+2. Command: `bun test packages/model-core/src/context-limit-resolver.test.ts`
+3. Full package suite: `bun test packages/model-core`
+4. Typecheck: `bunx tsgo --noEmit -p packages/model-core/tsconfig.json` and
+   `bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json` (consumer package).
+
+## WHAT WAS OBSERVED
+
+- RED (before fix): exactly the two new claude-opus-5 regression tests failed;
+  all 12 pre-existing tests plus the guard test passed.
+  `(fail) resolveActualContextLimit > returns GA 1M for claude-opus-5 without explicit 1M mode`
+  `(fail) resolveActualContextLimit > uses cached limit for claude-opus-5 when cache exists`
+  Summary line: `13 pass / 2 fail`.
+- GREEN (after fix): scoped file `15 pass / 0 fail`; full model-core package
+  `359 pass / 0 fail` (1295 expect() calls, 33 files).
+- Typecheck: model-core OK; omo-opencode (consumer) OK, exit 0.
+
+## WHY IT IS ENOUGH
+
+The change is a one-token alternation inside a pure, deterministic function.
+The co-located unit suite pins both affected branches of
+`resolveActualContextLimit` (hardcoded GA limit and cached provider limit) for
+the exact unmatched format from the issue (`claude-opus-5`), pins negative
+behavior for a non-GA Anthropic model, and the full model-core suite (359 tests)
+plus consumer-package typecheck cover regressions across every other caller of
+the resolver. The exported signature did not change.
+
+## WHAT WAS OMITTED
+
+- Live OpenCode harness QA (opencode-qa skill / SSE hook probe) was not run:
+  the edit is in harness-neutral `packages/model-core` (pure function, no
+  OpenCode API surface touched); the observable behavior is fully pinned by the
+  co-located unit tests above. The preemptive-compaction-trigger consumer was
+  typechecked but not driven live.
+- Bug 2 (latch-after-await double compaction) from issue #6640 is NOT fixed
+  here; it requires a design decision among the three alternatives proposed in
+  the issue and touches files adjacent to PR #7183's area.
+- `bun install` prepare step fails in this environment at
+  `materialize-shared-upstreams` (git submodule init for
+  packages/shared-skills/upstreams/* cannot reach its remotes). This is
+  pre-existing environment noise unrelated to this change; workspace deps
+  sufficient for the scoped suites were installed successfully.
+- No secrets, tokens, or env dumps are contained in this evidence.

--- a/packages/model-core/src/context-limit-resolver.test.ts
+++ b/packages/model-core/src/context-limit-resolver.test.ts
@@ -169,4 +169,49 @@ describe("resolveActualContextLimit", () => {
       anthropicContext1MEnabled: false,
     })).toBe(1_000_000)
   })
+
+  it("returns GA 1M for claude-opus-5 without explicit 1M mode", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    // when
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-opus-5", {
+      anthropicContext1MEnabled: false,
+    })
+
+    // then
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("uses cached limit for claude-opus-5 when cache exists", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+    const modelContextLimitsCache = new Map<string, number>()
+    modelContextLimitsCache.set("anthropic/claude-opus-5", 1_000_000)
+
+    // when
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-opus-5", {
+      anthropicContext1MEnabled: false,
+      modelContextLimitsCache,
+    })
+
+    // then
+    expect(actualLimit).toBe(1_000_000)
+  })
+
+  it("keeps 200K default for Anthropic models outside the GA 1M allowlist", () => {
+    // given
+    delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
+    delete process.env[VERTEX_CONTEXT_ENV_KEY]
+
+    // when
+    const actualLimit = resolveActualContextLimit("anthropic", "claude-sonnet-4-5", {
+      anthropicContext1MEnabled: false,
+    })
+
+    // then
+    expect(actualLimit).toBe(200_000)
+  })
 })

--- a/packages/model-core/src/context-limit-resolver.ts
+++ b/packages/model-core/src/context-limit-resolver.ts
@@ -26,7 +26,7 @@ function getAnthropicActualLimit(modelCacheState?: ContextLimitModelCacheState):
 
 function hasGA1MContext(modelID: string): boolean {
   return /^claude-(opus|sonnet)-4(?:-|\.)(?:6|7|8)(?:-high)?$/.test(modelID) ||
-    /^claude-(?:fable|mythos|sonnet)-5$/.test(modelID)
+    /^claude-(?:fable|mythos|sonnet|opus)-5$/.test(modelID)
 }
 
 export function resolveActualContextLimit(


### PR DESCRIPTION
## What

Add `opus` to the 5-family alternation in `hasGA1MContext()` (`packages/model-core/src/context-limit-resolver.ts`):

```diff
-    /^claude-(?:fable|mythos|sonnet)-5$/.test(modelID)
+    /^claude-(?:fable|mythos|sonnet|opus)-5$/.test(modelID)
```

Plus three co-located regression tests in `context-limit-resolver.test.ts` (given/when/then): GA 1M for `claude-opus-5` without explicit 1M mode, cached provider limit honored for `claude-opus-5`, and a guard test keeping the 200K default for non-GA Anthropic models.

## Why

`hasGA1MContext()` is the allowlist gate for Anthropic models whose real context window is 1M. Its 5-family pattern listed only `fable|mythos|sonnet`, so `claude-opus-5` matched neither alternation and `resolveActualContextLimit("anthropic", "claude-opus-5", ...)` fell back to `DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000`. The same regex gate also discarded a cached provider limit (`if (cachedLimit && hasGA1MContext(modelID))`). The preemptive-compaction hook compacts at 0.78 of the resolved limit, so opus-5 sessions were auto-compacted at ~156K tokens, about 15.6% of the model's actual 1M window, producing premature and duplicate auto-compactions as reported in the issue.

## Verified

- Failing-first: before the fix, exactly the two new `claude-opus-5` tests failed (`13 pass / 2 fail`); all pre-existing tests and the guard test passed.
- After the fix: scoped file `15 pass / 0 fail`; full `bun test packages/model-core` suite `359 pass / 0 fail`.
- Typecheck green for `packages/model-core` and consumer package `packages/omo-opencode` (`tsgo --noEmit`, exit 0).
- Evidence recorded in `.omo/evidence/20260824-6640-ga1m-context-gap/evidence.md`.

## Risk

Low. One-token allowlist widening inside a pure function; exported signatures unchanged; negative behavior for non-GA Anthropic models is pinned by a guard test so the allowlist does not become allow-all. Live-harness QA was not run because the change is in harness-neutral `model-core` with no OpenCode API surface touched; behavior is pinned at unit level.

Out of scope: Bug 2 from the issue (the `compactedSessions` latch is set only after the awaited summarize, so a >60s client timeout guarantees a second auto-compaction). That defect lives in `packages/omo-opencode/src/hooks/preemptive-compaction-trigger.ts`, needs a design decision among the alternatives proposed in the issue, and touches files adjacent to #7183; it deserves its own PR.

Fixes #6640


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `claude-opus-5` to the GA 1M context allowlist so `resolveActualContextLimit` returns 1,000,000 and honors a cached provider limit. Previously `claude-opus-5` fell back to 200,000, triggering preemptive compaction around 156k tokens and occasional duplicate compactions (issue #6640).

**Review notes**
- Changes one regex in `packages/model-core/src/context-limit-resolver.ts`; no API or signature changes.
- Adds three tests in `context-limit-resolver.test.ts`: resolves 1M for `claude-opus-5`, uses cached limit, and a guard that keeps 200K for non-GA Anthropic models.
- All `packages/model-core` tests pass; typecheck passes for `packages/model-core` and consumer `packages/omo-opencode`.
- No migration required; scope is limited to Anthropic `claude-opus-5`. The compaction latch ordering noted in the issue is out of scope.

<sup>Written for commit 41933b8c78983877add255d6ceb8d0cff83c97aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

