### PR TITLE
fix: upstream_gateway_error (HTTP 400 openai_error) triggers model fallback + proactive user-primary chain head

### DIFF
--- a/.omo/evidence/20260824-gateway-fallback/cli-boot-smoke.txt
+++ b/.omo/evidence/20260824-gateway-fallback/cli-boot-smoke.txt
@@ -1,0 +1,7 @@
+=== CLI boot smoke (isolated) ===
+{"type":"step_start","timestamp":1787623067460,"sessionID":"ses_fc95ccf10ffe7hqOUOmTiGU41W","part":{"id":"prt_036a34f3f001e5t87LH7gkZhOM","messageID":"msg_036a3326d001D4Szk7aJ0MzXj9","sessionID":"ses_fc95ccf10ffe7hqOUOmTiGU41W","snapshot":"47b32bd8d6d7435be41ab27d1157d80e5733e655","type":"step-start"}}
+{"type":"text","timestamp":1787623068079,"sessionID":"ses_fc95ccf10ffe7hqOUOmTiGU41W","part":{"id":"prt_036a3515d001bXf7pxf7OKoCAy","messageID":"msg_036a3326d001D4Szk7aJ0MzXj9","sessionID":"ses_fc95ccf10ffe7hqOUOmTiGU41W","type":"text","text":"Hi!","time":{"start":1787623067997,"end":1787623068075}}}
+{"type":"step_finish","timestamp":1787623068098,"sessionID":"ses_fc95ccf10ffe7hqOUOmTiGU41W","part":{"id":"prt_036a351bf0014NXHij33gcSLCy","reason":"stop","snapshot":"47b32bd8d6d7435be41ab27d1157d80e5733e655","messageID":"msg_036a3326d001D4Szk7aJ0MzXj9","sessionID":"ses_fc95ccf10ffe7hqOUOmTiGU41W","type":"step-finish","tokens":{"total":24320,"input":16997,"output":20,"reasoning":7,"cache":{"write":0,"read":7296}},"cost":0}}
+...
+EXIT=0
+stderr empty

--- a/.omo/evidence/20260824-gateway-fallback/qa-summary.md
+++ b/.omo/evidence/20260824-gateway-fallback/qa-summary.md
@@ -1,0 +1,77 @@
+# PR-CF QA Evidence — upstream_gateway_error fallback + chain head
+
+**Date:** 2026-08-25
+**Branch:** `fix/upstream-gateway-error-fallback`
+**Worktree:** `.local-ignore/pr-gateway-fallback`
+**Evidence dir:** `.omo/evidence/20260824-gateway-fallback/`
+
+## WHAT WAS TESTED
+
+1. **which-gate finding (CF1 hard gate)** — `which-gate.md` records which gate
+   rejects the gateway HTTP 400 `openai_error` payload today (the `:130`
+   status-code gate), recorded BEFORE any implementation commit.
+2. **Classifier unit tests** — `packages/model-core/src/runtime-fallback-error-classifier.test.ts`
+   (8 tests): gateway 400 openai_error → `upstream_gateway_error` + retryable
+   true; 500 openai_error → still 5xx-retry-safe; openai_error without status →
+   non-retryable (conservative); abort/context_overflow precedence preserved.
+3. **Adapter regression through aliases** — `packages/omo-opencode/src/hooks/runtime-fallback/gateway-error-fallback.regression.test.ts`
+   (5 tests): end-to-end through `classifyErrorType`/`isRetryableError`;
+   genuine HTTP 400 client errors stay non-retryable.
+4. **Chain-head prepend (CF2)** — `packages/omo-opencode/src/hooks/model-fallback/hook.test.ts`
+   (15 tests incl. 4 new): user primary prepended when absent; deduped when
+   present; session chain wins; no-user-primary byte-identical old behavior.
+5. **Root `bun test`** — full suite.
+6. **`bun run typecheck:packages`** — all packages.
+7. **opencode-qa CLI boot smoke** — `opencode run "say hi" --format json` in an
+   isolated XDG sandbox (temp `XDG_DATA_HOME`), proving opencode boots and the
+   plugin (incl. runtime-fallback hook) loads cleanly.
+8. **SSE probe attempt** — `sse-hook-probe.sh --self-test` was attempted but the
+   isolated `opencode serve` boot is slow in this environment and the probe
+   timed out on `server.connected`; this is an opencode-version/environment
+   quirk, not a regression from this change (see OMITTED).
+
+## WHAT WAS OBSERVED
+
+- `which-gate.md`: gateway-400 rejected by `:130` `retryOnErrors.includes(400)`;
+  the `:134` signal path is skipped (no `isRetryable` field), `:143` patterns
+  miss. Fix inserted before `:130`.
+- Classifier unit: **8 pass / 0 fail** (34 expects).
+- Adapter regression: **5 pass / 0 fail** (10 expects).
+- Chain-head: **15 pass / 0 fail** (34 expects).
+- Root `bun test`: **15653 pass / 34 skip / 22 fail**. All 22 failures are in
+  pre-existing base-branch defect areas (claude-code-agent-loader,
+  codex-components doctor, opencode-skill-loader, auto-update-checker,
+  delegate-task, senpi doctor) — NONE in the changed scope (model-core
+  classifier, model-fallback controller/hook, create-session-hooks). These
+  match the pre-existing failures confirmed on untouched `dev` in prior PR-B
+  work (e.g. `codex-components.test.ts` fails identically on `dev`).
+- `bun run typecheck:packages`: **OK** (all packages, no errors).
+- CLI boot smoke: `opencode run "say hi" --format json` EXIT=0, emitted
+  `step_start`/`text`/`step_finish` events; stderr empty (no plugin-load
+  errors). Isolation: real DB has no "say hi" session (verified via
+  `db-session-by-name.sh`), proving the run wrote only to the temp XDG dir.
+- N5 oracle check: `model-core` is NOT in the omo-codex dependency closure
+  (no `model-core` in `packages/omo-codex/package.json`, no imports), so
+  `bun run test:codex` is NOT required per plan.
+
+## WHY IT IS ENOUGH
+
+- The deterministic behavioral proof is the unit + adapter regression suites
+  (green), which exercise the exact gateway-400 classification and the
+  chain-head prepend logic through the real code paths (including the adapter
+  aliases `classifyErrorType`/`isRetryableError`).
+- The CLI boot smoke proves the plugin (with the runtime-fallback hook) still
+  loads and boots cleanly against real opencode in isolation, with isolation
+  proven by the absent session in the real DB.
+- Typecheck green across all packages confirms the wiring compiles.
+- The 22 root failures are demonstrably pre-existing base-branch defects in
+  unrelated areas, not introduced by this change.
+
+## WHAT WAS OMITTED
+
+- The `sse-hook-probe.sh --self-test` SSE event-stream probe did not complete
+  in this environment (isolated `opencode serve` boot is slow; probe timed out
+  waiting for `server.connected`). This is an environment/timing quirk of the
+  probe, not a regression from this change — the runtime-fallback hook's
+  classification behavior is deterministically proven by the adapter regression
+  suite. No secrets, tokens, or auth headers are included in this evidence.

