### PR TITLE
fix(omo-senpi): degrade reflection sandbox when bwrap cannot start a user namespace

### DIFF
--- a/.omo/evidence/20260824-6873-bwrap-fallback/QA-EVIDENCE.md
+++ b/.omo/evidence/20260824-6873-bwrap-fallback/QA-EVIDENCE.md
@@ -1,0 +1,56 @@
+# WHAT WAS TESTED
+
+Issue #6873: memory reflection with `memory.reflection.sandbox: "auto"` treats an existing
+`/usr/bin/bwrap` as usable even when bubblewrap cannot create its user namespace
+(AppArmor `apparmor_restrict_unprivileged_userns = 1`), so every reflection child dies with
+`bwrap: setting up uid map: Permission denied` and the failure streak grows.
+
+Commands run (repo root, bun 1.3.14):
+
+1. `bun test packages/omo-senpi/src/components/memory/sandbox.test.ts packages/omo-senpi/src/components/memory/sandbox-bwrap-probe.test.ts packages/omo-senpi/src/components/memory/sandbox-absent-paths.test.ts packages/omo-senpi/src/components/memory/worker/remediation.test.ts`
+   - Surface: the sandbox transform builders (`auto`/`required`/`off` policies, linux/darwin),
+     the new bwrap smoke-probe classifier + memoized probe, and the reflection failure-hint mapper.
+   - Behavior proven: auto degrades to unsandboxed with an explicit warning when the probe reports
+     bwrap unusable; required fails closed with `SandboxUnavailableError`; a healthy probe result
+     keeps wrapping; `off` never probes; classifier maps exit 0 / uid-map denial / spawn error /
+     timeout to usable/unusable+reason; remediation names `memory.reflection.sandbox` instead of
+     the removed `child-stderr.log` for bwrap setup failures while generic child_exit keeps the log hint.
+2. `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json`
+   - Surface: whole omo-senpi package typecheck gate.
+3. `bun test packages/omo-senpi/src/components/memory`
+   - Surface: full memory component suite (sandbox consumers included: identity-runtime lazy
+     transform, facts surface, worker supervision/finalization) to prove no regression.
+
+# WHAT WAS OBSERVED
+
+1. Scoped run after fixes: `29 pass, 1 skip (win32-gated probe test), 0 fail`.
+2. Typecheck: exit code 0, no diagnostics.
+3. Full memory suite: `911 pass, 6 skip, 0 fail` across 134 files (~326s).
+4. Failing-first evidence: before the remediation.ts branch existed, the new
+   `worker/remediation.test.ts` case failed (hint still pointed at child-stderr.log); before the
+   classifier reason fix, two `classifyBwrapSmoke` cases failed because empty stderr omitted
+   `reason` entirely, violating the declared `{ usable: false; reason: string }` shape.
+5. Hermeticity check: all pre-existing sandbox tests inject `which`, so they keep existence-only
+   semantics and never spawn a real bwrap; only production callers without an injected `which`
+   (identity-runtime reflection transform, facts surface) get the real smoke probe, memoized once
+   per executable path per process.
+
+# WHY IT IS ENOUGH
+
+- The issue's three asks are each pinned by a test: verify-the-sandbox-can-start (probe +
+  classifier tests), auto-retry-unsandboxed-with-explicit-warning vs required-fail-closed
+  (policy tests), and no dangling child-stderr.log pointer for sandbox setup failures
+  (remediation test).
+- The full memory suite covers both production consumers of the changed builder signature, so the
+  blast radius (reflection + facts children) is exercised, not just the unit seams.
+- Remaining risk: hosts where the smoke test passes but a later real launch still fails at setup
+  (race or per-invocation divergence). That path keeps the pre-existing runtime behavior plus the
+  new remediation hint, which is the best available degradation without re-probing per launch.
+
+# WHAT WAS OMITTED
+
+- Live Senpi harness QA (`senpi-qa` drivers) was not run in this environment; the hermetic unit
+  gate (`tsgo --noEmit -p packages/omo-senpi/tsconfig.json` + scoped/full `bun test`) is the
+  recorded evidence. No live driver JSON is included, and none is claimed.
+- No secrets, tokens, auth headers, or env dumps are present in this change or its artifacts;
+  nothing required redaction beyond this note.

