### PR TITLE
fix(atlas): cap unbounded FILE CHANGES SUMMARY after subagent completion

### DIFF
--- a/.omo/evidence/20260824-7124-atlas-file-changes-bound/EVIDENCE.md
+++ b/.omo/evidence/20260824-7124-atlas-file-changes-bound/EVIDENCE.md
@@ -1,0 +1,28 @@
+# Evidence: #7124 atlas FILE CHANGES SUMMARY bound
+
+## WHAT WAS TESTED
+
+- `bun test packages/utils/src/git-worktree/ packages/omo-opencode/src/shared/git-worktree/` — formatter unit + mirror suites through both barrels (`@oh-my-opencode/utils` real impl and the `packages/omo-opencode/src/shared/git-worktree` re-export shim).
+- New failing-first regression tests (added BEFORE the fix, confirmed red):
+  1. given >20 files in one group when formatting then group capped at 20 with deterministic `...and 5 more modified files` note, overflow paths omitted.
+  2. given 6500 changed files when formatting then serialized summary <= 32 KiB with explicit `Output truncated: true` marker carrying total count.
+  3. given ~2000-char paths exceeding the byte cap when formatting then byte cap holds AND `[NOTEPAD UPDATED]` block survives truncation.
+- Consumer hook suites unchanged behavior: `bun test packages/omo-opencode/src/hooks/atlas/tool-execute-after-subagent-completion.test.ts tool-execute-after-task-timers.test.ts tool-execute-after-background-launch.test.ts`.
+- `bun run typecheck` (tsgo root + script + all workspace packages).
+
+## WHAT WAS OBSERVED
+
+- RED (before fix): new tests failed — unbounded summary was 60,749 bytes for the long-path fixture (> 32 KiB), no per-group cap (`src/modified_20.ts` present), no truncation marker. Existing 6 formatter tests kept passing before and after.
+- GREEN (after fix): 33 pass / 0 fail across both mirror dirs (103 expect calls); atlas consumer suites 27 pass / 0 fail; typecheck green end-to-end.
+- Fix shape: per-group cap of 20 paths with deterministic `...and N more <modified|created|deleted> files` notes; 32 KiB byte cap over header+group lines with a `...summary truncated at 32768 bytes` note; final `Output truncated: true (total changed files: N)` marker whenever anything was cut; `[NOTEPAD UPDATED]` block appended after capping so it always survives.
+
+## WHY IT IS ENOUGH
+
+- The issue's failure mode is the serialized summary growing without limit; the regression tests pin the exact invariant at the only seam that produces the string (`formatFileChanges`), exercised through BOTH import paths used in production (utils barrel + adapter shim mirror, kept byte-identical).
+- Caps are deterministic (stable input order -> stable output), so the truncation note is reproducible for reviewers.
+- Consumer hooks inject `formatFileChanges` as a dependency; their suites prove wiring is untouched, and the real implementation they receive is now bounded regardless of how many stats `collectGitDiffStats` returns.
+
+## WHAT WAS OMITTED
+
+- Scoping `collectGitDiffStats` enumeration to task-specific paths/worktrees (issue lists it as "preferably"): larger surface touching collection semantics; the required outcome (bounded summary) is fully covered. Collection cost itself is unchanged.
+- Live opencode harness drive via the `opencode-qa` skill (SSE hook probe / TUI smoke): time-boxed hotfix window; the changed surface is a pure string formatter covered by unit + mirror suites, and the hook-level composition is pinned by existing injected-dependency tests. No secrets, tokens, env dumps, or private logs are included in this evidence.

