### PR TITLE
fix(omo-senpi): recover claude-sdk-oauth account slots on re-login

### DIFF
--- a/.omo/evidence/20260824-7084-oauth-slots/after-fix-green.txt
+++ b/.omo/evidence/20260824-7084-oauth-slots/after-fix-green.txt
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 10 pass
+ 0 fail
+ 29 expect() calls
+Ran 10 tests across 1 file. [925.00ms]

--- a/.omo/evidence/20260824-7084-oauth-slots/before-fix-red.txt
+++ b/.omo/evidence/20260824-7084-oauth-slots/before-fix-red.txt
@@ -1,0 +1,108 @@
+bun test v1.3.14 (0d9b296a)
+
+packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:
+116 | 
+117 | describe("engine claude-sdk-oauth slot recovery (issue #7084)", () => {
+118 |   describe("#given the pinned senpi accounts module", () => {
+119 |     test("#then it exposes an upsert that replaces a same-name slot in place", async () => {
+120 |       const accounts = await describeAccounts()
+121 |       expect(typeof accounts.upsertAccount).toBe("function")
+                                                  ^
+error: expect(received).toBe(expected)
+
+Expected: "function"
+Received: "undefined"
+
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:121:45)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given the pinned senpi accounts module > #then it exposes an upsert that replaces a same-name slot in place [6.58ms]
+137 |       accounts.assertSentinelInvariant(next)
+138 |     })
+139 | 
+140 |     test("#then an unknown name still appends so explicit multi-account keeps working", async () => {
+141 |       const accounts = await describeAccounts()
+142 |       const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))
+                                     ^
+TypeError: accounts.upsertAccount is not a function. (In 'accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))', 'accounts.upsertAccount' is undefined)
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:142:32)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given the pinned senpi accounts module > #then an unknown name still appends so explicit multi-account keeps working [0.37ms]
+151 | 
+152 |   describe("#given a single logged-in Claude account #when /login succeeds again without an explicit new name", () => {
+153 |     test("#then the existing slot is refreshed in place instead of appending account-N+1", async () => {
+154 |       const accounts = await describeAccounts()
+155 |       const oauthLogin = await describeOAuthLogin()
+156 |       const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))
+                                     ^
+TypeError: accounts.upsertAccount is not a function. (In 'accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))', 'accounts.upsertAccount' is undefined)
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:156:32)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given a single logged-in Claude account #when /login succeeds again without an explicit new name > #then the existing slot is refreshed in place instead of appending account-N+1 [5.23ms]
+173 |     })
+174 | 
+175 |     test("#then a dead auth_error slot comes back live after re-login", async () => {
+176 |       const accounts = await describeAccounts()
+177 |       const oauthLogin = await describeOAuthLogin()
+178 |       const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a", { blockReason: "auth_error" }))
+                                     ^
+TypeError: accounts.upsertAccount is not a function. (In 'accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a", { blockReason: "auth_error" }))', 'accounts.upsertAccount' is undefined)
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:178:32)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given a single logged-in Claude account #when /login succeeds again without an explicit new name > #then a dead auth_error slot comes back live after re-login [0.40ms]
+193 | 
+194 |     test("#then accepting the prompt placeholder recovers the newest login slot instead of minting account-N+1", async () => {
+195 |       const accounts = await describeAccounts()
+196 |       const oauthLogin = await describeOAuthLogin()
+197 |       const imported = { ...loginSlot("imported-anthropic", "i"), source: "import" as const }
+198 |       const withImport = accounts.upsertAccount(accounts.emptyCredential(), imported)
+                                        ^
+TypeError: accounts.upsertAccount is not a function. (In 'accounts.upsertAccount(accounts.emptyCredential(), imported)', 'accounts.upsertAccount' is undefined)
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:198:35)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given a single logged-in Claude account #when /login succeeds again without an explicit new name > #then accepting the prompt placeholder recovers the newest login slot instead of minting account-N+1 [0.84ms]
+220 |     })
+221 | 
+222 |     test("#then a typed brand-new name still adds a second account", async () => {
+223 |       const accounts = await describeAccounts()
+224 |       const oauthLogin = await describeOAuthLogin()
+225 |       const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))
+                                     ^
+TypeError: accounts.upsertAccount is not a function. (In 'accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))', 'accounts.upsertAccount' is undefined)
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:225:32)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given a single logged-in Claude account #when /login succeeds again without an explicit new name > #then a typed brand-new name still adds a second account [0.42ms]
+241 |   describe("#given failover classifies an authentication failure", () => {
+242 |     test("#then the auth_error stamp carries an expiry instead of blocking forever", async () => {
+243 |       const accounts = await describeAccounts()
+244 |       const failover = await describeFailover()
+245 |       const now = 1_000_000
+246 |       const store = createInMemoryStore(accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a")))
+                                                       ^
+TypeError: accounts.upsertAccount is not a function. (In 'accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))', 'accounts.upsertAccount' is undefined)
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:246:50)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given failover classifies an authentication failure > #then the auth_error stamp carries an expiry instead of blocking forever [1.67ms]
+62 |     // against the cleared view before reporting the earliest available account.
+63 |     const cleared = clearExpiredBlocks(accounts, now);
+64 |     const afterClear = selectUnblocked(cleared, options, now);
+65 |     if (afterClear)
+66 |         return afterClear;
+67 |     throw new AllAccountsBlockedError(soonestUnblockAt(accounts, now));
+               ^
+AllAccountsBlockedError: All Claude SDK OAuth accounts are blocked until re-login.
+ soonestUnblockAt: undefined,
+
+      at selectAccount (/home/viprix/projects/oom-wt-7084/node_modules/.bun/@code-yeongyu+senpi@2026.8.23+3aa9f84f7136ce5f/node_modules/@code-yeongyu/senpi/dist/core/extensions/builtin/claude-sdk-oauth/affinity.js:67:11)
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:284:33)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given affinity selection over blocked slots > #then an elapsed auth_error stamp no longer blocks selection [0.95ms]
+294 | 
+295 |       // when expired blocks are cleared at any time
+296 |       const cleared = affinity.clearExpiredBlocks([legacyStamp], 5_000_000)
+297 | 
+298 |       // then the permanent legacy stamp is gone
+299 |       expect(cleared[0]?.blockReason).toBeUndefined()
+                                            ^
+error: expect(received).toBeUndefined()
+
+Received: "auth_error"
+
+      at <anonymous> (/home/viprix/projects/oom-wt-7084/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts:299:39)
+(fail) engine claude-sdk-oauth slot recovery (issue #7084) > #given affinity selection over blocked slots > #then clearing blocks also cleans legacy auth_error stamps that never had an expiry [0.35ms]
+
+ 1 pass
+ 9 fail
+ 4 expect() calls
+Ran 10 tests across 1 file. [278.00ms]

--- a/.omo/evidence/20260824-7084-oauth-slots/pin-tests.txt
+++ b/.omo/evidence/20260824-7084-oauth-slots/pin-tests.txt
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 15 pass
+ 0 fail
+ 21 expect() calls
+Ran 15 tests across 2 files. [970.00ms]

--- a/.omo/evidence/20260824-7084-oauth-slots/purity-shape.txt
+++ b/.omo/evidence/20260824-7084-oauth-slots/purity-shape.txt
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 5 pass
+ 0 fail
+ 27 expect() calls
+Ran 5 tests across 2 files. [1265.00ms]

--- a/.omo/evidence/20260824-7084-oauth-slots/qa.md
+++ b/.omo/evidence/20260824-7084-oauth-slots/qa.md
@@ -1,0 +1,84 @@
+# QA Evidence — Issue #7084: claude-sdk-oauth login appends slots; auth_error never expires
+
+Date: 2026-08-24 · Worktree: `/home/viprix/projects/oom-wt-7084` · Branch: `issue/7084-claude-sdk-oauth-slots`
+
+Final re-verification (same day, after evidence consolidation): regression suite 10 pass / 0 fail
+(`after-fix-green.txt`), scoped typecheck exit 0 (`typecheck-omo-senpi.txt`), manifest pin tests
+15 pass (`pin-tests.txt`), bundle purity + package shape 5 pass (`purity-shape.txt`).
+
+## WHAT WAS TESTED
+
+The two defect surfaces named in the issue, at module level, against the exact-pinned engine
+dependency `@code-yeongyu/senpi@2026.8.23` (the claude-sdk-oauth slot/failover/affinity plumbing
+ships inside that dependency; repo-wide greps prove none of it exists in workspace sources):
+
+1. **Bug 1 — login appends slots** (`dist/core/extensions/builtin/claude-sdk-oauth/oauth-login.js`
+   L24-33/L113 + `accounts.js` L29-35): `promptAccountName()` defaulted every re-login to a fresh
+   `account-${n+1}` and `login()` always `addAccount`ed (append-only, throws on duplicate names).
+2. **Bug 2 — auth_error never expires** (`failover.js` L48-52 stripped `blockedUntil` for
+   `auth_error`; `affinity.js` L28-40 short-circuited `isBlocked` on the reason string and
+   `clearExpiredBlocks` deliberately retained auth stamps forever).
+
+Surface driven: co-located Bun regression suite
+`packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts` importing the pinned dist
+modules via resolved file URLs (established repo pattern, cf. `senpi-test-runtime.ts`,
+`task-rpc-launch-parity.test.ts`). All inputs are dependency-injected (fake login flow, in-memory
+credential store, injected clock). **No real user credential store is read or written; no network;
+no token material anywhere in this directory.**
+
+Fix vehicle: bun `patchedDependencies` bridge patch `patches/@code-yeongyu%2Fsenpi@2026.8.23.patch`
+(151 lines, 6 dist files) wired in root `package.json` + `bun.lock`. Semantics implemented:
+
+- `upsertAccount()`: same-name slot replaced in place (fresh access/refresh/expires/source, block
+  stamps stripped); unknown name appends (explicit multi-account preserved).
+- Re-login default name = newest existing login/import slot name instead of `account-N+1`;
+  a typed brand-new name still adds a second account.
+- `AUTH_ERROR_BLOCK_MS = 30 min`: auth_error stamps now carry `blockedUntil`.
+- `isBlocked()` purely time-based; `clearExpiredBlocks()` clears any stamp whose `blockedUntil`
+  is absent-or-elapsed (also cleans legacy permanent stamps left by older versions).
+
+## WHAT WAS OBSERVED
+
+- **RED before fix**: `before-fix-red.txt` — 9 fail / 1 pass against the unpatched pin
+  (`upsertAccount is not a function`; `AllAccountsBlockedError ... until re-login`;
+  legacy auth_error stamp retained). The single pass is the rate-limit guard
+  (existing behavior preserved).
+- **GREEN after fix**: `after-fix-green.txt` — 10 pass / 0 fail.
+- **Fresh-install reproducibility**: removed `node_modules/@code-yeongyu/senpi`, re-ran
+  `OMO_SKIP_MATERIALIZE=1 bun install` → truncated patch applies cleanly (`upsertAccount`,
+  `defaultRecoveryName`, `AUTH_ERROR_BLOCK_MS` present in installed dist); suite re-run green.
+- **Scoped typecheck**: `tsgo --noEmit -p packages/omo-senpi/tsconfig.json` → exit 0
+  (`typecheck-omo-senpi.txt`).
+- **Manifest pins unaffected**: `bun test packages/omo-native/test/senpi-pin.test.ts
+  packages/omo-native/test/package-shape.test.ts` → 15 pass (`pin-tests.txt`).
+- **Bundle purity + package shape**: 5 pass (`purity-shape.txt`).
+
+## WHY IT IS ENOUGH
+
+The regression suite pins the exact user-visible semantics from the issue's Expected section:
+one Claude.com user → one live slot across re-logins; a dead auth_error slot recovers after
+re-login; an elapsed auth_error stamp can no longer dead-end pool selection; legacy permanent
+stamps are cleaned; rate-limit windows still block. Tests fail on the shipped pin and pass with
+the patch, so they lock the invariant for any future pin bump (a bump without the upstream fix
+turns this suite red again). The patch self-invalidates on version drift (loud install failure),
+forcing conscious re-review or upstream absorption.
+
+Residual risk: npm-installed `omo-ai` end users receive the fix only when upstream senpi absorbs
+it and OmO bumps the pin (same absorption path as issue #7169); until then the patch covers every
+bun-install consumer of this monorepo. The 30-minute auth_error TTL is a policy choice per the
+task directive ("auth_error gets TTL or explicit invalidation"); re-login remains the primary
+recovery path and still clears stamps immediately.
+
+## WHAT WAS OMITTED
+
+- Live TUI `/login claude-sdk-oauth` drive: requires a real Claude.com OAuth round trip
+  (account credentials + browser deep link); cannot be performed hermetically. The module-level
+  suite drives the exact functions the TUI login path invokes (`createOAuthConfig().login` with
+  both headless and onPrompt callback shapes).
+- `packages/omo-senpi/plugin/scripts/build-extension.test.mjs`: **pre-existing environmental
+  failure in this sandbox**, unrelated to the change — it rebuilds extension bundles under a
+  30s in-test timeout and spawns a Node minifier child; it times out here even with pristine
+  committed plugin artifacts restored (`git checkout -- packages/*/plugin`), i.e. it fails on
+  unmodified dev in this environment too. Captured in `senpi-suite.log`.
+- Raw command outputs are captured verbatim except that no credential, token, or auth-header
+  material appears anywhere in them (tests use synthetic `access-*` / `refresh-*` strings only).

--- a/.omo/evidence/20260824-7084-oauth-slots/typecheck-omo-senpi.txt
+++ b/.omo/evidence/20260824-7084-oauth-slots/typecheck-omo-senpi.txt
@@ -1,0 +1,1 @@
+typecheck exit=0

--- a/bun.lock
+++ b/bun.lock
@@ -428,6 +428,9 @@
   "trustedDependencies": [
     "@code-yeongyu/comment-checker",
   ],
+  "patchedDependencies": {
+    "@code-yeongyu/senpi@2026.8.23": "patches/@code-yeongyu%2Fsenpi@2026.8.23.patch",
+  },
   "overrides": {
     "@earendil-works/pi-agent-core": "0.84.2",
     "@earendil-works/pi-ai": "0.84.2",

--- a/package.json
+++ b/package.json
@@ -249,5 +249,8 @@
   },
   "trustedDependencies": [
     "@code-yeongyu/comment-checker"
-  ]
+  ],
+  "patchedDependencies": {
+    "@code-yeongyu/senpi@2026.8.23": "patches/@code-yeongyu%2Fsenpi@2026.8.23.patch"
+  }
 }

--- a/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts
+++ b/packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, test } from "bun:test"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+// Regression coverage for oh-my-openagent#7084 against the exact-pinned engine
+// dist (@code-yeongyu/senpi). The claude-sdk-oauth slot/failover/affinity
+// plumbing ships inside the pinned dependency, so the desired semantics are
+// pinned here: re-login upserts one stable slot and auth_error blocks expire.
+// Everything below runs on pure, dependency-injected modules - no real
+// credential store is read or written.
+
+const require = createRequire(import.meta.url)
+const senpiPackageDir = dirname(require.resolve("@code-yeongyu/senpi/package.json"))
+const oauthDistDir = join(senpiPackageDir, "dist", "core", "extensions", "builtin", "claude-sdk-oauth")
+
+type AccountSlot = {
+  name: string
+  refresh: string
+  access: string
+  expires: number
+  source: "login" | "import" | "env"
+  blockedUntil?: number
+  blockReason?: string
+}
+
+type SlotCredential = {
+  type: "oauth"
+  access: string
+  refresh: string
+  expires: number
+  accounts?: AccountSlot[]
+  pinned?: string
+  slotState?: Record<string, { blockedUntil?: number; blockReason?: string }>
+}
+
+type LoginCredential = { access: string; refresh: string; expires: number }
+
+type AccountsModule = {
+  SENTINEL_OAUTH_FIELDS: { access: string; refresh: string; expires: number }
+  emptyCredential(): SlotCredential
+  listAccounts(credential: SlotCredential): AccountSlot[]
+  addAccount(credential: SlotCredential, slot: AccountSlot): SlotCredential
+  upsertAccount(credential: SlotCredential, slot: AccountSlot): SlotCredential
+  assertSentinelInvariant(credential: SlotCredential): void
+}
+
+type OAuthLoginCallbacksShape = {
+  signal?: AbortSignal
+  onPrompt?: (prompt: { message: string; placeholder?: string }) => Promise<string>
+}
+
+type OAuthLoginModule = {
+  createOAuthConfig(deps: {
+    readCurrent: () => Promise<SlotCredential | undefined>
+    loginFlow?: { login(interaction: unknown): Promise<LoginCredential> }
+  }): {
+    login(callbacks: OAuthLoginCallbacksShape): Promise<SlotCredential>
+  }
+}
+
+type FailoverModule = {
+  AUTH_ERROR_BLOCK_MS: number
+  runFailover(input: {
+    accounts: readonly AccountSlot[]
+    selectFn: (accounts: readonly AccountSlot[]) => AccountSlot
+    runAttempt: (slot: AccountSlot) => AsyncIterable<unknown>
+    classify: (error: unknown) => { kind: string; retryable: boolean }
+    store: InMemoryStore
+    providerId: string
+    now?: () => number
+    baseBlockMs?: number
+  }): AsyncGenerator<unknown>
+}
+
+type AffinityModule = {
+  selectAccount(
+    accounts: readonly AccountSlot[],
+    options?: { now?: () => number; sessionId?: string; pinnedAccount?: string },
+  ): AccountSlot
+  clearExpiredBlocks(accounts: readonly AccountSlot[], now?: number): AccountSlot[]
+}
+
+type InMemoryStore = {
+  credential: SlotCredential | undefined
+  modify(providerId: string, transform: (current: SlotCredential | undefined) => SlotCredential | undefined): Promise<SlotCredential | undefined>
+}
+
+async function loadDistModule<T>(file: string): Promise<T> {
+  return (await import(pathToFileURL(join(oauthDistDir, file)).href)) as T
+}
+
+function loginCredential(suffix: string): LoginCredential {
+  return { access: `access-${suffix}`, refresh: `refresh-${suffix}`, expires: 1_000 + suffix.length }
+}
+
+function loginSlot(name: string, suffix: string, extra: Partial<AccountSlot> = {}): AccountSlot {
+  const credential = loginCredential(suffix)
+  return { name, access: credential.access, refresh: credential.refresh, expires: credential.expires, source: "login", ...extra }
+}
+
+function createInMemoryStore(initial: SlotCredential): InMemoryStore {
+  return {
+    credential: initial,
+    async modify(_providerId, transform) {
+      this.credential = await transform(this.credential)
+      return this.credential
+    },
+  }
+}
+
+const describeAccounts = () => loadDistModule<AccountsModule>("accounts.js")
+const describeOAuthLogin = () => loadDistModule<OAuthLoginModule>("oauth-login.js")
+const describeFailover = () => loadDistModule<FailoverModule>("failover.js")
+const describeAffinity = () => loadDistModule<AffinityModule>("affinity.js")
+
+describe("engine claude-sdk-oauth slot recovery (issue #7084)", () => {
+  describe("#given the pinned senpi accounts module", () => {
+    test("#then it exposes an upsert that replaces a same-name slot in place", async () => {
+      const accounts = await describeAccounts()
+      expect(typeof accounts.upsertAccount).toBe("function")
+
+      // given a credential holding one already-blocked login slot
+      const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a", { blockReason: "auth_error" }))
+
+      // when the same identity is upserted with fresh credentials
+      const next = accounts.upsertAccount(current, loginSlot("default", "b"))
+
+      // then the slot is replaced in place with block stamps stripped
+      const slots = accounts.listAccounts(next)
+      expect(slots.length).toBe(1)
+      expect(slots[0]?.name).toBe("default")
+      expect(slots[0]?.access).toBe("access-b")
+      expect(slots[0]?.refresh).toBe("refresh-b")
+      expect(slots[0]?.blockedUntil).toBeUndefined()
+      expect(slots[0]?.blockReason).toBeUndefined()
+      accounts.assertSentinelInvariant(next)
+    })
+
+    test("#then an unknown name still appends so explicit multi-account keeps working", async () => {
+      const accounts = await describeAccounts()
+      const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))
+
+      // when a distinct account name is upserted
+      const next = accounts.upsertAccount(current, loginSlot("work", "b"))
+
+      // then both slots exist
+      expect(accounts.listAccounts(next).map((slot) => slot.name)).toEqual(["default", "work"])
+    })
+  })
+
+  describe("#given a single logged-in Claude account #when /login succeeds again without an explicit new name", () => {
+    test("#then the existing slot is refreshed in place instead of appending account-N+1", async () => {
+      const accounts = await describeAccounts()
+      const oauthLogin = await describeOAuthLogin()
+      const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))
+      let stored = current
+      const config = oauthLogin.createOAuthConfig({
+        readCurrent: () => Promise.resolve(stored),
+        loginFlow: { login: () => Promise.resolve(loginCredential("b")) },
+      })
+
+      // when the recovery login runs (headless path: no onPrompt callback)
+      const next = await config.login({})
+      stored = next
+
+      // then one slot holds the fresh credentials under the stable name
+      const slots = accounts.listAccounts(next)
+      expect(slots.length).toBe(1)
+      expect(slots[0]?.name).toBe("default")
+      expect(slots[0]?.access).toBe("access-b")
+      expect(slots[0]?.refresh).toBe("refresh-b")
+    })
+
+    test("#then a dead auth_error slot comes back live after re-login", async () => {
+      const accounts = await describeAccounts()
+      const oauthLogin = await describeOAuthLogin()
+      const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a", { blockReason: "auth_error" }))
+      const config = oauthLogin.createOAuthConfig({
+        readCurrent: () => Promise.resolve(current),
+        loginFlow: { login: () => Promise.resolve(loginCredential("b")) },
+      })
+
+      // when the user follows the "after re-login" guidance
+      const next = await config.login({})
+
+      // then the recovered slot carries no block stamp
+      const slots = accounts.listAccounts(next)
+      expect(slots.length).toBe(1)
+      expect(slots[0]?.blockReason).toBeUndefined()
+      expect(slots[0]?.blockedUntil).toBeUndefined()
+    })
+
+    test("#then accepting the prompt placeholder recovers the newest login slot instead of minting account-N+1", async () => {
+      const accounts = await describeAccounts()
+      const oauthLogin = await describeOAuthLogin()
+      const imported = { ...loginSlot("imported-anthropic", "i"), source: "import" as const }
+      const withImport = accounts.upsertAccount(accounts.emptyCredential(), imported)
+      const current = accounts.upsertAccount(withImport, loginSlot("default", "a"))
+      const config = oauthLogin.createOAuthConfig({
+        readCurrent: () => Promise.resolve(current),
+        loginFlow: { login: () => Promise.resolve(loginCredential("b")) },
+      })
+      const promptedMessages: string[] = []
+
+      // when the interactive prompt is answered with its own placeholder (empty input)
+      const next = await config.login({
+        onPrompt: async (prompt) => {
+          promptedMessages.push(prompt.message)
+          return ""
+        },
+      })
+
+      // then the default slot was refreshed; no account-N+1 sibling appeared
+      const slots = accounts.listAccounts(next)
+      expect(slots.map((slot) => slot.name).sort()).toEqual(["default", "imported-anthropic"])
+      const refreshed = slots.find((slot) => slot.name === "default")
+      expect(refreshed?.access).toBe("access-b")
+      expect(promptedMessages.length).toBe(1)
+    })
+
+    test("#then a typed brand-new name still adds a second account", async () => {
+      const accounts = await describeAccounts()
+      const oauthLogin = await describeOAuthLogin()
+      const current = accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a"))
+      const config = oauthLogin.createOAuthConfig({
+        readCurrent: () => Promise.resolve(current),
+        loginFlow: { login: () => Promise.resolve(loginCredential("b")) },
+      })
+
+      // when the user explicitly names a second account
+      const next = await config.login({ onPrompt: () => Promise.resolve("work") })
+
+      // then both accounts coexist and the old one is untouched
+      const slots = accounts.listAccounts(next)
+      expect(slots.map((slot) => slot.name).sort()).toEqual(["default", "work"])
+      expect(slots.find((slot) => slot.name === "default")?.access).toBe("access-a")
+    })
+  })
+
+  describe("#given failover classifies an authentication failure", () => {
+    test("#then the auth_error stamp carries an expiry instead of blocking forever", async () => {
+      const accounts = await describeAccounts()
+      const failover = await describeFailover()
+      const now = 1_000_000
+      const store = createInMemoryStore(accounts.upsertAccount(accounts.emptyCredential(), loginSlot("default", "a")))
+      const failingAttempt = async function* () {
+        yield { type: "error", error: new Error("authentication_failed: invalid_grant") }
+      }
+
+      // when the single attempt fails with an auth_error classification
+      const run = (async () => {
+        for await (const _event of failover.runFailover({
+          accounts: [loginSlot("default", "a")],
+          selectFn: (candidates) => candidates[0] as AccountSlot,
+          runAttempt: () => failingAttempt(),
+          classify: () => ({ kind: "auth_error", retryable: true }),
+          store,
+          providerId: "claude-sdk-oauth",
+          now: () => now,
+        })) {
+          // no events expected before the throw
+        }
+      })()
+
+      // then the turn fails but the persisted stamp expires
+      expect(run).rejects.toThrow("invalid_grant")
+      await run.catch(() => undefined)
+      const stamped = accounts.listAccounts(store.credential as SlotCredential)[0]
+      expect(stamped?.blockReason).toBe("auth_error")
+      expect(stamped?.blockedUntil).toBe(now + failover.AUTH_ERROR_BLOCK_MS)
+      expect(failover.AUTH_ERROR_BLOCK_MS).toBeGreaterThan(0)
+    })
+  })
+
+  describe("#given affinity selection over blocked slots", () => {
+    test("#then an elapsed auth_error stamp no longer blocks selection", async () => {
+      const accounts = await describeAccounts()
+      const affinity = await describeAffinity()
+      const now = 2_000_000
+      const expiredAuthStamp = loginSlot("default", "a", { blockReason: "auth_error", blockedUntil: now - 1 })
+
+      // when every slot carries only an elapsed auth_error stamp
+      const selected = affinity.selectAccount([expiredAuthStamp], { now: () => now })
+
+      // then the pool is not dead-ended
+      expect(selected.name).toBe("default")
+    })
+
+    test("#then clearing blocks also cleans legacy auth_error stamps that never had an expiry", async () => {
+      const accounts = await describeAccounts()
+      const affinity = await describeAffinity()
+      const legacyStamp = loginSlot("account-5", "a", { blockReason: "auth_error" })
+
+      // when expired blocks are cleared at any time
+      const cleared = affinity.clearExpiredBlocks([legacyStamp], 5_000_000)
+
+      // then the permanent legacy stamp is gone
+      expect(cleared[0]?.blockReason).toBeUndefined()
+      expect(cleared[0]?.blockedUntil).toBeUndefined()
+    })
+
+    test("#then a live rate-limit window still blocks (existing behavior preserved)", async () => {
+      const accounts = await describeAccounts()
+      const affinity = await describeAffinity()
+      const now = 3_000_000
+      const rateLimited = loginSlot("default", "a", { blockReason: "rate_limit", blockedUntil: now + 60_000 })
+
+      // when the block window is still in the future
+      const cleared = affinity.clearExpiredBlocks([rateLimited], now)
+
+      // then the stamp survives
+      expect(cleared[0]?.blockReason).toBe("rate_limit")
+      expect(cleared[0]?.blockedUntil).toBe(now + 60_000)
+    })
+  })
+})

