### PR TITLE
fix(omo): honor explicit permission/tools overrides on restricted subagents

### DIFF
--- a/.omo/evidence/20260824-6877-subagent-overrides/QA-EVIDENCE.md
+++ b/.omo/evidence/20260824-6877-subagent-overrides/QA-EVIDENCE.md
@@ -1,0 +1,56 @@
+# Evidence: issue #6877 - restricted subagent permission/tools overrides silently ignored
+
+Date: 2026-08-24
+Branch: issue/6877-restricted-subagent-overrides (base: dev @8833800ae)
+
+## WHAT WAS TESTED
+
+1. Failing-first proof of the regression tests against the unpatched base:
+   - `git stash push` of all 9 non-test source files, keeping
+     `packages/omo-opencode/src/shared/agent-tool-restrictions.test.ts` and the
+     updated `packages/omo-opencode/src/tools/delegate-task/tools.test.ts`.
+   - `bun test packages/omo-opencode/src/shared/agent-tool-restrictions.test.ts`
+   - `bun test packages/omo-opencode/src/tools/delegate-task/tools.test.ts -t "#6877"`
+   - `git stash pop` to restore the fix.
+2. Scoped unit suites after the fix:
+   - `bun test packages/omo-opencode/src/shared/agent-tool-restrictions.test.ts`
+   - `bun test packages/omo-opencode/src/tools/delegate-task/tools.test.ts`
+   - `bun test packages/omo-opencode/src/agents/tool-restrictions.test.ts`
+   - `bun test packages/omo-opencode/src/features/background-agent packages/omo-opencode/src/tools/call-omo-agent`
+3. Repo typecheck gate: `bun run typecheck` (tsgo --noEmit + typecheck:script + typecheck:packages).
+
+## WHAT WAS OBSERVED
+
+- Failing-first (fix stashed): agent-tool-restrictions.test.ts -> 0 pass / 1 fail / 1 error
+  (`buildAgentSpawnTools` does not exist on base); delegate-task #6877 filter -> 1 fail
+  (`result.session_read` undefined on base because allows were dropped).
+- After fix: agent-tool-restrictions.test.ts 9 pass / 0 fail; delegate-task tools.test.ts
+  136 pass / 0 fail; agents/tool-restrictions.test.ts 14 pass / 0 fail;
+  background-agent + call-omo-agent 812 pass / 0 fail (71 files).
+- `bun run typecheck`: all three stages completed with no errors.
+- One crash-recovery defect was found and fixed before verification: the e2e test
+  "categories.<name>.tools propagates to session tools end-to-end" asserted
+  `storedTools.read === true` without `read: true` in its fixture; fixture corrected.
+
+## WHY IT IS ENOUGH
+
+- The failing-first run proves both new test files detect the bug on the unpatched base
+  (missing export + dropped allow), so they are genuine regression guards, not tautologies.
+- The merge-order contract is pinned at three layers: the pure builder
+  (`buildAgentSpawnTools`: defaults < fixed restrictions < explicit user entries, with
+  task/question harness pins intact), the delegate-task sync path end-to-end through
+  `sendSyncPrompt`, and the call-omo-agent path via override extraction in tools.ts.
+- The 812-test background-agent + call-omo-agent sweep covers every consumer of the
+  changed launch-tools construction (manager launch, resume, fallback retry) for
+  regressions in the deny baseline.
+- Full repo typecheck proves no consumer of `LaunchInput.userPermission` (widened to
+  `AgentSpawnUserPermission`) was broken by the type change.
+
+## WHAT WAS OMITTED
+
+- Live OpenCode harness QA (opencode-qa skill: TUI smoke, SSE hook probe, DB isolation)
+  was not driven for this change; coverage is unit + typecheck level per the task's
+  expected outcome. Residual risk: runtime behavior of session.prompt `tools` maps is
+  covered indirectly by existing integration tests only.
+- No secrets, tokens, env dumps, or auth headers are present in this evidence; test
+  output contained none.

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -9,8 +9,8 @@ import {
 import { isSessionActive as isOpenCodeSessionActive } from "../../hooks/shared/session-idle-settle"
 import { resolveDispatchClient } from "../../shared/live-server-route"
 import {
+  buildAgentSpawnTools,
   createInternalAgentTextPart,
-  getAgentToolRestrictions,
   hasInternalInitiatorMarker,
   isAmbiguousPostDispatchPromptFailure,
   log,
@@ -886,22 +886,9 @@ The fallback retry session is now created and can be inspected directly.
       applySessionPromptParams(sessionID, input.model)
     }
 
-    const userDenied: Record<string, boolean> = {}
-    if (input.userPermission) {
-      for (const [tool, value] of Object.entries(input.userPermission)) {
-        if (value === "deny") userDenied[tool] = false
-      }
-    }
-
-    const launchTools = {
-      task: false,
-      call_omo_agent: true,
-      question: false,
-      ...userDenied,
-      ...getAgentToolRestrictions(input.agent, {
-        includeTeamToolDenylist: input.teamRunId === undefined,
-      }),
-    }
+    const launchTools = buildAgentSpawnTools(input.agent, input.userPermission, {
+      includeTeamToolDenylist: input.teamRunId === undefined,
+    })
     setSessionTools(sessionID, launchTools)
 
     log("[background-agent] Launching task:", { taskId: task.id, sessionID, agent: input.agent })
@@ -1397,14 +1384,9 @@ The fallback retry session is now created and can be inspected directly.
           ...(resumeModel ? { model: resumeModel } : {}),
           ...(resumeVariant ? { variant: resumeVariant } : {}),
           tools: (() => {
-            const tools = {
-              task: false,
-              call_omo_agent: true,
-              question: false,
-              ...getAgentToolRestrictions(existingTask.agent, {
-                includeTeamToolDenylist: existingTask.teamRunId === undefined,
-              }),
-            }
+            const tools = buildAgentSpawnTools(existingTask.agent, undefined, {
+              includeTeamToolDenylist: existingTask.teamRunId === undefined,
+            })
             setSessionTools(existingTask.sessionId!, tools)
             return tools
           })(),

--- a/packages/omo-opencode/src/features/background-agent/spawner/task-prompt-body.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner/task-prompt-body.ts
@@ -1,4 +1,4 @@
-import { createInternalAgentTextPart, getAgentToolRestrictions } from "../../../shared"
+import { buildAgentSpawnTools, createInternalAgentTextPart, type AgentSpawnUserPermission } from "../../../shared"
 import type { LaunchInput } from "../types"
 
 type PromptModel = LaunchInput["model"]
@@ -11,6 +11,7 @@ type TaskPromptBodyOptions =
       readonly system: LaunchInput["skillContent"]
       readonly prompt: string
       readonly includeTeamToolDenylist: boolean
+      readonly userPermission?: AgentSpawnUserPermission
     }
   | {
       readonly kind: "resume"
@@ -18,6 +19,7 @@ type TaskPromptBodyOptions =
       readonly model: PromptModel
       readonly prompt: string
       readonly includeTeamToolDenylist: boolean
+      readonly userPermission?: AgentSpawnUserPermission
     }
 
 export type TaskPromptBody = {
@@ -50,14 +52,9 @@ export function buildTaskPromptBody(options: TaskPromptBodyOptions): TaskPromptB
     ...(promptModel ? { model: promptModel } : {}),
     ...(promptVariant ? { variant: promptVariant } : {}),
     ...(options.kind === "launch" ? { system: options.system } : {}),
-    tools: {
-      task: false,
-      call_omo_agent: true,
-      question: false,
-      ...getAgentToolRestrictions(options.agent, {
-        includeTeamToolDenylist: options.includeTeamToolDenylist,
-      }),
-    },
+    tools: buildAgentSpawnTools(options.agent, options.userPermission, {
+      includeTeamToolDenylist: options.includeTeamToolDenylist,
+    }),
     parts: [createInternalAgentTextPart(options.prompt)],
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/types.ts
+++ b/packages/omo-opencode/src/features/background-agent/types.ts
@@ -1,3 +1,4 @@
+import type { AgentSpawnUserPermission } from "../../shared/agent-tool-restrictions"
 import type { FallbackEntry } from "../../shared/model-requirements"
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import type { SessionPermissionRule } from "../../shared/question-denied-session-permission"
@@ -129,8 +130,8 @@ export interface LaunchInput {
   category?: string
   sessionPermission?: SessionPermissionRule[]
   onSessionCreated?: (sessionId: string) => void | Promise<void>
-  /** User tool overrides (ask/allow/deny) from category or agent config. Merged into launchTools before hardcoded restrictions. */
-  userPermission?: Record<string, "ask" | "allow" | "deny">
+  /** User tool overrides (ask/allow/deny, legacy booleans) from category or agent config. Merged after fixed restrictions per issue #6877. */
+  userPermission?: AgentSpawnUserPermission
 }
 
 export interface ResumeInput {

--- a/packages/omo-opencode/src/shared/agent-tool-restrictions.test.ts
+++ b/packages/omo-opencode/src/shared/agent-tool-restrictions.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test"
+import { buildAgentSpawnTools, getAgentToolRestrictions } from "./agent-tool-restrictions"
+
+describe("buildAgentSpawnTools", () => {
+  describe("#given a restricted subagent with no user overrides", () => {
+    test("#then fixed restrictions stay intact (issue #6877 regression guard)", () => {
+      // given
+      const agent = "explore"
+
+      // when
+      const tools = buildAgentSpawnTools(agent)
+
+      // then
+      expect(tools.write).toBe(false)
+      expect(tools.edit).toBe(false)
+      expect(tools.task).toBe(false)
+      expect(tools.call_omo_agent).toBe(false)
+      expect(tools.question).toBe(false)
+    })
+
+    test("#then multimodal-looker keeps its narrow baseline", () => {
+      // given
+      const agent = "multimodal-looker"
+
+      // when
+      const tools = buildAgentSpawnTools(agent)
+
+      // then
+      expect(tools.read).toBe(true)
+      expect(tools.grep).toBeUndefined()
+    })
+  })
+
+  describe("#given an explicit user allow for a denied plugin tool", () => {
+    test("#then the allow punches through the restriction table (issue #6877)", () => {
+      // given
+      const userPermission = {
+        session_read: "allow",
+        session_search: "allow",
+        session_list: "allow",
+        session_info: "allow",
+      } as Record<string, "allow" | "ask" | "deny">
+
+      // when
+      const tools = buildAgentSpawnTools("explore", userPermission)
+
+      // then
+      expect(tools.session_read).toBe(true)
+      expect(tools.session_search).toBe(true)
+      expect(tools.session_list).toBe(true)
+      expect(tools.session_info).toBe(true)
+    })
+
+    test("#then multimodal-looker honors the grant while keeping other denies", () => {
+      // given
+      const userPermission = { grep: "allow" } as Record<string, "allow" | "ask" | "deny">
+
+      // when
+      const tools = buildAgentSpawnTools("multimodal-looker", userPermission)
+
+      // then
+      expect(tools.grep).toBe(true)
+      expect(tools.read).toBe(true)
+    })
+  })
+
+  describe("#given an explicit user deny", () => {
+    test("#then the deny is preserved on top of the baseline", () => {
+      // given
+      const userPermission = { grep: "deny" } as Record<string, "allow" | "ask" | "deny">
+
+      // when
+      const tools = buildAgentSpawnTools("librarian", userPermission)
+
+      // then
+      expect(tools.grep).toBe(false)
+      expect(tools.write).toBe(false)
+    })
+  })
+
+  describe("#given a user ask value", () => {
+    test("#then ask does not flip the boolean baseline (tools map cannot express ask)", () => {
+      // given
+      const userPermission = { write: "ask", grep: "ask" } as Record<string, "allow" | "ask" | "deny">
+
+      // when
+      const tools = buildAgentSpawnTools("explore", userPermission)
+
+      // then
+      expect(tools.write).toBe(false)
+      expect(tools.grep).toBeUndefined()
+    })
+  })
+
+  describe("#given legacy boolean tools config", () => {
+    test("#then booleans migrate to permission semantics before merging", () => {
+      // given
+      const userTools = { session_read: true, webfetch: false }
+
+      // when
+      const tools = buildAgentSpawnTools("explore", userTools)
+
+      // then
+      expect(tools.session_read).toBe(true)
+      expect(tools.webfetch).toBe(false)
+    })
+  })
+
+  describe("#given harness integrity pins", () => {
+    test("#then task and question stay denied even when the user allows them", () => {
+      // given
+      const userPermission = { task: "allow", question: "allow" } as Record<string, "allow" | "ask" | "deny">
+
+      // when
+      const tools = buildAgentSpawnTools("explore", userPermission)
+
+      // then
+      expect(tools.task).toBe(false)
+      expect(tools.question).toBe(false)
+    })
+  })
+
+  describe("#given includeTeamToolDenylist option", () => {
+    test("#then team denylist entries are dropped when the flag is false", () => {
+      // given / when
+      const withTeam = buildAgentSpawnTools("sisyphus-junior", undefined, { includeTeamToolDenylist: false })
+      const withoutFlag = getAgentToolRestrictions("sisyphus-junior")
+
+      // then
+      expect(withTeam.team_create).toBeUndefined()
+      expect(withoutFlag.team_create).toBe(false)
+    })
+  })
+})

--- a/packages/omo-opencode/src/shared/agent-tool-restrictions.ts
+++ b/packages/omo-opencode/src/shared/agent-tool-restrictions.ts
@@ -1,4 +1,5 @@
 import { stripInvisibleAgentCharacters } from "./agent-display-names"
+import type { PermissionValue } from "./permission-compat"
 
 /**
  * Agent tool restrictions for session.prompt calls.
@@ -78,4 +79,57 @@ export function getAgentToolRestrictions(agentName: string, options: AgentToolRe
 export function hasAgentToolRestrictions(agentName: string): boolean {
   const restrictions = getAgentToolRestrictions(agentName)
   return Object.keys(restrictions).length > 0
+}
+
+export type AgentSpawnUserPermission = Record<string, PermissionValue | boolean>
+
+type AgentSpawnToolsOptions = AgentToolRestrictionsOptions & {
+  allowTask?: boolean
+}
+
+const HARNESS_PINNED_TOOLS = ["question"] as const
+
+/**
+ * Builds the `tools` map for a delegated subagent session prompt.
+ *
+ * Merge order (issue #6877): operational defaults, then the agent's fixed
+ * restriction table, then explicit user permission entries LAST so a user
+ * grant (`"allow"` / `true`) punches through the restricted baseline and a
+ * user deny stays denied. `task` keeps its caller-supplied operational value
+ * unless the user explicitly denies it, and `question` always stays false,
+ * matching the #5182/#5193 contract where hardcoded delegation-loop guards win.
+ */
+export function buildAgentSpawnTools(
+  agentName: string,
+  userPermission?: AgentSpawnUserPermission,
+  options: AgentSpawnToolsOptions = {},
+): Record<string, boolean> {
+  const operationalTask = options.allowTask ?? false
+  const tools: Record<string, boolean> = {
+    task: operationalTask,
+    call_omo_agent: true,
+    question: false,
+    ...getAgentToolRestrictions(agentName, options),
+  }
+
+  let userDeniedTask = false
+  if (userPermission) {
+    for (const [tool, value] of Object.entries(userPermission)) {
+      const permission: PermissionValue | undefined = typeof value === "boolean"
+        ? (value ? "allow" : "deny")
+        : value
+      if (permission === "allow") tools[tool] = true
+      if (permission === "deny") {
+        tools[tool] = false
+        if (tool === "task") userDeniedTask = true
+      }
+    }
+  }
+
+  tools.task = userDeniedTask ? false : operationalTask
+  for (const tool of HARNESS_PINNED_TOOLS) {
+    tools[tool] = false
+  }
+
+  return tools
 }

--- a/packages/omo-opencode/src/tools/call-omo-agent/background-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/background-executor.ts
@@ -2,6 +2,7 @@ import type { CallOmoAgentArgs } from "./types"
 import type { BackgroundManager } from "../../features/background-agent"
 import type { PluginInput } from "@opencode-ai/plugin"
 import { log } from "../../shared"
+import type { AgentSpawnUserPermission } from "../../shared/agent-tool-restrictions"
 import type { DelegatedModelConfig } from "../../shared/model-resolution-types"
 import type { FallbackEntry } from "../../shared/model-requirements"
 import { resolveMessageContext } from "../../features/hook-message-injector"
@@ -24,6 +25,7 @@ export async function executeBackground(
   client: PluginInput["client"],
   fallbackChain?: FallbackEntry[],
   model?: DelegatedModelConfig,
+  userPermission?: AgentSpawnUserPermission,
 ): Promise<string> {
   try {
     const messageDir = getMessageDir(toolContext.sessionID)
@@ -56,6 +58,7 @@ export async function executeBackground(
       parentTools: getSessionTools(toolContext.sessionID),
       model,
       fallbackChain,
+      userPermission,
     })
 
     const WAIT_FOR_SESSION_INTERVAL_MS = 50

--- a/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/sync-executor.ts
@@ -1,7 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { clearSessionAgent, handedBackSyncSessions, setSessionAgent, subagentSessions, syncSubagentSessions } from "../../features/claude-code-session-state"
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../hooks/shared/prompt-async-gate"
-import { getAgentToolRestrictions, isAmbiguousPostDispatchPromptFailure, log } from "../../shared"
+import { buildAgentSpawnTools, type AgentSpawnUserPermission, isAmbiguousPostDispatchPromptFailure, log } from "../../shared"
 import { normalizeAgentForPrompt, stripAgentListSortPrefix } from "../../shared/agent-display-names"
 import {
   clearDelegatedChildSessionBootstrap,
@@ -63,12 +63,8 @@ function buildPromptGenerationParams(model: DelegatedModelConfig | undefined): R
   }
 }
 
-function buildSyncPromptTools(agent: string): Record<string, boolean> {
-  return {
-    ...getAgentToolRestrictions(agent),
-    task: false,
-    question: false,
-  }
+function buildSyncPromptTools(agent: string, userPermission?: AgentSpawnUserPermission): Record<string, boolean> {
+  return buildAgentSpawnTools(agent, userPermission)
 }
 
 export async function executeSync(
@@ -85,6 +81,7 @@ export async function executeSync(
   fallbackChain?: FallbackEntry[],
   spawnReservation?: SpawnReservation,
   model?: DelegatedModelConfig,
+  userPermission?: AgentSpawnUserPermission,
 ): Promise<string> {
   let sessionID: string | undefined
   let createdSessionForExecution = false
@@ -120,7 +117,7 @@ export async function executeSync(
     log(`[call_omo_agent] Prompt text:`, args.prompt.substring(0, 100))
     const normalizedSubagentType = stripAgentListSortPrefix(args.subagent_type)
     const promptAgent = normalizeAgentForPrompt(normalizedSubagentType) ?? normalizedSubagentType
-    const promptTools = buildSyncPromptTools(normalizedSubagentType)
+    const promptTools = buildSyncPromptTools(normalizedSubagentType, userPermission)
     setSessionAgent(sessionID, promptAgent)
     setSessionTools(sessionID, promptTools)
     registerDelegatedChildSessionBootstrap({

--- a/packages/omo-opencode/src/tools/call-omo-agent/tools.ts
+++ b/packages/omo-opencode/src/tools/call-omo-agent/tools.ts
@@ -12,6 +12,7 @@ import { normalizeFallbackModels } from "../../shared/model-resolver"
 import { buildFallbackChainFromModels } from "../../shared/fallback-chain-from-models"
 import { log } from "../../shared"
 import { parseModelString } from "../../shared"
+import { migrateAgentConfig } from "../../shared/permission-compat"
 import { executeBackground } from "./background-executor"
 import { executeSync } from "./sync-executor"
 import { resolveCallableAgents } from "./agent-resolver"
@@ -183,11 +184,18 @@ export function createCallOmoAgent(
         userCategories,
       })
 
+      const overrideEntry = agentOverrides?.[args.subagent_type]
+        ?? Object.entries(agentOverrides ?? {}).find(([key]) => key.toLowerCase() === args.subagent_type.toLowerCase())?.[1]
+      const migratedOverride = overrideEntry
+        ? migrateAgentConfig(overrideEntry as Record<string, unknown>)
+        : undefined
+      const overridePermission = migratedOverride?.permission as Record<string, "ask" | "allow" | "deny"> | undefined
+
       if (args.run_in_background) {
         if (args.session_id) {
           return `Error: session_id is not supported in background mode. Use run_in_background=false to continue an existing session.`;
         }
-        return await executeBackground(args, toolCtx, backgroundManager, ctx.client, fallbackChain, resolvedModel)
+        return await executeBackground(args, toolCtx, backgroundManager, ctx.client, fallbackChain, resolvedModel, overridePermission)
       }
 
       if (!args.session_id) {
@@ -202,6 +210,7 @@ export function createCallOmoAgent(
             fallbackChain,
             spawnReservation,
             resolvedModel,
+            overridePermission,
           )
         } catch (error) {
           spawnReservation?.rollback()
@@ -217,6 +226,7 @@ export function createCallOmoAgent(
         fallbackChain,
         undefined,
         resolvedModel,
+        overridePermission,
       )
     },
   });

--- a/packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts
@@ -4,7 +4,7 @@ import { getDeliverableTag, isPlanFamily } from "./constants"
 import { handedBackSyncSessions } from "../../features/claude-code-session-state"
 import { publishToolMetadata } from "../../features/tool-metadata-store"
 import { getTaskToastManager } from "../../features/task-toast-manager"
-import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
+import { buildAgentSpawnTools } from "../../shared/agent-tool-restrictions"
 import { getMessageDir, normalizeSDKResponse } from "../../shared"
 import { promptWithModelSuggestionRetry } from "../../shared/model-suggestion-retry"
 import { resolveMessageContext } from "../../features/hook-message-injector"
@@ -156,12 +156,9 @@ export async function executeSyncContinuation(
     const allowTask = isPlanFamily(resumeAgent)
     const tddEnabled = sisyphusAgentConfig?.tdd
     const effectivePrompt = buildTaskPrompt(args.prompt, resumeAgent, tddEnabled)
-    const tools = {
-      task: allowTask,
-      call_omo_agent: true,
-      question: false,
-      ...(resumeAgent ? getAgentToolRestrictions(resumeAgent) : {}),
-    }
+    const tools = resumeAgent
+      ? buildAgentSpawnTools(resumeAgent, undefined, { allowTask })
+      : { task: allowTask, call_omo_agent: true, question: false }
     setSessionTools(continuationID, tools)
 
     await promptWithModelSuggestionRetry(client, {

--- a/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-prompt-sender.ts
@@ -1,6 +1,6 @@
 import type { SisyphusAgentConfig } from "../../config/schema"
 import { stripInvisibleAgentCharacters } from "../../shared/agent-display-names"
-import { getAgentToolRestrictions } from "../../shared/agent-tool-restrictions"
+import { buildAgentSpawnTools, type AgentSpawnUserPermission } from "../../shared/agent-tool-restrictions"
 import { createInternalAgentTextPart } from "../../shared/internal-initiator-marker"
 import {
   promptWithModelSuggestionRetry,
@@ -54,19 +54,9 @@ export function buildSyncPromptTools(
   agentToUse: string,
   permission?: Record<string, "ask" | "allow" | "deny">,
 ): Record<string, boolean> {
-  const userDenied: Record<string, boolean> = {}
-  if (permission) {
-    for (const [tool, value] of Object.entries(permission)) {
-      if (value === "deny") userDenied[tool] = false
-    }
-  }
-  return {
-    task: isPlanFamily(agentToUse),
-    call_omo_agent: true,
-    question: false,
-    ...userDenied,
-    ...getAgentToolRestrictions(agentToUse),
-  }
+  return buildAgentSpawnTools(agentToUse, permission as AgentSpawnUserPermission | undefined, {
+    allowTask: isPlanFamily(agentToUse),
+  })
 }
 
 export async function sendSyncPrompt(

--- a/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tools.test.ts
@@ -4805,11 +4805,11 @@ describe("buildSyncPromptTools (issue #5182)", () => {
   })
 
   test("categories.<name>.tools propagates to session tools end-to-end (issue #5182)", async () => {
-    // #given a categoryModel with tools restriction
+    // #given a categoryModel with tools restriction and an explicit allow
     const categoryModel = {
       providerID: "anthropic",
       modelID: "claude-sonnet-4-6",
-      tools: { grep: false, glob: false },
+      tools: { grep: false, glob: false, read: true },
     }
 
     const mockPromptResolve = () => Promise.resolve()
@@ -4858,8 +4858,29 @@ describe("buildSyncPromptTools (issue #5182)", () => {
     // unconditionally allowed tools remain unchanged
     expect(storedTools!.call_omo_agent).toBe(true)
     expect(storedTools!.question).toBe(false)
-    // buildSyncPromptTools only processes denials, not allows,
-    // so read:true from tools config does not appear in the result
-    expect(storedTools!.read).toBeUndefined()
+    // user allows must now punch through restricted baselines (issue #6877):
+    // tools config read:true migrates to an allow and lands in the session tools
+    expect(storedTools!.read).toBe(true)
+  })
+
+  test("user allow overrides fixed restriction baseline on restricted subagents (issue #6877)", () => {
+    // #given - explore denies write/edit/task/call_omo_agent via its fixed table,
+    //          and the user grants a plugin-registered session tool
+    const { buildSyncPromptTools } = require("./sync-prompt-sender")
+    const userPermission = {
+      session_read: "allow",
+      write: "deny",
+    }
+
+    // #when buildSyncPromptTools merges the user permission for explore
+    const result = buildSyncPromptTools("explore", userPermission)
+
+    // #then the explicit allow punches through the restriction table...
+    expect(result.session_read).toBe(true)
+    // ...the explicit deny is preserved...
+    expect(result.write).toBe(false)
+    // ...and harness integrity pins still hold
+    expect(result.task).toBe(false)
+    expect(result.question).toBe(false)
   })
 })


### PR DESCRIPTION
## What

Restricted subagents (explore, librarian, oracle, ...) silently ignored user-configured `permission` / `tools` overrides. Every spawn site built its session tool map as:

```ts
{ task: false, call_omo_agent: true, question: false, ...userDenied, ...getAgentToolRestrictions(agent) }
```

Two defects: the fixed restriction table was spread **last**, clobbering user entries, and only `"deny"` values were ever read, so an explicit allow could never land.

This PR centralizes the construction in a new `buildAgentSpawnTools()` (`packages/omo-opencode/src/shared/agent-tool-restrictions.ts`) with the merge contract:

1. operational defaults (`task`, `call_omo_agent`, `question`)
2. the agent's fixed restriction table
3. explicit user entries **last** — `allow`/`true` → `true`, `deny`/`false` → `false`, `ask` → no-op (the boolean tools map cannot express ask)
4. harness pins stay authoritative: `task` keeps its caller-supplied operational value unless the user explicitly denies it, and `question` stays `false` (#5182/#5193 delegation-loop guards)

Wired through all spawn sites: background launch/resume/fallback-retry (`BackgroundManager`), delegate-task sync prompt + continuation, and both `call_omo_agent` executors. Per-agent overrides are now extracted from agent config in `call-omo-agent/tools.ts` via `migrateAgentConfig()`, so legacy `tools: { read: true }` booleans migrate to permission semantics before merging. `LaunchInput.userPermission` widened to `AgentSpawnUserPermission` to carry legacy booleans end to end.

## Why

Issue #6877: users granting a restricted subagent an explicit tool override got a silent no-op with no diagnostic. Per the issue discussion, this implementation honors explicit user overrides (allow punches through the fixed deny baseline; deny stays denied; harness integrity pins remain non-overridable), which keeps the delegation-loop guards of #5182/#5193 intact while making user intent effective.

## Verified

- Failing-first: with the fix stashed, the new regression tests fail on base (`buildAgentSpawnTools` missing; `session_read` allow dropped); with the fix applied they pass.
- `bun test packages/omo-opencode/src/shared/agent-tool-restrictions.test.ts` → 9 pass (given/when/then: baseline intact, allow punch-through, deny preserved, ask no-op, legacy booleans, harness pins, team-denylist flag).
- `bun test packages/omo-opencode/src/tools/delegate-task/tools.test.ts` → 136 pass (incl. updated #5182 e2e now asserting allow propagation).
- `bun test packages/omo-opencode/src/agents/tool-restrictions.test.ts` → 14 pass.
- `bun test packages/omo-opencode/src/features/background-agent packages/omo-opencode/src/tools/call-omo-agent` → 812 pass across 71 files.
- `bun run typecheck` (tsgo --noEmit + script + all workspace packages) → green.
- QA evidence recorded at `.omo/evidence/20260824-6877-subagent-overrides/QA-EVIDENCE.md`.

## Risk

Low-to-moderate, behavioral by design: user allows now take effect on restricted subagents (that is the fix). Deny baselines still win for anything the user does not explicitly set, and `task`/`question` pins are unchanged, so delegation-loop invariants hold. The only type-surface change is widening `LaunchInput.userPermission`; all consumers flow into `buildAgentSpawnTools`.

Fixes #6877

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors explicit permission/tools overrides on restricted subagents so an explicit user allow now takes effect. Previously, spawn sites applied fixed restrictions last and only processed denies, so allows were silently dropped (addresses #6877).

- Introduces `buildAgentSpawnTools(agent, userPermission, { includeTeamToolDenylist, allowTask })` in `packages/omo-opencode/src/shared/agent-tool-restrictions.ts` with merge order: operational defaults (`task=false`, `call_omo_agent=true`, `question=false`) → fixed agent restrictions → explicit user entries last (allow/true → true, deny/false → false, ask → no-op). Harness pins remain: `task` keeps its operational value unless explicitly denied; `question` always false.
- Replaces ad-hoc tool-map assembly across background launch/resume/fallback, delegate-task sync prompt and continuation, and both `call_omo_agent` executors; all session tools now come from the builder.
- Migrates per-agent overrides in `call-omo-agent/tools.ts` via `migrateAgentConfig()` so legacy `tools` booleans convert to permission semantics before merging.
- Widens `LaunchInput.userPermission` to `AgentSpawnUserPermission` to carry legacy booleans; usage flows only into the builder.
- Adds focused regression tests asserting allow punch-through and preserves deny baselines; existing suites for background agent and `call_omo_agent` remain green.

<sup>Written for commit 19b5761d45eb6271e04b7016ab53280c6b260cb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