--- a/.omo/evidence/20260824-7124-atlas-file-changes-bound/PLAN.md
+++ b/.omo/evidence/20260824-7124-atlas-file-changes-bound/PLAN.md
@@ -1,0 +1,25 @@
+# Plan: #7124 — Bound atlas FILE CHANGES SUMMARY
+
+## Root cause (file:line)
+- `packages/utils/src/git-worktree/format-file-changes.ts:7` — `formatFileChanges()` emits one line per `GitFileStat` with no file-count or byte cap.
+- Called from `packages/omo-opencode/src/hooks/atlas/tool-execute-after-subagent-completion.ts:96-97` with stats collected over the ENTIRE verification worktree (`collectGitDiffStatsImpl(verificationDirectory)`), then embedded into `toolOutput.output` at lines 216-235 (`## SUBAGENT WORK COMPLETED`). Large dirty worktree => hundreds of KB injected into parent context after every subagent completion.
+- Shim chain: `packages/utils/src/git-worktree/index.ts` -> `packages/omo-opencode/src/shared/git-worktree/format-file-changes.ts` (re-export). Both test files are byte-identical mirrors and must stay in sync.
+
+## Blast radius
+- Consumers of `formatFileChanges`: only the two atlas hook files (`tool-execute-after.ts` passes through, `tool-execute-after-subagent-completion.ts` embeds). Hook tests inject mocks; formatter-level tests use real impl via both barrels.
+
+## Changes
+1. FAILING TESTS FIRST — add to BOTH mirrors (`packages/utils/src/git-worktree/git-worktree.test.ts`, `packages/omo-opencode/src/shared/git-worktree/git-worktree.test.ts`):
+   - given >20 modified files when formatting then caps group with deterministic `...and N more modified files` note and omits overflow paths.
+   - given thousands of changed files when formatting then summary <= 32 KiB with explicit `Output truncated: true` marker + total count.
+   - given extremely long paths when formatting then byte cap holds and notepad section survives truncation.
+2. FIX — `packages/utils/src/git-worktree/format-file-changes.ts`:
+   - Constants: `MAX_PATHS_PER_GROUP = 20`, `MAX_SUMMARY_BYTES = 32 * 1024`.
+   - Per-group cap: first 20 entries, then `  ...and N more <group> files`.
+   - Byte cap over header+group lines only; dropped tail replaced by single note; `[NOTEPAD UPDATED]` block appended after capping so it always survives.
+   - Explicit final marker when anything was cut: `Output truncated: true (total changed files: N)`.
+3. Verification: scoped `bun test` on utils git-worktree + omo-opencode shared/git-worktree + atlas subagent-completion hook tests; typecheck.
+
+## Not doing (OMITTED)
+- Scoping `collectGitDiffStats` to task-specific paths ("preferably" in issue; larger surface).
+- Live opencode harness QA drive (opencode-qa skill): time-boxed hotfix; unit + mirror coverage documented instead.

--- a/packages/omo-opencode/src/shared/git-worktree/git-worktree.test.ts
+++ b/packages/omo-opencode/src/shared/git-worktree/git-worktree.test.ts
@@ -73,4 +73,66 @@ describe("git-worktree", () => {
 
     expect(summary).not.toContain("[NOTEPAD UPDATED]")
   })
+
+  test("#given more than 20 files in one group #when formatting #then caps the group with a deterministic and-N-more note", () => {
+    const stats = Array.from({ length: 25 }, (_, i) => ({
+      path: `src/modified_${i}.ts`,
+      added: 1,
+      removed: 0,
+      status: "modified" as const,
+    }))
+
+    const summary = formatFileChanges(stats)
+
+    expect(summary).toContain("[FILE CHANGES SUMMARY]")
+    expect(summary).toContain("src/modified_19.ts")
+    expect(summary).not.toContain("src/modified_20.ts")
+    expect(summary).toContain("...and 5 more modified files")
+  })
+
+  test("#given thousands of changed files #when formatting #then summary stays bounded with explicit truncation marker", () => {
+    const modified = Array.from({ length: 3000 }, (_, i) => ({
+      path: `pkg/module_${i}/very/long/path/component_file_name.ts`,
+      added: 10,
+      removed: 5,
+      status: "modified" as const,
+    }))
+    const added = Array.from({ length: 2000 }, (_, i) => ({
+      path: `new/folder_${i}/created_file.ts`,
+      added: 100,
+      removed: 0,
+      status: "added" as const,
+    }))
+    const deleted = Array.from({ length: 1500 }, (_, i) => ({
+      path: `old/deleted_${i}/removed_file.ts`,
+      added: 0,
+      removed: 50,
+      status: "deleted" as const,
+    }))
+
+    const summary = formatFileChanges([...modified, ...added, ...deleted])
+
+    expect(Buffer.byteLength(summary)).toBeLessThanOrEqual(32 * 1024)
+    expect(summary).toContain("Output truncated: true")
+    expect(summary).toContain("6500")
+  })
+
+  test("#given extremely long paths exceeding the byte cap #when formatting #then byte cap holds and notepad section survives", () => {
+    const longSegment = "d".repeat(2000)
+    const stats = [
+      { path: ".omo/notepads/work/notes.md", added: 1, removed: 0, status: "modified" as const },
+      ...Array.from({ length: 30 }, (_, i) => ({
+        path: `${longSegment}/file_${i}.ts`,
+        added: 1,
+        removed: 0,
+        status: "modified" as const,
+      })),
+    ]
+
+    const summary = formatFileChanges(stats, ".omo/notepads/work/notes.md")
+
+    expect(Buffer.byteLength(summary)).toBeLessThanOrEqual(32 * 1024)
+    expect(summary).toContain("[NOTEPAD UPDATED]")
+    expect(summary).toContain(".omo/notepads/work/notes.md")
+  })
 })

