### PR TITLE
fix(omo-native): detect stale omo binaries on PATH in doctor

### DIFF
--- a/.omo/evidence/20260824-6686-stale-binary-cache/WHAT-TESTED-OBSERVED-WHY-OMITTED.md
+++ b/.omo/evidence/20260824-6686-stale-binary-cache/WHAT-TESTED-OBSERVED-WHY-OMITTED.md
@@ -1,0 +1,82 @@
+# WHAT WAS TESTED
+
+Issue #6686: after `npm i -g omo-ai@beta`, a zsh session can keep invoking a cached or
+higher-priority legacy `omo` wrapper (e.g. `~/.local/bin/omo`, OMO 4.19.4) even though the newly
+installed npm binary has higher PATH precedence. The shell command cache (`hash -r` / `rehash`)
+and PATH order are the two recovery levers named in the issue.
+
+Repo-side root cause: `packages/omo-native/bin/lib/doctor.js` (`runDoctor`, lines 54-98 at base
+8833800ae) had no diagnostic for competing `omo` commands on PATH, so an upgraded install could
+neither detect nor explain the stale-binary state. A package.json postinstall warning is not an
+option: `packages/omo-native/test/package-shape.test.ts` pins "no postinstall lifecycle hook
+exists" for the published `omo-ai` manifest.
+
+Tested surfaces:
+
+1. Failing-first regression suite `packages/omo-native/test/stale-bin.test.ts` (7 cases,
+   given/when/then):
+   - unit: `findOmoPathEntries` PATH ordering, dedupe, missing dirs, empty PATH,
+     non-executable skip (posix-only);
+   - integration through the real launcher (`node bin/omo.js doctor` spawned as a child with a
+     fully controlled PATH): legacy wrapper ahead of the upgraded install; upgraded install ahead
+     of a leftover copy; only the upgraded install on PATH (no false positives); foreign wrapper
+     whose --version fails.
+2. Scoped regression suites: `stale-bin.test.ts`, `doctor.test.ts`, `package-shape.test.ts`,
+   `launcher.test.ts` (66 pass / 0 fail).
+3. Full scoped package gate: `bun test packages/omo-native/test`.
+4. Typecheck: `bunx tsc -p packages/omo-native/tsconfig.json --noEmit`.
+5. Entry smoke: `node packages/omo-native/bin/omo.js --version`.
+6. Live manual QA of the new doctor check against a synthetic shadowing layout (see
+   live-doctor-shadowing.txt).
+
+# WHAT WAS OBSERVED
+
+- RED (before implementation): `bun test packages/omo-native/test/stale-bin.test.ts` failed with
+  `Cannot find module '../bin/lib/stale-bin.js'` - 0 pass, 1 fail. The regression suite could not
+  pass before the fix existed.
+- GREEN (after implementation): 7 pass / 0 fail for the new suite; 66 pass / 0 fail across the
+  four focused files; full package gate 132 pass / 6 skip / 1 fail where the single fail is the
+  pre-existing environment issue described below.
+- Doctor output for a shadowing layout (legacy stub reporting 4.19.4 ahead of the upgraded
+  install), exit code 0:
+  WARN stale omo binaries run ahead of this install on PATH: <legacy>/omo (reports 4.19.4)
+       beats <npm-bin>/omo
+  WARN refresh the shell command cache after upgrading: hash -r (zsh: rehash); if ~/.local/bin
+       precedes the npm global bin directory, prepend it:
+       export PATH="$(npm prefix -g)/bin:$PATH"
+- With only the upgraded install on PATH, doctor emits no stale-binary warnings (no false
+  positives). Warnings never flip the exit code: a leftover binary is an environment hazard, not
+  a broken install artifact.
+- Existing doctor tests still pass unchanged while inheriting the host PATH, because the check is
+  WARN-only.
+
+# WHY IT IS ENOUGH
+
+The failing-first test pins exactly the issue's acceptance shape: when a second, older `omo`
+binary exists on PATH relative to the upgraded install, diagnostics must name the stale path,
+report its version (proving which binary version would be served), and print the exact cache
+invalidation and PATH-order recovery commands from the issue thread (`hash -r`, zsh `rehash`,
+`export PATH="$(npm prefix -g)/bin:$PATH"`). The negative case proves no warnings without a
+competing binary. Version probing executes only foreign candidates (`--version`, 2s timeout, max
+3 probes, skipped entirely on Windows where Node refuses .cmd shims without a shell), so doctor
+gains real staleness signal without new side-effect surface. Remaining regression risk is limited
+to exotic PATH layouts (relative PATH entries are resolved by the OS the same way shells resolve
+them; broken symlinks degrade to "unknown version" rather than throwing).
+
+Pre-existing environment failure (NOT caused by this change): `payload.test.ts` full-build case
+fails because `bun install`'s prepare step cannot fetch submodule revision for
+`packages/shared-skills/upstreams/open-design` ("fatal: Unable to find current revision in
+submodule path"), so `build:materialize-shared-upstreams --strict` aborts before staging. The
+failure reproduces on the untouched base checkout in this worktree and involves only the
+submodule fetch + build pipeline, none of the files changed here. Documented per task instructions.
+
+# WHAT WAS OMITTED
+
+- No secrets, tokens, or env dumps are contained in these artifacts; all paths are mktemp
+  fixtures under /tmp.
+- Docs coverage (troubleshooting README, installation guide) is intentionally omitted here to
+  avoid colliding with the open docs PR #6687, which owns `docs/troubleshooting/README.md` and
+  `docs/guide/installation.md`; this PR stays scoped to the diagnostic surface.
+- Windows runtime probing of foreign binaries (--version) is deliberately unimplemented; entries
+  are still detected and reported with "(unknown version)".
+- Related plugin-cache lane #6680 was kept out of scope per task instructions.

--- a/.omo/evidence/20260824-6686-stale-binary-cache/green-test-results.txt
+++ b/.omo/evidence/20260824-6686-stale-binary-cache/green-test-results.txt
@@ -1,0 +1,22 @@
+GREEN PHASE (after stale-bin.js + doctor wiring)
+
+Command: bun test packages/omo-native/test/stale-bin.test.ts
+  7 pass
+  0 fail
+  21 expect() calls
+Ran 7 tests across 1 file. [659.00ms]
+
+Command: bun test packages/omo-native/test/stale-bin.test.ts packages/omo-native/test/doctor.test.ts packages/omo-native/test/package-shape.test.ts packages/omo-native/test/launcher.test.ts
+ 66 pass
+ 0 fail
+ 202 expect() calls
+Ran 66 tests across 4 files. [11.40s]
+
+Command: bun test packages/omo-native/test   (full scoped gate)
+ 132 pass
+ 6 skip
+ 1 fail      <- payload.test.ts full-build case only; pre-existing env issue:
+                git submodule revision for shared-skills/upstreams/open-design is
+                unfetchable in this worktree, build:materialize-shared-upstreams --strict
+                aborts before staging. Reproduces on untouched base; unrelated files.
+Ran 139 tests across 15 files. [18.91s]

--- a/.omo/evidence/20260824-6686-stale-binary-cache/live-doctor-shadowing.txt
+++ b/.omo/evidence/20260824-6686-stale-binary-cache/live-doctor-shadowing.txt
@@ -1,0 +1,10 @@
+FAIL plugin manifest: missing plugin/package.json
+FAIL extension: missing plugin/extensions/omo.js
+FAIL lsp-daemon runtime: missing plugin/runtime/lsp-daemon/dist/cli.js
+FAIL agent-toolkit runtime: missing plugin/runtime/agent-toolkit/cli.js
+PASS senpi CLI: /home/viprix/projects/oom-wt-6686/node_modules/.bun/@code-yeongyu+senpi@2026.8.23+3aa9f84f7136ce5f/node_modules/@code-yeongyu/senpi/dist/cli.js
+PASS senpi version 2026.8.23
+INFO omo 5.0.0-0.beta.18 (engine: senpi 2026.8.23)
+WARN stale omo binaries run ahead of this install on PATH: /tmp/tmp.a6g3j7xM7a/legacy/omo (reports 4.19.4) beats /tmp/tmp.a6g3j7xM7a/bin/omo
+WARN refresh the shell command cache after upgrading: hash -r (zsh: rehash); if ~/.local/bin precedes the npm global bin directory, prepend it: export PATH="$(npm prefix -g)/bin:$PATH"
+INFO no credentials found; run omo setup to review sibling stores

--- a/.omo/evidence/20260824-6686-stale-binary-cache/red-failing-first.txt
+++ b/.omo/evidence/20260824-6686-stale-binary-cache/red-failing-first.txt
@@ -1,0 +1,19 @@
+RED PHASE (failing-first proof, before stale-bin.js existed)
+
+Command: bun test packages/omo-native/test/stale-bin.test.ts
+
+Output:
+bun test v1.3.14 (0d9b296a)
+
+packages/omo-native/test/stale-bin.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+error: Cannot find module '../bin/lib/stale-bin.js' from '/home/viprix/projects/oom-wt-6686/packages/omo-native/test/stale-bin.test.ts'
+-------------------------------
+
+
+ 0 pass
+ 1 fail
+ 1 error
+Ran 1 test across 1 file. [405.00ms]

--- a/.omo/evidence/20260824-6686-stale-binary-cache/test-suite-final.txt
+++ b/.omo/evidence/20260824-6686-stale-binary-cache/test-suite-final.txt
@@ -1,0 +1,8 @@
+      at <anonymous> (/home/viprix/projects/oom-wt-6686/packages/omo-native/test/payload.test.ts:71:83)
+(fail) build:omo-native staged payload > #given a full plugin build > #when the payload is staged to a temp output dir > #then every required artifact is present with preserved modes and no dev clutter [6190.85ms]
+
+ 132 pass
+ 6 skip
+ 1 fail
+ 387 expect() calls
+Ran 139 tests across 15 files. [18.91s]

--- a/.omo/evidence/20260824-6686-stale-binary-cache/typecheck.txt
+++ b/.omo/evidence/20260824-6686-stale-binary-cache/typecheck.txt
@@ -1,0 +1,1 @@
+TYPECHECK_OK (bunx tsc -p packages/omo-native/tsconfig.json --noEmit)

--- a/packages/omo-native/bin/lib/doctor.js
+++ b/packages/omo-native/bin/lib/doctor.js
@@ -3,6 +3,7 @@ import { join } from "node:path"
 import { canonicalAgentDir } from "./agent-dir.js"
 import { packageManifest, packageRoot, readJson, resolveSenpi } from "./package-paths.js"
 import { needsSetupSuggestion } from "./setup-detect.js"
+import { staleBinWarnings } from "./stale-bin.js"
 
 const artifacts = [
   ["plugin manifest", "plugin/package.json"],
@@ -91,6 +92,9 @@ export function runDoctor(inventory) {
 
   lines.push(`INFO omo ${packageManifest().version} (engine: senpi ${engineVersionOrUnresolved(senpi)})`)
   lines.push(...warningsForSettings())
+  // A stale shell command cache or a leftover legacy wrapper keeps an old omo serving after an
+  // upgrade; surface every competing copy on PATH with the recovery commands.
+  lines.push(...staleBinWarnings())
   if (needsSetupSuggestion(inventory)) {
     lines.push("INFO no credentials found; run omo setup to review sibling stores")
   }

--- a/packages/omo-native/bin/lib/stale-bin.js
+++ b/packages/omo-native/bin/lib/stale-bin.js
@@ -1,0 +1,150 @@
+import { spawnSync } from "node:child_process"
+import { existsSync, realpathSync, statSync } from "node:fs"
+import { delimiter, join, sep } from "node:path"
+import { packageRoot } from "./package-paths.js"
+
+// Upgrading omo-ai does not reach every entry point at once: zsh and bash cache the resolved
+// command path per session, and a legacy wrapper left in ~/.local/bin can sit ahead of the npm
+// global bin directory. Both keep an old binary serving after a successful upgrade until the user
+// clears the cache or repairs PATH order, so diagnostics must surface every competing omo on PATH
+// together with the exact recovery commands.
+
+const VERSION_PROBE_TIMEOUT_MS = 2000
+const MAX_VERSION_PROBES = 3
+
+function commandCandidates(dir, platform) {
+  return platform === "win32" ? [join(dir, "omo.cmd"), join(dir, "omo.exe")] : [join(dir, "omo")]
+}
+
+function isExecutableFile(path, platform) {
+  let stat
+  try {
+    stat = statSync(path)
+  } catch {
+    return false
+  }
+  if (!stat.isFile()) return false
+  return platform === "win32" || (stat.mode & 0o111) !== 0
+}
+
+/**
+ * Every omo command reachable through PATH, in PATH order, duplicates collapsed. Missing
+ * directories and non-executable entries are skipped because a shell could not resolve them either.
+ */
+export function findOmoPathEntries(pathEnv, platform = process.platform) {
+  const seen = new Set()
+  const entries = []
+  for (const dir of String(pathEnv ?? "").split(delimiter)) {
+    if (dir.length === 0) continue
+    const key = platform === "win32" ? dir.toLowerCase() : dir
+    if (seen.has(key)) continue
+    seen.add(key)
+    for (const candidate of commandCandidates(dir, platform)) {
+      if (!existsSync(candidate)) continue
+      if (!isExecutableFile(candidate, platform)) continue
+      entries.push(candidate)
+      break
+    }
+  }
+  return entries
+}
+
+function realPathOf(path) {
+  try {
+    return realpathSync(path)
+  } catch {
+    return path
+  }
+}
+
+function isInsideRoot(path, root) {
+  const resolvedPath = realPathOf(path)
+  const resolvedRoot = realPathOf(root)
+  return resolvedPath === resolvedRoot || resolvedPath.startsWith(resolvedRoot.endsWith(sep) ? resolvedRoot : resolvedRoot + sep)
+}
+
+/**
+ * Runs `<candidate> --version` and returns the first output line. Windows is skipped without
+ * spawning: Node refuses .cmd/.exe shims without a shell, and shelling out on attacker-shaped PATH
+ * entries is not worth a version string. Any failure degrades to null instead of throwing.
+ */
+export function readInstalledVersion(binPath, timeoutMs = VERSION_PROBE_TIMEOUT_MS) {
+  if (process.platform === "win32") return null
+  try {
+    const result = spawnSync(binPath, ["--version"], { encoding: "utf8", timeout: timeoutMs, windowsHide: true })
+    const line = String(result.stdout ?? "").split("\n")[0]?.trim() ?? ""
+    return line.length > 0 ? line : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Classifies the omo commands on PATH against this install. Foreign copies that appear before the
+ * first copy belonging to this package shadow it outright; the rest are leftovers a cached shell
+ * command may still resolve to.
+ */
+export function collectStaleOmoBins({
+  pathEnv = process.env.PATH,
+  platform = process.platform,
+  root = packageRoot,
+  probeVersion = readInstalledVersion,
+} = {}) {
+  const entries = findOmoPathEntries(pathEnv, platform)
+  const oursIndex = entries.findIndex((entry) => isInsideRoot(entry, root))
+
+  let probes = 0
+  const describe = (path) => {
+    const version = probes < MAX_VERSION_PROBES && !isInsideRoot(path, root) ? probeVersion(path) : null
+    probes += 1
+    return { path, version }
+  }
+
+  if (oursIndex === -1) {
+    return { oursOnPath: false, oursPath: undefined, ahead: entries.map(describe), behind: [] }
+  }
+  return {
+    oursOnPath: true,
+    oursPath: entries[oursIndex],
+    ahead: entries.slice(0, oursIndex).map(describe),
+    behind: entries.slice(oursIndex + 1).map(describe),
+  }
+}
+
+function formatEntry(entry) {
+  return entry.version === null ? `${entry.path} (unknown version)` : `${entry.path} (reports ${entry.version})`
+}
+
+function formatList(entries) {
+  return entries.map(formatEntry).join(", ")
+}
+
+/**
+ * Doctor-ready WARN lines describing competing omo commands on PATH and how to invalidate the
+ * stale shell command cache. Warnings never fail the run: a leftover binary is an environment
+ * hazard, not a broken install artifact.
+ */
+export function staleBinWarnings(options = {}) {
+  const stale = collectStaleOmoBins(options)
+  const recovery =
+    'refresh the shell command cache after upgrading: hash -r (zsh: rehash); if ~/.local/bin precedes the npm global bin directory, prepend it: export PATH="$(npm prefix -g)/bin:$PATH"'
+  if (!stale.oursOnPath) {
+    if (stale.ahead.length === 0) return []
+    return [
+      `WARN omo on PATH is not this install (${options.root ?? packageRoot}): ${formatList(stale.ahead)}`,
+      `WARN ${recovery}`,
+    ]
+  }
+  if (stale.ahead.length > 0) {
+    return [
+      `WARN stale omo binaries run ahead of this install on PATH: ${formatList(stale.ahead)} beats ${stale.oursPath}`,
+      `WARN ${recovery}`,
+    ]
+  }
+  if (stale.behind.length > 0) {
+    return [
+      `WARN other omo copies remain on PATH behind this install: ${formatList(stale.behind)}; a shell that already ran one keeps starting it until its command cache is refreshed: hash -r (zsh: rehash)`,
+    ]
+  }
+  return []
+}

--- a/packages/omo-native/test/stale-bin.test.ts
+++ b/packages/omo-native/test/stale-bin.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, dirname, join, resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { findOmoPathEntries } from "../bin/lib/stale-bin.js"
+
+const SOURCE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
+const roots: string[] = []
+const artifacts = [
+  ["plugin manifest", "plugin/package.json"],
+  ["extension", "plugin/extensions/omo.js"],
+  ["lsp-daemon runtime", "plugin/runtime/lsp-daemon/dist/cli.js"],
+  ["agent-toolkit runtime", "plugin/runtime/agent-toolkit/cli.js"],
+] as const
+
+type Fixture = {
+  root: string
+  packageRoot: string
+  launcher: string
+  agentDir: string
+  npmBinDir: string
+  npmOmo: string
+  legacyDir: string
+  legacyOmo: string
+}
+
+function writeFile(path: string, content = "fixture\n", mode?: number): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content, mode === undefined ? undefined : { mode })
+}
+
+function commandName(): string {
+  return process.platform === "win32" ? "omo.cmd" : "omo"
+}
+
+/**
+ * A stand-in for the legacy managed wrapper left behind by an older OMO install. It answers
+ * --version with a fixed old version so the doctor probe has something stale to report; a null
+ * version stubs a wrapper whose --version fails.
+ */
+function writeLegacyStub(dir: string, version: string | null): string {
+  mkdirSync(dir, { recursive: true })
+  const stub = join(dir, commandName())
+  if (process.platform === "win32") {
+    writeFile(stub, version === null ? "@echo off\r\nexit /b 1\r\n" : `@echo off\r\necho ${version}\r\n`)
+  } else {
+    // The shebang pins the running interpreter so the stub resolves without any system PATH.
+    const body = version === null
+      ? `#!${process.execPath}\nprocess.exit(1)\n`
+      : `#!${process.execPath}\nif (process.argv[2] === "--version") console.log(${JSON.stringify(version)})\n`
+    writeFile(stub, body)
+    chmodSync(stub, 0o755)
+  }
+  return stub
+}
+
+function createFixture(options: { legacyVersion?: string | null } = {}): Fixture {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "omo-stale-bin-")))
+  roots.push(root)
+  const packagePath = join(root, "prefix", "lib", "node_modules", "omo-ai")
+  mkdirSync(packagePath, { recursive: true })
+  const packageRoot = realpathSync(packagePath)
+  cpSync(join(SOURCE_ROOT, "bin"), join(packageRoot, "bin"), { recursive: true })
+  writeFile(join(packageRoot, "package.json"), JSON.stringify({
+    name: "omo-ai",
+    version: "5.0.0-0.beta.test",
+    type: "module",
+    dependencies: { "@code-yeongyu/senpi": "2026.8.9" },
+  }))
+  const senpiRoot = join(packageRoot, "node_modules", "@code-yeongyu", "senpi")
+  writeFile(join(senpiRoot, "package.json"), JSON.stringify({
+    name: "@code-yeongyu/senpi",
+    version: "2026.8.9",
+    type: "module",
+    exports: { ".": "./dist/index.js" },
+  }))
+  writeFile(join(senpiRoot, "dist", "index.js"), "export const fixture = true\n")
+  writeFile(join(senpiRoot, "dist", "cli.js"), "process.exit(0)\n")
+  for (const [, artifact] of artifacts) writeFile(join(packageRoot, artifact))
+  const agentDir = join(root, "agent")
+  mkdirSync(agentDir, { recursive: true })
+
+  // The upgraded install is reached the way npm reaches it: an omo link in the global bin
+  // directory pointing back into the package tree.
+  const npmBinDir = join(root, "prefix", "bin")
+  mkdirSync(npmBinDir, { recursive: true })
+  const npmOmo = join(npmBinDir, commandName())
+  if (process.platform === "win32") {
+    writeFile(npmOmo, `@echo off\r\nnode "${join(packageRoot, "bin", "omo.js")}" %*\r\n`)
+  } else {
+    symlinkSync(join(packageRoot, "bin", "omo.js"), npmOmo)
+  }
+
+  const legacyDir = join(root, "home", ".local", "bin")
+  const legacyOmo = writeLegacyStub(legacyDir, options.legacyVersion === undefined ? "4.19.4" : options.legacyVersion)
+  return { root, packageRoot, launcher: join(packageRoot, "bin", "omo.js"), agentDir, npmBinDir, npmOmo, legacyDir, legacyOmo }
+}
+
+function run(fixture: Fixture, pathEnv: string): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, [fixture.launcher, "doctor"], {
+    encoding: "utf8",
+    env: { ...process.env, SENPI_CODING_AGENT_DIR: fixture.agentDir, PATH: pathEnv },
+  })
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("stale omo binary detection", () => {
+  describe("findOmoPathEntries", () => {
+    describe("#given a PATH containing missing directories and duplicates", () => {
+      test("#then existing omo commands are returned in PATH order without duplicates", () => {
+        const fixture = createFixture()
+        const first = join(fixture.root, "first")
+        writeFile(join(first, commandName()), "stub\n", 0o755)
+        const entries = findOmoPathEntries(
+          [fixture.npmBinDir, first, "/does-not-exist", fixture.npmBinDir].join(delimiter),
+        )
+        expect(entries).toEqual([fixture.npmOmo, join(first, commandName())])
+      })
+    })
+
+    describe("#given an empty PATH", () => {
+      test("#then no entries are collected", () => {
+        expect(findOmoPathEntries("")).toEqual([])
+      })
+    })
+
+    test.skipIf(process.platform === "win32")(
+      "#given a non-executable file named omo #when entries are collected #then it is skipped",
+      () => {
+        const fixture = createFixture()
+        const dir = join(fixture.root, "not-executable")
+        writeFile(join(dir, "omo"), "not executable\n", 0o644)
+        expect(findOmoPathEntries(dir)).toEqual([])
+      },
+    )
+  })
+
+  describe("omo doctor stale-binary diagnostics", () => {
+    describe("#given a legacy wrapper earlier on PATH than the upgraded install", () => {
+      test("#then doctor names the stale binary, its version, and the cache-clear recipe without failing", () => {
+        const fixture = createFixture()
+        const result = run(fixture, [fixture.legacyDir, fixture.npmBinDir].join(delimiter))
+        expect(result.status).toBe(0)
+        const stdout = String(result.stdout)
+        expect(stdout).toContain("WARN")
+        expect(stdout).toContain(fixture.legacyOmo)
+        expect(stdout).toContain("4.19.4")
+        expect(stdout).toContain("hash -r")
+        expect(stdout).toContain("rehash")
+        expect(stdout).toContain('export PATH="$(npm prefix -g)/bin:$PATH"')
+      })
+    })
+
+    describe("#given the upgraded install precedes a leftover legacy copy on PATH", () => {
+      test("#then doctor warns that shells may keep starting the cached old binary", () => {
+        const fixture = createFixture()
+        const result = run(fixture, [fixture.npmBinDir, fixture.legacyDir].join(delimiter))
+        expect(result.status).toBe(0)
+        const stdout = String(result.stdout)
+        expect(stdout).toContain("WARN")
+        expect(stdout).toContain(fixture.legacyOmo)
+        expect(stdout).toContain("hash -r")
+        expect(stdout).toContain("rehash")
+      })
+    })
+
+    describe("#given only the upgraded install on PATH", () => {
+      test("#then doctor emits no stale-binary warnings", () => {
+        const fixture = createFixture()
+        const result = run(fixture, fixture.npmBinDir)
+        expect(result.status).toBe(0)
+        const stdout = String(result.stdout)
+        expect(stdout).not.toContain("hash -r")
+        expect(stdout).not.toContain("stale omo")
+      })
+    })
+
+    describe("#given a foreign omo whose --version fails", () => {
+      test("#then it is still reported as an unknown-version copy and doctor stays green", () => {
+        const fixture = createFixture({ legacyVersion: null })
+        const result = run(fixture, [fixture.legacyDir, fixture.npmBinDir].join(delimiter))
+        expect(result.status).toBe(0)
+        const stdout = String(result.stdout)
+        expect(stdout).toContain(fixture.legacyOmo)
+        expect(stdout).toContain("unknown version")
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What

`omo doctor` now detects every competing `omo` command on PATH, classifies each against the running install by real path, probes foreign copies with `--version`, and warns with the exact recovery commands:

- legacy/stale copies running ahead of this install on PATH
- leftover copies behind this install that a cached shell command may still resolve to
- PATH entries that are not this install at all

New module `packages/omo-native/bin/lib/stale-bin.js` (pure, injectable PATH/platform/probe) wired into `runDoctor()`; regression suite `packages/omo-native/test/stale-bin.test.ts`.

Example output for the #6686 reproduction shape (legacy 4.19.4 wrapper ahead of the upgraded install):

```
WARN stale omo binaries run ahead of this install on PATH: ~/.local/bin/omo (reports 4.19.4) beats <npm-global-bin>/omo
WARN refresh the shell command cache after upgrading: hash -r (zsh: rehash); if ~/.local/bin precedes the npm global bin directory, prepend it: export PATH="$(npm prefix -g)/bin:$PATH"
```

## Why

Installing `omo-ai@beta` does not reach every entry point at once: zsh/bash cache the resolved command path per session, and a legacy managed wrapper in `~/.local/bin` can sit ahead of the npm global bin directory. Both keep an old binary serving after a successful upgrade until the user clears the cache or repairs PATH order (#6686). Doctor had no diagnostic for this state, and a package.json postinstall warning is not available because `package-shape.test.ts` pins the published `omo-ai` manifest to have no postinstall hook.

Design notes:
- Warnings never flip the exit code: a leftover binary is an environment hazard, not a broken install artifact.
- Version probing executes only foreign candidates (`--version`, 2s timeout, max 3 probes) and is skipped entirely on Windows, where Node refuses `.cmd` shims without a shell; those entries report `(unknown version)`.
- Broken symlinks and non-executable entries degrade gracefully instead of throwing.
- Docs coverage for the same recovery steps is intentionally left to #6687, which owns `docs/troubleshooting/README.md` and `docs/guide/installation.md`; this PR stays scoped to the diagnostic surface. Plugin-cache lane #6680 is untouched.

## Verified

- Failing-first: `bun test packages/omo-native/test/stale-bin.test.ts` failed before implementation (`Cannot find module '../bin/lib/stale-bin.js'`), passes after: 7 pass / 0 fail (given/when/then).
- Scoped suites green: stale-bin + doctor + package-shape + launcher = 66 pass / 0 fail; existing doctor tests stay green while inheriting the host PATH because the check is WARN-only.
- Full scoped gate `bun test packages/omo-native/test`: 132 pass / 6 skip / 1 fail - the single failure is the pre-existing environment issue where `payload.test.ts`'s full build aborts on an unfetchable submodule revision (`shared-skills/upstreams/open-design`); it reproduces on the untouched base checkout and involves none of these files.
- Typecheck: `bunx tsc -p packages/omo-native/tsconfig.json --noEmit` clean.
- Entry smoke: `node packages/omo-native/bin/omo.js --version` reports the branded version.
- Live manual QA against a synthetic shadowing layout captured in `.omo/evidence/20260824-6686-stale-binary-cache/live-doctor-shadowing.txt`.
- Evidence directory: `.omo/evidence/20260824-6686-stale-binary-cache/` (red run, green runs, live doctor output, WHAT TESTED/OBSERVED/WHY ENOUGH/OMITTED).

## Risk

Low. The check is additive WARN-only output in `omo doctor`; no launcher dispatch, engine spawn, packaging, or payload changes. Worst case is a missed or extra warning line on exotic PATH layouts; probing is bounded (2s timeout, max 3 foreign candidates, none on Windows).

Fixes #6686

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects stale `omo` binaries on PATH in `omo doctor` and prints exact recovery steps. Previously, doctor could not see competing `omo` commands, so upgrades could still run an old binary; now it scans PATH, classifies entries relative to this install, probes foreign versions, and emits WARN-only messages.

- Adds `packages/omo-native/bin/lib/stale-bin.js` and wires it into `runDoctor()` via `staleBinWarnings()`.
- Scans PATH in order, classifies `omo` entries as ahead/behind/not-this-install, and shows each path with a probed version; caps probes (3) with a 2s timeout; skips version probing on Windows (reports “unknown version”).
- Keeps behavior WARN-only; exit code remains 0. Adds `packages/omo-native/test/stale-bin.test.ts`; existing doctor behavior stays unchanged otherwise.
- No migration for maintainers. Users should refresh the shell command cache after upgrading (hash -r; zsh: rehash) and put the npm global bin first if needed: export PATH="$(npm prefix -g)/bin:$PATH". Fixes #6686.

<sup>Written for commit 42de7a261e6cffc77d4d4ec468fff1728656ad7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

