### PR TITLE
fix(utils): resolve windows sweep launchers from System32 and annotate ENOENT

### DIFF
--- a/.omo/evidence/20260824-6747-powershell-enoent/QA.md
+++ b/.omo/evidence/20260824-6747-powershell-enoent/QA.md
@@ -1,0 +1,59 @@
+# QA evidence: Windows sweep launcher resolution, spawn powershell.exe ENOENT (#6747)
+
+Date: 2026-08-24
+Branch: issue/6747-lsp-daemon-powershell-enoent (base: dev @ 8833800ae)
+Scope: packages/utils/src/process-sweep/exec.ts (+ co-located exec.test.ts)
+
+## WHAT WAS TESTED
+
+1. Failing-first regression proof (`failing-first-base.txt`): with the exec.ts fix stashed and
+   only the new test present, `bun test packages/utils/src/process-sweep/exec.test.ts` fails on
+   the base commit with
+   `SyntaxError: Export named 'resolveWindowsSystemBinary' not found` (0 pass / 1 fail).
+2. Scoped suite after the fix (`scoped-test-after.txt`): same command, 7 pass / 0 fail:
+   - resolveWindowsSystemBinary unit tests (platform-agnostic, injected env + fileExists):
+     SystemRoot absolute path wins; windir fallback tree used; missing candidate falls back to
+     the bare PATH name; no SystemRoot/windir keeps the bare name.
+   - End-to-end enumeration through a fake %SystemRoot% whose System32 carries an executable
+     stand-in for powershell.exe: parsed process rows come from the resolved absolute binary.
+   - End-to-end kill/terminate through a fake System32 taskkill.exe stand-in: the resolved
+     absolute binary runs with `/PID <pid> /T [/F]`.
+   - ENOENT annotation: with no SystemRoot and no launcher on PATH, the rejection message names
+     the attempted launcher (`"powershell.exe"`) and carries `cause.code === "ENOENT"`, so the
+     consumer log line (`lsp-daemon proxy sweep skipped: ...`) in
+     packages/omo-opencode/src/shared/omo-process-sweep.ts now shows which binary failed to
+     launch instead of a bare `spawn powershell.exe ENOENT undefined`.
+3. Full packages/utils Bun suite (`utils-package-suite.txt`): 506 pass / 0 fail.
+4. Typecheck (`typecheck.txt`): `tsgo --noEmit -p tsconfig.json` exit 0.
+5. `bunx biome check` on both changed files: clean.
+
+## WHAT WAS OBSERVED
+
+- The win32 launchers in exec.ts previously resolved powershell.exe / taskkill.exe through PATH
+  only. Under a daemon with a curated or mutated PATH (the #6747 reporter's machine had both
+  directories on PATH yet still saw ENOENT from the spawned sweep), the lookup fails and the
+  proxy sweep is skipped for the whole session, so orphaned LSP proxies are never reaped.
+- After the fix, both launchers prefer `%SystemRoot%\System32\...` (SystemRoot, then windir)
+  when that file exists, keeping the bare name as fallback; ENOENT rejections are wrapped with
+  the launcher name plus the original error as `cause`.
+
+## WHY IT IS ENOUGH
+
+- The resolver contract is pinned platform-agnostically via injected env/fileExists, so it holds
+  regardless of host OS.
+- The end-to-end tests drive the real execFile path against executable stand-ins, proving the
+  resolved path is actually the one spawned and that arguments are unchanged.
+- The annotation test pins the user-visible improvement the issue asked for in point (2).
+
+## WHAT WAS OMITTED
+
+- Live win32 runtime verification is impossible from this Linux host: the end-to-end stand-ins
+  are POSIX shell scripts and are gated with `test.skipIf(process.platform === "win32")`
+  (the win32 loader cannot execute them). Real-Windows behavior of
+  `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe` and `%SystemRoot%\System32\taskkill.exe`
+  follows the documented layout; CI's windows platform smoke covers the package build but not
+  this runtime path.
+- No live LSP daemon or OpenCode/Codex session was driven: the change is confined to launcher
+  resolution inside packages/utils; the consumer log line was verified by reading the
+  interpolation at packages/omo-opencode/src/shared/omo-process-sweep.ts (message text only).
+- No secrets, tokens, or private host paths appear in the captured outputs.

