### PR TITLE
fix(shared-skills): route start-work around apply_patch-only worker lanes

### DIFF
--- a/.omo/evidence/20260824-6709-startwork-deadlock/EVIDENCE.md
+++ b/.omo/evidence/20260824-6709-startwork-deadlock/EVIDENCE.md
@@ -1,0 +1,55 @@
+# Evidence: issue #6709 start-work deadlock in apply_patch-only repositories
+
+Date: 2026-08-24
+Worktree: /home/viprix/projects/oom-wt-6709
+Branch: issue/6709-start-work-apply-patch-only (base dev @ 8833800ae)
+
+## WHAT WAS TESTED
+
+1. Failing-first regression proof for the new machine-consumed contract:
+   - `bun test tests/start-work-mutation-capability-contract.test.ts` with
+     `packages/shared-skills/skills/start-work/SKILL.md` reverted to base
+     (`git checkout -- <file>`), then restored with the fix.
+2. Scoped root invariant suite: `bun test tests/*.test.ts`.
+3. Full typecheck gate: `bun run typecheck`
+   (tsgo root + typecheck:script + typecheck:packages).
+4. Codex sync safety: inspected `packages/omo-codex/plugin/scripts/sync-skills.mjs`
+   `applyCodexSkillOverlays("start-work", ...)` anchors to confirm the new
+   SKILL.md section does not collide with the two exact-string replacements.
+
+## WHAT WAS OBSERVED
+
+1. Base SKILL.md (no contract block): test file errors before running any case -
+   "missing start-work-mutation-capability-contract json block" (0 pass / 1 error).
+   With the fix restored: 6 pass / 0 fail / 23 expect() calls.
+2. Root invariants: 26 pass / 0 fail across 6 files (83 expect calls), including
+   the precedent ulw-plan review-convergence contract test (issue #6128 pattern).
+3. Typecheck: all three stages completed with no errors.
+4. Overlay anchors ("When all top-level checkboxes..." completion text and the
+   ultraqa hard-rule bullet list) are disjoint from the inserted section between
+   the Phase 3 ultraqa trigger map and "## Phase 4"; sync-skills.mjs replaces by
+   exact string, so an additive section cannot break the Codex overlay.
+
+## WHY IT IS ENOUGH
+
+The fix is skill content plus a machine-consumed JSON contract block, per the
+issue's suggested direction 1 (plan-level capability contract; harness-neutral,
+works for every model/category). The regression test pins only the
+machine-consumed contract fields (probe triggers/method, routing flows, broker
+author/applier/verbatim/scope/fail-closed/verification, forbidden list) - the
+same sanctioned seam as tests/ulw-plan-review-convergence-contract.test.ts - and
+errors when the block is absent, which is the failing-first proof. Remaining
+risk: the prose around the contract is guidance read by models and has no
+automated seam by repo rule (prompt/prose contract tests are forbidden); it is
+covered by review. Runtime behavior of live workers is unchanged code-wise
+(no TS source touched), so no harness QA surface (opencode/codex/senpi skills)
+is triggered by this diff.
+
+## WHAT WAS OMITTED
+
+- Live end-to-end worker spawn against a real apply_patch-only fixture repo:
+  requires live model credentials and a spawned harness session; the issue body
+  already documents that reproduction (worker tool list without apply_patch,
+  BLOCKED_NO_LEGAL_MUTATION_PATH) and this change alters no runtime code path.
+- Hashline sandbox suite: unrelated to this markdown-only + test-only change.
+- No secrets, tokens, or env dumps were produced or recorded; nothing to redact.

--- a/packages/shared-skills/skills/start-work/SKILL.md
+++ b/packages/shared-skills/skills/start-work/SKILL.md
@@ -169,6 +169,44 @@ Each sub-task message must include:
 
 The 9 ultraqa classes are trigger-mapped: new input parsing → malformed input; untrusted external text → prompt injection; resumable or long-running flows → cancel/resume; generated or cached artifacts → stale state; uncommitted user files in scope → dirty worktree; long external commands → hung or long commands; new or timing-sensitive tests → flaky tests; log-based success claims → misleading success output; mid-operation interrupts → repeated interruptions. A class applies when its trigger fact holds. Probe each applicable class; record the rest as not-applicable with a one-line reason.
 