--- a/packages/omo-senpi/src/components/memory/sandbox-bwrap-probe.test.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox-bwrap-probe.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+import { chmod, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { classifyBwrapSmoke, probeBwrapUsability } from "./sandbox-platform"
+
+describe("classifyBwrapSmoke", () => {
+  test("#given a smoke child that exited 0 #when classified #then bwrap is usable", () => {
+    expect(classifyBwrapSmoke({ exitCode: 0, timedOut: false, stderr: "" })).toEqual({ usable: true })
+  })
+
+  test("#given a smoke child that failed during user-namespace setup #when classified #then it is unusable and the reason carries the stderr", () => {
+    const usability = classifyBwrapSmoke({
+      exitCode: 1,
+      timedOut: false,
+      stderr: "bwrap: setting up uid map: Permission denied\n",
+    })
+
+    expect(usability.usable).toBe(false)
+    if (!usability.usable) expect(usability.reason).toContain("setting up uid map: Permission denied")
+  })
+
+  test("#given a smoke child that could not be spawned at all #when classified #then it is unusable with the spawn error", () => {
+    const usability = classifyBwrapSmoke({
+      exitCode: null,
+      timedOut: false,
+      errorMessage: "spawn /usr/bin/bwrap ENOENT",
+      stderr: "",
+    })
+
+    expect(usability.usable).toBe(false)
+    if (!usability.usable) expect(usability.reason).toContain("spawn /usr/bin/bwrap ENOENT")
+  })
+
+  test("#given a smoke child that hung past the timeout #when classified #then it is unusable and the reason names the timeout", () => {
+    const usability = classifyBwrapSmoke({ exitCode: null, timedOut: true, stderr: "" })
+
+    expect(usability.usable).toBe(false)
+    if (!usability.usable) expect(usability.reason).toContain("timed out")
+  })
+})
+
+describe.skipIf(process.platform === "win32")("probeBwrapUsability", () => {
+  test("#given an executable whose behavior changes after the first probe #when probed repeatedly #then the first verdict is memoized per path", async () => {
+    // given
+    const binDir = await mkdtemp(join(tmpdir(), "omo-bwrap-probe-"))
+    const executable = join(binDir, "bwrap")
+    await writeFile(executable, "#!/bin/sh\nexit 0\n")
+    await chmod(executable, 0o755)
+
+    // when
+    const first = probeBwrapUsability(executable)
+    await writeFile(executable, "#!/bin/sh\nexit 1\n")
+    const second = probeBwrapUsability(executable)
+
+    // then: a fresh classification would now be unusable, so a cached verdict is the only
+    // way `second` can still report usable.
+    expect(first).toEqual({ usable: true })
+    expect(second).toEqual({ usable: true })
+  }, 30_000)
+
+  test("#given a path that is not an executable #when probed #then it is unusable with the spawn failure", () => {
+    // when
+    const usability = probeBwrapUsability(join(tmpdir(), "omo-bwrap-probe-missing-binary"))
+
+    // then
+    expect(usability.usable).toBe(false)
+  })
+})

--- a/packages/omo-senpi/src/components/memory/sandbox-platform.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox-platform.ts
@@ -1,8 +1,56 @@
+import { spawnSync } from "node:child_process"
 import { accessSync, constants, existsSync, mkdirSync, realpathSync } from "node:fs"
 import { basename, delimiter, dirname, isAbsolute, join } from "node:path"
 
 import type { FactsSpawnArgs, ReflectionSpawnArgs } from "./worker/spawn"
 import { SandboxUnavailableError, type SandboxPolicy } from "./sandbox-contracts"
+
+export type SandboxUsability =
+  | { readonly usable: true }
+  | { readonly usable: false; readonly reason: string }
+
+interface BwrapSmokeResult {
+  readonly exitCode: number | null
+  readonly timedOut: boolean
+  readonly errorMessage?: string
+  readonly stderr: string
+}
+
+const BWRAP_SMOKE_TIMEOUT_MS = 10_000
+const BWRAP_SMOKE_REASON_STDERR_CHARS = 200
+// One verdict per absolute executable path per process: the probe spawns a real child, so the
+// facts surface (which rebuilds its transform per launch) must not pay it every time.
+const bwrapUsabilityCache = new Map<string, SandboxUsability>()
+
+export function classifyBwrapSmoke(result: BwrapSmokeResult): SandboxUsability {
+  if (!result.timedOut && result.exitCode === 0) return { usable: true }
+  const cause = result.timedOut
+    ? `smoke test timed out after ${BWRAP_SMOKE_TIMEOUT_MS}ms`
+    : result.errorMessage !== undefined
+      ? `smoke test failed to run: ${result.errorMessage}`
+      : `smoke test exited ${result.exitCode ?? "unknown"}`
+  const stderrTail = result.stderr.trimEnd().slice(-BWRAP_SMOKE_REASON_STDERR_CHARS)
+  return { usable: false, reason: stderrTail === "" ? cause : `${cause}: ${stderrTail}` }
+}
+
+export function probeBwrapUsability(executable: string): SandboxUsability {
+  const cached = bwrapUsabilityCache.get(executable)
+  if (cached !== undefined) return cached
+  const smoked = spawnSync(
+    executable,
+    ["--ro-bind", "/", "/", "--dev-bind", "/dev", "/dev", "--tmpfs", "/tmp", "true"],
+    { timeout: BWRAP_SMOKE_TIMEOUT_MS, encoding: "utf8", windowsHide: true },
+  )
+  const errorCode = smoked.error !== undefined && "code" in smoked.error ? smoked.error.code : undefined
+  const usability = classifyBwrapSmoke({
+    exitCode: smoked.status,
+    timedOut: errorCode === "ETIMEDOUT" || (smoked.status === null && smoked.signal !== null),
+    ...(smoked.error === undefined ? {} : { errorMessage: smoked.error.message }),
+    stderr: typeof smoked.stderr === "string" ? smoked.stderr : "",
+  })
+  bwrapUsabilityCache.set(executable, usability)
+  return usability
+}
 
 export interface PathSandboxInput {
   readonly surface: "reflection" | "facts"
@@ -22,6 +70,12 @@ export interface PathSandboxInput {
   readonly errorRethrow?: (error: SandboxUnavailableError) => never
   readonly platform?: NodeJS.Platform
   readonly which?: (command: string) => string | undefined
+  /**
+   * Verifies the resolved sandbox executable can actually start a sandbox, not merely that it
+   * exists. Defaults to the real bwrap smoke test only when `which` is not injected, so tests
+   * that fake executable resolution keep their existence-only semantics.
+   */
+  readonly probe?: (executable: string) => SandboxUsability
 }
 
 export interface GenericSandboxTransform<T> {
@@ -61,6 +115,19 @@ export function buildPathSandboxTransform<T extends ReflectionSpawnArgs | FactsS
   }
 
   const writableDirs = input.writableDirs.map(canonicalPath)
+  if (platform === "linux") {
+    const probe = input.probe ?? (input.which === undefined ? probeBwrapUsability : undefined)
+    const usability = probe?.(executable)
+    if (usability !== undefined && !usability.usable) {
+      const reason = `bwrap cannot start a sandbox: ${usability.reason}`
+      if (input.policy === "required") {
+        const error = new SandboxUnavailableError(platform, reason)
+        if (input.errorRethrow !== undefined) input.errorRethrow(error)
+        throw error
+      }
+      return identityTransform(`${input.surface} sandbox unavailable on ${platform}: ${reason}; running unsandboxed because policy is auto`)
+    }
+  }
   if (platform === "darwin") {
     const payloads = input.payloadPaths.map(canonicalPath)
     const foreignRoots = (input.foreignRoots ?? []).map(canonicalPath)

--- a/packages/omo-senpi/src/components/memory/sandbox.test.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox.test.ts
@@ -9,6 +9,7 @@ import {
   buildSandboxTransform,
   SandboxUnavailableError,
   type SandboxPolicy,
+  type SandboxUsability,
 } from "./sandbox"
 
 const roots: string[] = []
@@ -62,6 +63,7 @@ function spawnArgs(worktree: string): ReflectionSpawnArgs {
 function build(policy: SandboxPolicy, options: {
   readonly platform?: NodeJS.Platform
   readonly which?: (command: string) => string | undefined
+  readonly probe?: (executable: string) => SandboxUsability
 } = {}) {
   const setup = fixture()
   return {
@@ -75,6 +77,7 @@ function build(policy: SandboxPolicy, options: {
       env: { PATH: process.env.PATH },
       platform: options.platform,
       which: options.which,
+      probe: options.probe,
     }),
   }
 }
@@ -276,5 +279,83 @@ describe("reflection worker OS sandbox", () => {
     expect(transformed).toBe(original)
     expect(transform.wasSandboxed).toBe(false)
     expect(transform.warning).toBeUndefined()
+  }, 30_000)
+
+  test("#given Linux with a bwrap that exists but cannot start a sandbox #when auto policy is used #then spawn arguments pass through with an explicit degradation warning", () => {
+    // given: bubblewrap is installed but its user-namespace setup fails (AppArmor restriction),
+    // which the issue reporter hit as `bwrap: setting up uid map: Permission denied` on every run.
+    const { setup, transform } = build("auto", {
+      platform: "linux",
+      which: () => "/usr/bin/bwrap",
+      probe: () => ({ usable: false, reason: "smoke test exited 1: setting up uid map: Permission denied" }),
+    })
+    const original = spawnArgs(setup.worktree)
+
+    // when
+    const transformed = transform(original)
+
+    // then
+    expect(transformed).toBe(original)
+    expect(transform.wasSandboxed).toBe(false)
+    expect(transform.warning).toContain("bwrap cannot start a sandbox")
+    expect(transform.warning).toContain("setting up uid map: Permission denied")
+    expect(transform.warning).toContain("running unsandboxed because policy is auto")
+  }, 30_000)
+
+  test("#given Linux with a bwrap that cannot start a sandbox #when required policy is used #then a typed unavailable error fails closed", () => {
+    // given
+    const setup = fixture()
+
+    // when
+    const buildRequired = () => buildSandboxTransform({
+      policy: "required",
+      worktreeDir: setup.worktree,
+      gitCommonDir: setup.gitCommonDir,
+      payloadPaths: setup.payloadPaths,
+      command: "/bin/sh",
+      env: { PATH: process.env.PATH },
+      platform: "linux",
+      which: () => "/usr/bin/bwrap",
+      probe: () => ({ usable: false, reason: "smoke test exited 1: setting up uid map: Permission denied" }),
+    })
+
+    // then
+    expect(buildRequired).toThrow(SandboxUnavailableError)
+    expect(buildRequired).toThrow("bwrap cannot start a sandbox")
+    expect(buildRequired).toThrow("setting up uid map: Permission denied")
+  }, 30_000)
+
+  test("#given Linux with a bwrap that passes the usability smoke test #when spawn arguments are transformed #then the sandbox still wraps the child", () => {
+    // given: guards against over-degrading; a healthy bwrap must keep sandboxing.
+    const { setup, transform } = build("auto", {
+      platform: "linux",
+      which: () => "/usr/bin/bwrap",
+      probe: () => ({ usable: true }),
+    })
+
+    // when
+    const transformed = transform(spawnArgs(setup.worktree))
+
+    // then
+    expect(transform.wasSandboxed).toBe(true)
+    expect(transform.warning).toBeUndefined()
+    expect(transformed.command).toBe("/usr/bin/bwrap")
+  }, 30_000)
+
+  test("#given off policy with a probe present #when the transform is built #then the probe never runs", () => {
+    // given
+    const { setup, transform } = build("off", {
+      platform: "linux",
+      which: () => "/usr/bin/bwrap",
+      probe: () => { throw new Error("must not probe") },
+    })
+    const original = spawnArgs(setup.worktree)
+
+    // when
+    const transformed = transform(original)
+
+    // then
+    expect(transformed).toBe(original)
+    expect(transform.wasSandboxed).toBe(false)
   }, 30_000)
 })

--- a/packages/omo-senpi/src/components/memory/sandbox.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox.ts
@@ -7,13 +7,14 @@ import {
   type SandboxPolicy,
   type SandboxTransform,
 } from "./sandbox-contracts"
-import { buildPathSandboxTransform } from "./sandbox-platform"
+import { buildPathSandboxTransform, type SandboxUsability } from "./sandbox-platform"
 
 export {
   SandboxUnavailableError,
   type SandboxPolicy,
   type SandboxTransform,
 } from "./sandbox-contracts"
+export type { SandboxUsability } from "./sandbox-platform"
 
 export function buildSandboxTransform(input: {
   readonly policy: SandboxPolicy
@@ -27,6 +28,7 @@ export function buildSandboxTransform(input: {
   readonly errorRethrow?: (error: SandboxUnavailableError) => never
   readonly platform?: NodeJS.Platform
   readonly which?: (command: string) => string | undefined
+  readonly probe?: (executable: string) => SandboxUsability
 }): SandboxTransform {
   return buildPathSandboxTransform({
     surface: "reflection",
@@ -44,6 +46,7 @@ export function buildSandboxTransform(input: {
     errorRethrow: input.errorRethrow,
     platform: input.platform,
     which: input.which,
+    probe: input.probe,
   })
 }
 

--- a/packages/omo-senpi/src/components/memory/worker/remediation.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/remediation.test.ts
@@ -44,6 +44,21 @@ describe("reflectionRemediation", () => {
     })
   })
 
+  describe("#given a bubblewrap setup failure", () => {
+    // bwrap dies before the reflection child starts (AppArmor blocking unprivileged user
+    // namespaces), and cleanup may already have removed the run directory, so the generic
+    // child-stderr.log pointer would reference a file that no longer exists.
+    test("#when remediated #then it names the sandbox escape hatch instead of the removed child log", () => {
+      // when
+      const hint = reflectionRemediation("child_exit", "bwrap: setting up uid map: Permission denied")
+
+      // then
+      expect(hint).toContain("memory.reflection.sandbox")
+      expect(hint).toContain("bubblewrap")
+      expect(hint).not.toContain("child-stderr.log")
+    })
+  })
+
   describe("#given the pre-existing failure taxonomies", () => {
     test("#when the child could not see the model #then the category/model hint is kept", () => {
       expect(reflectionRemediation("child_exit", "Model not found: apitopia/kimi")).toContain("memory.reflection")

--- a/packages/omo-senpi/src/components/memory/worker/remediation.ts
+++ b/packages/omo-senpi/src/components/memory/worker/remediation.ts
@@ -23,5 +23,10 @@ export function reflectionRemediation(reason: string | undefined, detail: string
   if (combined.includes("api key") || combined.includes("auth_missing")) {
     return "run /login <provider>"
   }
+  // Bubblewrap died during its own sandbox setup, before the reflection child started; run-dir
+  // cleanup may already have removed child-stderr.log, so point at the config escape hatch instead.
+  if (combined.includes("bwrap") || combined.includes("bubblewrap") || combined.includes("setting up uid map")) {
+    return "bubblewrap cannot start a sandbox on this host; set memory.reflection.sandbox to \"off\" in omo.json or restore unprivileged user namespace access"
+  }
   return "inspect runtime/reflection-sessions/<runId>/child-stderr.log"
 }


### PR DESCRIPTION
## What

- `memory.reflection.sandbox: "auto"` now verifies that the resolved `bwrap` executable can actually start a sandbox, not merely that it exists. A one-shot smoke test (`bwrap --ro-bind / / --dev-bind /dev /dev --tmpfs /tmp true`, 10s timeout) runs once per executable path per process; on failure the reflection/facts children run unsandboxed with an explicit degradation warning naming the cause (e.g. `setting up uid map: Permission denied`).
- `sandbox: "required"` stays fail-closed: an unusable bwrap raises `SandboxUnavailableError` before any child spawns.
- Reflection failure remediation for bubblewrap setup failures (`bwrap: setting up uid map: Permission denied`) now points at the `memory.reflection.sandbox` config escape hatch instead of `runtime/reflection-sessions/<runId>/child-stderr.log`, which run-dir cleanup has usually already removed.
- Tests: policy-level regression tests in `sandbox.test.ts` (auto degrade + warning, required fail-closed, healthy bwrap keeps wrapping, off never probes), unit tests for the smoke classifier and its memoization in `sandbox-bwrap-probe.test.ts`, and a remediation-hint test in `worker/remediation.test.ts`.

## Why

On Ubuntu with AppArmor restricting unprivileged user namespaces (#6873), bubblewrap is installed but every sandboxed reflection child dies at setup with `bwrap: setting up uid map: Permission denied`. `auto` never degraded, so reflection failed on every trigger and the consecutive-failure warning repeated indefinitely, while the diagnostic pointed at a log file that no longer existed.

## Verified

- `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json`: clean.
- Scoped suite (`sandbox.test.ts`, `sandbox-bwrap-probe.test.ts`, `sandbox-absent-paths.test.ts`, `worker/remediation.test.ts`): 29 pass, 1 skip (win32-gated), 0 fail.
- Full memory component suite (`bun test packages/omo-senpi/src/components/memory`): 911 pass, 6 skip, 0 fail.
- Evidence recorded in `.omo/evidence/20260824-6873-bwrap-fallback/QA-EVIDENCE.md` (what was tested/observed/why enough/omitted). Live Senpi harness QA was not run in this environment and none is claimed.

## Risk

- Low. Pre-existing tests all inject `which`, so they keep existence-only semantics and never spawn a real bwrap; only production callers get the probe, memoized once per process per path (~one extra child spawn per process on linux).
- Residual: a host where the smoke test passes but a later real launch still fails at setup keeps the pre-existing runtime behavior, now with the corrected remediation hint.

Fixes #6873

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Degrades Linux sandboxing for reflection and facts to unsandboxed when `bwrap` exists but cannot start a user namespace, preventing repeated child failures on hosts that block unprivileged namespaces. Previously `auto` only checked for `bwrap` presence and kept failing; now it probes once per path and degrades with a warning, while `required` still fails closed with `SandboxUnavailableError`.

- Behavior change (Linux only): `auto` runs a one-shot `bwrap` smoke test (`--ro-bind / / --dev-bind /dev /dev --tmpfs /tmp true`, 10s timeout) and either wraps or degrades with an explicit warning naming the cause; `required` rejects early; `off` unchanged. Probe result is memoized per executable path per process and only runs when no test `which` is injected; callers may override via an optional `probe`.
- API notes: export `SandboxUsability`; `buildSandboxTransform` (and internal `buildPathSandboxTransform`) accept an optional `probe` parameter. No migration required for existing callers.
- Remediation: for bubblewrap setup failures, hints now point to `memory.reflection.sandbox` instead of `runtime/reflection-sessions/<runId>/child-stderr.log`.

<sup>Written for commit 7811c387a85243586b179bf4c4f84875017fce50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

