### PR TITLE
fix(omo-native): resolve the ancestor node_modules/.bin holding the senpi shim in scoped npm installs

### DIFF
--- a/.omo/evidence/20260824-6847-reflection-scoped-npm/PLAN.md
+++ b/.omo/evidence/20260824-6847-reflection-scoped-npm/PLAN.md
@@ -1,0 +1,42 @@
+# Plan: fix #6847 memory reflection ENOENT on scoped npm Windows installs
+
+Branch: issue/6847-memory-reflection-scoped-npm (base dev @ 8833800ae)
+
+## Root cause
+
+`packages/omo-native/bin/lib/package-paths.js`, `nearestNodeBin()` (lines 49-63 at base):
+the walk returns the FIRST EXISTING `node_modules/.bin` without checking that it contains
+the executable shim. On Windows scoped npm installs, npm materializes
+`...\omo-ai\node_modules\@code-yeongyu\senpi\node_modules\.bin` even when it holds no
+shims, and it shadows the ancestor `...\omo-ai\node_modules\.bin\senpi.cmd`.
+
+Consequence chain in `bin/lib/launcher.js` `senpiEnvironment()`:
+1. `nearestNodeBin(senpiRoot)` returns the empty scoped bin.
+2. That dir is prepended to the child PATH.
+3. The launcher deletes inherited `SENPI_BIN` and recomputes it, but
+   `join(binDir, "senpi.cmd")` does not exist there, so `SENPI_BIN` stays absent.
+4. Memory reflection children fall back to spawning bare `senpi`, which resolves nowhere
+   on PATH: `spawn senpi ENOENT`, repeated on every reflection boundary.
+
+## Fix direction
+
+`nearestNodeBin(startPath, options)` gains `{ executable?, platform?, fileExists? }`:
+a candidate bin qualifies only if it holds the platform shim for the executable
+(`<name>.cmd` on win32, `<name>` elsewhere). Injected platform/fileExists keep the
+decision testable portably (pattern from merged #7205 `resolveWindowsCmdPath`).
+`launcher.js` passes `{ executable: "senpi" }`. No-executable calls keep the legacy
+first-existing-bin walk; when no bin carries the shim the function returns undefined,
+which leaves PATH and SENPI_BIN untouched instead of pointing at a dead directory.
+
+## Files
+
+1. EDIT packages/omo-native/bin/lib/package-paths.js - shim-aware nearestNodeBin + private hasBinShim.
+2. EDIT packages/omo-native/bin/lib/launcher.js - pass { executable: "senpi" } (#6847 comment).
+3. NEW packages/omo-native/test/package-paths.test.ts - unit suite, injected platform cases.
+4. EDIT packages/omo-native/test/launcher.test.ts - FixtureOptions.scopedEmptyBin + e2e regression
+   asserting SENPI_BIN and the PATH head survive an empty scoped .bin.
+
+## Verification
+
+- Failing-first: both new suites RED before implementation (logs in this directory).
+- bun test packages/omo-native/test green; tsc -p packages/omo-native/tsconfig.json --noEmit exit 0.

--- a/.omo/evidence/20260824-6847-reflection-scoped-npm/QA.md
+++ b/.omo/evidence/20260824-6847-reflection-scoped-npm/QA.md
@@ -1,0 +1,59 @@
+# QA evidence: memory reflection scoped-npm ENOENT on Windows (#6847)
+
+Date: 2026-08-24
+Branch: issue/6847-memory-reflection-scoped-npm (base: dev @ 8833800ae)
+Scope: packages/omo-native/bin/lib/package-paths.js + launcher.js call site, tests under
+packages/omo-native/test/ only.
+
+## WHAT WAS TESTED
+
+1. Failing-first regression tests, written before the implementation:
+   - packages/omo-native/test/package-paths.test.ts (new): 6 cases for nearestNodeBin.
+     The #6847 case builds the exact npm layout (scoped package with its own EMPTY
+     node_modules/.bin plus an ancestor bin holding the shim) and asserts the ancestor bin
+     wins. Platform decision is simulated portably via an injected platform option:
+     win32 requires senpi.cmd, POSIX requires senpi; a win32 host with only an
+     extensionless shim qualifies no bin; no matching shim anywhere returns undefined;
+     calls without executable keep the legacy first-existing-bin walk; hoisted sibling
+     layouts still resolve.
+   - packages/omo-native/test/launcher.test.ts (extended): FixtureOptions.scopedEmptyBin
+     materializes the empty scoped .bin in the fixture tree; the new end-to-end case spawns
+     the real launcher through node and asserts the child environment recomputes
+     SENPI_BIN to the ancestor shim (a stale inherited SENPI_BIN is handed in to prove
+     recompute) and that the PATH head is the ancestor bin, not the empty scoped one.
+2. Scoped suite after implementation: bun test packages/omo-native/test/
+   (green-omo-native-full.txt): 133 pass, 0 fail, 6 skip across 15 files.
+3. Typecheck: bunx tsc -p packages/omo-native/tsconfig.json --noEmit, exit 0 (typecheck.txt).
+
+## WHAT WAS OBSERVED
+
+- RED before the fix: red-package-paths.txt shows 4 fail / 2 pass; the win32-injected and
+  shim-aware cases received the empty scoped bin instead of the ancestor bin.
+  red-launcher-scoped-empty-bin.txt shows the end-to-end case failing with
+  SENPI_BIN undefined, which is exactly the reporter's failure chain (launcher deletes the
+  inherited SENPI_BIN, recomputes against the empty bin, finds no senpi.cmd, and the
+  reflection child then fails spawning bare senpi with ENOENT).
+- GREEN after the fix: full scoped package suite 133 pass / 0 fail; typecheck exit 0.
+
+## WHY IT IS ENOUGH
+
+- The resolver contract is pinned with injected platform/fileExists seams, so the win32
+  decision runs in CI on Linux and cannot drift with the host.
+- The end-to-end case drives the real launcher subprocess over the real fixture tree, so
+  what is asserted is the actual child environment (PATH head + SENPI_BIN) that memory
+  reflection children inherit when they spawn senpi by name.
+- The legacy no-executable walk and the hoisted-layout normalization are pinned, so the
+  fix cannot regress either pre-existing caller shape.
+
+## WHAT WAS OMITTED
+
+- Live Windows verification: this QA host is Linux, so the real win32 CreateProcess lookup
+  of senpi.cmd could not be driven; the injected-platform unit cases plus the portable e2e
+  environment assertions cover the decision logic, and residual risk is documented here.
+- bun install prepare step failed in this environment (git submodule fetch network reset +
+  frontend materialization), the known harmless env quirk also recorded by PR #7196;
+  dependencies resolved and all scoped tests ran. The prepare step's partial build output
+  dirtied generated packages/omo-senpi/plugin/extensions/*.js artifacts; they were restored
+  and are NOT part of this change. Nothing from packages/shared-skills/upstreams/* is staged.
+- No secrets, tokens, or host-identifying paths appear in the captured outputs; fixture
+  paths live under the OS temp dir.

--- a/.omo/evidence/20260824-6847-reflection-scoped-npm/green-omo-native-full.txt
+++ b/.omo/evidence/20260824-6847-reflection-scoped-npm/green-omo-native-full.txt
@@ -1,0 +1,7 @@
+bun test v1.3.14 (0d9b296a)
+
+ 133 pass
+ 6 skip
+ 0 fail
+ 398 expect() calls
+Ran 139 tests across 15 files. [93.09s]

--- a/.omo/evidence/20260824-6847-reflection-scoped-npm/red-launcher-scoped-empty-bin.txt
+++ b/.omo/evidence/20260824-6847-reflection-scoped-npm/red-launcher-scoped-empty-bin.txt
@@ -1,0 +1,23 @@
+bun test v1.3.14 (0d9b296a)
+
+packages/omo-native/test/launcher.test.ts:
+217 |       test("#then an empty scoped package .bin does not shadow the ancestor shim", () => {
+218 |         const fixture = createFixture({ scopedEmptyBin: true })
+219 |         const result = run(fixture, ["say", "hi"], { SENPI_BIN: "/stale/senpi" })
+220 |         const environment = capture(fixture).env
+221 |         expect(result.status).toBe(0)
+222 |         expect(environment.SENPI_BIN).toBe(fixture.shimPath)
+                                            ^
+error: expect(received).toBe(expected)
+
+Expected: "/tmp/omo-launcher-KuVSYh/app/node_modules/.bin/senpi"
+Received: undefined
+
+      at <anonymous> (/home/viprix/projects/oom-wt-6847/packages/omo-native/test/launcher.test.ts:222:39)
+(fail) omo launcher > #given a fake senpi package > #when the default command is launched > #then an empty scoped package .bin does not shadow the ancestor shim [313.85ms]
+
+ 0 pass
+ 37 filtered out
+ 1 fail
+ 2 expect() calls
+Ran 1 test across 1 file. [1242.00ms]

--- a/.omo/evidence/20260824-6847-reflection-scoped-npm/red-package-paths.txt
+++ b/.omo/evidence/20260824-6847-reflection-scoped-npm/red-package-paths.txt
@@ -1,0 +1,62 @@
+bun test v1.3.14 (0d9b296a)
+
+packages/omo-native/test/package-paths.test.ts:
+48 | 
+49 |       // when
+50 |       const resolved = nearestNodeBin(scopedPackageRoot, { executable: "senpi" })
+51 | 
+52 |       // then
+53 |       expect(resolved).toBe(ancestorBin)
+                            ^
+error: expect(received).toBe(expected)
+
+Expected: "/tmp/omo-package-paths-ikzkzR/app/node_modules/.bin"
+Received: "/tmp/omo-package-paths-ikzkzR/app/node_modules/@code-yeongyu/senpi/node_modules/.bin"
+
+      at <anonymous> (/home/viprix/projects/oom-wt-6847/packages/omo-native/test/package-paths.test.ts:53:24)
+(fail) nearestNodeBin > #given a scoped package with its own empty .bin and an ancestor bin holding the senpi shim > #when resolving from the scoped package root #then the ancestor bin wins over the empty scoped one [3.80ms]
+59 | 
+60 |       // when
+61 |       const resolved = nearestNodeBin(scopedPackageRoot, { executable: "senpi", platform: "win32" })
+62 | 
+63 |       // then
+64 |       expect(resolved).toBe(ancestorBin)
+                            ^
+error: expect(received).toBe(expected)
+
+Expected: "/tmp/omo-package-paths-D1Eblh/app/node_modules/.bin"
+Received: "/tmp/omo-package-paths-D1Eblh/app/node_modules/@code-yeongyu/senpi/node_modules/.bin"
+
+      at <anonymous> (/home/viprix/projects/oom-wt-6847/packages/omo-native/test/package-paths.test.ts:64:24)
+(fail) nearestNodeBin > #given a scoped package with its own empty .bin and an ancestor bin holding the senpi shim > #when resolving on win32 #then the ancestor bin holding senpi.cmd wins over the empty scoped one [3.24ms]
+70 | 
+71 |       // when
+72 |       const resolved = nearestNodeBin(scopedPackageRoot, { executable: "senpi", platform: "win32" })
+73 | 
+74 |       // then
+75 |       expect(resolved).toBeUndefined()
+                            ^
+error: expect(received).toBeUndefined()
+
+Received: "/tmp/omo-package-paths-6gk3L8/app/node_modules/@code-yeongyu/senpi/node_modules/.bin"
+
+      at <anonymous> (/home/viprix/projects/oom-wt-6847/packages/omo-native/test/package-paths.test.ts:75:24)
+(fail) nearestNodeBin > #given a scoped package with its own empty .bin and an ancestor bin holding the senpi shim > #when resolving on win32 and only an extensionless shim exists #then no bin qualifies [0.72ms]
+83 | 
+84 |       // when
+85 |       const resolved = nearestNodeBin(scopedPackageRoot, { executable: "senpi" })
+86 | 
+87 |       // then
+88 |       expect(resolved).toBeUndefined()
+                            ^
+error: expect(received).toBeUndefined()
+
+Received: "/tmp/omo-package-paths-TqVXKt/app/node_modules/@code-yeongyu/senpi/node_modules/.bin"
+
+      at <anonymous> (/home/viprix/projects/oom-wt-6847/packages/omo-native/test/package-paths.test.ts:88:24)
+(fail) nearestNodeBin > #given no bin in the ancestry contains the requested executable > #when resolving #then it returns undefined instead of a shimless bin [3.82ms]
+
+ 2 pass
+ 4 fail
+ 6 expect() calls
+Ran 6 tests across 1 file. [1290.00ms]

--- a/packages/omo-native/bin/lib/launcher.js
+++ b/packages/omo-native/bin/lib/launcher.js
@@ -73,7 +73,9 @@ function senpiEnvironment(senpiRoot) {
   env.SENPI_RUNTIME = process.versions.bun ? "bun" : "node"
   env.SENPI_BRAND = JSON.stringify(brandProfile())
 
-  const binDir = nearestNodeBin(senpiRoot)
+  // #6847: only a bin holding the senpi shim may win, so an empty scoped package .bin cannot
+  // shadow the ancestor dependency bin that carries it.
+  const binDir = nearestNodeBin(senpiRoot, { executable: "senpi" })
   if (binDir) {
     const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH"
     const path = env[pathKey]

--- a/packages/omo-native/bin/lib/package-paths.js
+++ b/packages/omo-native/bin/lib/package-paths.js
@@ -46,7 +46,7 @@ export function resolveSenpi() {
   return { cliPath, packageRoot: dirname(dirname(indexPath)) }
 }
 
-export function nearestNodeBin(startPath) {
+export function nearestNodeBin(startPath, options = {}) {
   // Hoisted layouts place the engine package inside a shared node_modules (…/node_modules/senpi),
   // whose .bin is a sibling, not a child - starting the climb inside node_modules would walk to the
   // filesystem root and never find it. Begin at the package's parent so that sibling .bin is seen.
@@ -54,10 +54,20 @@ export function nearestNodeBin(startPath) {
     : basename(dirname(startPath)) === "node_modules" ? dirname(dirname(startPath))
     : startPath
   const root = parse(current).root
+  const platform = options.platform ?? process.platform
+  const fileExists = options.fileExists ?? existsSync
   while (true) {
     const candidate = join(current, "node_modules", ".bin")
-    if (existsSync(candidate)) return candidate
+    // #6847: scoped npm installs materialize a node_modules/.bin inside the scoped package even
+    // when it holds no shims, and that empty bin would shadow the ancestor bin carrying the
+    // executable. Only a bin that can actually serve name lookups may be returned.
+    if (fileExists(candidate) && (!options.executable || hasBinShim(candidate, options.executable, platform, fileExists))) return candidate
     if (current === root) return undefined
     current = dirname(current)
   }
+}
+
+function hasBinShim(binDir, executable, platform, fileExists) {
+  const shim = join(binDir, platform === "win32" ? `${executable}.cmd` : executable)
+  return fileExists(shim)
 }

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -19,6 +19,14 @@ type Fixture = {
 
 type InstallLayout = "bun" | "bun-legacy" | "bun-posix-special" | "npm" | "unknown"
 
+type FixtureOptions = {
+  hoisted?: boolean
+  shim?: boolean
+  installLayout?: InstallLayout
+  /** Creates the empty node_modules/.bin npm materializes inside the scoped senpi package (#6847). */
+  scopedEmptyBin?: boolean
+}
+
 function writeFile(path: string, content: string, mode?: number): void {
   mkdirSync(dirname(path), { recursive: true })
   writeFileSync(path, content, mode === undefined ? undefined : { mode })
@@ -38,7 +46,7 @@ function expandShortPath(path: string): string {
   }
 }
 