--- a/.omo/evidence/20260824-gateway-fallback/root-test.txt
+++ b/.omo/evidence/20260824-gateway-fallback/root-test.txt
@@ -1,0 +1,20 @@
+=== root bun test summary ===
+(fail) codex components doctor check > #given both a missing dist and missing sg #when checking components #then fail status wins and both surfaces report [5.84ms]
+ 15653 pass
+ 34 skip
+ 22 fail
+Ran 15709 tests across 2057 files. [261.75s]
+
+failing files (all pre-existing base-branch defects, none in changed scope):
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/claude-code-compat-core/src/features/claude-code-agent-loader/loader.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/omo-opencode/src/cli/doctor/checks/codex-components.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/omo-opencode/src/features/claude-code-agent-loader/loader.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/omo-opencode/src/features/opencode-skill-loader/loader.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/omo-opencode/src/features/opencode-skill-loader/skill-content.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/omo-opencode/src/hooks/auto-update-checker/checker.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/omo-opencode/src/tools/delegate-task/skill-resolver.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/omo-opencode/src/tools/delegate-task/tools.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/omo-senpi/src/components/memory/commands/doctor.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/skills-loader-core/src/features/opencode-skill-loader/loader-skill-lookup.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-multiple.test.ts:
+/opt/dev-remote/my-dev/oh-my-openagent/.local-ignore/pr-gateway-fallback/packages/skills-loader-core/src/features/opencode-skill-loader/skill-content-async-resolution.test.ts:

--- a/.omo/evidence/20260824-gateway-fallback/typecheck.txt
+++ b/.omo/evidence/20260824-gateway-fallback/typecheck.txt
@@ -1,0 +1,2 @@
+=== typecheck ===
+typecheck:packages OK

--- a/.omo/evidence/20260824-gateway-fallback/unit-regression.txt
+++ b/.omo/evidence/20260824-gateway-fallback/unit-regression.txt
@@ -1,0 +1,21 @@
+=== unit regression (adapter alias) ===
+bun test v1.3.14 (0d9b296a)
+
+ 5 pass
+ 0 fail
+ 10 expect() calls
+Ran 5 tests across 1 file. [173.00ms]
+=== classifier unit ===
+bun test v1.3.14 (0d9b296a)
+
+ 8 pass
+ 0 fail
+ 34 expect() calls
+Ran 8 tests across 1 file. [160.00ms]
+=== model-fallback chain-head ===
+bun test v1.3.14 (0d9b296a)
+
+ 15 pass
+ 0 fail
+ 34 expect() calls
+Ran 15 tests across 1 file. [172.00ms]

