### PR TITLE
fix(memory): stop reflection bare-runId collisions after a run-counter reset

### DIFF
--- a/.omo/evidence/20260824-7095-runid-collision/QA.md
+++ b/.omo/evidence/20260824-7095-runid-collision/QA.md
@@ -1,0 +1,70 @@
+# QA Evidence - Issue #7095: reflection bare-runId completion-record collision
+
+Date: 2026-08-24
+Branch: `issue/7095-reflection-runid-collision` (worktree `/home/viprix/projects/oom-wt-7095`, base dev @8833800ae)
+
+## WHAT WAS TESTED
+
+Surface: reflection reservation/run-id minting (`packages/memory-core/src/reflection/reservation.ts`,
+`packages/omo-senpi/src/components/memory/reflection-run-id.ts`) and its regression coverage.
+
+Commands (bun 1.3.14, hermetic tmpdir fixtures only; no real `~/.senpi/agent`, no network):
+
+1. Failing-first reproduction (scratch test, NOT committed): wired the PRE-FIX per-process counter
+   factory (`reflection-run-${++counter}` restarting at 1 per store instance = simulated restart)
+   against seeded generation-one debris (`completions/reflection-run-1.json`) and two reserve
+   generations across a simulated restart.
+   `bun test packages/omo-senpi/src/components/memory/scratch-legacy-counter-repro.test.ts`
+2. Fixed behavior, targeted:
+   `bun test packages/memory-core/src/reflection/reservation.test.ts`
+   `bun test packages/omo-senpi/src/components/memory/reflection-run-id.test.ts packages/omo-senpi/src/components/memory/reflection-run-id-collision.test.ts`
+3. Scoped suites:
+   `bun test packages/memory-core/src`
+   `bun test packages/omo-senpi/src/components/memory`
+4. Typechecks:
+   `bun run --cwd packages/memory-core typecheck`
+   `bun run --cwd packages/omo-senpi typecheck`
+
+## WHAT WAS OBSERVED
+
+1. Failing-first: scratch repro FAILED with exactly the error reported in #7095 -
+   `Reflection completion record mismatch for reflection-run-1` thrown at
+   `worker/completion-records.ts:15` when the second generation re-minted `reflection-run-1`
+   while generation one's consumed completion record was still on disk. Scratch file deleted
+   after capture.
+2. Targeted after fix: reservation suite 10 pass / 0 fail (includes new async run-id factory
+   case minting under the scheduler lock); run-id factory + collision regression suites
+   7 pass / 0 fail (fresh ids continue above every persisted id across a simulated restart;
+   stale record untouched beside the new one).
+3. Scoped suites: memory-core 545 pass / 0 fail (68 files); omo-senpi memory component
+   907 pass, 6 skip / 0 fail (135 files).
+4. Typechecks: both packages clean.
+
+Isolation proof: all fixtures live under `mkdtemp(tmpdir())`; no command touched the real senpi
+agent dir or any harness state. Worktree-only verification; branch never touched `dev`.
+
+## WHY IT IS ENOUGH
+
+The committed regression test (`reflection-run-id-collision.test.ts`) pins the exact reported
+wedge end-to-end through the real `ReflectionReservationStore`: stale completion record +
+run directory from an earlier generation, then two fresh stores reserving across a restart must
+never re-mint a persisted id, and publishing a new completion must leave the stale record
+byte-identical. The scratch run proves this test fails against the pre-fix counter behavior with
+the issue's literal error string, so it guards the defect, not just the implementation. The
+factory unit tests pin disk-scoped high-water semantics (completions, run dirs, live
+reservation state, non-run names ignored, strictly increasing within a process). Remaining risk:
+ids minted by processes running concurrently on hosts where the scheduler lock is bypassed are
+out of scope (the lock is the existing cross-process seam; minting now happens inside it).
+
+## WHAT WAS OMITTED
+
+- Raw bun test output beyond the counts above (no secrets present, trimmed for size).
+- The scratch reproduction file itself (deleted from the worktree after capture; its content is
+  described above).
+- Live Senpi driver QA: this change is exercised hermetically through the real reservation store
+  and real filesystem fixtures; no senpi binary surface changed. Not run, and would add no
+  coverage of the minted-id contract beyond the suites above.
+- Changeset triage note: the crashed session also left an unrelated sandbox-degradation fallback
+  changeset (bwrap spawn-failure retry, tracked upstream as #6873) in the worktree. It is
+  EXCLUDED from this fix/PR and preserved outside the commit; issue #7095 itself marks Defect 1
+  as already covered by #6873.

--- a/packages/memory-core/src/reflection/reservation.test.ts
+++ b/packages/memory-core/src/reflection/reservation.test.ts
@@ -11,7 +11,7 @@ import { realpathSync } from "node:fs"
 const roots: string[] = []
 afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
 
-async function fixture(stepCount = 2) {
+async function fixture(stepCount = 2, createRunId?: () => string | Promise<string>) {
   const root = realpathSync.native(await mkdtemp(join(tmpdir(), "reflection-reservation-")))
   roots.push(root)
   const identity: MemoryIdentity = { id: "agent-test", safeSlug: "agent-test", paths: buildIdentityPaths(root, "agent-test") }
@@ -33,7 +33,7 @@ async function fixture(stepCount = 2) {
       if (!found) throw new Error(`missing journal: ${id}`)
       return found
     },
-    createRunId: () => `run-${++nextId}`,
+    createRunId: createRunId ?? (() => `run-${++nextId}`),
   })
   return { identity, journal, store }
 }