-function createFixture(options: { hoisted?: boolean; shim?: boolean; installLayout?: InstallLayout } = {}): Fixture {
+function createFixture(options: FixtureOptions = {}): Fixture {
   // Windows hands back the 8.3 short form (RUNNER~1) here while the launcher reports the long path, so
   // the fixture root is canonicalized once and every derived path inherits the same spelling.
   const root = expandShortPath(realpathSync(mkdtempSync(join(tmpdir(), "omo-launcher-"))))
@@ -90,6 +98,7 @@ if (process.env.FAKE_STDOUT) console.log(process.env.FAKE_STDOUT)
 if (process.env.FAKE_SIGNAL) process.kill(process.pid, process.env.FAKE_SIGNAL)
 process.exit(Number(process.env.FAKE_EXIT ?? 0))
 `)
+  if (options.scopedEmptyBin) mkdirSync(join(senpiRoot, "node_modules", ".bin"), { recursive: true })
 
   let shimPath: string | undefined
   if (options.shim !== false) {
@@ -199,6 +208,22 @@ describe("omo launcher", () => {
         const result = run(fixture, ["say", "hi"], { SENPI_BIN: "/stale/senpi" })
         expect(result.status).toBe(0)
         expect(capture(fixture).env.SENPI_BIN).toBeUndefined()
+      })
+
+      // Regression for #6847: npm materializes an empty node_modules/.bin inside the scoped
+      // @code-yeongyu/senpi package, and the senpi shim lives only in the ancestor dependency
+      // bin. The launcher must skip the shimless bin so the reflection child resolves bare
+      // `senpi` through PATH and SENPI_BIN instead of failing with spawn ENOENT.
+      test("#then an empty scoped package .bin does not shadow the ancestor shim", () => {
+        const fixture = createFixture({ scopedEmptyBin: true })
+        const result = run(fixture, ["say", "hi"], { SENPI_BIN: "/stale/senpi" })
+        const environment = capture(fixture).env
+        expect(result.status).toBe(0)
+        expect(environment.SENPI_BIN).toBe(fixture.shimPath)
+        const path = Object.entries(environment).find(([key]) => key.toLowerCase() === "path")?.[1]
+        const binDir = path?.split(process.platform === "win32" ? ";" : ":")[0]
+        expect(binDir).toBeDefined()
+        expect(realpathSync.native(binDir ?? "")).toBe(realpathSync.native(dirname(fixture.shimPath ?? "")))
       })
     })
 

--- a/packages/omo-native/test/package-paths.test.ts
+++ b/packages/omo-native/test/package-paths.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { nearestNodeBin } from "../bin/lib/package-paths.js"
+
+const roots: string[] = []
+
+type ShimName = "senpi" | "senpi.cmd" | "other"
+
+type LayoutOptions = {
+  /** Creates the empty node_modules/.bin npm materializes inside the scoped package (#6847). */
+  scopedEmptyBin?: boolean
+  /** Which shim the ancestor dependency bin holds. */
+  ancestorShim?: ShimName
+}
+
+function createLayout(options: LayoutOptions = {}): { root: string; scopedPackageRoot: string; ancestorBin: string } {
+  const root = mkdtempSync(join(tmpdir(), "omo-package-paths-"))
+  roots.push(root)
+  const modulesRoot = join(root, "app", "node_modules")
+  const scopedPackageRoot = join(modulesRoot, "@code-yeongyu", "senpi")
+  mkdirSync(join(scopedPackageRoot, "dist"), { recursive: true })
+  writeFileSync(join(scopedPackageRoot, "package.json"), "{}\n")
+  writeFileSync(join(scopedPackageRoot, "dist", "cli.js"), "export {}\n")
+  if (options.scopedEmptyBin) {
+    // npm creates this directory for a scoped package's own transitive bins even when it stays empty.
+    mkdirSync(join(scopedPackageRoot, "node_modules", ".bin"), { recursive: true })
+  }
+  const ancestorBin = join(modulesRoot, ".bin")
+  const shim = options.ancestorShim
+  if (shim) {
+    mkdirSync(ancestorBin, { recursive: true })
+    writeFileSync(join(ancestorBin, shim), "fixture shim\n", { mode: 0o755 })
+  }
+  return { root, scopedPackageRoot, ancestorBin }
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("nearestNodeBin", () => {
+  describe("#given a scoped package with its own empty .bin and an ancestor bin holding the senpi shim", () => {
+    test("#when resolving from the scoped package root #then the ancestor bin wins over the empty scoped one", () => {
+      // given - the exact npm layout from #6847
+      const { scopedPackageRoot, ancestorBin } = createLayout({ scopedEmptyBin: true, ancestorShim: "senpi" })
+
+      // when
+      const resolved = nearestNodeBin(scopedPackageRoot, { executable: "senpi" })
+
+      // then
+      expect(resolved).toBe(ancestorBin)
+    })
+
+    test("#when resolving on win32 #then the ancestor bin holding senpi.cmd wins over the empty scoped one", () => {
+      // given - npm ships .cmd shims on Windows; the decision must be simulated portably
+      const { scopedPackageRoot, ancestorBin } = createLayout({ scopedEmptyBin: true, ancestorShim: "senpi.cmd" })
+
+      // when
+      const resolved = nearestNodeBin(scopedPackageRoot, { executable: "senpi", platform: "win32" })
+
+      // then
+      expect(resolved).toBe(ancestorBin)
+    })
+
+    test("#when resolving on win32 and only an extensionless shim exists #then no bin qualifies", () => {
+      // given - the launcher spawns senpi.cmd on win32, so an extensionless shim cannot serve it
+      const { scopedPackageRoot } = createLayout({ scopedEmptyBin: true, ancestorShim: "senpi" })
+
+      // when
+      const resolved = nearestNodeBin(scopedPackageRoot, { executable: "senpi", platform: "win32" })
+
+      // then
+      expect(resolved).toBeUndefined()
+    })
+  })
+
+  describe("#given no bin in the ancestry contains the requested executable", () => {
+    test("#when resolving #then it returns undefined instead of a shimless bin", () => {
+      // given - both bins exist but hold only an unrelated tool
+      const { scopedPackageRoot } = createLayout({ scopedEmptyBin: true, ancestorShim: "other" })
+
+      // when
+      const resolved = nearestNodeBin(scopedPackageRoot, { executable: "senpi" })
+
+      // then
+      expect(resolved).toBeUndefined()
+    })
+  })
+
+  describe("#given no executable is requested", () => {
+    test("#when resolving #then the first existing bin wins, preserving the legacy walk", () => {
+      // given
+      const { scopedPackageRoot } = createLayout({ scopedEmptyBin: true, ancestorShim: "senpi" })
+
+      // when
+      const resolved = nearestNodeBin(scopedPackageRoot)
+
+      // then
+      expect(resolved).toBe(join(scopedPackageRoot, "node_modules", ".bin"))
+    })
+  })
+
+  describe("#given a hoisted layout where the engine package sits directly in node_modules", () => {
+    test("#when resolving with an executable #then the sibling bin holding the shim is found", () => {
+      // given
+      const root = mkdtempSync(join(tmpdir(), "omo-package-paths-"))
+      roots.push(root)
+      const modulesRoot = join(root, "app", "node_modules")
+      const hoistedPackageRoot = join(modulesRoot, "senpi")
+      mkdirSync(hoistedPackageRoot, { recursive: true })
+      const ancestorBin = join(modulesRoot, ".bin")
+      mkdirSync(ancestorBin, { recursive: true })
+      writeFileSync(join(ancestorBin, "senpi"), "fixture shim\n", { mode: 0o755 })
+
+      // when
+      const resolved = nearestNodeBin(hoistedPackageRoot, { executable: "senpi" })
+
+      // then
+      expect(resolved).toBe(ancestorBin)
+    })
+  })
+})


### PR DESCRIPTION
## What

`nearestNodeBin()` in the `omo-ai` launcher (`packages/omo-native/bin/lib/package-paths.js`) returned the first existing `node_modules/.bin` walking up from the pinned engine package, without checking that the directory contains the executable shim. On Windows scoped npm installs, npm materializes an empty `node_modules/.bin` inside `@code-yeongyu/senpi`, which shadowed the ancestor dependency bin holding `senpi.cmd`.

The resolver now takes `{ executable, platform, fileExists }`: a candidate bin qualifies only when it holds the platform shim for the executable (`<name>.cmd` on win32, `<name>` elsewhere). The launcher passes `{ executable: "senpi" }`. Calls without `executable` keep the legacy first-existing-bin walk, and a bin ancestry with no matching shim yields `undefined` so PATH and `SENPI_BIN` are left untouched instead of pointing at a dead directory.

## Why

Memory reflection children on Windows failed on every reflection boundary with `spawn senpi ENOENT` (#6847): the launcher prepended the empty scoped `.bin` to the child PATH, deleted the inherited `SENPI_BIN`, and its recompute found no `senpi.cmd` in that directory, so reflection children fell back to spawning bare `senpi`, which resolves nowhere in a scoped global install.

## Verified

- Failing-first: new unit suite `packages/omo-native/test/package-paths.test.ts` (6 cases; win32 decision simulated via injected `platform`, no real Windows needed) and an end-to-end `launcher.test.ts` case over the exact npm layout (empty scoped `.bin` + ancestor shim) were RED before the fix and GREEN after. RED logs captured in `.omo/evidence/20260824-6847-reflection-scoped-npm/`.
- The e2e case hands a stale inherited `SENPI_BIN` to the launcher and asserts the child environment recomputes it to the ancestor shim and that the PATH head is the ancestor bin.
- `bun test packages/omo-native/test/`: 133 pass / 0 fail / 6 skip.
- `bunx tsc -p packages/omo-native/tsconfig.json --noEmit`: exit 0.

## Risk

Low. Single caller updated; the no-`executable` walk is unchanged and pinned by tests. When no bin carries the shim the launcher now skips the PATH prepend entirely, which only affects layouts where the prepend was already useless. Live Windows execution was not driven from this Linux host; the platform branch is covered by injected-platform tests, residual risk recorded in the evidence QA.md.

Fixes #6847


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip shimless scoped `.bin` directories when resolving the `senpi` shim to prevent Windows reflection children failing with ENOENT. Old behavior picked the first existing `node_modules/.bin`; new behavior only accepts a `.bin` that contains the platform shim for the requested executable, otherwise leaves PATH/SENPI_BIN unchanged. Fixes #6847.

- nearestNodeBin: signature extends to `nearestNodeBin(startPath, { executable?, platform?, fileExists? })`. When `executable` is set, it returns the nearest `.bin` that holds the platform shim (`<name>.cmd` on win32, `<name>` elsewhere) or `undefined` if none; calls without `executable` keep the legacy walk.
- Launcher: `packages/omo-native/bin/lib/launcher.js` now calls `nearestNodeBin(senpiRoot, { executable: "senpi" })` so an empty scoped `node_modules/.bin` under `@code-yeongyu/senpi` cannot shadow the ancestor bin that carries the shim.
- Tests: adds a focused unit suite for the resolver (with injected platform) and an end-to-end launcher case over the exact npm layout. No migration required for other callers.

<sup>Written for commit 38d89427373ff13f92202802e68f63817a948d49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