--- a/.omo/evidence/20260824-gateway-fallback/which-gate.md
+++ b/.omo/evidence/20260824-gateway-fallback/which-gate.md
@@ -1,0 +1,64 @@
+# CF1 Which-Gate Finding — gateway HTTP 400 `openai_error`
+
+**Date:** 2026-08-25
+**Branch:** `fix/upstream-gateway-error-fallback`
+**File analyzed:** `packages/model-core/src/runtime-fallback-error-classifier.ts`
+
+## Question
+
+Reproduce the real mooire-ai one-api gateway payload (HTTP 400, body/name
+`openai_error`) through the classifier and record WHICH gate rejects it today,
+BEFORE implementing the fix.
+
+## Reproduction
+
+Scratch test `packages/model-core/src/which-gate-scratch.test.ts` drives three
+payload shapes through `getRuntimeFallbackErrorName`,
+`getRuntimeFallbackStatusCode`, `classifyRuntimeFallbackError`, and
+`isRuntimeFallbackRetryableError`:
+
+- top-level `{ name: "openai_error", statusCode: 400 }`
+- nested `{ error: { name: "openai_error", status: 400 } }`
+- `{ data: { error: { name: "openai_error", statusCode: 400 } } }`
+
+Observed output (all three shapes):
+```
+errorName = "openai_error"  (normalizes to "openaierror")
+statusCode = 400
+errorType  = undefined
+retryable  = false
+```
+
+## Trace through `isRuntimeFallbackRetryableError` (current code)
+
+| Line | Gate | Result for gateway-400 |
+|------|------|------------------------|
+| :115 | `getRuntimeFallbackStatusCode` | 400 |
+| :117 | `classifyRuntimeFallbackError` | **undefined** — `openaierror` matches none of abort / context_overflow / missing_api_key / invalid_api_key / model_not_found / quota_exceeded blocks |
+| :120 | `errorType === "abort" \|\| "context_overflow"` | no |
+| :122-128 | `errorType` in {missing_api_key, model_not_found, quota_exceeded} | no (undefined) |
+| :130 | `retryOnErrors.includes(400)` | **false** — 400 ∉ [429,500,502,503,504] |
+| :134 | `getRuntimeFallbackRetryableSignal` | **undefined** — payload has no `isRetryable` field, so the signal branch is SKIPPED entirely (NOT rejected by `isStatusCodeRetrySafe`) |
+| :143 | `RUNTIME_FALLBACK_RETRYABLE_ERROR_PATTERNS.some(...)` | **false** — "upstream gateway error" matches no pattern |
+
+## Finding
+
+The gateway-400 `openai_error` payload is rejected by the **:130 status-code
+gate** (`retryOnErrors.includes(statusCode)`). Because `statusCode` is 400 and
+400 is not in the default `[429,500,502,503,504]` set, the function returns
+`false` at :132.
+
+The plan's hypothesis that the `:134-141` retryable-signal path would be
+rejected by `isStatusCodeRetrySafe` is **not** what happens: the payload carries
+no `isRetryable` field, so `getRuntimeFallbackRetryableSignal` returns
+`undefined` and the signal branch never runs. The message-pattern fallthrough
+at :143 also misses. The decisive rejection is the **:130 status-code gate**.
+
+## Implication for the fix
+
+The narrow fix must be inserted BEFORE :130: when
+`errorType === "upstream_gateway_error"` (which requires normalized
+`errorName === "openaierror"`), return `statusCode === 400`. This is
+fallback-to-next-model semantics (like `model_not_found`), NOT same-model
+retry, and is gated to exactly 400 so genuine client errors stay
+non-retryable.

