### PR TITLE
fix(background-agent): strip platform session-id prefix before existence check

### DIFF
--- a/.omo/evidence/20260824-6263-session-prefix/EVIDENCE.md
+++ b/.omo/evidence/20260824-6263-session-prefix/EVIDENCE.md
@@ -1,0 +1,31 @@
+# Evidence — 20260824 — issue #6263 session-existence prefix false negatives
+
+## WHAT WAS TESTED
+
+- Command: `bun test packages/omo-opencode/src/features/background-agent/session-existence.test.ts`
+- Surface: `checkSessionExistence()` in `packages/omo-opencode/src/features/background-agent/session-existence.ts` — the cheap existence check consumed by `task-poller.ts` (lines 238, 288) for background-task recovery decisions.
+- Behavior under test: a platform-prefixed session id (`opencode:` / `codex:` / `senpi:`, the format boulder.json stores via `normalizeSessionId` in `@oh-my-opencode/boulder-state`) must resolve to the same existence result as the raw id, because the storage layer resolves bare ids only.
+- Regression fixture: mock client resolves ONLY the bare id (`ses_bare123`) and returns a 404 "Session not found" error for anything else — mirroring the real storage layer's behavior described in issue #6263.
+
+## WHAT WAS OBSERVED
+
+- RED (before fix): prefixed lookups returned `"missing"` while raw lookup returned `"exists"`:
+  - `(fail) #given an opencode:-prefixed session id ... Expected: "exists" Received: "missing"` at session-existence.test.ts:74
+  - `(fail) #given codex:- or senpi:-prefixed session ids ... Expected: "exists" Received: "missing"` at session-existence.test.ts:88
+  - This reproduces the issue's production failure mode: live subagent sessions classified as gone every poll cycle, triggering recovery re-sends (the reported 6.09M-token runaway loop).
+- GREEN (after fix): `5 pass, 0 fail` in session-existence.test.ts; prefixed ids are stripped to bare form before `client.session.get({ path: { id } })` (asserted via captured requested ids), missing-behind-prefix still classifies `"missing"`.
+- Scoped suite: `bun test packages/omo-opencode/src/features/background-agent/` → `746 pass, 0 fail` across 59 files (includes all task-poller consumer tests).
+- Typecheck: `bun run typecheck` (tsgo --noEmit + typecheck:script + typecheck:packages) → exit 0.
+
+## WHY IT IS ENOUGH
+
+- The failing-first pair proves both the defect (prefixed != raw) and the fix (prefixed == raw) at the exact boundary named in the issue triage (`session-existence.ts`, SDK path construction).
+- The fixture encodes the real-world contract (bare-id-only resolution), so the test fails again if anyone reverts to passing the raw/prefixed id through.
+- All 746 background-agent tests stay green, covering every caller of `checkSessionExistence`/`verifySessionExists` (task-poller recovery paths); repo-wide typecheck confirms no signature drift from the new exported `bareSessionId()` helper.
+- Residual risk: other subsystems that consume prefixed ids from boulder.json against the SDK were out of scope; this change is confined to the session-existence boundary named by the issue and its owner triage comment.
+
+## WHAT WAS OMITTED
+
+- No live OpenCode harness drive: the fix surface is a pure SDK-path normalization verified deterministically at unit level; no opencode spawn was required and none was performed, so there is no DB/session-count isolation proof to record.
+- No secrets, tokens, env dumps, or auth headers appear in this evidence or the test fixtures; mock ids are synthetic (`ses_bare123`, `ses_gone999`).
+- `bun install` was run with `--ignore-scripts`: the prepare script hangs fetching submodules in this environment (known-harmless per worktree setup notes); dependency resolution itself completed cleanly.

--- a/packages/omo-opencode/src/features/background-agent/session-existence.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-existence.test.ts
@@ -41,3 +41,63 @@ describe("verifySessionExists", () => {
     expect(result).toBe("unknown")
   })
 })
