### PR TITLE
fix(omo-senpi): neutralize claude-sdk-oauth host-denial leak into later tool turns

### DIFF
--- a/.omo/evidence/20260824-7115-oauth-denial-leak/EVIDENCE.md
+++ b/.omo/evidence/20260824-7115-oauth-denial-leak/EVIDENCE.md
@@ -1,0 +1,80 @@
+WHAT WAS TESTED
+===============
+
+Change: packages/omo-senpi new component `host-denial-guard` (message_end guard neutralizing the
+senpi claude-sdk-oauth host-tool denial literal, upstream issue #7115).
+
+1. Failing-first regression proof (RED):
+   Command: `bun test packages/omo-senpi/src/components/host-denial-guard/`
+   Result: 0 pass / 1 fail - "Cannot find module './constants'" (implementation absent).
+   Artifact: red-run.log
+
+2. Green run after implementation:
+   Command: `bun test packages/omo-senpi/src/components/host-denial-guard/`
+   Result: 7 pass / 0 fail, 29 expect() calls. Covers:
+   - assistant echo of the denial literal is replaced (role preserved, surroundings intact)
+   - mid-sentence and repeated literals swap; clean text unchanged
+   - clean assistant/toolResult messages and user-role messages pass through untouched
+     (user wording is never rewritten)
+   - following-turn composition: sanitized turn-1 + later toolCall/toolResult history contains no
+     denial literal, while the unsanitized control does (leak regression proof)
+   - malformed message_end payloads keep the guard silent
+   - drift tripwire: literal extracted from installed @code-yeongyu/senpi dist tools.js equals the
+     locally pinned constant
+
+3. Typecheck:
+   Command: `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json`
+   Result: exit 0.
+
+4. Full Senpi package gate:
+   Command: `OMO_SKIP_MATERIALIZE=1 bun run test:senpi`
+   Result: exit 0. lsp-daemon + ast-grep-mcp builds, runtime staging, build-extension bundle,
+   sync-skills, embed-directive --check, build-install all completed; package suite
+   "Ran 2240 tests across 307 files ... 0 fail" (6946 expect calls); evidence-dir script suite
+   "Ran 10 tests across 1 file", 10 pass.
+   Artifact: test-senpi-gate.log (first attempt), test-senpi-gate2.log (green run)
+
+WHAT WAS OBSERVED
+=================
+
+- Root cause (host side, external dep @code-yeongyu/senpi@2026.8.23): dist
+  core/extensions/builtin/claude-sdk-oauth/tools.js lines 21/25-40 define
+  HOST_TOOL_EXECUTION_DENIED_MESSAGE and HOST_TOOL_DENIAL_HOOKS (PreToolUse deny with that reason
+  for Bash|Write|Edit|Read|Grep|Glob|mcp__custom-tools__.*); options.js line 215 wires the hooks
+  into every claude-sdk-oauth query. The denial reason becomes model-facing transcript content
+  that surfaces in assistant replies and replays into later turns.
+- Upstream check: senpi 2026.8.24's claude-sdk-oauth dist directory is byte-identical to 2026.8.23
+  (diff verified from the published tarball), so a version bump alone does not fix #7115.
+- OMO-side seam: senpi ExtensionAPI types.d.ts MessageEndEventResult.message ("Replace the
+  finalized message. The replacement must keep the original message role.") - the guard uses it.
+- Isolation: unit-only verification; no senpi agent dir was written (no live driver run; see
+  OMITTED). No real ~/.senpi/agent or ~/.codex paths touched by any command in this evidence.
+
+WHY IT IS ENOUGH
+================
+
+The regression test proves the exact issue contract: a host denial (the pinned literal) does not
+leak into following tool turns - after the guard processes turn 1, composed later-turn history is
+free of the instruction, and the unsanitized control shows the test would catch a regression.
+Identity-passthrough cases bound the blast radius (clean messages, user wording, malformed
+payloads). The drift tripwire keeps the local literal honest against the installed runtime without
+value-importing the dep (bundle purity). tsgo plus the full 2240-test package gate show no
+regression across the adapter, including session-start ordering and bundle checks.
+
+Residual risk: sessions whose assistant reply merely QUOTES the sentence in legitimate prose get
+the quote swapped too; accepted because the sentence is a reserved host wire literal authored by
+the lane itself, and the replacement marker preserves readability.
+
+WHAT WAS OMITTED
+================
+
+- Live senpi QA drivers were not run: exercising the real claude-sdk-oauth lane requires an
+  explicit stored Claude OAuth account, which this environment does not have. The hermetic unit
+  gate plus the leak-regression test stand in; live-lane confirmation remains open for review.
+- First full-gate attempt hung in `git submodule update --init --recursive` cloning
+  packages/shared-skills/upstreams/open-design (network-restricted environment). This matches the
+  pre-existing hazard noted in the task brief; rerun used the script's own sanctioned
+  OMO_SKIP_MATERIALIZE=1 skip. Side effects left UNSTAGED and UNCOMMITTED: regenerated tracked
+  bundles under packages/omo-senpi/plugin/extensions/*.js and a submodule content touch on
+  packages/shared-skills/upstreams/designpowers. Neither is part of this change.
+- Raw gate logs are summarized above; no tokens, auth material, or private paths are copied here.

--- a/.omo/evidence/20260824-7115-oauth-denial-leak/red-run.log
+++ b/.omo/evidence/20260824-7115-oauth-denial-leak/red-run.log
@@ -1,0 +1,14 @@
+bun test v1.3.14 (0d9b296a)
+
+packages/omo-senpi/src/components/host-denial-guard/index.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+error: Cannot find module './constants' from '/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/host-denial-guard/index.test.ts'
+-------------------------------
+
+
+ 0 pass
+ 1 fail
+ 1 error
+Ran 1 test across 1 file. [258.00ms]

--- a/.omo/evidence/20260824-7115-oauth-denial-leak/test-senpi-gate.log
+++ b/.omo/evidence/20260824-7115-oauth-denial-leak/test-senpi-gate.log
@@ -1,0 +1,33 @@
+$ bun run build:senpi-plugin && tsgo --noEmit -p packages/omo-senpi/tsconfig.json && bun test packages/omo-senpi && bun test ./.agents/skills/senpi-qa/scripts/resolve-evidence-dir.test.mjs
+$ bun run build:lsp-daemon && bun run build:ast-grep-mcp && bun run build:senpi-plugin:stage
+$ npm --prefix packages/lsp-daemon ci && npm --prefix packages/lsp-daemon run build
+
+added 51 packages, and audited 54 packages in 4s
+
+18 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+
+> @code-yeongyu/lsp-daemon@0.1.0 build
+> node scripts/clean-dist.mjs && tsc -p tsconfig.build.json && bun build src/cli.ts src/index.ts src/client.ts --outdir dist --target node --format esm && node scripts/stamp-dist-version.mjs
+
+Bundled 80 modules in 27ms
+
+  cli.js     235.49 KB  (entry point)
+  index.js   216.35 KB  (entry point)
+  client.js  213.91 KB  (entry point)
+
+$ bun run --cwd packages/ast-grep-mcp build
+$ bun build src/cli.ts --outdir dist --target node --format esm
+Bundled 254 modules in 41ms
+
+  cli.js  84.65 KB  (entry point)
+
+$ bun run build:materialize-frontend && node packages/omo-senpi/plugin/scripts/stage-lsp-daemon-runtime.mjs && node packages/omo-senpi/plugin/scripts/stage-ast-grep-mcp-runtime.mjs && node packages/omo-senpi/plugin/scripts/stage-agent-toolkit.mjs && node packages/omo-senpi/plugin/scripts/build-extension.mjs && node packages/omo-senpi/plugin/scripts/sync-skills.mjs && node packages/omo-senpi/plugin/scripts/embed-directive.mjs --check && node packages/omo-senpi/plugin/scripts/build-install.mjs
+$ node packages/omo-codex/plugin/scripts/materialize-shared-upstreams.mjs --strict
+Cloning into '/home/viprix/projects/oom-wt-7115/packages/shared-skills/upstreams/open-design'...
+error: script "test:senpi" was terminated by signal SIGTERM (Polite quit request)
+error: script "build:senpi-plugin:stage" was terminated by signal SIGTERM (Polite quit request)
+error: script "build:materialize-frontend" was terminated by signal SIGTERM (Polite quit request)
+error: script "build:senpi-plugin" was terminated by signal SIGTERM (Polite quit request)

--- a/.omo/evidence/20260824-7115-oauth-denial-leak/test-senpi-gate2.log
+++ b/.omo/evidence/20260824-7115-oauth-denial-leak/test-senpi-gate2.log
@@ -1,0 +1,437 @@
+$ bun run build:senpi-plugin && tsgo --noEmit -p packages/omo-senpi/tsconfig.json && bun test packages/omo-senpi && bun test ./.agents/skills/senpi-qa/scripts/resolve-evidence-dir.test.mjs
+$ bun run build:lsp-daemon && bun run build:ast-grep-mcp && bun run build:senpi-plugin:stage
+$ npm --prefix packages/lsp-daemon ci && npm --prefix packages/lsp-daemon run build
+
+added 51 packages, and audited 54 packages in 3s
+
+18 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+
+> @code-yeongyu/lsp-daemon@0.1.0 build
+> node scripts/clean-dist.mjs && tsc -p tsconfig.build.json && bun build src/cli.ts src/index.ts src/client.ts --outdir dist --target node --format esm && node scripts/stamp-dist-version.mjs
+
+Bundled 80 modules in 36ms
+
+  cli.js     235.49 KB  (entry point)
+  index.js   216.35 KB  (entry point)
+  client.js  213.91 KB  (entry point)
+
+$ bun run --cwd packages/ast-grep-mcp build
+$ bun build src/cli.ts --outdir dist --target node --format esm
+Bundled 254 modules in 79ms
+
+  cli.js  84.65 KB  (entry point)
+
+$ bun run build:materialize-frontend && node packages/omo-senpi/plugin/scripts/stage-lsp-daemon-runtime.mjs && node packages/omo-senpi/plugin/scripts/stage-ast-grep-mcp-runtime.mjs && node packages/omo-senpi/plugin/scripts/stage-agent-toolkit.mjs && node packages/omo-senpi/plugin/scripts/build-extension.mjs && node packages/omo-senpi/plugin/scripts/sync-skills.mjs && node packages/omo-senpi/plugin/scripts/embed-directive.mjs --check && node packages/omo-senpi/plugin/scripts/build-install.mjs
+$ node packages/omo-codex/plugin/scripts/materialize-shared-upstreams.mjs --strict
+[materialize] skipped (OMO_SKIP_MATERIALIZE=1)
+Staged Senpi LSP runtime: /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/runtime/lsp-daemon/dist
+Staged Senpi ast-grep MCP runtime: /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/runtime/ast-grep-mcp/cli.js
+
+added 77 packages, and audited 97 packages in 9s
+
+19 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+
+> @code-yeongyu/codex-ulw-loop@5.0.0-beta.18 build
+> tsc -p tsconfig.build.json
+
+Bundled 38 modules in 24ms
+
+  cli.js  154.84 KB  (entry point)
+
+Usage:
+  omo-agent-toolkit ulw-loop <subcommand> [args]
+  omo-agent-toolkit hook user-prompt-submit [--with-ultrawork]  (Codex UserPromptSubmit hook)
+  omo-agent-toolkit help | --help | -h                          (this message)
+
+Run `omo-agent-toolkit ulw-loop help` for ulw-loop subcommands.
+Staged Senpi agent-toolkit runtime: /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/runtime/agent-toolkit
+Bundled 807 modules in 120ms
+
+  omo.js  1.29 MB  (entry point)
+
+Bundled 669 modules in 74ms
+
+  omo-task.js  0.92 MB  (entry point)
+
+Bundled 284 modules in 42ms
+
+  omo-member.js  175.60 KB  (entry point)
+
+Bundled 94 modules in 12ms
+
+  omo-memory-mcp.js  97.19 KB  (entry point)
+
+Bundled 125 modules in 15ms
+
+  memory-run-supervisor.mjs  29.25 KB  (entry point)
+
+Bundled 115 modules in 16ms
+
+  omo-init-deep-advisor.js  68.87 KB  (entry point)
+
+Built omo-senpi extensions: /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/extensions/omo.js, /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/extensions/omo-task.js, /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/extensions/omo-member.js, /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/extensions/omo-memory-mcp.js, /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/extensions/memory-run-supervisor.mjs, /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/extensions/omo-init-deep-advisor.js
+synced omo-senpi skills to /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/skills
+generated directive is current: /home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/ultrawork/generated-directive.ts
+Bundled 6 modules in 16ms
+
+  install.mjs  19.87 KB  (entry point)
+
+Built omo-senpi installer: /home/viprix/projects/oom-wt-7115/packages/omo-senpi/plugin/scripts/install.mjs
+bun test v1.3.14 (0d9b296a)
+Bundled 807 modules in 106ms
+
+  omo.js  1.29 MB  (entry point)
+
+Bundled 669 modules in 56ms
+
+  omo-task.js  0.92 MB  (entry point)
+
+Bundled 284 modules in 76ms
+
+  omo-member.js  175.60 KB  (entry point)
+
+Bundled 94 modules in 15ms
+
+  omo-memory-mcp.js  97.19 KB  (entry point)
+
+Bundled 125 modules in 25ms
+
+  memory-run-supervisor.mjs  29.25 KB  (entry point)
+
+Bundled 115 modules in 20ms
+
+  omo-init-deep-advisor.js  68.87 KB  (entry point)
+
+Bundled 807 modules in 93ms
+
+  omo.js  1.29 MB  (entry point)
+
+Bundled 669 modules in 132ms
+
+  omo-task.js  0.92 MB  (entry point)
+
+Bundled 284 modules in 60ms
+
+  omo-member.js  175.60 KB  (entry point)
+
+Bundled 94 modules in 12ms
+
+  omo-memory-mcp.js  97.19 KB  (entry point)
+
+Bundled 125 modules in 16ms
+
+  memory-run-supervisor.mjs  29.25 KB  (entry point)
+
+Bundled 115 modules in 15ms
+
+  omo-init-deep-advisor.js  68.87 KB  (entry point)
+
+Bundled 807 modules in 85ms
+
+  omo.js  1.29 MB  (entry point)
+
+Bundled 675 modules in 87ms
+
+  omo-task.js  0.92 MB  (entry point)
+
+Bundled 284 modules in 46ms
+
+  omo-member.js  175.60 KB  (entry point)
+
+Bundled 94 modules in 12ms
+
+  omo-memory-mcp.js  97.19 KB  (entry point)
+
+Bundled 125 modules in 13ms
+
+  memory-run-supervisor.mjs  29.25 KB  (entry point)
+
+Bundled 115 modules in 15ms
+
+  omo-init-deep-advisor.js  68.87 KB  (entry point)
+
+Bundled 807 modules in 93ms
+
+  omo.js  1.29 MB  (entry point)
+
+Bundled 669 modules in 62ms
+
+  omo-task.js  0.92 MB  (entry point)
+
+Bundled 284 modules in 33ms
+
+  omo-member.js  175.60 KB  (entry point)
+
+Bundled 94 modules in 22ms
+
+  omo-memory-mcp.js  97.19 KB  (entry point)
+
+Bundled 125 modules in 13ms
+
+  memory-run-supervisor.mjs  29.25 KB  (entry point)
+
+Bundled 115 modules in 17ms
+
+  omo-init-deep-advisor.js  68.87 KB  (entry point)
+
+Bundled 807 modules in 87ms
+
+  omo.js  1.29 MB  (entry point)
+
+Bundled 669 modules in 63ms
+
+  omo-task.js  0.92 MB  (entry point)
+
+Bundled 284 modules in 34ms
+
+  omo-member.js  175.60 KB  (entry point)
+
+Bundled 94 modules in 24ms
+
+  omo-memory-mcp.js  97.19 KB  (entry point)
+
+Bundled 125 modules in 26ms
+
+  memory-run-supervisor.mjs  29.25 KB  (entry point)
+
+Bundled 115 modules in 26ms
+
+  omo-init-deep-advisor.js  68.87 KB  (entry point)
+
+Bundled 807 modules in 105ms
+
+  omo.js  1.29 MB  (entry point)
+
+Bundled 669 modules in 72ms
+
+  omo-task.js  0.92 MB  (entry point)
+
+Bundled 284 modules in 38ms
+
+  omo-member.js  175.60 KB  (entry point)
+
+Bundled 94 modules in 13ms
+
+  omo-memory-mcp.js  97.19 KB  (entry point)
+
+Bundled 125 modules in 14ms
+
+  memory-run-supervisor.mjs  29.25 KB  (entry point)
+
+Bundled 115 modules in 22ms
+
+  omo-init-deep-advisor.js  68.87 KB  (entry point)
+
+ulw-loop help
+ulw-loop help
+ulw-loop help
+ulw-loop help
+ulw-loop help
+ulw-loop help
+ulw-loop help
+changed
+ulw-loop help
+
+packages/omo-senpi/src/extension/compose.test.ts:
+omo-senpi component disabled by flag {
+  component: "beta",
+}
+
+packages/omo-senpi/src/extension/index.test.ts:
+omo-senpi ulw-loop inactive; omo binary not found undefined
+omo-senpi memory component skipped: missing ExtensionAPI capabilities {
+  missing: [ "appendEntry", "registerEntryRenderer" ],
+}
+config-watch skipped: events capability missing undefined
+omo-senpi ulw-loop inactive; omo binary not found undefined
+omo-senpi memory component skipped: missing ExtensionAPI capabilities {
+  missing: [ "appendEntry", "registerEntryRenderer" ],
+}
+config-watch skipped: events capability missing undefined
+
+packages/omo-senpi/src/components/ultrawork/ultrawork-arming.test.ts:
+omo-senpi memory component skipped: missing ExtensionAPI capabilities {
+  missing: [ "appendEntry", "registerEntryRenderer" ],
+}
+config-watch skipped: events capability missing undefined
+omo-senpi memory component skipped: missing ExtensionAPI capabilities {
+  missing: [ "appendEntry", "registerEntryRenderer" ],
+}
+config-watch skipped: events capability missing undefined
+
+packages/omo-senpi/src/components/task/dag-runtime.test.ts:
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishDurableEvents (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:542:58)
+      at writeCheckpoint (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:108:9)
+      at <anonymous> (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:110:21)
+      at withLock (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/store.ts:570:12)
+      at appendPayload (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:90:32)
+      at <anonymous> (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/manager.ts:386:13)
+
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishSchedulerEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:149:65)
+      at deliver (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:238:11)
+      at drain (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:226:13)
+      at <anonymous> (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:209:12)
+
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishSchedulerEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:149:65)
+      at deliver (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:238:11)
+      at drain (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:226:13)
+
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishSchedulerEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:149:65)
+      at deliver (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:238:11)
+      at drain (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:226:13)
+
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishSchedulerEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:149:65)
+      at deliver (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:238:11)
+      at drain (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:226:13)
+      at <anonymous> (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:209:12)
+
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishSchedulerEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:149:65)
+      at deliver (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:238:11)
+      at drain (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:226:13)
+
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishSchedulerEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:149:65)
+      at deliver (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:238:11)
+      at drain (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:226:13)
+
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishSchedulerEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:149:65)
+      at deliver (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:238:11)
+      at drain (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:226:13)
+
+DAG runtime subscriber failed 652 |     cleanupRoots.push(cwd)
+653 |     const runner = new ScriptedRunner()
+654 |     const pi = Object.assign(new FakeExtensionAPI(), {
+655 |       rpc: {
+656 |         emit: (name: string) => {
+657 |           if (name === "omo.dag.event") throw new Error("subscriber exploded")
+                                                        ^
+error: subscriber exploded
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.test.ts:657:51)
+      at emit (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:68:13)
+      at forward (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-rpc-bridge.ts:77:5)
+      at deliverDurableEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:551:5)
+      at publishSchedulerEvent (/home/viprix/projects/oom-wt-7115/packages/omo-senpi/src/components/task/dag-runtime.ts:149:65)
+      at deliver (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:238:11)
+      at drain (/home/viprix/projects/oom-wt-7115/packages/senpi-task/src/dag/journal.ts:226:13)
+
+Preparing worktree (new branch 'linked-branch')
+fatal: not a git repository (or any of the parent directories): .git
+fatal: git cat-file: could not get object info
+fatal: git cat-file: could not get object info
+fatal: not a git repository (or any of the parent directories): .git
+fatal: not a git repository (or any of the parent directories): .git
+fatal: not a git repository (or any of the parent directories): .git
+
+ 2233 pass
+ 7 skip
+ 0 fail
+ 6946 expect() calls
+Ran 2240 tests across 307 files. [213.15s]
+bun test v1.3.14 (0d9b296a)
+
+ 10 pass
+ 0 fail
+ 31 expect() calls
+Ran 10 tests across 1 file. [682.00ms]
+exit=0

--- a/packages/omo-senpi/changes.md
+++ b/packages/omo-senpi/changes.md
@@ -1,3 +1,18 @@
+## 2026-08-24 — Neutralize the claude-sdk-oauth host-denial leak (#7115)
+
+The senpi claude-sdk-oauth lane denies every host-captured tool through a PreToolUse hook whose
+permission reason is an internal handoff instruction ("This tool call is captured and executed by
+the host. Do not retry with other tools; end the turn."). The SDK records that reason into its
+model-facing transcript, so it surfaces in assistant replies and persists into later turns,
+contaminating subsequent requests and results. Upstream senpi 2026.8.24 still ships the hook
+unchanged, so the adapter now guards the conversation itself: the new `host-denial-guard`
+component listens on `message_end` and swaps the exact literal for a neutral `[host tool handoff]`
+marker in assistant and toolResult messages. User wording is never rewritten, clean messages pass
+through untouched (identity return), and the component is gated by the compose-registered
+`omo-senpi-host-denial-guard-disabled` flag. The literal is pinned locally with a drift tripwire
+test against the installed runtime's dist, since adapter components must not value-import the
+senpi runtime.
+
 ## 2026-08-22 — One exception-free keyword table for every ULW skill pointer
 
 The mass-ulw and ulw-skill-pointers components were the same mechanism written twice, and the

--- a/packages/omo-senpi/src/components/host-denial-guard/constants.ts
+++ b/packages/omo-senpi/src/components/host-denial-guard/constants.ts
@@ -1,0 +1,10 @@
+// Provenance: @code-yeongyu/senpi dist core/extensions/builtin/claude-sdk-oauth/tools.js
+// (HOST_TOOL_EXECUTION_DENIED_MESSAGE). The lane's HOST_TOOL_DENIAL_HOOKS return this sentence as
+// the PreToolUse permissionDecisionReason for every host-captured tool, and options.js wires those
+// hooks into each claude-sdk-oauth query, so the text reaches the model transcript and can leak
+// into assistant replies and later turns. Pinned locally because adapter components must not
+// value-import the senpi runtime; the co-located drift tripwire test fails when the host rewords it.
+export const HOST_TOOL_DENIAL_LEAK_TEXT =
+  "This tool call is captured and executed by the host. Do not retry with other tools; end the turn."
+
+export const HOST_DENIAL_REPLACEMENT_TEXT = "[host tool handoff]"

--- a/packages/omo-senpi/src/components/host-denial-guard/index.test.ts
+++ b/packages/omo-senpi/src/components/host-denial-guard/index.test.ts
@@ -1,0 +1,177 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+
+import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
+import type { ComponentContext } from "../../extension/types"
+import { HOST_DENIAL_REPLACEMENT_TEXT, HOST_TOOL_DENIAL_LEAK_TEXT } from "./constants"
+import { createHostDenialGuardComponent } from "./index"
+import { sanitizeAgentMessage, sanitizeDenialLeakText } from "./sanitize"
+
+function textBlock(text: string): Record<string, unknown> {
+  return { type: "text", text }
+}
+
+function assistantMessage(content: unknown[]): Record<string, unknown> {
+  return { role: "assistant", content }
+}
+
+function toolResultMessage(content: unknown[]): Record<string, unknown> {
+  return { role: "toolResult", toolCallId: "tool-1", toolName: "read", isError: false, content }
+}
+
+function userMessage(content: unknown[]): Record<string, unknown> {
+  return { role: "user", content }
+}
+
+function messageEndPayload(message: unknown): Record<string, unknown> {
+  return { type: "message_end", message }
+}
+
+const fakeComponentContext: ComponentContext = {
+  logger: {
+    info() {},
+    warn() {},
+    error() {},
+  },
+  config: {
+    getFlag: () => undefined,
+  },
+}
+
+async function dispatchMessageEnd(payload: unknown): Promise<unknown[]> {
+  const pi = new FakeExtensionAPI()
+  createHostDenialGuardComponent().register(pi, fakeComponentContext)
+  return pi.dispatch("message_end", payload)
+}
+
+function readInstalledSenpiToolsJs(): string {
+  const entry = Bun.resolveSync("@code-yeongyu/senpi", import.meta.dir)
+  return readFileSync(join(dirname(entry), "core/extensions/builtin/claude-sdk-oauth/tools.js"), "utf8")
+}
+
+describe("host-denial-guard", () => {
+  describe("#given an assistant reply echoing the host denial instruction", () => {
+    test("#when the host finalizes the message #then the replacement carries no denial text and keeps the role", async () => {
+      // given
+      const payload = messageEndPayload(
+        assistantMessage([textBlock(`I could not run that directly. ${HOST_TOOL_DENIAL_LEAK_TEXT} Anything else?`)]),
+      )
+
+      // when
+      const results = await dispatchMessageEnd(payload)
+
+      // then
+      expect(results).toHaveLength(1)
+      const result = results[0] as { message?: { role: string; content: Array<{ type: string; text?: string }> } }
+      expect(result.message).toBeDefined()
+      expect(result.message?.role).toBe("assistant")
+      const serialized = JSON.stringify(result.message)
+      expect(serialized).not.toContain(HOST_TOOL_DENIAL_LEAK_TEXT)
+      expect(serialized).toContain(HOST_DENIAL_REPLACEMENT_TEXT)
+      expect(result.message?.content[0]?.text).toContain("Anything else?")
+    })
+  })
+
+  describe("#given sanitizeDenialLeakText", () => {
+    test("#when the literal sits mid-sentence or repeats #then only the literal is swapped and surroundings survive", () => {
+      // given
+      const once = `prefix ${HOST_TOOL_DENIAL_LEAK_TEXT} suffix`
+      const twice = `${HOST_TOOL_DENIAL_LEAK_TEXT}\n${HOST_TOOL_DENIAL_LEAK_TEXT}`
+
+      // when
+      const sanitizedOnce = sanitizeDenialLeakText(once)
+      const sanitizedTwice = sanitizeDenialLeakText(twice)
+
+      // then
+      expect(sanitizedOnce).toBe(`prefix ${HOST_DENIAL_REPLACEMENT_TEXT} suffix`)
+      expect(sanitizedTwice).not.toContain(HOST_TOOL_DENIAL_LEAK_TEXT)
+      expect(sanitizedTwice.split(HOST_DENIAL_REPLACEMENT_TEXT)).toHaveLength(3)
+    })
+
+    test("#when the text never contained the literal #then it comes back unchanged", () => {
+      // given
+      const clean = "plain assistant prose"
+
+      // when
+      const sanitized = sanitizeDenialLeakText(clean)
+
+      // then
+      expect(sanitized).toBe(clean)
+    })
+  })
+
+  describe("#given messages that must pass through untouched", () => {
+    test("#when content is clean or the role is user #then no replacement is returned", async () => {
+      // given
+      const cleanAssistant = messageEndPayload(assistantMessage([textBlock("all good")]))
+      const cleanToolResult = messageEndPayload(toolResultMessage([textBlock("file contents")]))
+      const leakingUser = messageEndPayload(userMessage([textBlock(HOST_TOOL_DENIAL_LEAK_TEXT)]))
+
+      // when
+      const [assistantResult, toolResultResult, userResult] = await Promise.all([
+        dispatchMessageEnd(cleanAssistant),
+        dispatchMessageEnd(cleanToolResult),
+        dispatchMessageEnd(leakingUser),
+      ])
+
+      // then
+      expect(assistantResult).toHaveLength(1)
+      expect(assistantResult[0]).toBeUndefined()
+      expect(toolResultResult).toHaveLength(1)
+      expect(toolResultResult[0]).toBeUndefined()
+      expect(userResult).toHaveLength(1)
+      expect(userResult[0]).toBeUndefined()
+    })
+  })
+
+  describe("#given a sanitized turn followed by another tool turn", () => {
+    test("#when the later-turn history is composed #then the denial instruction appears nowhere", () => {
+      // given
+      const leakedTurn = assistantMessage([textBlock(HOST_TOOL_DENIAL_LEAK_TEXT)])
+      const sanitizedTurn = sanitizeAgentMessage(leakedTurn)?.message
+
+      // when
+      const laterTurnHistory = [
+        sanitizedTurn,
+        toolResultMessage([textBlock("real host tool output")]),
+        assistantMessage([textBlock("continuing the next tool turn")]),
+      ]
+
+      // then
+      expect(JSON.stringify([leakedTurn])).toContain(HOST_TOOL_DENIAL_LEAK_TEXT)
+      expect(sanitizedTurn).toBeDefined()
+      expect(JSON.stringify(laterTurnHistory)).not.toContain(HOST_TOOL_DENIAL_LEAK_TEXT)
+    })
+  })
+
+  describe("#given malformed message_end payloads", () => {
+    test("#when the payload shape is unexpected #then the guard stays silent", async () => {
+      // given
+      const payloads = [undefined, {}, messageEndPayload(undefined), messageEndPayload({ role: "assistant" })]
+
+      // when
+      const results = await Promise.all(payloads.map((payload) => dispatchMessageEnd(payload)))
+
+      // then
+      for (const result of results) {
+        expect(result).toHaveLength(1)
+        expect(result[0]).toBeUndefined()
+      }
+    })
+  })
+
+  test("#given the installed senpi runtime #when its dist declares the denial literal #then it matches our pinned constant", () => {
+    // given
+    const toolsJs = readInstalledSenpiToolsJs()
+
+    // when
+    const match = /HOST_TOOL_EXECUTION_DENIED_MESSAGE\s*=\s*"((?:[^"\\]|\\.)*)"/.exec(toolsJs)
+
+    // then
+    expect(match).not.toBeNull()
+    expect(JSON.parse(`"${match?.[1]}"`)).toBe(HOST_TOOL_DENIAL_LEAK_TEXT)
+  })
+})

--- a/packages/omo-senpi/src/components/host-denial-guard/index.ts
+++ b/packages/omo-senpi/src/components/host-denial-guard/index.ts
@@ -1,0 +1,23 @@
+import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
+import { isRecord, sanitizeAgentMessage } from "./sanitize"
+
+/**
+ * Guards the conversation against the senpi claude-sdk-oauth host-tool denial leak (#7115): the
+ * lane's PreToolUse hook denies captured tools with an internal handoff instruction that surfaces
+ * in assistant replies and persists into later turns. On message_end we swap the exact literal
+ * for a neutral marker so no following tool turn ever sees it. Disable via the compose-registered
+ * omo-senpi-host-denial-guard-disabled flag.
+ */
+export function createHostDenialGuardComponent(): OmoSenpiComponent {
+  return {
+    name: "host-denial-guard",
+    register(pi: SenpiExtensionAPI, _ctx: ComponentContext): void {
+      pi.on("message_end", (payload) => {
+        if (!isRecord(payload)) {
+          return undefined
+        }
+        return sanitizeAgentMessage(payload.message)
+      })
+    },
+  }
+}

--- a/packages/omo-senpi/src/components/host-denial-guard/sanitize.ts
+++ b/packages/omo-senpi/src/components/host-denial-guard/sanitize.ts
@@ -1,0 +1,55 @@
+import { HOST_DENIAL_REPLACEMENT_TEXT, HOST_TOOL_DENIAL_LEAK_TEXT } from "./constants"
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Swap every occurrence of the senpi claude-sdk-oauth host-denial instruction for a neutral,
+ * non-instructional marker. Purely mechanical: text without the exact literal comes back
+ * unchanged, and surrounding prose is never touched.
+ */
+export function sanitizeDenialLeakText(text: string): string {
+  if (!text.includes(HOST_TOOL_DENIAL_LEAK_TEXT)) {
+    return text
+  }
+  return text.split(HOST_TOOL_DENIAL_LEAK_TEXT).join(HOST_DENIAL_REPLACEMENT_TEXT)
+}
+
+function sanitizeTextBlocks(content: unknown[]): { content: unknown[]; changed: boolean } {
+  let changed = false
+  const next = content.map((block) => {
+    if (!isRecord(block) || block.type !== "text" || typeof block.text !== "string") {
+      return block
+    }
+    const sanitized = sanitizeDenialLeakText(block.text)
+    if (sanitized === block.text) {
+      return block
+    }
+    changed = true
+    return { ...block, text: sanitized }
+  })
+  return { content: next, changed }
+}
+
+/**
+ * Neutralize the host-denial literal inside one finalized agent message. Only assistant and
+ * toolResult messages are rewritten (user wording is never touched); returns undefined when the
+ * message is already clean so handlers stay identity-preserving.
+ */
+export function sanitizeAgentMessage(message: unknown): { message: Record<string, unknown> } | undefined {
+  if (!isRecord(message)) {
+    return undefined
+  }
+  if (message.role !== "assistant" && message.role !== "toolResult") {
+    return undefined
+  }
+  if (!Array.isArray(message.content)) {
+    return undefined
+  }
+  const { content, changed } = sanitizeTextBlocks(message.content)
+  if (!changed) {
+    return undefined
+  }
+  return { message: { ...message, content } }
+}

--- a/packages/omo-senpi/src/extension/component-list.ts
+++ b/packages/omo-senpi/src/extension/component-list.ts
@@ -4,6 +4,7 @@ import { createConfigStartupComponent } from "../components/config-startup"
 import { createConfigWatchComponent } from "../components/config-watch"
 import { createFallbackArchitectComponent } from "../components/fallback-architect"
 import { createGitMasterAttributionComponent } from "../components/git-master"
+import { createHostDenialGuardComponent } from "../components/host-denial-guard"
 import { createInitDeepAdvisorComponent } from "../components/init-deep-advisor"
 import { createLspComponent } from "../components/lsp"
 import { createMemoryComponent } from "../components/memory"
@@ -32,6 +33,7 @@ export function createOmoSenpiComponents(taskComponent: OmoSenpiComponent): OmoS
     createGitMasterAttributionComponent(),
     createFallbackArchitectComponent(),
     createCommentCheckerComponent(),
+    createHostDenialGuardComponent(),
     createAstGrepComponent(),
     createLspComponent(),
     taskComponent,


### PR DESCRIPTION
## What

Adds a `host-denial-guard` component to the Senpi adapter (`packages/omo-senpi`). It listens on the ExtensionAPI `message_end` event and replaces the exact senpi claude-sdk-oauth host-handoff denial sentence with a neutral `[host tool handoff]` marker in finalized assistant and toolResult messages. User wording is never rewritten; clean messages return no replacement (identity passthrough); malformed payloads keep the guard silent. The component is gated by the compose-registered `omo-senpi-host-denial-guard-disabled` flag and registered right after `comment-checker` in the content-guard cluster.

The literal is pinned locally in `constants.ts` (adapter components must not value-import the senpi runtime), with a drift tripwire test that extracts `HOST_TOOL_EXECUTION_DENIED_MESSAGE` from the installed runtime's dist and fails on rewording.

## Why

#7115: the claude-sdk-oauth lane denies every host-captured tool (`Bash|Write|Edit|Read|Grep|Glob|mcp__custom-tools__.*`) through a PreToolUse hook whose `permissionDecisionReason` is an internal instruction — "This tool call is captured and executed by the host. Do not retry with other tools; end the turn." (`@code-yeongyu/senpi` dist `core/extensions/builtin/claude-sdk-oauth/tools.js:21,25-40`, wired into every query at `options.js:215`). The SDK records that reason as model-facing transcript content, so it surfaces in assistant replies and persists into later turns, contaminating subsequent requests and results.

Upstream check: senpi `2026.8.24`'s `claude-sdk-oauth` dist directory is byte-identical to `2026.8.23` (verified by diffing the published tarball), so a pin bump alone does not fix the issue. The Senpi ExtensionAPI offers a first-class seam — `MessageEndEventResult.message` ("Replace the finalized message. The replacement must keep the original message role.") — which this guard uses, mirroring how `comment-checker` already transforms tool_result content.

## Verified

- Failing-first regression test (`index.test.ts`, given/when/then): RED before implementation (`Cannot find module './constants'`), GREEN after — 7 pass / 0 fail.
  - Leak contract: after the guard sanitizes a turn-1 assistant echo, composed later-turn history (toolCall + toolResult) contains no denial literal; the unsanitized control does.
  - Blast radius: clean assistant/toolResult messages, user-role messages (never rewritten), mid-sentence/repeated literals, malformed payloads.
  - Drift tripwire against the installed senpi dist.
- `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json` — exit 0.
- Full gate `bun run test:senpi` — exit 0: bundle build + staging + `embed-directive --check` pass, package suite `Ran 2240 tests across 307 files ... 0 fail`, evidence-dir script suite 10/10.
- Evidence: `.omo/evidence/20260824-7115-oauth-denial-leak/` (WHAT TESTED / OBSERVED / WHY ENOUGH / OMITTED, redacted logs incl. the RED run).

Note: the first full-gate attempt hung in `git submodule update` cloning `shared-skills/upstreams/open-design` (network-restricted environment; pre-existing hazard). The rerun used the materialize script's own `OMO_SKIP_MATERIALIZE=1` skip. Live-lane QA with a real stored Claude OAuth account was not possible in this environment and is called out in the evidence as omitted.

## Risk

Low. Exact-literal matching only; the sentence is a reserved wire literal authored by the lane itself, so legitimate prose quoting it gets the same swap (documented residual risk). No dep value imports (bundle purity preserved), no component reorder, no config schema change.

Fixes #7115

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Neutralizes the `claude-sdk-oauth` host-denial instruction leaking into assistant outputs and later tool turns. Previously, the SDK’s internal handoff reason appeared in assistant/toolResult messages and persisted; now the adapter replaces that exact sentence with a neutral “[host tool handoff]” marker during `message_end`. Fixes #7115.

- Adds `host-denial-guard` in `packages/omo-senpi`: on `message_end`, swaps only the exact denial literal and preserves the original role.
- Rewrites only `assistant` and `toolResult`; never rewrites `user`. Clean messages return unchanged; malformed payloads no-op.
- Gate via `omo-senpi-host-denial-guard-disabled`; registered after `comment-checker`.
- Pins the literal locally and adds a drift tripwire test against the `@code-yeongyu/senpi` dist; avoids runtime value imports.
- Residual risk: legitimate quotes of the exact sentence will also be replaced.

<sup>Written for commit 1dea8b7fb40e58793cf423ddfd330649cfc5dc22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

