### PR TITLE
fix(omo-senpi): create identity runtime dirs before reflection launch

### DIFF
--- a/.omo/evidence/20260824-7012-reflection-dir-enoent/PLAN.md
+++ b/.omo/evidence/20260824-7012-reflection-dir-enoent/PLAN.md
@@ -1,0 +1,44 @@
+# Plan: fix #7012 reflection ENOENT when runtime/reflection-sessions is missing
+
+Branch: issue/7012-reflection-dir-enoent (base dev @ 8833800ae)
+
+## Root cause
+
+`createIdentityRuntime` (`packages/omo-senpi/src/components/memory/identity-runtime.ts`,
+`lazySandbox` at lines 81-106 at base) grants the reflection sandbox `runtimeWrites`
+including `identityPaths.reflectionSessions`. The repo's first-write seam
+`ensureIdentityRuntimeDirs` (`context.ts:51`) mkdir -p's every identity runtime dir
+including `reflectionSessions`, but the reflection launch path never runs it:
+`launch -> runner.launch -> executeReflectionRun -> runReflectionChild -> lazySandbox`.
+`prepareReflectionSpawn` only mkdirs `<runtime>/reflection/runs/<runId>` (a different
+tree), so `<runtime>/reflection-sessions` can still be absent at sandbox-build/spawn time.
+Commit 12c176e02 already stopped the sandbox build itself from throwing (walk-up
+canonicalPath), but on Linux bwrap still cannot `--bind` an entry that does not exist
+("Can't find source path"), so a fresh identity's first reflection dies pre-spawn with
+spawn_failed. The maintainer diagnosis on #7012 names option 1: call
+`ensureIdentityRuntimeDirs` before building the reflection sandbox.
+
+## Fix direction
+
+In `createIdentityRuntime`, guarantee the identity runtime dirs once, lazily, and await
+that guarantee at the start of every launch, before `runner.launch`. `launch` returns the
+underlying promise (`Promise<void>`) so callers and tests can await completion; it keeps
+its internal catch, so fire-and-forget callers are unchanged. Reconcile revivals ride the
+same wrapped closure. No sandbox-platform changes; scope stays the missing-directory
+problem.
+
+## Files
+
+1. EDIT packages/omo-senpi/src/components/memory/identity-runtime.ts - lazy
+   ensureRuntimeDirsOnce + awaited launch; MemoryIdentityRuntime.launch returns
+   Promise<void>.
+2. EDIT packages/omo-senpi/src/components/memory/identity-runtime.test.ts - new
+   failing-first regression case: fresh identity with NO runtime dirs, manual reservation
+   through the runtime's own store, launch, then assert runtime/reflection-sessions exists.
+
+## Verification
+
+- Failing-first: new test RED before the implementation (log in this directory).
+- Scoped suite green after: bun test packages/omo-senpi/src/components/memory/identity-runtime.test.ts,
+  then the whole memory component dir.
+- Typecheck: tsgo --noEmit -p packages/omo-senpi/tsconfig.json exit 0.