--- a/.omo/evidence/20260824-6747-powershell-enoent/failing-first-base.txt
+++ b/.omo/evidence/20260824-6747-powershell-enoent/failing-first-base.txt
@@ -1,0 +1,14 @@
+bun test v1.3.14 (0d9b296a)
+
+packages/utils/src/process-sweep/exec.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+SyntaxError: Export named 'resolveWindowsSystemBinary' not found in module '/home/viprix/projects/oom-wt-6747/packages/utils/src/process-sweep/exec.ts'.
+-------------------------------
+
+
+ 0 pass
+ 1 fail
+ 1 error
+Ran 1 test across 1 file. [1127.00ms]

--- a/.omo/evidence/20260824-6747-powershell-enoent/scoped-test-after.txt
+++ b/.omo/evidence/20260824-6747-powershell-enoent/scoped-test-after.txt
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 7 pass
+ 0 fail
+ 9 expect() calls
+Ran 7 tests across 1 file. [543.00ms]

--- a/.omo/evidence/20260824-6747-powershell-enoent/typecheck.txt
+++ b/.omo/evidence/20260824-6747-powershell-enoent/typecheck.txt
@@ -1,0 +1,2 @@
+$ tsgo --noEmit -p tsconfig.json
+typecheck exit=0

--- a/.omo/evidence/20260824-6747-powershell-enoent/utils-package-suite.txt
+++ b/.omo/evidence/20260824-6747-powershell-enoent/utils-package-suite.txt
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 506 pass
+ 0 fail
+ 1054 expect() calls
+Ran 506 tests across 67 files. [19.62s]