+
+describe("checkSessionExistence with platform-prefixed session ids", () => {
+  // Regression fixture for #6263: the storage layer resolves bare ids only,
+  // so prefixed ids must be stripped before the SDK path or they 404.
+  function createBareIdOnlyClient(): { client: OpencodeClient; requestedIds: string[] } {
+    const requestedIds: string[] = []
+    const get = mock(async (args: { path: { id: string } }) => {
+      requestedIds.push(args.path.id)
+      if (args.path.id === "ses_bare123") {
+        return { data: { id: "ses_bare123" } }
+      }
+      return { error: { message: "Session not found", status: 404 }, data: undefined }
+    })
+    const client = unsafeTestValue<OpencodeClient>({
+      session: {
+        get,
+      },
+    })
+    return { client, requestedIds }
+  }
+
+  test("#given an opencode:-prefixed session id #when existence is checked #then the bare id is looked up and the result matches the raw-id lookup", async () => {
+    // given
+    const { client, requestedIds } = createBareIdOnlyClient()
+
+    // when
+    const prefixedResult = await checkSessionExistence(client, "opencode:ses_bare123")
+    const rawResult = await checkSessionExistence(client, "ses_bare123")
+
+    // then
+    expect(prefixedResult).toBe(rawResult)
+    expect(prefixedResult).toBe("exists")
+    expect(requestedIds[0]).toBe("ses_bare123")
+  })
+
+  test("#given codex:- or senpi:-prefixed session ids #when existence is checked #then the bare id is looked up for each platform prefix", async () => {
+    // given
+    const { client, requestedIds } = createBareIdOnlyClient()
+
+    // when
+    const codexResult = await checkSessionExistence(client, "codex:ses_bare123")
+    const senpiResult = await checkSessionExistence(client, "senpi:ses_bare123")
+
+    // then
+    expect(codexResult).toBe("exists")
+    expect(senpiResult).toBe("exists")
+    expect(requestedIds).toEqual(["ses_bare123", "ses_bare123"])
+  })
+
+  test("#given a missing session behind a prefix #when existence is checked #then the result stays missing", async () => {
+    // given
+    const { client } = createBareIdOnlyClient()
+
+    // when
+    const result = await checkSessionExistence(client, "opencode:ses_gone999")
+
+    // then
+    expect(result).toBe("missing")
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/session-existence.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-existence.ts
@@ -3,6 +3,14 @@ import type { OpencodeClient } from "./opencode-client"
 export const MIN_SESSION_GONE_POLLS = 3
 export type SessionExistenceStatus = "exists" | "missing" | "unknown"
 
+// boulder.json stores ids prefixed via normalizeSessionId
+// (@oh-my-opencode/boulder-state); the storage layer resolves bare ids.
+const SESSION_ID_PLATFORM_PREFIX_PATTERN = /^(codex|opencode|senpi):/
+
+export function bareSessionId(sessionID: string): string {
+  return sessionID.replace(SESSION_ID_PLATFORM_PREFIX_PATTERN, "")
+}
+
 function extractErrorMessage(error: unknown): string | undefined {
   if (typeof error === "string") {
     return error
@@ -43,7 +51,7 @@ export async function checkSessionExistence(
 ): Promise<SessionExistenceStatus> {
   try {
     const response = await client.session.get({
-      path: { id: sessionID },
+      path: { id: bareSessionId(sessionID) },
       ...(directory ? { query: { directory } } : {}),
     })
 


### PR DESCRIPTION
## What

`checkSessionExistence()` in `packages/omo-opencode/src/features/background-agent/session-existence.ts` passed the incoming session id straight into `client.session.get({ path: { id } })`. Boulder state (`.omo/boulder.json`) records session ids normalized with a platform prefix (`opencode:` / `codex:` / `senpi:`, via `normalizeSessionId` in `@oh-my-opencode/boulder-state`), while the storage layer resolves bare ids only. This change adds a `bareSessionId()` helper at that boundary and strips the prefix before constructing the SDK path, so prefixed and raw ids resolve identically.

## Why

With a prefixed id, the SDK path became `/session/opencode%3Ases_...`, which 404s even though the session exists. The task poller (both call sites in `task-poller.ts`) then classified live subagent sessions as missing every poll cycle and attempted recovery by re-sending full turn context to fresh subagent turns — the runaway retry loop reported in #6263 (a single task burned ~6.09M input tokens in ~50 minutes across 81 duplicate turns before exhausting quota).

## Verified

- Failing-first regression test in `session-existence.test.ts`: a fixture client resolves only the bare id and 404s anything else. Before the fix, `opencode:ses_bare123` returned `"missing"` while `ses_bare123` returned `"exists"` (exact issue reproduction). After the fix both return `"exists"`, with the captured SDK path id asserted to be the bare form; codex:/senpi: prefixes covered; missing-behind-prefix still classifies `"missing"`.
- Scoped suite: `bun test packages/omo-opencode/src/features/background-agent/` → 746 pass / 0 fail across 59 files (all task-poller consumer paths).
- Repo typecheck: `bun run typecheck` → exit 0.
- Evidence recorded in `.omo/evidence/20260824-6263-session-prefix/EVIDENCE.md` (WHAT TESTED / OBSERVED / WHY ENOUGH / OMITTED).

## Risk

Low. The normalization is confined to the session-existence boundary named in the issue triage; raw ids are unaffected (the prefix pattern only matches a leading `opencode:`/`codex:`/`senpi:`). Other subsystems that consume prefixed ids against the SDK were intentionally left out of scope.

Fixes #6263

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip platform prefix from session IDs before existence checks so prefixed and raw IDs resolve identically. Previously we sent the prefixed ID to `client.session.get`, which 404’d and made the task poller misclassify live sessions as missing, triggering duplicate recovery turns (Fixes #6263).

- Adds `bareSessionId()` and uses it in `checkSessionExistence()` to remove `opencode:`/`codex:`/`senpi:`; normalization is limited to this boundary.
- Regression tests cover all prefixes: prefixed IDs now return "exists" like the bare ID; missing-behind-prefix still returns "missing".
- No migration. Risk is low and localized; other SDK callers are unchanged.

<sup>Written for commit dee15bfbc079605be264a4f77f8b4cba9217b5fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