--- a/.omo/evidence/20260824-7012-reflection-dir-enoent/QA.md
+++ b/.omo/evidence/20260824-7012-reflection-dir-enoent/QA.md
@@ -1,0 +1,60 @@
+# QA evidence: #7012 reflection ENOENT when runtime/reflection-sessions is missing
+
+Date: 2026-08-25
+Branch: issue/7012-reflection-dir-enoent (base: dev @ 8833800ae)
+Scope: packages/omo-senpi/src/components/memory/identity-runtime.ts (+ its colocated test)
+only.
+
+## WHAT WAS TESTED
+
+1. Failing-first regression test, written before the implementation
+   (identity-runtime.test.ts, "memory identity runtime first-write seam"): builds a fresh
+   identity via buildIdentityPaths with NO runtime directory created anywhere (the exact
+   fresh-machine shape from #7012; every pre-existing suite mkdir'd these dirs first,
+   which masked the bug), reserves a manual run through the identity runtime's own
+   ReflectionReservationStore, drives runtime.launch(), and asserts
+   runtime/reflection-sessions exists afterwards.
+2. Scoped suite after the implementation: bun test
+   packages/omo-senpi/src/components/memory (green-memory-suite.txt).
+3. Typecheck: bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json, exit 0
+   (typecheck.txt).
+
+## WHAT WAS OBSERVED
+
+- RED before the fix (red-identity-runtime-first-write.txt): only the new case failed -
+  after launch completed, runtime/reflection-sessions was still absent
+  ("Expected: true, Received: false"); the 4 pre-existing cases in the file passed.
+- GREEN after the fix: the same file passes 5/5; the whole memory component suite runs
+  901 pass / 6 skip / 0 fail across 133 files; typecheck exit 0.
+- The fix: createIdentityRuntime now guarantees ensureIdentityRuntimeDirs (mkdir
+  recursive over every identity runtime dir incl. reflectionSessions) once, lazily, and
+  awaits it at the start of every launch before runner.launch can build the lazy sandbox;
+  MemoryIdentityRuntime.launch now returns Promise<void> so callers/tests can await it.
+  Reconcile revivals ride the same wrapped closure.
+
+## WHY IT IS ENOUGH
+
+- The regression test reproduces the reporter's precondition exactly (payload machinery
+  never ran, no runtime dir exists) and pins the maintainer-endorsed option 1 seam: dirs
+  are guaranteed before the sandbox that grants runtime/reflection-sessions as a writable
+  is built, so bwrap never receives an absent --bind source and seatbelt grants name real
+  directories on every platform.
+- The assertion targets the directory the issue names, and the fixture deliberately skips
+  the mkdir every neighboring suite performs, so the test cannot silently pass by fixture
+  accident.
+- The full memory component suite (907 tests) guards the surrounding reflection/facts/
+  wiring behavior against regressions from the launch-path change.
+
+## WHAT WAS OMITTED
+
+- Live senpi harness QA was not driven for this change: the touched surface is the
+  parent-side launch seam exercised hermetically above; no hook, tool, config schema, or
+  installer surface changed. Residual risk recorded here per the evidence contract.
+- bun install prepare step fails/hangs in this environment (git submodule fetch network);
+  known harmless env quirk also recorded by PR #7231. Dependencies resolved via
+  `bun install --ignore-scripts`; the pre-existing dirty submodule flag on
+  packages/shared-skills/upstreams/designpowers predates all edits and is NOT part of
+  this change. Nothing under packages/shared-skills/upstreams/* or plugin dist artifacts
+  is staged.
+- No secrets, tokens, or host-identifying paths appear in the captured outputs; fixture
+  paths live under the OS temp dir.

--- a/.omo/evidence/20260824-7012-reflection-dir-enoent/green-memory-suite.txt
+++ b/.omo/evidence/20260824-7012-reflection-dir-enoent/green-memory-suite.txt
@@ -1,0 +1,7 @@
+bun test v1.3.14 (0d9b296a)
+
+ 901 pass
+ 6 skip
+ 0 fail
+ 2988 expect() calls
+Ran 907 tests across 133 files. [80.23s]

--- a/.omo/evidence/20260824-7012-reflection-dir-enoent/red-identity-runtime-first-write.txt
+++ b/.omo/evidence/20260824-7012-reflection-dir-enoent/red-identity-runtime-first-write.txt
@@ -1,0 +1,22 @@
+bun test v1.3.14 (0d9b296a)
+
+packages/omo-senpi/src/components/memory/identity-runtime.test.ts:
+231 | 
+232 |     // when
+233 |     await runtime.launch(reserved.run)
+234 | 
+235 |     // then
+236 |     expect(existsSync(paths.reflectionSessions)).toBe(true)
+                                                       ^
+error: expect(received).toBe(expected)
+
+Expected: true
+Received: false
+
+      at <anonymous> (/home/viprix/projects/oom-wt-7012/packages/omo-senpi/src/components/memory/identity-runtime.test.ts:236:50)
+(fail) memory identity runtime first-write seam > #given a fresh identity whose runtime directories were never created #when a reserved reflection run launches through the identity runtime #then the missing runtime/reflection-sessions is created before the runner settles the run [24.11ms]
+
+ 4 pass
+ 1 fail
+ 6 expect() calls
+Ran 5 tests across 1 file. [1.61s]

--- a/packages/omo-senpi/src/components/memory/identity-runtime.test.ts
+++ b/packages/omo-senpi/src/components/memory/identity-runtime.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { realpathSync } from "node:fs"
+import { existsSync, realpathSync } from "node:fs"
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -199,6 +199,43 @@ function sandboxGrantsAgentDir(renderedArgs: readonly string[], agentDirReal: st
   }
   return false
 }
+
+describe("memory identity runtime first-write seam", () => {
+  test("#given a fresh identity whose runtime directories were never created #when a reserved reflection run launches through the identity runtime #then the missing runtime/reflection-sessions is created before the runner settles the run", async () => {
+    // given - no mkdir anywhere under the identity root. Every other suite pre-creates
+    // these dirs, which is exactly what masked #7012: the lazy sandbox grants
+    // runtime/reflection-sessions as writable, and on Linux bwrap cannot bind an entry
+    // that does not exist yet, so the first reflection on a fresh identity died pre-spawn.
+    const root = await mkdtemp(join(tmpdir(), "omo-memory-identity-runtime-first-write-"))
+    roots.push(root)
+    const paths = buildIdentityPaths(root, "agent-test")
+    expect(existsSync(paths.reflectionSessions)).toBe(false)
+    const identity = createMemoryIdentityContext({
+      identity: "agent-test",
+      identityPaths: paths,
+      binding: { identity: "agent-test", repoPathHash: "hash", boundAt: 1 },
+    })
+    const ctx = componentContext()
+    const runtime = createIdentityRuntime(identity, {
+      loadConfig: () => loadedMemoryConfig(memorySettings()),
+      cwd: () => root,
+      resolveModelRegistry: () => undefined,
+      logger: ctx.logger,
+    })
+    const reserved = await runtime.store.tryReserve({
+      trigger: "manual",
+      conversationIds: ["conversation-a"],
+      snapshots: [],
+    })
+    if (reserved.status !== "active") throw new Error("expected an active manual reservation")
+
+    // when
+    await runtime.launch(reserved.run)
+
+    // then
+    expect(existsSync(paths.reflectionSessions)).toBe(true)
+  }, 30_000)
+})
 
 describe("memory identity runtime agent-dir resolution", () => {
   test.skipIf(process.platform !== "darwin" && process.platform !== "linux")(

--- a/packages/omo-senpi/src/components/memory/identity-runtime.ts
+++ b/packages/omo-senpi/src/components/memory/identity-runtime.ts
@@ -13,6 +13,7 @@ import type { ComponentLogger } from "../../extension/types"
 import { resolveAgentHome } from "../agent-home/resolve-agent-home"
 import type { SenpiOmoConfigResult } from "../config-resolution"
 import type { MemoryIdentityContext } from "./context"
+import { ensureIdentityRuntimeDirs } from "./context"
 import { buildSandboxTransform, type SandboxPolicy, type SandboxTransform } from "./sandbox"
 import {
   resolveAgentReflectionSettings,
@@ -48,7 +49,7 @@ export interface MemoryIdentityRuntime {
   readonly store: ReflectionReservationStore
   readonly reservationPort: ReflectionReservationPort
   readonly runner: SenpiSubprocessRunner
-  launch(run: ReservedRun): void
+  launch(run: ReservedRun): Promise<void>
   reconcile(): Promise<void>
 }
 
@@ -121,13 +122,24 @@ export function createIdentityRuntime(
       new TranscriptJournal({ journalDir: join(identity.identityPaths.transcripts, conversationId) }).getState(),
     ...(deps.liveSession === undefined ? {} : { liveSession: deps.liveSession }),
   })
-  const launch = (run: ReservedRun): void => {
-    void runner.launch(run).then((result) => {
-      if (result.launch !== undefined) launch(result.launch)
-    }).catch((error: unknown) => {
-      deps.logger?.warn("memory reflection launch failed", { error: describe(error) })
-    })
+  // #7012 first-write seam: the lazy sandbox grants runtimeWrites including
+  // identityPaths.reflectionSessions, and bwrap cannot bind an entry that does not exist
+  // yet, so every launch must guarantee the identity runtime dirs (mkdir recursive)
+  // before the runner can build the sandbox or spawn a child.
+  let runtimeDirsReady: Promise<void> | undefined
+  const ensureRuntimeDirsOnce = (): Promise<void> => {
+    runtimeDirsReady ??= ensureIdentityRuntimeDirs(identity.identityPaths)
+    return runtimeDirsReady
   }
+  const launch = (run: ReservedRun): Promise<void> =>
+    ensureRuntimeDirsOnce()
+      .then(() => runner.launch(run))
+      .then((result) => {
+        if (result.launch !== undefined) void launch(result.launch)
+      })
+      .catch((error: unknown) => {
+        deps.logger?.warn("memory reflection launch failed", { error: describe(error) })
+      })
   const runtime: MemoryIdentityRuntime = {
     identity,
     store,


### PR DESCRIPTION
## What

`createIdentityRuntime` now guarantees the identity runtime directories exist before any reflection launch: it runs the existing first-write seam `ensureIdentityRuntimeDirs` (mkdir recursive over every identity runtime dir, including `runtime/reflection-sessions`) once, lazily, and awaits it at the start of every `launch()` before `runner.launch()` can build the lazy OS sandbox. `MemoryIdentityRuntime.launch` now returns `Promise<void>` so callers and tests can await completion; reconcile revivals ride the same wrapped closure.

## Why

On a fresh identity, `runtime/reflection-sessions` is granted as a sandbox writable (`identity-runtime.ts` `lazySandbox` -> `runtimeWrites`) but nothing on the reflection spawn path ever created it. `prepareReflectionSpawn` only mkdirs `<runtime>/reflection/runs/<runId>` (a different tree), and commit 12c176e02 only stopped the sandbox build itself from throwing. On Linux, bwrap still cannot `--bind` an entry that does not exist ("Can't find source path"), so the first reflection after binding an identity died pre-spawn with `spawn_failed` and the transcript cursor never advanced (#7012 completion record). The maintainer diagnosis on the issue names this exact fix (option 1): run `ensureIdentityRuntimeDirs` before building the reflection sandbox.

## Verified

- Failing-first regression test in `identity-runtime.test.ts`: builds a fresh identity with NO runtime directory created anywhere, reserves a manual run through the runtime's own store, launches, and asserts `runtime/reflection-sessions` exists. RED before the change (only the new case failed: directory still absent after launch), GREEN after.
- Scoped suite: `bun test packages/omo-senpi/src/components/memory` - 901 pass / 6 skip / 0 fail across 133 files.
- Typecheck: `tsgo --noEmit -p packages/omo-senpi/tsconfig.json` - exit 0.
- Evidence (red/green logs, plan, QA notes): `.omo/evidence/20260824-7012-reflection-dir-enoent/`.

## Risk

Low. The seam reuses the existing `ensureIdentityRuntimeDirs` helper that the memory tools surface already runs; mkdir recursive is idempotent and the guarantee is computed once per identity runtime. Launches keep their internal catch, so fire-and-forget wiring callers are unchanged. A mkdir failure now surfaces as the standard "memory reflection launch failed" warning instead of a mid-spawn ENOENT.

Fixes #7012

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure identity runtime dirs exist before any reflection launch to prevent first-run ENOENT. Previously we granted runtime/reflection-sessions as writable without creating it; now we create dirs once and await them before launching, and `launch()` returns a promise.

- Runs the first-write seam to create all identity runtime dirs lazily once, and awaits it at the start of each launch before building the sandbox.
- Changes `MemoryIdentityRuntime.launch` to return `Promise<void>`; callers can await completion. No change for fire-and-forget call sites.
- Adds a failing-first regression test for fresh identities; suite stays green.
- Risk is low: mkdir -p is idempotent; failures surface as the standard “memory reflection launch failed” warning.

<sup>Written for commit fe859f9da66065f7bf63c07cdf5b11d681800a3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