--- a/packages/utils/src/git-worktree/format-file-changes.ts
+++ b/packages/utils/src/git-worktree/format-file-changes.ts
@@ -1,39 +1,77 @@
 import type { GitFileStat } from "./types"
 
+const MAX_PATHS_PER_GROUP = 20
+const MAX_SUMMARY_BYTES = 32 * 1024
+
 function normalizePath(path: string): string {
   return path.replaceAll("\\", "/")
+}
+
+interface FileChangeGroup {
+  heading: string
+  noun: string
+  files: GitFileStat[]
+  describe: (stat: GitFileStat) => string
+}
+
+function buildGroups(stats: GitFileStat[]): FileChangeGroup[] {
+  return [
+    {
+      heading: "Modified files:",
+      noun: "modified",
+      files: stats.filter((s) => s.status === "modified"),
+      describe: (f) => `  ${f.path}  (+${f.added}, -${f.removed})`,
+    },
+    {
+      heading: "Created files:",
+      noun: "created",
+      files: stats.filter((s) => s.status === "added"),
+      describe: (f) => `  ${f.path}  (+${f.added})`,
+    },
+    {
+      heading: "Deleted files:",
+      noun: "deleted",
+      files: stats.filter((s) => s.status === "deleted"),
+      describe: (f) => `  ${f.path}  (-${f.removed})`,
+    },
+  ]
 }
 
 export function formatFileChanges(stats: GitFileStat[], notepadPath?: string): string {
   if (stats.length === 0) return "[FILE CHANGES SUMMARY]\nNo file changes detected.\n"
 
-  const modified = stats.filter((s) => s.status === "modified")
-  const added = stats.filter((s) => s.status === "added")
-  const deleted = stats.filter((s) => s.status === "deleted")
-
   const lines: string[] = ["[FILE CHANGES SUMMARY]"]
+  let truncated = false
 
-  if (modified.length > 0) {
-    lines.push("Modified files:")
-    for (const f of modified) {
-      lines.push(`  ${f.path}  (+${f.added}, -${f.removed})`)
+  for (const group of buildGroups(stats)) {
+    if (group.files.length === 0) continue
+    lines.push(group.heading)
+    const shown = group.files.slice(0, MAX_PATHS_PER_GROUP)
+    for (const f of shown) {
+      lines.push(group.describe(f))
+    }
+    if (group.files.length > shown.length) {
+      truncated = true
+      lines.push(`  ...and ${group.files.length - shown.length} more ${group.noun} files`)
     }
     lines.push("")
   }
 
-  if (added.length > 0) {
-    lines.push("Created files:")
-    for (const f of added) {
-      lines.push(`  ${f.path}  (+${f.added})`)
-    }
+  // Byte cap applies to the header + group listing only; the notepad block is
+  // appended afterwards so [NOTEPAD UPDATED] always survives truncation.
+  let byteTruncated = false
+  while (lines.length > 1 && Buffer.byteLength(lines.join("\n"), "utf8") > MAX_SUMMARY_BYTES) {
+    lines.pop()
+    byteTruncated = true
+  }
+  if (byteTruncated) {
+    truncated = true
+    lines.push(`  ...summary truncated at ${MAX_SUMMARY_BYTES} bytes`)
     lines.push("")
   }
 
-  if (deleted.length > 0) {
-    lines.push("Deleted files:")
-    for (const f of deleted) {
-      lines.push(`  ${f.path}  (-${f.removed})`)
-    }
+  if (truncated) {
+    lines.push(`Output truncated: true (total changed files: ${stats.length})`)
     lines.push("")
   }
 

--- a/packages/utils/src/git-worktree/git-worktree.test.ts
+++ b/packages/utils/src/git-worktree/git-worktree.test.ts
@@ -73,4 +73,66 @@ describe("git-worktree", () => {
 
     expect(summary).not.toContain("[NOTEPAD UPDATED]")
   })
+
+  test("#given more than 20 files in one group #when formatting #then caps the group with a deterministic and-N-more note", () => {
+    const stats = Array.from({ length: 25 }, (_, i) => ({
+      path: `src/modified_${i}.ts`,
+      added: 1,
+      removed: 0,
+      status: "modified" as const,
+    }))
+
+    const summary = formatFileChanges(stats)
+
+    expect(summary).toContain("[FILE CHANGES SUMMARY]")
+    expect(summary).toContain("src/modified_19.ts")
+    expect(summary).not.toContain("src/modified_20.ts")
+    expect(summary).toContain("...and 5 more modified files")
+  })
+
+  test("#given thousands of changed files #when formatting #then summary stays bounded with explicit truncation marker", () => {
+    const modified = Array.from({ length: 3000 }, (_, i) => ({
+      path: `pkg/module_${i}/very/long/path/component_file_name.ts`,
+      added: 10,
+      removed: 5,
+      status: "modified" as const,
+    }))
+    const added = Array.from({ length: 2000 }, (_, i) => ({
+      path: `new/folder_${i}/created_file.ts`,
+      added: 100,
+      removed: 0,
+      status: "added" as const,
+    }))
+    const deleted = Array.from({ length: 1500 }, (_, i) => ({
+      path: `old/deleted_${i}/removed_file.ts`,
+      added: 0,
+      removed: 50,
+      status: "deleted" as const,
+    }))
+
+    const summary = formatFileChanges([...modified, ...added, ...deleted])
+
+    expect(Buffer.byteLength(summary)).toBeLessThanOrEqual(32 * 1024)
+    expect(summary).toContain("Output truncated: true")
+    expect(summary).toContain("6500")
+  })
+
+  test("#given extremely long paths exceeding the byte cap #when formatting #then byte cap holds and notepad section survives", () => {
+    const longSegment = "d".repeat(2000)
+    const stats = [
+      { path: ".omo/notepads/work/notes.md", added: 1, removed: 0, status: "modified" as const },
+      ...Array.from({ length: 30 }, (_, i) => ({
+        path: `${longSegment}/file_${i}.ts`,
+        added: 1,
+        removed: 0,
+        status: "modified" as const,
+      })),
+    ]
+
+    const summary = formatFileChanges(stats, ".omo/notepads/work/notes.md")
+
+    expect(Buffer.byteLength(summary)).toBeLessThanOrEqual(32 * 1024)
+    expect(summary).toContain("[NOTEPAD UPDATED]")
+    expect(summary).toContain(".omo/notepads/work/notes.md")
+  })
 })


### PR DESCRIPTION
## What

Bounds the `[FILE CHANGES SUMMARY]` block that atlas appends to every completed subagent result. `formatFileChanges()` now:

- caps each group (modified / created / deleted) at 20 paths and appends a deterministic overflow note (`...and N more modified files`);
- enforces a 32 KiB byte cap on the serialized header + group listing, replacing the dropped tail with `...summary truncated at 32768 bytes`;
- emits an explicit `Output truncated: true (total changed files: N)` marker whenever anything was cut, so aggregate counts stay visible;
- appends the `[NOTEPAD UPDATED]` block after capping so it always survives truncation.

## Why

Atlas collects git stats over the entire verification worktree and formats one line per file with no file-count or byte limit (packages/utils/src/git-worktree/format-file-changes.ts). In a large dirty worktree the same global file list was serialized into the parent model context after every subagent completion — captured results in #7124 carried ~700 KB of generated summary per result.

## Verified

- Failing-first regression tests (confirmed red before the fix) added to both byte-identical mirrors (utils real impl + omo-opencode shared shim):
  - >20 files in a group -> capped at 20 with deterministic `...and N more <group> files` note; overflow paths omitted.
  - 6500 changed files -> serialized summary <= 32 KiB with explicit `Output truncated: true` marker carrying the total count.
  - ~2000-char paths exceeding the byte cap -> cap holds and `[NOTEPAD UPDATED]` survives.
- After fix: `bun test packages/utils/src/git-worktree/ packages/omo-opencode/src/shared/git-worktree/` -> 33 pass / 0 fail.
- Consumer hook suites unchanged: tool-execute-after-subagent-completion / task-timers / background-launch -> 27 pass / 0 fail.
- `bun run typecheck` green (tsgo root + script + all workspace packages).
- Evidence recorded under `.omo/evidence/20260824-7124-atlas-file-changes-bound/` (PLAN.md, EVIDENCE.md).

## Risk

Low. Output shape is additive for small worktrees (existing grouped format unchanged when nothing is truncated); all existing formatter tests pass untouched. Completion gates, task tracking, and the original subagent response are not modified. Not addressed here (follow-up candidates): scoping `collectGitDiffStats` enumeration itself to task-specific paths, and live-harness QA drive of the hook end-to-end.

Fixes #7124

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the FILE CHANGES SUMMARY appended after subagent completion to prevent large context payloads. Previously the formatter listed every changed path with no limit; now it caps groups and total bytes, emits a truncation marker, and always preserves the notepad notice. Fixes #7124.

- Caps each of modified/created/deleted to 20 paths with a deterministic "...and N more <group> files" note.
- Enforces a 32 KiB cap on the header + group listing and adds "...summary truncated at 32768 bytes" when applied.
- Emits "Output truncated: true (total changed files: N)" whenever anything is dropped; behavior is unchanged for small worktrees.
- Appends "[NOTEPAD UPDATED]" after capping so it survives truncation; no changes to hook wiring. Regression tests added for the utils implementation and the `packages/omo-opencode` mirror.

<sup>Written for commit 887483f093a25e7db5e60b66c148c2a987ed4ed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