+### Mutation capability routing (restricted-mutation repositories)
+
+Some repositories restrict which tools may mutate product files (for example a `MUTATION_POLICY.md` permitting only `apply_patch`). Delegated workers do not necessarily inherit the parent session's builtin tools (in-process task children load no builtin extensions at all), so a worker can lack `apply_patch` entirely while policy forbids `edit`/`write`: that lane has zero legal mutation paths and ends BLOCKED no matter how often it is re-prompted. Route around it instead of retrying blind:
+
+1. **Probe capability before the first implementation dispatch**, and again whenever a worker reports being blocked without a legal mutator: ask the worker to list the file-mutating tools it actually has. Never assume it holds your tool surface.
+2. **Route by what the probe returns.** A worker holding policy-legal `edit`/`write` implements directly. In an apply_patch-only repository whose worker lacks `apply_patch`, run the **patch-broker flow**: the worker authors a PatchProposal as message text (touched paths, base commit, test patch, production patch), you reject any path outside the task's scope, then apply the patch VERBATIM with `git apply` inside the task worktree, and the SAME worker proves the test patch RED and the production patch GREEN plus its QA channels. You applying a worker-authored patch verbatim is delivery mechanics, not implementation: you never author, edit, extend, or repair a single hunk yourself.
+3. **Fail the broker closed.** An apply failure or a stale base commit goes back to the SAME worker for regeneration with the exact failure output; you never hand-repair a stale proposal. Only the same worker's verified GREEN closes the lane.
+
+<!-- start-work-mutation-capability-contract -->
+```json
+{
+  "schema_version": 1,
+  "capability_probe": {
+    "when": ["before_first_implementation_dispatch", "on_worker_blocked_without_legal_mutator"],
+    "method": "worker_reports_its_actual_mutating_tool_names",
+    "known_mutating_tools": ["edit", "write", "apply_patch"]
+  },
+  "routing": [
+    { "flow": "edit_write", "when": "worker_has_edit_or_write_and_repo_policy_permits_them" },
+    { "flow": "patch_broker", "when": "repo_policy_permits_only_apply_patch_and_worker_lacks_apply_patch" }
+  ],
+  "patch_broker": {
+    "proposal_fields": ["paths", "base_commit", "test_patch", "production_patch"],
+    "author": "worker",
+    "applier": "orchestrator",
+    "apply_is_verbatim": true,
+    "scope_check": "reject_paths_outside_task_scope_before_apply",
+    "on_apply_failure": "return_to_same_worker_for_regeneration",
+    "on_stale_base": "never_repaired_by_orchestrator_regenerate_with_worker",
+    "verification": "same_worker_proves_test_patch_red_then_production_patch_green"
+  },
+  "forbidden": [
+    "orchestrator_authors_or_edits_product_content",
+    "orchestrator_repairs_a_stale_proposal"
+  ]
+}
+```
+
 ## Phase 4: Verify and record evidence
 
 For each checkbox, complete all five gates before marking it done:

--- a/tests/start-work-mutation-capability-contract.test.ts
+++ b/tests/start-work-mutation-capability-contract.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+const repoRoot = join(import.meta.dir, "..")
+
+// Issue #6709: start-work is unsatisfiable in repositories whose mutation policy permits only
+// `apply_patch` for product files. In-process task workers never receive the `apply_patch`
+// builtin (children load an empty extension set), while the skill forbids the orchestrator from
+// editing product files, so an apply_patch-only repo leaves a worker lane with zero legal
+// mutation paths and the plan stalls in BLOCKED. The fix is a dispatch-time capability probe
+// plus a patch-broker flow, pinned by this machine-consumed contract embedded in the skill
+// (same pattern as the ulw-plan review convergence contract, issue #6128): the JSON block is
+// structured policy a machine can parse, so it is guarded here; the surrounding prose is not.
+const skillPath = join(repoRoot, "packages", "shared-skills", "skills", "start-work", "SKILL.md")
+const CONTRACT_NAME = "start-work-mutation-capability-contract"
+
+function readContract(): Record<string, unknown> {
+	const content = readFileSync(skillPath, "utf8")
+	const fence = "```"
+	const pattern = new RegExp(`<!-- ${CONTRACT_NAME} -->\\s*${fence}json\\s*([\\s\\S]*?)\\s*${fence}`)
+	const match = content.match(pattern)
+	if (!match?.[1]) throw new Error(`missing ${CONTRACT_NAME} json block in ${skillPath}`)
+	return JSON.parse(match[1]) as Record<string, unknown>
+}
+
+function asRecordArray(value: unknown): Record<string, unknown>[] {
+	return Array.isArray(value) ? (value as Record<string, unknown>[]) : []
+}
+
+describe("#given the start-work skill mutation capability contract", () => {
+	describe("#when the contract block is parsed from SKILL.md", () => {
+		const contract = readContract()
+
+		test("#then it declares schema version 1", () => {
+			expect(contract.schema_version).toBe(1)
+		})
+
+		test("#then the capability probe runs before the first dispatch and on a blocked worker", () => {
+			const probe = contract.capability_probe as Record<string, unknown>
+			const triggers = Array.isArray(probe?.when) ? (probe.when as string[]) : []
+			expect(triggers).toContain("before_first_implementation_dispatch")
+			expect(triggers).toContain("on_worker_blocked_without_legal_mutator")
+			expect(probe?.method).toBe("worker_reports_its_actual_mutating_tool_names")
+		})
+
+		test("#then routing covers the direct edit/write flow and the patch-broker flow", () => {
+			const routing = asRecordArray(contract.routing)
+			const flows = routing.map((entry) => entry.flow)
+			expect(flows).toContain("edit_write")
+			expect(flows).toContain("patch_broker")
+			for (const entry of routing) {
+				expect(typeof entry.when).toBe("string")
+				expect((entry.when as string).length).toBeGreaterThan(0)
+			}
+		})
+
+		test("#then the patch-broker flow keeps authoring with the worker and applying with the orchestrator", () => {
+			const broker = contract.patch_broker as Record<string, unknown>
+			expect(broker?.author).toBe("worker")
+			expect(broker?.applier).toBe("orchestrator")
+			expect(broker?.apply_is_verbatim).toBe(true)
+
+			const fields = Array.isArray(broker?.proposal_fields) ? (broker.proposal_fields as string[]) : []
+			for (const required of ["paths", "base_commit", "test_patch", "production_patch"]) {
+				expect(fields).toContain(required)
+			}
+		})
+
+		test("#then the broker fails closed on scope, stale base, and apply failure", () => {
+			const broker = contract.patch_broker as Record<string, unknown>
+			expect(broker?.scope_check).toBe("reject_paths_outside_task_scope_before_apply")
+			expect(broker?.on_apply_failure).toBe("return_to_same_worker_for_regeneration")
+			expect(broker?.on_stale_base).toBe("never_repaired_by_orchestrator_regenerate_with_worker")
+			expect(broker?.verification).toBe("same_worker_proves_test_patch_red_then_production_patch_green")
+		})
+
+		test("#then the contract forbids the orchestrator from authoring content or repairing proposals", () => {
+			const forbidden = Array.isArray(contract.forbidden) ? (contract.forbidden as string[]) : []
+			expect(forbidden).toContain("orchestrator_authors_or_edits_product_content")
+			expect(forbidden).toContain("orchestrator_repairs_a_stale_proposal")
+		})
+	})
+})


### PR DESCRIPTION
## What

Adds a **mutation capability routing** section to the `start-work` shared skill (`packages/shared-skills/skills/start-work/SKILL.md`) plus a machine-consumed contract JSON block pinned by a new regression test (`tests/start-work-mutation-capability-contract.test.ts`). No runtime TypeScript is touched.

The new section instructs the orchestrator to:

1. **Probe worker mutation capability** before the first implementation dispatch (and again whenever a worker reports being blocked without a legal mutator) by asking the worker to list the file-mutating tools it actually has.
2. **Route on the probe result**: direct `edit`/`write` implementation where repo policy permits them; otherwise, in an apply_patch-only repository whose worker lacks `apply_patch`, run the **patch-broker flow** - the worker authors a PatchProposal as message text (touched paths, base commit, test patch, production patch), the orchestrator rejects out-of-scope paths and applies the proposal VERBATIM with `git apply` in the task worktree, and the SAME worker proves test RED then production GREEN plus its QA channels.
3. **Fail the broker closed**: apply failures and stale base commits return to the same worker for regeneration with the exact failure output; the orchestrator never authors, edits, or repairs a single hunk.

## Why

`start-work` is unsatisfiable in repositories whose mutation policy permits only `apply_patch` for product files (#6709). Three intentional design decisions combine into a deadlock:

- In-process task children load an EMPTY extension set (`packages/senpi-task/src/runners/in-process/child-loader.ts:5-20`), so workers never receive `apply_patch`.
- `start-work` forbids the orchestrator from editing product files ("DELEGATE EVERYTHING. YOU NEVER IMPLEMENT.").
- `apply_patch` is model-denied for workers by design (#5200), so no category config can restore it.

Result: the worker's only policy-legal mutator is absent, its remaining mutators are policy-forbidden, the lane ends BLOCKED, and the plan stalls. This implements the issue's suggested direction 1 (plan-level capability contract): skill-content only, harness-neutral, works for every model/category.

## Verified

- Failing-first: with SKILL.md reverted to base, `bun test tests/start-work-mutation-capability-contract.test.ts` errors ("missing start-work-mutation-capability-contract json block", 0 pass / 1 error); with the fix, 6 pass / 0 fail / 23 expect calls.
- Scoped root invariants: `bun test tests/*.test.ts` - 26 pass / 0 fail across 6 files.
- Typecheck: `bun run typecheck` (tsgo root + script + packages) green.
- Codex sync safety: the two exact-string overlay anchors for start-work in `packages/omo-codex/plugin/scripts/sync-skills.mjs` are disjoint from the inserted section, so the additive change cannot break the Codex skill overlay.
- The test pins ONLY machine-consumed contract fields (probe triggers/method, routing flows, broker author/applier/verbatim/scope/fail-closed/verification, forbidden list), following the sanctioned `tests/ulw-plan-review-convergence-contract.test.ts` precedent (#6128); surrounding prose is not pinned, per the prompt/prose contract test ban.
- Evidence recorded in `.omo/evidence/20260824-6709-startwork-deadlock/EVIDENCE.md` (WHAT TESTED / OBSERVED / WHY ENOUGH / OMITTED).

## Risk

Low. The change is additive skill guidance plus a contract-pinning test; no runtime code path changes, so no harness behavior can regress mechanically. Residual risk: live end-to-end worker behavior under an apply_patch-only policy was not re-run here (needs live model credentials); the issue body documents that reproduction, and this PR changes no execution code. If maintainers prefer the doctor preflight (direction 3) or selective builtin restore (direction 2) additionally or instead, this section composes with both and can be adjusted.

Fixes #6709

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `start-work` around apply_patch-only worker lanes by adding a capability-probing and routing contract to the skill. Previously, workers without `apply_patch` stalled because `edit`/`write` were forbidden and the orchestrator never edits; now the orchestrator probes mutator availability and either dispatches direct `edit`/`write` where policy allows or runs a patch-broker flow that applies worker-authored patches verbatim and fails closed.

**Reviewer notes**
- The machine-consumed contract JSON lives under `<!-- start-work-mutation-capability-contract -->` in `packages/shared-skills/skills/start-work/SKILL.md`; `tests/start-work-mutation-capability-contract.test.ts` pins probe triggers, routing flows, broker semantics (author=worker, applier=orchestrator, verbatim apply, scope check, stale/apply failure returns to same worker), and forbidden actions (orchestrator authoring/repairing).
- No runtime TypeScript changed; impact is limited to skill guidance and a regression test.
- Addresses issue #6709 by implementing a plan-level capability contract that is harness-neutral and does not reintroduce `apply_patch` to workers.

<sup>Written for commit b645298c66d3d58931db2a9f22a24f6a4ef0f598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