@@ -74,6 +74,19 @@ describe("persisted reflection reservation", () => {
     expect(result?.status).toBe("active")
     expect(result?.run.request.trigger).toBe("step-count")
     expect(result?.run.request.snapshots[0]?.snapshot.end_message_id).toBe("assistant-2")
+  })
+
+  it("#given an async run-id factory #when a reservation is made #then the awaited id names the reserved run", async () => {
+    // given
+    const { journal, store } = await fixture(2, async () => "run-async-1")
+
+    // when
+    const result = await store.tryReserve(await captured(journal, "step-count"))
+
+    // then
+    expect(result.status).toBe("active")
+    expect(result.run.runId).toBe("run-async-1")
+    expect((await store.readState()).active?.runId).toBe("run-async-1")
   })
 
   it("#given a new active reservation #when it is published #then launch-owner identity and reservation time are durable in the same record", async () => {

--- a/packages/memory-core/src/reflection/reservation.ts
+++ b/packages/memory-core/src/reflection/reservation.ts
@@ -29,7 +29,7 @@ export interface ReflectionReservationStoreOptions {
   readonly identity: MemoryIdentity
   readonly config: TriggerConfig
   readonly getJournal: (conversationId: string) => Promise<TranscriptJournal>
-  readonly createRunId?: () => string
+  readonly createRunId?: () => string | Promise<string>
   readonly now?: () => Date
   readonly launcherIdentity?: () => Promise<ReflectionLauncherIdentity>
 }
@@ -48,7 +48,7 @@ export class ReflectionReservationStore {
   private readonly activePath: string
   private readonly pendingPath: string
   private readonly schedulerLockPath: string
-  private readonly createRunId: () => string
+  private readonly createRunId: () => string | Promise<string>
   private readonly now: () => Date
   private readonly launcherIdentity: () => Promise<ReflectionLauncherIdentity>
 
@@ -87,8 +87,11 @@ export class ReflectionReservationStore {
   }
 
   async tryReserve(request: ReflectionRequest, signal?: AbortSignal): Promise<ReservationResult> {
-    const runId = this.createRunId()
-    return this.locked(runId, async () => {
+    // The id is minted under the scheduler lock so two processes racing to reserve can never
+    // observe the same disk state and derive the same run id.
+    return this.locked(undefined, async () => {
+      signal?.throwIfAborted()
+      const runId = await this.createRunId()
       signal?.throwIfAborted()
       const current = await this.readStateUnlocked()
       signal?.throwIfAborted()

--- a/packages/omo-senpi/src/components/memory/AGENTS.md
+++ b/packages/omo-senpi/src/components/memory/AGENTS.md
@@ -13,6 +13,7 @@ The memory architecture - the git-backed memory filesystem, the memory tool sema
 | `index.ts` | Component factory: capability checks, config latch, session binding (`senpi-memory.session-binding`), fail-closed resume conflicts, supervisor refcount, shutdown cleanup. |
 | `wiring.ts` | Registration surface: prompt handler, journal routing, tools, guard, skills scope, commands, trigger wiring, completion renderer/consumption, policy registration, status refresh. |
 | `identity-runtime.ts` | Per-identity reflection assembly: reservation store (trigger engine), worker runner, lazy OS-sandbox transform. |
+| `reflection-run-id.ts` | Mints reflection run ids as one past the highest id still on disk (completion records, run directories, live reservation state), the facts lane's attempt-sequence precedent. A per-process counter restarted at 1 each launch and re-minted retired ids whose durable completion records then collided ("Reflection completion record mismatch"), wedging launch, reconcile, and finalization permanently. |
 | `prompt.ts` | Per-run compiled-memory injection via `before_agent_start`; composes the incoming prompt, sentinel-delimited block, (template,HEAD) cache. |
 | `tools.ts` | `memory` + `memory_apply_patch` ToolDefinitions over the core engines under the `memory-write` cross-process lock; execute-time activation gating. |
 | `journal-wiring.ts` | `agent_settled` branch-delta scan + `session_start` crash reconcile into per-session transcript journals (v3_assistant_steps cursor). |

--- a/packages/omo-senpi/src/components/memory/identity-runtime.ts
+++ b/packages/omo-senpi/src/components/memory/identity-runtime.ts
@@ -13,6 +13,7 @@ import type { ComponentLogger } from "../../extension/types"
 import { resolveAgentHome } from "../agent-home/resolve-agent-home"
 import type { SenpiOmoConfigResult } from "../config-resolution"
 import type { MemoryIdentityContext } from "./context"
+import { createReflectionRunIdFactory } from "./reflection-run-id"
 import { buildSandboxTransform, type SandboxPolicy, type SandboxTransform } from "./sandbox"
 import {
   resolveAgentReflectionSettings,
@@ -52,8 +53,6 @@ export interface MemoryIdentityRuntime {
   reconcile(): Promise<void>
 }
 
-let runCounter = 0
-
 function asMemoryIdentity(context: MemoryIdentityContext): MemoryIdentity {
   return {
     id: context.identity,
@@ -73,7 +72,7 @@ export function createIdentityRuntime(
     config: resolveReflectionTriggerConfig(settings, identity.identity),
     getJournal: async (conversationId: string) =>
       new TranscriptJournal({ journalDir: `${identity.identityPaths.transcripts}/${conversationId}` }),
-    createRunId: () => `reflection-run-${++runCounter}`,
+    createRunId: createReflectionRunIdFactory({ reflectionDir: identity.identityPaths.reflection }),
   })
 
   let builtSandbox: SandboxTransform | undefined

--- a/packages/omo-senpi/src/components/memory/reflection-run-id-collision.test.ts
+++ b/packages/omo-senpi/src/components/memory/reflection-run-id-collision.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { realpathSync } from "node:fs"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  ReflectionReservationStore,
+  TranscriptJournal,
+  buildIdentityPaths,
+  type MemoryIdentity,
+  type MemoryIdentityPaths,
+} from "@oh-my-opencode/memory-core"
+
+import { createReflectionRunIdFactory } from "./reflection-run-id"
+import { ensureReflectionCompletion } from "./worker/completion-records"
+
+const roots: string[] = []
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
+
+interface Fixture {
+  readonly identity: MemoryIdentity
+  readonly paths: MemoryIdentityPaths
+  readonly journal: TranscriptJournal
+}
+
+async function fixture(): Promise<Fixture> {
+  const root = realpathSync.native(await mkdtemp(join(tmpdir(), "reflection-runid-collision-")))
+  roots.push(root)
+  const identity: MemoryIdentity = { id: "agent-test", safeSlug: "agent-test", paths: buildIdentityPaths(root, "agent-test") }
+  const journal = new TranscriptJournal({ journalDir: join(identity.paths.transcripts, "conversation-a") })
+  await journal.reconcile([{ kind: "assistant", messageId: "assistant-1", textBlocks: ["one"] }])
+  return { identity, paths: identity.paths, journal }
+}
+
+/** A store wired the way identity-runtime wires it after the fix: ids scoped to persisted state. */
+function storeFor(state: Fixture): ReflectionReservationStore {
+  return new ReflectionReservationStore({
+    identity: state.identity,
+    config: { stepCount: 1, onCompaction: true },
+    getJournal: async (conversationId) => {
+      if (conversationId !== "conversation-a") throw new Error(`unknown conversation: ${conversationId}`)
+      return state.journal
+    },
+    createRunId: createReflectionRunIdFactory({ reflectionDir: state.paths.reflection }),
+  })
+}
+
+async function manualRequest(state: Fixture) {
+  const snapshot = await state.journal.captureReflectionSnapshot()
+  if (snapshot === null) throw new Error("expected a reflection snapshot")
+  return { trigger: "manual" as const, conversationIds: ["conversation-a"], snapshots: [{ conversationId: "conversation-a", snapshot }] }
+}
+
+/** Generation one's debris: a consumed failure record plus its run directory, as the issue found them. */
+async function seedStaleGeneration(reflectionDir: string): Promise<void> {
+  const completionsDir = join(reflectionDir, "completions")
+  await mkdir(completionsDir, { recursive: true, mode: 0o700 })
+  await mkdir(join(reflectionDir, "runs", "reflection-run-1"), { recursive: true, mode: 0o700 })
+  await writeFile(join(completionsDir, "reflection-run-1.json"), `${JSON.stringify({
+    schemaVersion: 1,
+    runId: "reflection-run-1",
+    identity: "agent-test",
+    category: "quick",
+    conversationIds: ["conversation-a"],
+    trigger: "step-count",
+    outcome: "failed",
+    reason: "child_exit",
+    detail: "bwrap: setting up uid map: Permission denied",
+    startedAt: "2026-08-22T10:07:00.000Z",
+    finishedAt: "2026-08-22T10:07:00.200Z",
+    durationMs: 200,
+    consecutiveFailures: 7,
+    delivery: { status: "consumed" },
+  }, null, 2)}\n`, "utf8")
+}
+
+describe("reflection run id collision across a counter reset", () => {
+  test("#given stale generation-one records #when fresh stores reserve across a simulated restart #then no persisted run id is ever reused", async () => {
+    // given
+    const state = await fixture()
+    await seedStaleGeneration(state.paths.reflection)
+
+    // when
+    const firstGeneration = storeFor(state)
+    const first = await firstGeneration.tryReserve(await manualRequest(state))
+    if (first.status !== "active") throw new Error("expected an active reservation")
+    await firstGeneration.complete(first.run.runId, "no_changes")
+    // The runner settle always publishes a completion record; generation one's is what wedged
+    // the lane in the issue, so it must be on disk before the restart.
+    await ensureReflectionCompletion(join(state.paths.reflection, "completions"), {
+      schemaVersion: 1,
+      runId: first.run.runId,
+      identity: "agent-test",
+      category: "quick",
+      conversationIds: ["conversation-a"],
+      trigger: "manual",
+      outcome: "no_changes",
+      startedAt: "2026-08-24T08:00:00.000Z",
+      finishedAt: "2026-08-24T08:01:00.000Z",
+      durationMs: 60_000,
+      consecutiveFailures: 0,
+      delivery: { status: "consumed" },
+    })
+    await state.journal.reconcile([{ kind: "assistant", messageId: "assistant-2", textBlocks: ["two"] }])
+
+    const secondGeneration = storeFor(state)
+    const second = await secondGeneration.tryReserve(await manualRequest(state))
+    if (second.status !== "active") throw new Error("expected an active reservation")
+
+    // then
+    expect(first.run.runId).not.toBe("reflection-run-1")
+    expect(second.run.runId).not.toBe("reflection-run-1")
+    expect(second.run.runId).not.toBe(first.run.runId)
+  })
+
+  test("#given a new generation run #when its completion is published #then it lands beside the stale record and the stale record is untouched", async () => {
+    // given
+    const state = await fixture()
+    await seedStaleGeneration(state.paths.reflection)
+    const staleBefore = await readFile(join(state.paths.reflection, "completions", "reflection-run-1.json"), "utf8")
+    const generation = storeFor(state)
+    const reserved = await generation.tryReserve(await manualRequest(state))
+    if (reserved.status !== "active") throw new Error("expected an active reservation")
+    const completionsDir = join(state.paths.reflection, "completions")
+
+    // when
+    await ensureReflectionCompletion(completionsDir, {
+      schemaVersion: 1,
+      runId: reserved.run.runId,
+      identity: "agent-test",
+      category: "quick",
+      conversationIds: ["conversation-a"],
+      trigger: "manual",
+      outcome: "merged",
+      startedAt: "2026-08-24T09:00:00.000Z",
+      finishedAt: "2026-08-24T09:01:00.000Z",
+      durationMs: 60_000,
+      consecutiveFailures: 0,
+      delivery: { status: "pending" },
+    })
+
+    // then
+    const published = JSON.parse(await readFile(
+      join(completionsDir, `${reserved.run.runId}.json`),
+      "utf8",
+    ))
+    expect(published).toMatchObject({ runId: reserved.run.runId, outcome: "merged" })
+    expect(await readFile(join(completionsDir, "reflection-run-1.json"), "utf8")).toBe(staleBefore)
+  })
+})

--- a/packages/omo-senpi/src/components/memory/reflection-run-id.test.ts
+++ b/packages/omo-senpi/src/components/memory/reflection-run-id.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { realpathSync } from "node:fs"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { createReflectionRunIdFactory } from "./reflection-run-id"
+
+const roots: string[] = []
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 }))))
+
+async function fixture(): Promise<string> {
+  const root = realpathSync.native(await mkdtemp(join(tmpdir(), "reflection-run-id-")))
+  roots.push(root)
+  return join(root, "reflection")
+}
+
+describe("disk-scoped reflection run ids", () => {
+  test("#given completion records and run directories left by an earlier generation #when a fresh process mints ids #then they continue above every persisted id", async () => {
+    // given
+    const reflectionDir = await fixture()
+    const completionsDir = join(reflectionDir, "completions")
+    const runsDir = join(reflectionDir, "runs")
+    await mkdir(completionsDir, { recursive: true, mode: 0o700 })
+    await mkdir(join(runsDir, "reflection-run-7"), { recursive: true, mode: 0o700 })
+    await writeFile(join(completionsDir, "reflection-run-13.json"), "{}\n", "utf8")
+
+    // when
+    const firstProcess = createReflectionRunIdFactory({ reflectionDir })
+    const first = await firstProcess()
+    await writeFile(join(completionsDir, `${first}.json`), "{}\n", "utf8")
+    const secondProcess = createReflectionRunIdFactory({ reflectionDir })
+    const second = await secondProcess()
+
+    // then
+    expect(first).toBe("reflection-run-14")
+    expect(second).toBe("reflection-run-15")
+  })
+
+  test("#given no reflection state on disk #when the first id is minted #then numbering starts at one", async () => {
+    // given
+    const reflectionDir = await fixture()
+
+    // when
+    const id = await createReflectionRunIdFactory({ reflectionDir })()
+
+    // then
+    expect(id).toBe("reflection-run-1")
+  })
+
+  test("#given names in the scanned directories that are not run ids #when minting #then they are ignored", async () => {
+    // given
+    const reflectionDir = await fixture()
+    const completionsDir = join(reflectionDir, "completions")
+    const runsDir = join(reflectionDir, "runs")
+    await mkdir(completionsDir, { recursive: true, mode: 0o700 })
+    await mkdir(runsDir, { recursive: true, mode: 0o700 })
+    await writeFile(join(completionsDir, "not-a-run.json"), "{}\n", "utf8")
+    await writeFile(join(completionsDir, "reflection-run-notanumber.json"), "{}\n", "utf8")
+    await mkdir(join(runsDir, "reflection-run-4"), { recursive: true, mode: 0o700 })
+
+    // when
+    const id = await createReflectionRunIdFactory({ reflectionDir })()
+
+    // then
+    expect(id).toBe("reflection-run-5")
+  })
+
+  test("#given a live reservation holding a run id no artifact records yet #when minting #then the live id is skipped too", async () => {
+    // given
+    const reflectionDir = await fixture()
+    await mkdir(reflectionDir, { recursive: true, mode: 0o700 })
+    await writeFile(join(reflectionDir, "active.lock"), `${JSON.stringify({
+      runId: "reflection-run-9",
+      request: { trigger: "step-count", conversationIds: ["conversation-a"], snapshots: [] },
+      reservedAt: "2026-08-24T09:00:00.000Z",
+    })}\n`, "utf8")
+
+    // when
+    const id = await createReflectionRunIdFactory({ reflectionDir })()
+
+    // then
+    expect(id).toBe("reflection-run-10")
+  })
+
+  test("#given repeated mints within one process #when nothing new lands on disk between them #then ids stay strictly increasing", async () => {
+    // given
+    const reflectionDir = await fixture()
+    const mint = createReflectionRunIdFactory({ reflectionDir })
+
+    // when
+    const ids = [await mint(), await mint(), await mint()]
+
+    // then
+    expect(ids).toEqual(["reflection-run-1", "reflection-run-2", "reflection-run-3"])
+  })
+})

--- a/packages/omo-senpi/src/components/memory/reflection-run-id.ts
+++ b/packages/omo-senpi/src/components/memory/reflection-run-id.ts
@@ -1,0 +1,39 @@
+import { readdir, readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+const RUN_ID_PATTERN = /^reflection-run-(\d+)(?:\.json)?$/
+const RUN_ID_TEXT_PATTERN = /reflection-run-(\d+)/g
+const RUN_ID_PREFIX = "reflection-run-"
+const RESERVATION_STATE_FILES = ["active.lock", "pending.json"] as const
+
+/**
+ * Mints reflection run ids the way the facts lane derives its attempt sequence: one past the
+ * highest id still ON DISK, across completion records, run directories, and the live
+ * reservation state alike. A per-process counter restarts at 1 on every launch, so a later
+ * generation re-mints a retired id, collides with that run's durable completion record
+ * ("Reflection completion record mismatch") and wedges the lane permanently. A name is handed
+ * back only once no trace of it survives, which is also what makes manual cleanup effective.
+ */
+export function createReflectionRunIdFactory(input: {
+  readonly reflectionDir: string
+}): () => Promise<string> {
+  let highWater = 0
+  return async () => {
+    for (const dir of [join(input.reflectionDir, "completions"), join(input.reflectionDir, "runs")]) {
+      const names = await readdir(dir).catch(() => [] as string[])
+      for (const name of names) {
+        const parsed = Number(RUN_ID_PATTERN.exec(name)?.[1] ?? Number.NaN)
+        if (Number.isInteger(parsed) && parsed > highWater) highWater = parsed
+      }
+    }
+    for (const name of RESERVATION_STATE_FILES) {
+      const contents = await readFile(join(input.reflectionDir, name), "utf8").catch(() => "")
+      for (const match of contents.matchAll(RUN_ID_TEXT_PATTERN)) {
+        const parsed = Number(match[1])
+        if (Number.isInteger(parsed) && parsed > highWater) highWater = parsed
+      }
+    }
+    highWater += 1
+    return `${RUN_ID_PREFIX}${highWater}`
+  }
+}


### PR DESCRIPTION
## What

Reflection run ids are no longer a per-process counter. A new `createReflectionRunIdFactory` mints each id as one past the highest id still on disk - scanning durable completion records (`runtime/reflection/completions/`), run directories, and the live reservation state files - and `ReflectionReservationStore` now mints the id inside the scheduler lock through an async factory, so two processes racing to reserve can never observe the same disk state and derive the same id.

## Why

#7095 (Defect 2): the per-process counter restarted at 1 on every launch. When the persisted reflection-sessions state was recreated (#7012), the next generation re-minted retired ids such as `reflection-run-1` while their consumed completion records were still on disk. Every subsequent launch and bind-time reconcile then aborted with `Reflection completion record mismatch for reflection-run-1`, finalization reported missing completions, and orphan memory worktrees/branches accumulated - permanently wedging the lane until manual cleanup of the lock, completion records, AND the stale run directory.

## Verified

- Failing-first: a scratch test wiring the pre-fix counter factory fails with the issue's literal error (`Reflection completion record mismatch for reflection-run-1`, thrown at `worker/completion-records.ts:15`); the scratch file was removed after capture.
- New regression coverage (given/when/then, co-located):
  - `reflection-run-id-collision.test.ts` - two generations reserving across a simulated restart never re-mint a persisted id; a new completion lands beside the stale record, which stays byte-identical.
  - `reflection-run-id.test.ts` - high-water semantics over completions/run dirs/live reservation state; non-run names ignored; strictly increasing within one process.
  - `reservation.test.ts` - an async run-id factory is awaited under the scheduler lock.
- `bun test packages/memory-core/src`: 545 pass / 0 fail.
- `bun test packages/omo-senpi/src/components/memory`: 907 pass, 6 skip / 0 fail.
- Typecheck clean: `packages/memory-core`, `packages/omo-senpi`.
- Evidence: `.omo/evidence/20260824-7095-runid-collision/QA.md`.

## Risk

Low. Ids only move forward and existing consumers treat run ids as opaque strings. Fresh installs still start at `reflection-run-1`. Cross-process uniqueness rides the existing `reflection-scheduler` lock, which now also covers minting.

Fixes #7095


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops reflection run-id collisions after restarts by replacing the per-process counter with a disk-scoped minting strategy. Previously the counter restarted at 1 and could re-mint retired ids, colliding with durable completion records and aborting launch/reconcile/finalization; now ids are minted one past the highest id on disk (completions, run directories, live reservation state) and minted inside the scheduler lock to prevent races.

- `packages/omo-senpi/src/components/memory/reflection-run-id.ts` adds `createReflectionRunIdFactory` (disk-scoped high-water minting, fresh installs start at `reflection-run-1`, strictly increasing within a process).
- `packages/memory-core/src/reflection/reservation.ts` mints the id under the scheduler lock and accepts an async `createRunId` (string or Promise<string>).
- Tests: new collision and factory suites in `packages/omo-senpi/src/components/memory`, plus a lock-await case in `packages/memory-core/src/reflection/reservation.test.ts`. QA evidence in `.omo/evidence/20260824-7095-runid-collision/QA.md`. Fixes #7095.

<sup>Written for commit 216bbd24346f48ba1739fc0fd6ea681d9103eb22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