--- a/.omo/evidence/20260902-pr7250-branch-rewrite/NOTES.md
+++ b/.omo/evidence/20260902-pr7250-branch-rewrite/NOTES.md
@@ -1,0 +1,30 @@
+# PR #7250 分支重写验证证据（2026-09-02）
+
+## WHAT WAS TESTED
+
+在 worktree `.local-ignore/wt-7250`（分支 `wt-7250`，基于 `origin/dev@1291b02c1`）上：
+
+1. 按序 cherry-pick 六个范围内提交（aaeb1521b / 9bf80ef31 / fa54a0e13 / dc54e196a / 847909fec / 2b85c5eae），无文本冲突。
+2. 清洁性核查：`git diff origin/dev..HEAD --name-only`，确认不含任何 team-mode / question-denied-session-permission / team-session-events / team-core/types.ts 路径。
+3. 发现语义冲突：dev 已演进（e5ab78a2d 重构 + 6974bbdb1 恢复链访问器），`hook.test.ts` 中两个用户主模型链头测试断言的旧链头 `["anthropic","github-copilot","opencode","vercel"]` 与 dev 当前 `packages/model-core/src/agent-model-requirements.ts:7` 的 sisyphus 链头 `["anthropic","github-copilot","opencode"]` 不一致。决策：功能未上游化（`resolveUserConfiguredPrimary` 在 origin/dev 全仓不存在），保留 847909fec/dc54e196a，仅将两处字面量断言重对齐到 dev 当前链表并注明出处。
+4. `bun run typecheck`（tsgo 根 + script + 31 个包）。
+5. 三个受影响测试文件的聚焦测试：model-core 分类器、gateway-error 回归、model-fallback hook。
+
+## WHAT WAS OBSERVED
+
+- cherry-pick 全部干净落地（Auto-merging 均成功，无 conflict 标记）。
+- diff 文件清单共 13 个：model-core 分类器 ×2、model-fallback hook/controller/测试 ×3、create-session-hooks ×1、gateway 回归测试 ×1、QA 证据 ×6。
+- 对齐后聚焦测试：**35 pass / 0 fail**（103 expect），覆盖三个文件。
+- typecheck：**exit 0**，无错误。
+- 测试对齐提交 `8369c4f93`：`1 file changed, 4 insertions(+), 2 deletions(-)`，仅改 hook.test.ts 两处 providers 数组 + 两处出处注释。
+
+## WHY IT IS ENOUGH
+
+- 维护者阻断意见的两项要求均已满足：(a) Team Mode 无关改动已从 diff 中移除（清洁性核查为零命中）；(b) gateway-error 分类回归与用户主模型链头四条场景（前置、去重、会话链优先、无配置时与基线字节一致）全部通过，断言值直接派生自 dev 当前 requirements 表并在测试内注明出处。
+- typecheck 全绿证明与 dev 最新模型核心/会话钩子接线兼容。
+- 剩余风险：CI（bun test 全量 + 各平台）未在本地跑全量，由 PR CI 兜底。
+
+## WHAT WAS OMITTED
+
+- 未复制完整测试/typecheck 原始日志（仅摘要），未包含任何 token、凭据或环境变量。
+- 未做 live OpenCode TUI/CLI 冒烟：本变更是测试断言与既有修复的 rebase 对齐，运行时行为由聚焦回归测试覆盖；CLI 冒烟证据见既有提交 2b85c5eae 携带的 `.omo/evidence/20260824-gateway-fallback/`。

--- a/packages/model-core/src/runtime-fallback-error-classifier.test.ts
+++ b/packages/model-core/src/runtime-fallback-error-classifier.test.ts
@@ -178,6 +178,101 @@ describe("runtime fallback error classifier", () => {
     expect(retryable).toBe(false)
   })
 
