### PR TITLE
fix(memory): advance reflection chain on kimi billing-cycle quota 403

### DIFF
--- a/.omo/evidence/20260824-6808-kimi-quota403/PLAN.md
+++ b/.omo/evidence/20260824-6808-kimi-quota403/PLAN.md
@@ -1,0 +1,71 @@
+# Plan - issue #6808 Kimi-only quick route quota-403 recovery
+
+## Root cause
+
+Memory Reflection defaults to the `quick` category whose shipped builtin default is
+Kimi-only (`packages/senpi-task/src/category/openai-categories.ts:128-133`,
+`config: { model: "kimi-coding/kimi-for-coding-highspeed" }`). When the reflection
+child dies with Kimi's billing-cycle response:
+
+```
+403 permission_error
+You've reached your usage limit for this billing cycle
+```
+
+`classifyRetryableModelMiss` (`packages/omo-senpi/src/components/memory/worker/model-miss.ts:20-40`)
+returns `undefined` (terminal) because:
+
+1. `providerFailureDetail` (:43-49) keeps only the FIRST non-empty stderr line
+   (`"403 permission_error"`), discarding the billing-cycle reason line.
+2. The shared classifier `isRetryableModelError`
+   (`packages/model-core/src/model-error-classifier.ts:181-186`) retries only
+   429/503/529 status codes; `"403 permission_error"` matches no retryable message
+   pattern and no STOP pattern either, so it falls through to terminal.
+
+Result: the candidate chain in `runMemoryModelAttempts`
+(`memory-model-attempts.ts:37-52`) never advances to the next candidate; the run is
+recorded dead. Users without usable Kimi access get silently failing reflections.
+
+## Fix (consumer-layer, mirrors PR #7182 session-stable fallback convention)
+
+Classify the reproduced Kimi billing-cycle quota-403 shape as retryable
+`provider_unavailable` at the memory-worker seam, so the existing chain machinery
+advances to the next candidate. Shared classifier untouched (its billing/quota STOP
+table keeps generic org-quota terminal for every other consumer).
+
+### Files
+
+1. `packages/omo-senpi/src/components/memory/worker/model-miss.ts`
+   - Add `KIMI_PERMISSION_ERROR_CONTEXT_PATTERN` (403 adjacent to permission_error,
+     either order) + `KIMI_BILLING_CYCLE_LIMIT_PATTERN` ("you've reached your usage
+     limit for this billing cycle", straight/curly apostrophe, case-insensitive).
+   - In `classifyRetryableModelMiss`, after the auth_missing check: if both patterns
+     match the full output, return `{ kind: "provider_unavailable", detail }` with a
+     bounded multi-line detail (non-empty stderr/stdout lines joined " | ", capped at
+     PROVIDER_DETAIL_MAX_CHARS). Other classifications keep byte-identical details.
+2. `packages/omo-senpi/src/components/memory/worker/model-miss.test.ts`
+   - Regression: given exact issue payload stderr, when classified, then retryable
+     provider_unavailable with both lines preserved.
+3. `packages/omo-senpi/src/components/memory/worker/memory-model-attempts.test.ts`
+   - Regression: given primary dies with the payload and a fallback exists, when the
+     chain runs, then it attempts both candidates and returns the fallback result.
+
+### Deliberately unchanged / terminal pins kept green
+
+- Generic org-quota exhaustion ("Error: quota exceeded for this organization")
+  stays terminal (existing tests model-miss.test.ts:60, memory-model-attempts.test.ts:80).
+- Bare 403 without the billing-cycle usage-limit text stays terminal (shared classifier).
+- Chain exhaustion still throws typed MemoryModelExhaustedError with fingerprint detail.
+- No changes to model-core shared table, senpi-task category defaults, fixtures, or
+  generated plugin artifacts.
+
+## Verification
+
+1. RED first: scoped new tests fail before implementation.
+2. GREEN after: `bun test packages/omo-senpi/src/components/memory/worker`.
+3. `tsgo --noEmit -p packages/omo-senpi/tsconfig.json`.
+
+## Evidence
+
+This directory records plan, red/green outputs, and the WHAT/OBSERVED/WHY/OMITTED
+summary. No secrets; raw env dumps omitted.

--- a/.omo/evidence/20260824-6808-kimi-quota403/README.md
+++ b/.omo/evidence/20260824-6808-kimi-quota403/README.md
@@ -1,0 +1,59 @@
+# QA Evidence - issue #6808 Kimi-only quick route quota-403 recovery
+
+## WHAT WAS TESTED
+
+- `bun test packages/omo-senpi/src/components/memory/worker/model-miss.test.ts packages/omo-senpi/src/components/memory/worker/memory-model-attempts.test.ts`
+  - Failing-first: two new regression tests written BEFORE the fix, run RED, then the
+    classifier fix applied and the same run went GREEN.
+  - Behavior proven: Kimi's billing-cycle response (`403 permission_error` +
+    "You've reached your usage limit for this billing cycle", exact issue #6808 payload)
+    classifies as retryable `provider_unavailable`, so `runMemoryModelAttempts`
+    advances to the next candidate instead of recording a dead reflection run.
+- `bun test packages/omo-senpi/src/components/memory/worker` (full worker suite,
+  all consumers of `model-miss.ts` including `run-outcome-publication.ts`).
+- `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json` (Senpi type gate).
+
+## WHAT WAS OBSERVED
+
+- RED (before fix), verbatim assertion failures:
+  - `classifyRetryableModelMiss > #given a kimi billing-cycle quota 403 child failure ...`:
+    expected `{kind:"provider_unavailable", detail:"403 permission_error | You've reached your usage limit for this billing cycle"}`, received `undefined`.
+  - `runMemoryModelAttempts > #given a kimi billing-cycle quota 403 on the primary ...`:
+    expected attempted `["extension-only/primary","builtin/fallback"]`, received only
+    `["extension-only/primary"]` (chain did not advance).
+  - 15 pre-existing tests passed in the same run.
+- GREEN (after fix): scoped run 17 pass / 0 fail (`test-scoped-green.log`);
+  full worker suite 222 pass / 0 fail across 35 files (`test-worker-green.log`);
+  typecheck exit code 0 (`typecheck.log`).
+- Terminal semantics preserved: generic org-quota ("Error: quota exceeded for this
+  organization"), bare `403 permission_error` without the billing-cycle usage-limit
+  text, context-length, timeout, and success cases all stayed non-retryable
+  (existing + new negative pins green).
+
+## WHY IT IS ENOUGH
+
+The two new tests pin both halves of the recovery contract at the exact seam that
+changed: classification (retryable with both error lines preserved) and chain
+advance (fallback candidate actually attempted and returned). The full worker suite
+covers every consumer of the classifier, including exhausted-chain fingerprinting
+and outcome publication. The shared model-core STOP table is untouched, so all other
+consumers (OpenCode runtime-fallback, delegate routing) keep byte-identical behavior;
+the Senpi type gate proves no interface drift. Residual risk: a future Kimi payload
+rewording could evade the two regexes; the negative pin keeps any such drift visible.
+
+## WHAT WAS OMITTED
+
+- No live Senpi driver run: this change is a pure unit-seam classifier edit with no
+  spawn/supervisor surface change; per task scope the verification gate is scoped bun
+  tests + typecheck. The worker suite includes the supervisor/runner integration tests.
+- Raw env dumps, credentials, provider logs: none copied; only test summaries and
+  exit codes are recorded.
+- `bun run test:senpi` full package gate not executed: its materialize pre-step is a
+  known environment failure on this Windows-linked worktree under WSL (documented in
+  the sibling PR #6834 evidence); the equivalent core steps (worker suite + tsgo)
+  were run directly and are recorded here.
+- `bun install` ran once: dependency installation succeeded (tests + tsgo executed
+  against the installed tree); its postinstall `prepare` step failed in
+  `build:materialize-frontend` with exit 1 - the same pre-existing WSL
+  Windows-linked-worktree `.git` pointer incompatibility, harmless for this change.
+- payload.test.ts env-pre-existing failure: not hit in any scoped run.

--- a/.omo/evidence/20260824-6808-kimi-quota403/test-scoped-green.log
+++ b/.omo/evidence/20260824-6808-kimi-quota403/test-scoped-green.log
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 17 pass
+ 0 fail
+ 29 expect() calls
+Ran 17 tests across 2 files. [665.00ms]

--- a/.omo/evidence/20260824-6808-kimi-quota403/test-worker-green.log
+++ b/.omo/evidence/20260824-6808-kimi-quota403/test-worker-green.log
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 222 pass
+ 0 fail
+ 1094 expect() calls
+Ran 222 tests across 35 files. [32.90s]

--- a/.omo/evidence/20260824-6808-kimi-quota403/typecheck.log
+++ b/.omo/evidence/20260824-6808-kimi-quota403/typecheck.log
@@ -1,0 +1,1 @@
+tsgo exit:0

--- a/packages/omo-senpi/src/components/memory/worker/memory-model-attempts.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/memory-model-attempts.test.ts
@@ -77,6 +77,24 @@ describe("runMemoryModelAttempts", () => {
     expect(result.child.code).toBe(0)
   })
 
+  test("#given a kimi billing-cycle quota 403 on the primary #when a fallback exists #then it retries the fallback instead of dying", async () => {
+    // given
+    const attempted: string[] = []
+
+    // when
+    const result = await runMemoryModelAttempts(candidates, async (candidate) => {
+      attempted.push(candidate.model)
+      return candidate.model === "extension-only/primary"
+        ? child({ stderr: "403 permission_error\nYou've reached your usage limit for this billing cycle" })
+        : child({ code: 0 })
+    })
+
+    // then
+    expect(attempted).toEqual(["extension-only/primary", "builtin/fallback"])
+    expect(result.candidate.model).toBe("builtin/fallback")
+    expect(result.child.code).toBe(0)
+  })
+
   test("#given a billing exhaustion failure #when a fallback exists #then it does not burn the chain", async () => {
     // given
     const attempted: string[] = []

--- a/packages/omo-senpi/src/components/memory/worker/model-miss.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-miss.test.ts
@@ -57,6 +57,32 @@ describe("classifyRetryableModelMiss", () => {
     })
   })
 
+  test("#given a kimi billing-cycle quota 403 child failure #when classified #then it is retryable so the chain can advance to another provider", () => {
+    // given: the exact two-line stderr from issue #6808 - the shipped quick route
+    // is kimi-only, so this provider-plan limit must not terminate the reflection
+    const child = result([
+      "403 permission_error",
+      "You've reached your usage limit for this billing cycle",
+    ].join("\n"))
+
+    // when
+    const miss = classifyRetryableModelMiss(child)
+
+    // then
+    expect(miss).toEqual({
+      kind: "provider_unavailable",
+      detail: "403 permission_error | You've reached your usage limit for this billing cycle",
+    })
+  })
+
+  test("#given a bare 403 permission error without a billing-cycle usage limit #when classified #then it is not retryable", () => {
+    // given
+    const child = result("403 permission_error")
+
+    // when / then
+    expect(classifyRetryableModelMiss(child)).toBeUndefined()
+  })
+
   test("#given a billing exhaustion child failure #when classified #then it is not retryable because another model cannot fix it", () => {
     // given
     const child = result("Error: quota exceeded for this organization")

--- a/packages/omo-senpi/src/components/memory/worker/model-miss.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-miss.ts
@@ -15,6 +15,8 @@ export type RetryableModelMiss =
 const MODEL_NOT_FOUND_PATTERN = /^Error: Model "([^"]+)" not found\. Use --list-models to see available models\.$/m
 const API_KEY_NOT_FOUND_PATTERN = /^(?:Error:\s*)?No API key found for\s+([^\s.]+)/m
 const HTTP_STATUS_PATTERN = /(?:^|\s)(\d{3})\s*:/
+const KIMI_PERMISSION_ERROR_CONTEXT_PATTERN = /(?:\b403\b[\s\S]*\bpermission_error\b|\bpermission_error\b[\s\S]*\b403\b)/i
+const KIMI_BILLING_CYCLE_LIMIT_PATTERN = /\byou(?:'|’)ve reached your usage limit for this billing cycle\b/i
 const PROVIDER_DETAIL_MAX_CHARS = 200
 
 export function classifyRetryableModelMiss(result: ModelMissResult): RetryableModelMiss | undefined {
@@ -24,6 +26,13 @@ export function classifyRetryableModelMiss(result: ModelMissResult): RetryableMo
   if (model !== undefined) return { kind: "model_not_visible", id: model }
   const provider = API_KEY_NOT_FOUND_PATTERN.exec(output)?.[1]
   if (provider !== undefined) return { kind: "auth_missing", provider }
+  // A Kimi billing-cycle quota 403 (issue #6808) is provider-plan exhaustion, not a
+  // wrong-model or account-wide defect: another candidate can still serve the
+  // reflection, so the chain must advance instead of recording a dead run. Generic
+  // org-quota/billing STOP cases stay terminal through the shared classifier below.
+  if (isKimiBillingCycleLimit(output)) {
+    return { kind: "provider_unavailable", detail: boundedOutputDetail(result) }
+  }
   // A provider-side outage (cooldown, 429/503, overload) says nothing about THIS model being wrong,
   // so the reflection chain must move to the next candidate instead of recording a dead run. The
   // shared classifier owns the pattern table, including the billing/quota STOP cases that another
@@ -37,6 +46,19 @@ export function classifyRetryableModelMiss(result: ModelMissResult): RetryableMo
   })
     ? { kind: "provider_unavailable", detail }
     : undefined
+}
+
+function isKimiBillingCycleLimit(output: string): boolean {
+  return KIMI_PERMISSION_ERROR_CONTEXT_PATTERN.test(output)
+    && KIMI_BILLING_CYCLE_LIMIT_PATTERN.test(output)
+}
+
+function boundedOutputDetail(result: ModelMissResult): string {
+  const lines = [result.stderr, result.stdout]
+    .flatMap((stream) => stream.split("\n"))
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+  return lines.join(" | ").slice(0, PROVIDER_DETAIL_MAX_CHARS)
 }
 
 /** First meaningful child error line: senpi prints the fatal provider error and exits. */


### PR DESCRIPTION
## What

Memory Reflection's retry classifier now treats Kimi's billing-cycle quota response as a retryable provider failure, so the candidate chain advances to the next model instead of recording a dead run.

- `packages/omo-senpi/src/components/memory/worker/model-miss.ts`: `classifyRetryableModelMiss` recognizes the reproduced payload shape - `403 permission_error` adjacent to "You've reached your usage limit for this billing cycle" (straight or curly apostrophe, case-insensitive) - and returns `provider_unavailable` with a bounded multi-line detail (non-empty stderr/stdout lines joined with `" | "`, capped at the existing 200-char limit). All other classifications keep byte-identical details.
- Co-located regression tests in `model-miss.test.ts` and `memory-model-attempts.test.ts`, written failing-first.

## Why

The shipped default `quick` category resolves to a single Kimi model (`kimi-coding/kimi-for-coding-highspeed`). When Kimi answers with its billing-cycle 403, the child dies and the miss classified terminal: `providerFailureDetail` kept only the first stderr line (`403 permission_error`), which matches neither the shared STOP table nor the retryable set, and the shared status-code check retries only 429/503/529. The chain never advanced, so reflections failed silently forever for anyone without usable Kimi access (#6808).

This is a provider-plan limit, not an account-wide or wrong-model defect: another candidate can serve the reflection, so advancing mirrors how 429/503 outages are already handled. Generic org-quota exhaustion ("Error: quota exceeded for this organization"), bare 403 without the billing-cycle text, context-length, timeout, and success cases all stay terminal; the shared model-core classifier is untouched, so every other consumer keeps its exact behavior. Chain exhaustion still throws the typed `MemoryModelExhaustedError` with the attempted-candidates fingerprint.

Note: an independent open PR (#6834) targets the same issue with an overlapping edit to the same classifier; this PR is a separate take kept as small as possible.

## Verified

- Failing-first: both new tests ran RED before the fix (classifier returned `undefined`; chain attempted only the primary), then GREEN after.
- Scoped: `bun test .../model-miss.test.ts .../memory-model-attempts.test.ts` - 17 pass / 0 fail.
- Full worker suite (all consumers of the classifier): 222 pass / 0 fail across 35 files.
- `tsgo --noEmit -p packages/omo-senpi/tsconfig.json`: exit 0.
- Evidence: `.omo/evidence/20260824-6808-kimi-quota403/` (plan, red/green summaries, typecheck log; no secrets).

## Risk

Low. The change adds one narrow pattern pair ahead of the existing classification path inside the memory worker only. A future rewording of Kimi's quota message could evade the regexes; the new negative pin (bare 403 stays terminal) plus the existing org-quota pins keep any drift visible. The multi-line detail changes only the fingerprint text of this one newly-retryable case.

Fixes #6808

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats Kimi’s billing‑cycle quota 403 as a retryable provider failure so Memory Reflection advances to the next model. Previously this 403 ended the run and the chain never advanced on the default Kimi‑only quick route.

- Updates `packages/omo-senpi/src/components/memory/worker/model-miss.ts` to detect `403 permission_error` with "you’ve reached your usage limit for this billing cycle" and return `provider_unavailable` with a bounded multi-line detail (stderr/stdout lines joined by " | ", capped at 200 chars).
- Leaves all other cases unchanged: generic org‑quota exhaustion and bare 403 remain terminal; shared model-core classifier is untouched.
- Adds regression tests in `model-miss.test.ts` and `memory-model-attempts.test.ts`; worker suite and typecheck pass.
- Fixes #6808.

<sup>Written for commit 4794b9bb58084f5acaeac89bebc6175ac605e04e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