--- a/packages/utils/src/process-sweep/exec.test.ts
+++ b/packages/utils/src/process-sweep/exec.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test"
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { createDefaultProcessKiller, enumerateProcesses, resolveWindowsSystemBinary } from "./exec"
+
+interface SystemRootRestore {
+  readonly name: "SystemRoot" | "windir"
+  readonly previous: string | undefined
+}
+
+function pointSystemRootAt(root: string): SystemRootRestore[] {
+  const restores: SystemRootRestore[] = []
+  for (const name of ["SystemRoot", "windir"] as const) {
+    restores.push({ name, previous: process.env[name] })
+    process.env[name] = root
+  }
+  return restores
+}
+
+function restoreSystemRoot(restores: SystemRootRestore[]): void {
+  for (const { name, previous } of restores) {
+    if (previous === undefined) delete process.env[name]
+    else process.env[name] = previous
+  }
+}
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, body)
+  chmodSync(path, 0o755)
+}
+
+/**
+ * Builds a fake %SystemRoot% whose System32 carries executable stand-ins for
+ * the two sweep launchers. The stand-ins are POSIX shell scripts, so the
+ * end-to-end tests driving them are skipped on win32 (see each test).
+ */
+function makeFakeSystemRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "omo-sweep-systemroot-"))
+  mkdirSync(join(root, "System32", "WindowsPowerShell", "v1.0"), { recursive: true })
+  writeExecutable(
+    join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+    "#!/bin/sh\nprintf '%s' '[{\"ProcessId\":4242,\"ParentProcessId\":1,\"CommandLine\":\"node lsp-daemon-proxy.js mcp\"}]'\n",
+  )
+  const taskkillLog = join(root, "taskkill-args.log")
+  writeExecutable(
+    join(root, "System32", "taskkill.exe"),
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> "${taskkillLog}"\n`,
+  )
+  return root
+}
+
+describe("windows sweep launcher resolution", () => {
+  describe("resolveWindowsSystemBinary", () => {
+    test("#given SystemRoot with the binary under System32 #when resolving #then the absolute path wins over the bare name", () => {
+      // given
+      const absolute = join("C:\\WINDOWS", "System32", "taskkill.exe")
+      const env = { SystemRoot: "C:\\WINDOWS" } as NodeJS.ProcessEnv
+      const fileExists = (candidate: string) => candidate === absolute
+
+      // when
+      const resolved = resolveWindowsSystemBinary("taskkill.exe", ["taskkill.exe"], { env, fileExists })
+
+      // then
+      expect(resolved).toBe(absolute)
+    })
+
+    test("#given only windir set #when resolving #then the windir tree is used", () => {
+      // given
+      const env = { windir: "D:\\Win" } as NodeJS.ProcessEnv
+      const fileExists = (candidate: string) =>
+        candidate === join("D:\\Win", "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+
+      // when
+      const resolved = resolveWindowsSystemBinary(
+        "powershell.exe",
+        ["WindowsPowerShell", "v1.0", "powershell.exe"],
+        { env, fileExists },
+      )
+
+      // then
+      expect(resolved).toBe(join("D:\\Win", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"))
+    })
+
+    test("#given the SystemRoot candidate missing on disk #when resolving #then the bare name is kept as the PATH fallback", () => {
+      // given
+      const env = { SystemRoot: "C:\\WINDOWS" } as NodeJS.ProcessEnv
+
+      // when
+      const resolved = resolveWindowsSystemBinary("taskkill.exe", ["taskkill.exe"], {
+        env,
+        fileExists: () => false,
+      })
+
+      // then
+      expect(resolved).toBe("taskkill.exe")
+    })
+
+    test("#given neither SystemRoot nor windir #when resolving #then the bare name is kept", () => {
+      // given
+      const env = {} as NodeJS.ProcessEnv
+
+      // when
+      const resolved = resolveWindowsSystemBinary(
+        "powershell.exe",
+        ["WindowsPowerShell", "v1.0", "powershell.exe"],
+        { env, fileExists: () => true },
+      )
+
+      // then
+      expect(resolved).toBe("powershell.exe")
+    })
+  })
+
+  // The end-to-end tests below execute POSIX shell stand-ins for the Windows
+  // launchers, which the win32 loader cannot run; the resolution logic itself
+  // is covered platform-agnostically by resolveWindowsSystemBinary above.
+  const unixOnly = test.skipIf(process.platform === "win32")
+
+  unixOnly("#given a fake SystemRoot powershell tree #when enumerating win32 processes #then rows come from the resolved absolute binary", async () => {
+    // given
+    const root = makeFakeSystemRoot()
+    const restores = pointSystemRootAt(root)
+    try {
+      // when
+      const processes = await enumerateProcesses("win32")
+
+      // then
+      expect(processes).toEqual([
+        { command: "node lsp-daemon-proxy.js mcp", pid: 4242, ppid: 1 },
+      ])
+    } finally {
+      restoreSystemRoot(restores)
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  unixOnly("#given a fake SystemRoot taskkill tree #when the win32 killer terminates and kills #then the absolute taskkill runs with the expected arguments", async () => {
+    // given
+    const root = makeFakeSystemRoot()
+    const restores = pointSystemRootAt(root)
+    try {
+      // when
+      const killer = createDefaultProcessKiller("win32")
+      await killer.terminate(4242)
+      await killer.kill(4243)
+
+      // then
+      expect(readFileSync(join(root, "taskkill-args.log"), "utf8").split("\n").filter((line) => line.length > 0)).toEqual([
+        "/PID 4242 /T",
+        "/PID 4243 /T /F",
+      ])
+    } finally {
+      restoreSystemRoot(restores)
+      rmSync(root, { force: true, recursive: true })
+    }
+  })
+
+  unixOnly("#given no SystemRoot and no powershell on PATH #when enumerating win32 processes #then the rejection names the attempted launcher", async () => {
+    // given
+    const restores: SystemRootRestore[] = []
+    for (const name of ["SystemRoot", "windir"] as const) {
+      restores.push({ name, previous: process.env[name] })
+      delete process.env[name]
+    }
+    try {
+      // when
+      const failure = await enumerateProcesses("win32").catch((error: unknown) => error)
+
+      // then
+      const launcherFailure = failure as Error & { readonly cause?: unknown }
+      expect(launcherFailure).toBeInstanceOf(Error)
+      expect(launcherFailure.message).toContain('"powershell.exe"')
+      expect((launcherFailure.cause as Error & { readonly code?: string }).code).toBe("ENOENT")
+    } finally {
+      restoreSystemRoot(restores)
+    }
+  })
+})

--- a/packages/utils/src/process-sweep/exec.ts
+++ b/packages/utils/src/process-sweep/exec.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
 
 import { parsePosixProcessTable, parseWindowsProcessTable, type ProcessInfo } from "./process-table"
 
@@ -6,6 +8,11 @@ export interface ProcessKiller {
   readonly isAlive: (pid: number) => boolean | Promise<boolean>
   readonly kill: (pid: number) => Promise<void>
   readonly terminate: (pid: number) => Promise<void>
+}
+
+export interface ResolveWindowsSystemBinaryOptions {
+  readonly env?: NodeJS.ProcessEnv
+  readonly fileExists?: (path: string) => boolean
 }
 
 /** Backward-compatible aliases: the codegraph family was the first consumer. */
@@ -31,6 +38,28 @@ export function defaultIsProcessAlive(pid: number): boolean {
   }
 }
 
+const POWERSHELL_SYSTEM_SEGMENTS = ["WindowsPowerShell", "v1.0", "powershell.exe"] as const
+const TASKKILL_SYSTEM_SEGMENTS = ["taskkill.exe"] as const
+
+/**
+ * Prefers the absolute %SystemRoot%\System32 location over a PATH lookup:
+ * spawned daemons can run with a curated or mutated PATH where bare names
+ * stop resolving (upstream #6747). Falls back to the bare name when
+ * SystemRoot is unknown or the candidate file does not exist.
+ */
+export function resolveWindowsSystemBinary(
+  bareName: string,
+  systemRelativeSegments: readonly string[],
+  options: ResolveWindowsSystemBinaryOptions = {},
+): string {
+  const env = options.env ?? process.env
+  const fileExists = options.fileExists ?? existsSync
+  const systemRoot = nonEmptyText(env.SystemRoot) ?? nonEmptyText(env.windir)
+  if (systemRoot === undefined) return bareName
+  const absolute = join(systemRoot, "System32", ...systemRelativeSegments)
+  return fileExists(absolute) ? absolute : bareName
+}
+
 function enumeratePosixProcesses(): Promise<ProcessInfo[]> {
   return execFileText("ps", ["-eo", "pid=,ppid=,command="]).then(parsePosixProcessTable)
 }
@@ -41,7 +70,8 @@ function enumerateWindowsProcesses(): Promise<ProcessInfo[]> {
     "Select-Object ProcessId,ParentProcessId,CommandLine",
     "ConvertTo-Json -Compress -Depth 2",
   ].join(" | ")
-  return execFileText("powershell.exe", ["-NoProfile", "-Command", command]).then(parseWindowsProcessTable)
+  const powershell = resolveWindowsSystemBinary("powershell.exe", POWERSHELL_SYSTEM_SEGMENTS)
+  return execFileText(powershell, ["-NoProfile", "-Command", command]).then(parseWindowsProcessTable)
 }
 
 function createPosixKiller(): ProcessKiller {
@@ -59,10 +89,11 @@ function createPosixKiller(): ProcessKiller {
 }
 
 function createWindowsKiller(): ProcessKiller {
+  const taskkill = resolveWindowsSystemBinary("taskkill.exe", TASKKILL_SYSTEM_SEGMENTS)
   return {
     isAlive: defaultIsProcessAlive,
-    kill: (pid) => execFileVoid("taskkill.exe", ["/PID", String(pid), "/T", "/F"]),
-    terminate: (pid) => execFileVoid("taskkill.exe", ["/PID", String(pid), "/T"]),
+    kill: (pid) => execFileVoid(taskkill, ["/PID", String(pid), "/T", "/F"]),
+    terminate: (pid) => execFileVoid(taskkill, ["/PID", String(pid), "/T"]),
   }
 }
 
@@ -70,12 +101,22 @@ function execFileText(command: string, args: readonly string[]): Promise<string>
   return new Promise((resolvePromise, reject) => {
     execFile(command, [...args], { encoding: "utf8", maxBuffer: 16 * 1024 * 1024, windowsHide: true }, (error, stdout) => {
       if (error !== null) {
-        reject(error)
+        reject(annotateLauncherFailure(command, error))
         return
       }
       resolvePromise(stdout)
     })
   })
+}
+
+function annotateLauncherFailure(command: string, error: Error): Error {
+  const code = typeof error === "object" && "code" in error ? error.code : undefined
+  if (code !== "ENOENT") return error
+  return new Error(`process sweep could not launch "${command}": ${error.message}`, { cause: error })
+}
+
+function nonEmptyText(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim().length > 0 ? value : undefined
 }
 
 function execFileVoid(command: string, args: readonly string[]): Promise<void> {


### PR DESCRIPTION
## What

`packages/utils/src/process-sweep/exec.ts` resolved its Windows launchers through PATH only: `enumerateWindowsProcesses()` spawned bare `powershell.exe` and `createWindowsKiller()` spawned bare `taskkill.exe`. Under a daemon process with a curated or mutated PATH that lookup fails with ENOENT, the error is folded into a generic `lsp-daemon proxy sweep skipped:` line, and orphaned LSP proxy processes are never reaped for the rest of the session (#6747).

This PR:

1. Adds `resolveWindowsSystemBinary()`: both launchers now prefer the absolute `%SystemRoot%\System32\...` location (`SystemRoot`, then `windir`) when that file exists, keeping the bare name as the fallback when `SystemRoot` is unknown or the candidate is missing, so a broken PATH can no longer disable the sweep.
2. Annotates ENOENT launch failures with the attempted launcher name (`process sweep could not launch "powershell.exe": ...`, original error preserved as `cause`). The consumer log at `packages/omo-opencode/src/shared/omo-process-sweep.ts` interpolates `error.message`, so the skip line now names the binary instead of `spawn powershell.exe ENOENT undefined`.

Adds a co-located regression suite `packages/utils/src/process-sweep/exec.test.ts`: platform-agnostic resolver unit tests (injected env + `fileExists`) plus end-to-end tests driving the real `execFile` path against executable stand-ins under a fake `%SystemRoot%`, gated with `test.skipIf(process.platform === "win32")` because the stand-ins are POSIX shell scripts.

## Why

The issue reporter's machine had both `System32` and the WindowsPowerShell directory on PATH yet still saw `spawn powershell.exe ENOENT` from the spawned sweep, so a PATH-only lookup is not reliable in the environment the daemon runs under. Resolving from the documented absolute system location removes that dependency, and naming the failed launcher makes the permanent loss of process reaping visible instead of silent.

## Verified

- Failing-first: with only the test present on base dev @ 8833800ae, the suite fails (`Export named 'resolveWindowsSystemBinary' not found`, 0 pass / 1 fail); after the fix it is green (7 pass / 0 fail). Captured in `.omo/evidence/20260824-6747-powershell-enoent/failing-first-base.txt` and `scoped-test-after.txt`.
- Full `packages/utils` Bun suite: 506 pass / 0 fail (`utils-package-suite.txt`).
- Typecheck: `tsgo --noEmit -p packages/utils/tsconfig.json` exit 0; `bunx biome check` clean on both changed files.
- QA evidence (including the Linux-host limitation for live win32 runtime testing) is committed under `.omo/evidence/20260824-6747-powershell-enoent/QA.md`.

## Risk

Low. Behavior changes only when `%SystemRoot%\System32\<candidate>` exists, which is the documented layout on every supported Windows version; otherwise the previous bare-name lookup is used unchanged. Non-Windows paths (`ps`, POSIX killers) are untouched. Live verification on a real Windows host was not possible from this Linux environment; the win32-gated e2e tests cover the spawn path hermetically.

Fixes #6747