### PR TITLE
fix(model-routing): exclude gateway providers from fallback lanes

### DIFF
--- a/packages/omo-opencode/src/cli/fallback-lane-policy.ts
+++ b/packages/omo-opencode/src/cli/fallback-lane-policy.ts
@@ -1,0 +1,7 @@
+const EXCLUDED_FALLBACK_PROVIDERS = new Set(["openrouter", "opencode", "vercel"])
+
+export function isExcludedFallbackLaneModel(model: string): boolean {
+  const slashIndex = model.indexOf("/")
+  if (slashIndex <= 0) return false
+  return EXCLUDED_FALLBACK_PROVIDERS.has(model.slice(0, slashIndex).toLowerCase())
+}

--- a/packages/omo-opencode/src/cli/model-fallback-providers.test.ts
+++ b/packages/omo-opencode/src/cli/model-fallback-providers.test.ts
@@ -10,6 +10,7 @@ function createConfig(overrides: Partial<InstallConfig> = {}): InstallConfig {
     platform: "opencode",
     hasOpenCode: true,
     hasCodex: false,
+    hasSenpi: false,
     codexAutonomous: false,
     hasClaude: false,
     isMax20: false,
@@ -216,6 +217,24 @@ describe("generateModelConfig provider routes", () => {
   })
 
   describe("Vercel AI Gateway provider", () => {
+    test("does not add gateway or OpenCode Zen routes to fallback lanes", () => {
+      // given native, OpenCode Zen, and Vercel AI Gateway providers are available
+      const config = createConfig({
+        hasOpenAI: true,
+        hasClaude: true,
+        hasOpencodeZen: true,
+        hasVercelAiGateway: true,
+      })
+
+      // when the generated model config is resolved
+      const result = generateModelConfig(config)
+      const serializedFallbacks = JSON.stringify(result.agents?.explore?.fallback_models ?? [])
+
+      // then only native provider routes remain in the fallback lane
+      expect(serializedFallbacks).not.toContain('"model":"opencode/')
+      expect(serializedFallbacks).not.toContain('"model":"vercel/')
+    })
+
     test("explore uses gateway minimax when only gateway is available", () => {
       // given only Vercel AI Gateway is available
       const config = createConfig({ hasVercelAiGateway: true })

--- a/packages/omo-opencode/src/cli/model-fallback.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.ts
@@ -18,6 +18,7 @@ import {
 	resolveModelFromChain,
 } from "./fallback-chain-resolution"
 import { transformModelForProvider } from "./provider-model-id-transform"
+import { isExcludedFallbackLaneModel } from "./fallback-lane-policy"
 
 export type { GeneratedOmoConfig } from "./model-fallback-types"
 
@@ -120,6 +121,7 @@ function attachFallbackModels<T extends AgentConfig | CategoryConfig>(
   }
 
   const fallbackModels = uniqueFallbacks.slice(primaryIndex + 1)
+    .filter((entry) => !isExcludedFallbackLaneModel(entry.model))
   if (fallbackModels.length === 0) {
     return config
   }
@@ -136,7 +138,9 @@ function attachAllFallbackModels<T extends AgentConfig | CategoryConfig>(
   availability: ReturnType<typeof toProviderAvailability>,
 ): T {
   const uniqueFallbacks = collectAvailableFallbacks(fallbackChain, availability)
-  const fallbackModels = uniqueFallbacks.filter((entry) => entry.model !== config.model)
+  const fallbackModels = uniqueFallbacks
+    .filter((entry) => entry.model !== config.model)
+    .filter((entry) => !isExcludedFallbackLaneModel(entry.model))
   if (fallbackModels.length === 0) {
     return config
   }


### PR DESCRIPTION
## Summary
Exclude Vercel AI Gateway and OpenCode Zen models from generated secondary fallback lanes, matching the existing OpenRouter policy. Primary model selection is unchanged, so these providers remain usable when they are the selected route.

## Changes
- Added a small provider-prefix policy for fallback lane filtering.
- Applied it to both standard and all-fallback model attachment paths.
- Added regression coverage while preserving gateway and Zen primary-route behavior.

## QA & Evidence
- **RED:** `bun test packages/omo-opencode/src/cli/model-fallback-providers.test.ts` failed on the new exclusion assertion before implementation. Artifact: `.omo/evidence/20260825-fallback-gateway-exclusions/red.txt`.
- **GREEN:** focused and related fallback suites passed. Artifacts: `.omo/evidence/20260825-fallback-gateway-exclusions/green.txt`, `.omo/evidence/20260825-fallback-gateway-exclusions/scoped-suite.txt`.
- **Real surface:** Bun imported `generateModelConfig` and verified no `openrouter/`, `opencode/`, or `vercel/` entries in generated `fallback_models`, while native primary routes remained selected. Artifact: `.omo/evidence/20260825-fallback-gateway-exclusions/manual-policy-probe.json`.
- **OpenCode QA:** isolated QA helper self-check passed. Artifact: `.omo/evidence/20260825-fallback-gateway-exclusions/opencode-qa-self-check.txt`.
- **Typecheck:** `bun run typecheck` passed.

## Risks & Residuals
The exclusion applies only to secondary generated fallback lanes. Explicit primary selection and provider availability behavior remain unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude Vercel AI Gateway and OpenCode Zen from generated fallback lanes to align with the existing OpenRouter exclusion. Previously these gateways could appear in fallback lanes; now only native providers do. Primary route selection is unchanged.

- Adds `isExcludedFallbackLaneModel` with a provider-prefix set: `openrouter`, `opencode`, `vercel`.
- Applies the filter in both standard and all-fallback attachments in `packages/omo-opencode/src/cli/model-fallback.ts`.
- Adds regression tests to confirm exclusion and preserve gateway/Zen as primary when explicitly selected.

<sup>Written for commit f245668c0ef24c56c3f7e6201f211c4bb2520fbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