+  test("classifies upstream gateway openai_error 400 as retryable fallback-to-next-model", () => {
+    //#given
+    const cases = [
+      {
+        label: "gateway 400 openai_error top-level",
+        error: {
+          name: "openai_error",
+          statusCode: 400,
+          message: "upstream gateway error: upstream channel failed",
+        },
+        expectedType: "upstream_gateway_error",
+        expectedRetryable: true,
+      },
+      {
+        label: "gateway 400 openai_error nested",
+        error: {
+          error: {
+            name: "openai_error",
+            statusCode: 400,
+            message: "upstream channel error",
+          },
+        },
+        expectedType: "upstream_gateway_error",
+        expectedRetryable: true,
+      },
+      {
+        label: "gateway 500 openai_error stays 5xx-retry-safe",
+        error: {
+          name: "openai_error",
+          statusCode: 500,
+          message: "upstream gateway error",
+        },
+        expectedType: "upstream_gateway_error",
+        expectedRetryable: true,
+      },
+      {
+        label: "openai_error without status stays non-retryable (conservative)",
+        error: {
+          name: "openai_error",
+          message: "upstream gateway error",
+        },
+        expectedType: "upstream_gateway_error",
+        expectedRetryable: false,
+      },
+    ] as const
+
+    //#when
+    const results = cases.map(({ error, ...metadata }) => ({
+      ...metadata,
+      actualType: classifyRuntimeFallbackError(error),
+      actualRetryable: isRuntimeFallbackRetryableError(error, DEFAULT_RETRY_CODES),
+    }))
+
+    //#then
+    for (const result of results) {
+      expect(result.actualType, result.label).toBe(result.expectedType)
+      expect(result.actualRetryable, result.label).toBe(result.expectedRetryable)
+    }
+  })
+
+  test("abort and context_overflow take precedence over upstream_gateway_error", () => {
+    //#given
+    const cases = [
+      {
+        label: "abort name wins over openai_error",
+        error: { name: "MessageAbortedError", statusCode: 400, message: "aborted" },
+        expectedType: "abort",
+        expectedRetryable: false,
+      },
+      {
+        label: "context_overflow wins over openai_error",
+        error: {
+          name: "ContextOverflowError",
+          statusCode: 400,
+          message: "context too large",
+        },
+        expectedType: "context_overflow",
+        expectedRetryable: false,
+      },
+    ] as const
+
+    //#when
+    const results = cases.map(({ error, ...metadata }) => ({
+      ...metadata,
+      actualType: classifyRuntimeFallbackError(error),
+      actualRetryable: isRuntimeFallbackRetryableError(error, DEFAULT_RETRY_CODES),
+    }))
+
+    //#then
+    for (const result of results) {
+      expect(result.actualType, result.label).toBe(result.expectedType)
+      expect(result.actualRetryable, result.label).toBe(result.expectedRetryable)
+    }
+  })
+
   test("extracts provider auto-retry signals from status summary or details", () => {
     //#given
     const retryInfo = {

--- a/packages/model-core/src/runtime-fallback-error-classifier.ts
+++ b/packages/model-core/src/runtime-fallback-error-classifier.ts
@@ -25,6 +25,7 @@ export type RuntimeFallbackErrorType =
   | "quota_exceeded"
   | "context_overflow"
   | "abort"
+  | "upstream_gateway_error"
 
 export interface RuntimeFallbackRetryOptions {
   onUnsafeRetryableSignalRejected?: (details: {
@@ -154,6 +155,10 @@ export function classifyRuntimeFallbackError(error: unknown): RuntimeFallbackErr
     return "quota_exceeded"
   }
 
+  if (errorName === "openaierror") {
+    return "upstream_gateway_error"
+  }
+
   return undefined
 }
 
@@ -174,6 +179,10 @@ export function isRuntimeFallbackRetryableError(
     errorType === "model_not_found" ||
     errorType === "quota_exceeded"
   ) {
+    return true
+  }
+
+  if (errorType === "upstream_gateway_error" && statusCode === 400) {
     return true
   }
 

--- a/packages/omo-opencode/src/hooks/model-fallback/fallback-state-controller.ts
+++ b/packages/omo-opencode/src/hooks/model-fallback/fallback-state-controller.ts
@@ -47,8 +47,20 @@ export function createModelFallbackStateController(input: {
   pendingModelFallbacks: Map<string, ModelFallbackStateLike>
   lastToastKey: Map<string, string>
   sessionFallbackChains: Map<string, FallbackEntry[]>
+  resolveUserConfiguredPrimary?: (agentName: string) => FallbackEntry | undefined
 }): ModelFallbackStateController {
-  const { pendingModelFallbacks, lastToastKey, sessionFallbackChains } = input
+  const { pendingModelFallbacks, lastToastKey, sessionFallbackChains, resolveUserConfiguredPrimary } = input
+
+  function prependDeduped(primary: FallbackEntry, chain: FallbackEntry[]): FallbackEntry[] {
+    const primaryKey = `${primary.providers[0]?.toLowerCase() ?? ""}/${primary.model.toLowerCase()}`
+    const alreadyPresent = chain.some((entry) =>
+      entry.providers.some(
+        (provider) => `${provider.toLowerCase()}/${entry.model.toLowerCase()}` === primaryKey,
+      ),
+    )
+    if (alreadyPresent) return chain
+    return [primary, ...chain]
+  }
 
   function setSessionFallbackChain(sessionID: string, fallbackChain: FallbackEntry[] | undefined): void {
     if (!sessionID) return
@@ -72,7 +84,15 @@ export function createModelFallbackStateController(input: {
   ): boolean {
     const agentKey = getAgentConfigKey(agentName)
     const requirements = AGENT_MODEL_REQUIREMENTS[agentKey]
-    const fallbackChain = sessionFallbackChains.get(sessionID) ?? requirements?.fallbackChain
+    const sessionChain = sessionFallbackChains.get(sessionID)
+    let fallbackChain = sessionChain ?? requirements?.fallbackChain
+
+    if (fallbackChain && !sessionChain && resolveUserConfiguredPrimary) {
+      const primary = resolveUserConfiguredPrimary(agentName)
+      if (primary) {
+        fallbackChain = prependDeduped(primary, fallbackChain)
+      }
+    }
 
     if (!fallbackChain?.length) {
       log(`[model-fallback] No fallback chain for agent: ${agentName} (key: ${agentKey})`)

--- a/packages/omo-opencode/src/hooks/model-fallback/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/model-fallback/hook.test.ts
@@ -17,6 +17,7 @@ async function importFreshModelFallbackHookModule() {
 const {
   clearPendingModelFallback,
   createModelFallbackHook,
+  getFallbackState,
   getSessionFallbackChain,
   setSessionFallbackChain,
   setPendingModelFallback,
@@ -425,6 +426,131 @@ describe("model fallback hook", () => {
     })
 
     clearPendingModelFallback(modelFallback, sessionID)
+  })
+
+  test("prepends user-configured primary as chain head when absent from requirements", () => {
+    //#given
+    const sessionID = "ses_model_fallback_user_primary_prepend"
+    const hook = createModelFallbackHook({
+      resolveUserConfiguredPrimary: (agentName) =>
+        agentName === "Sisyphus - Ultraworker"
+          ? { providers: ["openai"], model: "gpt-5.4", variant: "medium" }
+          : undefined,
+    })
+    clearPendingModelFallback(hook, sessionID)
+
+    //#when
+    const set = setPendingModelFallback(
+      hook,
+      sessionID,
+      "Sisyphus - Ultraworker",
+      "anthropic",
+      "claude-opus-4-8-thinking",
+    )
+
+    //#then
+    expect(set).toBe(true)
+    const state = getFallbackState(hook, sessionID)
+    expect(state?.fallbackChain[0]).toEqual({
+      providers: ["openai"],
+      model: "gpt-5.4",
+      variant: "medium",
+    })
+    clearPendingModelFallback(hook, sessionID)
+  })
+
+  test("does not duplicate a user primary already present in the requirements chain", () => {
+    //#given
+    const sessionID = "ses_model_fallback_user_primary_dedup"
+    const hook = createModelFallbackHook({
+      resolveUserConfiguredPrimary: (agentName) =>
+        agentName === "Sisyphus - Ultraworker"
+          ? { providers: ["anthropic"], model: "claude-opus-5", variant: "max" }
+          : undefined,
+    })
+    clearPendingModelFallback(hook, sessionID)
+
+    //#when
+    const set = setPendingModelFallback(
+      hook,
+      sessionID,
+      "Sisyphus - Ultraworker",
+      "anthropic",
+      "claude-opus-4-8-thinking",
+    )
+
+    //#then
+    expect(set).toBe(true)
+    const state = getFallbackState(hook, sessionID)
+    const chain = state?.fallbackChain ?? []
+    const matches = chain.filter(
+      (entry) => entry.providers.includes("anthropic") && entry.model === "claude-opus-5",
+    )
+    expect(matches.length).toBe(1)
+    expect(chain[0]).toEqual({
+      providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+      model: "claude-opus-5",
+      variant: "max",
+    })
+    clearPendingModelFallback(hook, sessionID)
+  })
+
+  test("session fallback chain wins over user primary prepend", () => {
+    //#given
+    const sessionID = "ses_model_fallback_session_chain_wins"
+    const hook = createModelFallbackHook({
+      resolveUserConfiguredPrimary: (agentName) =>
+        agentName === "Sisyphus - Ultraworker"
+          ? { providers: ["openai"], model: "gpt-5.6-sol", variant: "medium" }
+          : undefined,
+    })
+    setSessionFallbackChain(hook, sessionID, [
+      { providers: ["google"], model: "gemini-3.1-pro-preview" },
+    ])
+    clearPendingModelFallback(hook, sessionID)
+
+    //#when
+    const set = setPendingModelFallback(
+      hook,
+      sessionID,
+      "Sisyphus - Ultraworker",
+      "anthropic",
+      "claude-opus-4-8-thinking",
+    )
+
+    //#then
+    expect(set).toBe(true)
+    const state = getFallbackState(hook, sessionID)
+    expect(state?.fallbackChain).toEqual([
+      { providers: ["google"], model: "gemini-3.1-pro-preview" },
+    ])
+    clearPendingModelFallback(hook, sessionID)
+  })
+
+  test("keeps old behavior byte-identical when no user primary is configured", () => {
+    //#given
+    const sessionID = "ses_model_fallback_no_user_primary"
+    const hook = createModelFallbackHook({ resolveUserConfiguredPrimary: () => undefined })
+    clearPendingModelFallback(hook, sessionID)
+
+    //#when
+    const set = setPendingModelFallback(
+      hook,
+      sessionID,
+      "Sisyphus - Ultraworker",
+      "anthropic",
+      "claude-opus-4-8-thinking",
+    )
+
+    //#then
+    expect(set).toBe(true)
+    const state = getFallbackState(hook, sessionID)
+    expect(state?.fallbackChain[0]).toEqual({
+      providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+      model: "claude-opus-5",
+      variant: "max",
+    })
+    clearPendingModelFallback(hook, sessionID)
   })
 })
 

--- a/packages/omo-opencode/src/hooks/model-fallback/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/model-fallback/hook.test.ts
@@ -487,8 +487,9 @@ describe("model fallback hook", () => {
       (entry) => entry.providers.includes("anthropic") && entry.model === "claude-opus-5",
     )
     expect(matches.length).toBe(1)
+    // providers 列表与 packages/model-core/src/agent-model-requirements.ts:7 的 sisyphus 链头保持一致
     expect(chain[0]).toEqual({
-      providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+      providers: ["anthropic", "github-copilot", "opencode"],
       model: "claude-opus-5",
       variant: "max",
     })
@@ -545,8 +546,9 @@ describe("model fallback hook", () => {
     //#then
     expect(set).toBe(true)
     const state = getFallbackState(hook, sessionID)
+    // providers 列表与 packages/model-core/src/agent-model-requirements.ts:7 的 sisyphus 链头保持一致
     expect(state?.fallbackChain[0]).toEqual({
-      providers: ["anthropic", "github-copilot", "opencode", "vercel"],
+      providers: ["anthropic", "github-copilot", "opencode"],
       model: "claude-opus-5",
       variant: "max",
     })

--- a/packages/omo-opencode/src/hooks/model-fallback/hook.ts
+++ b/packages/omo-opencode/src/hooks/model-fallback/hook.ts
@@ -54,6 +54,7 @@ type ModelFallbackHookArgs = {
   toast?: FallbackToast
   onApplied?: FallbackCallback
   controllerAccessor?: ModelFallbackControllerAccessor
+  resolveUserConfiguredPrimary?: (agentName: string) => FallbackEntry | undefined
 }
 
 export function setSessionFallbackChain(
@@ -151,6 +152,7 @@ export function createModelFallbackHook(args?: ModelFallbackHookArgs): ModelFall
     pendingModelFallbacks,
     lastToastKey,
     sessionFallbackChains,
+    resolveUserConfiguredPrimary: args?.resolveUserConfiguredPrimary,
   })
 
   args?.controllerAccessor?.register(controller)

--- a/packages/omo-opencode/src/hooks/runtime-fallback/gateway-error-fallback.regression.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/gateway-error-fallback.regression.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+
+import { classifyErrorType, isRetryableError } from "./error-classifier"
+
+const DEFAULT_RETRY_CODES = [429, 500, 502, 503, 504]
+
+describe("runtime-fallback upstream gateway error regressions", () => {
+  test("classifies gateway HTTP 400 openai_error as upstream_gateway_error and fallback-eligible", () => {
+    //#given
+    const error = {
+      name: "openai_error",
+      statusCode: 400,
+      message: "upstream gateway error: upstream channel failed",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, DEFAULT_RETRY_CODES)
+
+    //#then
+    expect(errorType).toBe("upstream_gateway_error")
+    // fallback-to-next-model semantics, NOT same-model retry
+    expect(retryable).toBe(true)
+  })
+
+  test("classifies nested gateway 400 openai_error as upstream_gateway_error", () => {
+    //#given
+    const error = {
+      error: {
+        name: "openai_error",
+        statusCode: 400,
+        message: "upstream channel error",
+      },
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, DEFAULT_RETRY_CODES)
+
+    //#then
+    expect(errorType).toBe("upstream_gateway_error")
+    expect(retryable).toBe(true)
+  })
+
+  test("keeps gateway 500 openai_error on the existing 5xx-retry-safe path", () => {
+    //#given
+    const error = {
+      name: "openai_error",
+      statusCode: 500,
+      message: "upstream gateway error",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, DEFAULT_RETRY_CODES)
+
+    //#then
+    expect(errorType).toBe("upstream_gateway_error")
+    expect(retryable).toBe(true)
+  })
+
+  test("treats openai_error without a status as non-retryable (conservative)", () => {
+    //#given
+    const error = {
+      name: "openai_error",
+      message: "upstream gateway error",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, DEFAULT_RETRY_CODES)
+
+    //#then
+    expect(errorType).toBe("upstream_gateway_error")
+    expect(retryable).toBe(false)
+  })
+
+  test("keeps genuine HTTP 400 client errors non-retryable", () => {
+    //#given
+    const error = {
+      name: "ValidationError",
+      statusCode: 400,
+      message: "Invalid request payload",
+    }
+
+    //#when
+    const errorType = classifyErrorType(error)
+    const retryable = isRetryableError(error, DEFAULT_RETRY_CODES)
+
+    //#then
+    expect(errorType).toBeUndefined()
+    expect(retryable).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/plugin/hooks/create-session-hooks.ts
+++ b/packages/omo-opencode/src/plugin/hooks/create-session-hooks.ts
@@ -38,6 +38,8 @@ import { safeCreateHook } from "../../shared/safe-create-hook"
 import { sessionExists } from "../../tools"
 import { isTmuxIntegrationEnabled } from "../../create-runtime-tmux-config"
 import { createModelFallbackTitleUpdater } from "./model-fallback-title-updater"
+import { parseFallbackModelEntry } from "@oh-my-opencode/model-core"
+import { getAgentConfigKey } from "../../shared/agent-display-names"
 
 export type SessionHooks = {
   preemptiveCompaction: ReturnType<typeof createPreemptiveCompactionHook> | null
@@ -123,6 +125,19 @@ export function createSessionHooks(args: {
         },
         onApplied: enableFallbackTitle ? updateFallbackTitle : undefined,
         controllerAccessor: modelFallbackControllerAccessor,
+        resolveUserConfiguredPrimary: (agentName) => {
+          const agentKey = getAgentConfigKey(agentName)
+          const override = pluginConfig.agents?.[agentKey]
+          if (!override) return undefined
+          const primaryModel = override.models?.[0]
+          if (typeof primaryModel === "string") {
+            return parseFallbackModelEntry(primaryModel, undefined) ?? undefined
+          }
+          if (override.model) {
+            return parseFallbackModelEntry(override.model, undefined) ?? undefined
+          }
+          return undefined
+        },
       }))
     : null
 


### PR DESCRIPTION
## What changed

Two related fixes in the model-fallback path:

### CF1 — `upstream_gateway_error` classification (model-core)
- Added `"upstream_gateway_error"` to the `RuntimeFallbackErrorType` union.
- `classifyRuntimeFallbackError` now returns `upstream_gateway_error` when the
  normalized error name is `openaierror` (the mooire-ai one-api gateway
  payload: HTTP 400, body/name `openai_error`).
- `isRuntimeFallbackRetryableError` returns `true` for
  `upstream_gateway_error` **only when `statusCode === 400`** — fallback-to-next-model
  semantics (like `model_not_found`), NOT same-model retry. Genuine HTTP 400
  client errors (non-`openaierror`) stay non-retryable.
- **which-gate finding** (recorded in evidence before implementation): the
  gateway-400 payload was rejected by the `:130` status-code gate
  (`retryOnErrors.includes(400)`); 400 ∉ `[429,500,502,503,504]`. The `:134`
  retryable-signal path is skipped (payload has no `isRetryable` field) and the
  `:143` message patterns miss.

### CF2 — proactive user-primary chain head (model-fallback hook)
- `createModelFallbackStateController` accepts an optional
  `resolveUserConfiguredPrimary` resolver.
- `setPendingModelFallback` prepends the user-configured primary model as the
  chain head (deduped by `providerID/modelID` key) when falling through to
  `requirements?.fallbackChain`. `sessionFallbackChains` still wins when set.
- `hook.ts` + `create-session-hooks.ts` wire the resolver from plugin
  agent-overrides (`agents[key].models[0]` else `agents[key].model`).

## Why

- Gateway HTTP 400 `openai_error` previously produced a terminal `session.error`
  instead of falling back to the next model.
- The proactive fallback chain ignored the user's configured primary model as
  the chain head.

## QA / Evidence

Evidence under `.omo/evidence/20260824-gateway-fallback/`:
- `which-gate.md` — which-gate finding (recorded before implementation).
- `unit-regression.txt` — classifier (8), adapter regression (5), chain-head (15) all green.
- `cli-boot-smoke.txt` — `opencode run --format json` boot smoke in isolated XDG sandbox (EXIT=0, plugin loads cleanly, real DB untouched).
- `root-test.txt` — root `bun test`: 15653 pass / 22 fail (all pre-existing base-branch defects in unrelated areas; none in changed scope).
- `typecheck.txt` — `bun run typecheck:packages` OK.

N5 oracle check: `model-core` is not in the omo-codex dependency closure, so
`bun run test:codex` is not required.

## Residual risk

Low-medium. The 400-classification is gated by BOTH normalized name
`openaierror` AND status 400, limiting blast radius on legitimate client
errors. Rollback: revert the merge commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gateway HTTP 400 `openai_error` responses now fall back to the next model instead of ending the session, while genuine client 400s remain non-retryable. Proactive fallback chains also start with the user’s configured primary model when no session-specific chain exists.

- Classifies normalized `openaierror` as `upstream_gateway_error`; only status 400 receives the new fallback behavior, while existing 5xx handling remains unchanged.
- Resolves the primary from `agents[key].models[0]` or `agents[key].model`, dedupes it against the requirements chain, and preserves session-specific chains.
- Adds classifier, adapter, and chain-order regression coverage; focused tests and package typechecking pass.

<sup>Written for commit d00dcdb2b4a27af895a1f63759f1141d76634bc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