--- a/patches/@code-yeongyu%2Fsenpi@2026.8.23.patch
+++ b/patches/@code-yeongyu%2Fsenpi@2026.8.23.patch
@@ -1,0 +1,151 @@
+diff --git a/dist/core/extensions/builtin/claude-sdk-oauth/accounts.d.ts b/dist/core/extensions/builtin/claude-sdk-oauth/accounts.d.ts
+index f1e1cbe2ec6bf3c9b60fbaff16f9d4e117f268e6..17ad3a850e7ff0d66401c91f60ab48c14480d32b 100644
+--- a/dist/core/extensions/builtin/claude-sdk-oauth/accounts.d.ts
++++ b/dist/core/extensions/builtin/claude-sdk-oauth/accounts.d.ts
+@@ -26,6 +26,7 @@ export declare function emptyCredential(): ClaudeSdkOauthCredential;
+ export declare function listAccounts(credential: ClaudeSdkOauthCredential, env?: (name: string) => string | undefined): AccountSlot[];
+ export declare function assertValidAccountName(name: string): void;
+ export declare function addAccount(credential: ClaudeSdkOauthCredential, slot: AccountSlot): ClaudeSdkOauthCredential;
++export declare function upsertAccount(credential: ClaudeSdkOauthCredential, slot: AccountSlot): ClaudeSdkOauthCredential;
+ export declare function removeAccount(credential: ClaudeSdkOauthCredential, name: string): ClaudeSdkOauthCredential;
+ export declare function pinAccount(credential: ClaudeSdkOauthCredential, name: string): ClaudeSdkOauthCredential;
+ export declare function assertSentinelInvariant(credential: ClaudeSdkOauthCredential): void;
+diff --git a/dist/core/extensions/builtin/claude-sdk-oauth/accounts.js b/dist/core/extensions/builtin/claude-sdk-oauth/accounts.js
+index 351f94fd1abdf6cd8eb70964a4a3fc51f729f650..0fe0baa805ccecdb0b461e9ff7746577b6f8e0c1 100644
+--- a/dist/core/extensions/builtin/claude-sdk-oauth/accounts.js
++++ b/dist/core/extensions/builtin/claude-sdk-oauth/accounts.js
+@@ -33,6 +33,29 @@ export function addAccount(credential, slot) {
+     }
+     return { ...credential, accounts: [...storedSlots(credential), slot] };
+ }
++export function upsertAccount(credential, slot) {
++    assertValidAccountName(slot.name);
++    const existing = storedSlots(credential);
++    if (!existing.some((candidate) => candidate.name === slot.name)) {
++        return addAccount(credential, slot);
++    }
++    return {
++        ...credential,
++        accounts: existing.map((candidate) => {
++            if (candidate.name !== slot.name)
++                return candidate;
++            const { blockedUntil: _blockedUntil, blockReason: _blockReason, ...available } = candidate;
++            return {
++                ...available,
++                name: slot.name,
++                access: slot.access,
++                refresh: slot.refresh,
++                expires: slot.expires,
++                source: slot.source,
++            };
++        }),
++    };
++}
+ export function removeAccount(credential, name) {
+     const accounts = storedSlots(credential).filter((slot) => slot.name !== name);
+     const next = { ...credential, accounts };
+diff --git a/dist/core/extensions/builtin/claude-sdk-oauth/affinity.js b/dist/core/extensions/builtin/claude-sdk-oauth/affinity.js
+index 80888e3052094d39add8d7dcec5fadf92f8a1fd6..78a36600da39dd34b7fadd7857c49b42cab67535 100644
+--- a/dist/core/extensions/builtin/claude-sdk-oauth/affinity.js
++++ b/dist/core/extensions/builtin/claude-sdk-oauth/affinity.js
+@@ -26,16 +26,17 @@ export function rendezvousOrder(key, accounts) {
+         .map(({ account }) => account);
+ }
+ function isBlocked(account, now) {
+-    return account.blockReason === "auth_error" || (account.blockedUntil !== undefined && account.blockedUntil > now);
++    return account.blockedUntil !== undefined && account.blockedUntil > now;
+ }
+-/** Removes elapsed rate/capacity blocks but deliberately retains auth blocks until login refreshes the slot. */
++/** Removes elapsed blocks; every stamp including auth_error expires, and stamps without an expiry are cleared. */
+ export function clearExpiredBlocks(accounts, now = Date.now()) {
+     return accounts.map((account) => {
+-        if (account.blockReason !== "auth_error" && account.blockedUntil !== undefined && account.blockedUntil <= now) {
+-            const { blockedUntil: _blockedUntil, blockReason: _blockReason, ...available } = account;
+-            return available;
+-        }
+-        return account;
++        if (account.blockReason === undefined && account.blockedUntil === undefined)
++            return account;
++        if (account.blockedUntil !== undefined && account.blockedUntil > now)
++            return account;
++        const { blockedUntil: _blockedUntil, blockReason: _blockReason, ...available } = account;
++        return available;
+     });
+ }
+ function selectUnblocked(accounts, options, now) {
+diff --git a/dist/core/extensions/builtin/claude-sdk-oauth/failover.d.ts b/dist/core/extensions/builtin/claude-sdk-oauth/failover.d.ts
+index f3e7e767b94481d3478429c5bf9efe5c69600a60..e47423238e0a7592495fddb33d42d19f264bd783 100644
+--- a/dist/core/extensions/builtin/claude-sdk-oauth/failover.d.ts
++++ b/dist/core/extensions/builtin/claude-sdk-oauth/failover.d.ts
+@@ -3,6 +3,7 @@ import type { AccountSlot } from "./accounts.ts";
+ import type { SdkErrorClassification } from "./errors.ts";
+ export declare const MAX_RATE_LIMIT_BLOCK_MS: number;
+ export declare const DEFAULT_RATE_LIMIT_BLOCK_MS = 60000;
++export declare const AUTH_ERROR_BLOCK_MS: number;
+ export declare const TURN_RETRY_SUPPRESSION_PREFIX = "senpi:no-turn-retry:";
+ export type FailoverEvent = {
+     account: AccountSlot;
+diff --git a/dist/core/extensions/builtin/claude-sdk-oauth/failover.js b/dist/core/extensions/builtin/claude-sdk-oauth/failover.js
+index c1155bb9674753c7de14e864fb0361a28389db95..1d285c885aed179c5844d65b7daa246cbb700566 100644
+--- a/dist/core/extensions/builtin/claude-sdk-oauth/failover.js
++++ b/dist/core/extensions/builtin/claude-sdk-oauth/failover.js
+@@ -45,10 +45,10 @@ function retryAfterMs(error) {
+     const seconds = text.match(/\bretry[-_ ]?after\s*[:=]\s*(\d+(?:\.\d+)?)/i);
+     return seconds ? Math.ceil(Number(seconds[1]) * 1_000) : undefined;
+ }
++export const AUTH_ERROR_BLOCK_MS = 30 * 60 * 1_000;
+ function blockedAccount(account, classification, now, attempt, baseBlockMs, error) {
+     if (classification.kind === "auth_error") {
+-        const { blockedUntil: _blockedUntil, ...withoutExpiry } = account;
+-        return { ...withoutExpiry, blockReason: "auth_error" };
++        return { ...account, blockedUntil: now + AUTH_ERROR_BLOCK_MS, blockReason: "auth_error" };
+     }
+     const fallback = Math.min(MAX_RATE_LIMIT_BLOCK_MS, baseBlockMs * 2 ** attempt);
+     const duration = Math.min(MAX_RATE_LIMIT_BLOCK_MS, retryAfterMs(error) ?? fallback);
+diff --git a/dist/core/extensions/builtin/claude-sdk-oauth/oauth-login.js b/dist/core/extensions/builtin/claude-sdk-oauth/oauth-login.js
+index 3e20b3a15f490dcee64fd9d093ea5e5e9d2d5e3e..b46be6bc9b13105f56c319cb6541173dabcf9ec0 100644
+--- a/dist/core/extensions/builtin/claude-sdk-oauth/oauth-login.js
++++ b/dist/core/extensions/builtin/claude-sdk-oauth/oauth-login.js
+@@ -1,5 +1,5 @@
+ import { loadAnthropicOAuth } from "@earendil-works/pi-ai/oauth";
+-import { addAccount, emptyCredential, listAccounts, SENTINEL_OAUTH_FIELDS, } from "./accounts.js";
++import { addAccount, emptyCredential, listAccounts, SENTINEL_OAUTH_FIELDS, upsertAccount, } from "./accounts.js";
+ import { readAmbientClaudeAuthStatus } from "./availability.js";
+ export const CLAUDE_SDK_OAUTH_NAME = "Claude SDK OAuth (Claude Pro/Max)";
+ const ENV_TOKEN_NAMES = [
+@@ -21,16 +21,23 @@ function requestClaudeEnvironment(value) {
+ function toSlot(credential, name, source) {
+     return { name, access: credential.access, refresh: credential.refresh, expires: credential.expires, source };
+ }
++function defaultRecoveryName(existing) {
++    const loginSlots = existing.filter((slot) => slot.source === "login" || slot.source === "import");
++    if (loginSlots.length > 0)
++        return loginSlots[loginSlots.length - 1].name;
++    return `account-${existing.length + 1}`;
++}
+ async function promptAccountName(callbacks, existing) {
+     if (existing.length === 0)
+         return "default";
++    const recovery = defaultRecoveryName(existing);
+     if (!callbacks.onPrompt)
+-        return `account-${existing.length + 1}`;
++        return recovery;
+     const answer = (await callbacks.onPrompt({
+         message: `Name for this account (existing: ${existing.map((slot) => slot.name).join(", ")})`,
+-        placeholder: `account-${existing.length + 1}`,
++        placeholder: recovery,
+     })).trim();
+-    return answer || `account-${existing.length + 1}`;
++    return answer || recovery;
+ }
+ export function createOAuthConfig(deps) {
+     const claudeEnvironment = async (ctx) => {
+@@ -110,7 +117,7 @@ export function createOAuthConfig(deps) {
+             const credential = await flow.login(interaction);
+             const existingAfter = listAccounts(current);
+             const name = await promptAccountName(callbacks, existingAfter);
+-            return addAccount(current, toSlot(credential, name, "login"));
++            return upsertAccount(current, toSlot(credential, name, "login"));
+         },
+         async refreshToken(credentials) {
+             return credentials;


### PR DESCRIPTION
## What changed

Fixes both claude-sdk-oauth account-pool defects from #7084. Both ship inside the exact-pinned engine dependency `@code-yeongyu/senpi@2026.8.23` (the slot/failover/affinity/oauth-login plumbing lives in its `dist/core/extensions/builtin/claude-sdk-oauth/`; repo-wide greps confirm none of it exists in workspace sources), so the fix lands as a bun `patchedDependencies` bridge patch on the pin:

- **accounts.js**: new `upsertAccount()` replaces a same-name slot in place (fresh access/refresh/expires/source, block stamps stripped); unknown names still append so explicit multi-account keeps working.
- **oauth-login.js**: default recovery name is the newest existing login/import slot instead of minting `account-N+1`; a typed brand-new name still adds a second account; accepting the prompt placeholder recovers the newest login slot.
- **failover.js**: `AUTH_ERROR_BLOCK_MS` (30 min) gives `auth_error` stamps an expiry instead of blocking forever.
- **affinity.js**: `isBlocked()` is purely time-based and `clearExpiredBlocks()` clears any stamp whose expiry is absent or elapsed — cleaning legacy permanent stamps left by older versions. Live rate-limit windows still block.

The patch self-invalidates on pin drift (loud install failure), forcing conscious re-review or upstream senpi absorption.

## Why

`/login claude-sdk-oauth` appended a new named slot on every re-login (`addAccount`, name = `account-${n+1}`) while `auth_error` blocks were stamped with no `blockedUntil` and retained forever. One `invalid_grant` dead-ended the whole pool behind "All Claude accounts are currently blocked … after re-login", and the printed recovery path (`/login`) could never clear it because it only appended more slots.

## Failing-first test

Co-located regression suite `packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts` imports the installed dist modules via resolved file URLs (established repo pattern, cf. `senpi-test-runtime.ts`), fully dependency-injected (fake login flow, in-memory credential store, injected clock; no real credential store, no network):

- **RED** on the unpatched pin: 9 fail / 1 pass (`upsertAccount is not a function`, `AllAccountsBlockedError … until re-login`, legacy stamp retained).
- **GREEN** with the patch: 10 pass / 0 fail.

It pins: same-name upsert replaces in place; unknown names append; headless + prompt-placeholder re-login refreshes the stable slot; dead auth_error slot recovers after re-login; auth_error stamps carry an expiry; elapsed stamps stop blocking selection; legacy permanent stamps are cleaned; live rate-limit windows still block.

## QA evidence

`.omo/evidence/20260824-7084-oauth-slots/` (committed): WHAT TESTED / OBSERVED / WHY ENOUGH / OMITTED plus raw captures — red/green runs, scoped `tsgo` typecheck exit 0, manifest pin tests 15 pass, bundle purity + package shape 5 pass, fresh-install patch-application check.

## Residual risk

npm-installed `omo-ai` end users receive the fix when upstream senpi absorbs it and the pin is bumped (same absorption path as #7169); until then the patch covers every bun-install consumer of this monorepo. The 30-minute auth_error TTL is a policy choice; re-login remains the primary recovery path and clears stamps immediately. Live TUI `/login` drive omitted (requires a real Claude.com OAuth round trip); the module-level suite drives the exact functions that path invokes.

Fixes #7084

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover Claude OAuth account slots on re-login and add expiry to auth_error blocks to prevent pool dead-ends. Old: re-login appended `account-N+1` and `auth_error` blocks never expired. New: re-login upserts the same slot; `auth_error` blocks expire after 30 minutes. Fixes #7084.

**Review notes**
- Patches pinned engine `@code-yeongyu/senpi@2026.8.23` via Bun `patchedDependencies`.
- `accounts`: add `upsertAccount()` that replaces a same-name slot in place and clears block stamps; unknown names still append.
- `oauth-login`: default recovery name is the newest login/import slot; placeholder accepts to recover; typing a new name still adds a second account.
- `failover`: `AUTH_ERROR_BLOCK_MS = 30m` stamps `auth_error` with `blockedUntil`.
- `affinity`: blocking is time-based; `clearExpiredBlocks()` removes expired and legacy no-expiry stamps; rate-limit behavior unchanged.
- Adds regression suite `packages/omo-senpi/src/engine-claude-sdk-oauth-slot-recovery.test.ts` (red on unpatched pin, green with patch).

**Rollout**
- No migration required; re-login now refreshes the existing slot.
- If you bump `@code-yeongyu/senpi`, the patch will fail to apply; either remove it after upstream absorption or rebase it and re-run the suite.

<sup>Written for commit b61a7b4c90825065ef7e559b1057b2e7ea32a7df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

