### PR TITLE
fix(config-chain): surgical degradation for invalid agents/categories leaves

### DIFF
--- a/.omo/evidence/20260824-config-chain-degrade/README.md
+++ b/.omo/evidence/20260824-config-chain-degrade/README.md
@@ -1,0 +1,119 @@
+# PR-B: Config-chain surgical degradation — QA evidence
+
+Date: 2026-08-25
+Branch: `fix/config-chain-surgical-degradation`
+Worktree: `.local-ignore/pr-config-chain`
+Plan: `.omo/plans/20260824-configchain-wake-openai-fix.md` PR-B (B1→B4)
+Brief: `.omo/tasks/pr-b-delegation.md`
+
+## WHAT WAS TESTED
+
+The config-chain surgical-degradation change: when a user config contains an
+invalid record leaf (`agents.<name>` / `categories.<name>`), the loader prunes
+only the offending leaf and keeps healthy siblings, instead of wholesale
+falling back to `DEFAULT_RAW_CONFIG`.
+
+Surfaces driven:
+1. Unit: `bun test packages/omo-config-core` (loader-prune.test.ts hard-invariant
+   tests) and `bun test packages/omo-opencode/src/config` (core-schema-parity.test.ts
+   drift guard).
+2. Type: `tsgo --noEmit -p packages/omo-config-core/tsconfig.json` and
+   `packages/omo-opencode/tsconfig.json`; full `bun run typecheck`.
+3. Root suite: `bun test` (15624 pass / 45 fail — all pre-existing base-branch
+   or environment defects in unrelated modules, see OMITTED).
+4. Codex gate: `bun run test:codex` — blocked by a pre-existing dependency
+   defect (see OMITTED); the codex-codegraph typecheck that consumes
+   `omo-config-core` through the codex closure passes clean.
+5. opencode-qa CLI case in `script/agent/qa-sandbox.sh` isolation with a
+   PROJECT-LAYER fixture `<tmp-project>/.omo/omo.jsonc` (never `~/.omo/**`).
+
+## WHAT WAS OBSERVED
+
+### Loader surgical pruning (deterministic, exact QA fixture)
+
+Fixture `<tmp-project>/.omo/omo.jsonc`:
+```jsonc
+{
+  "agents": {
+    "sisyphus": { "model": "anthropic/claude-opus-5", "prompt_append": "QA-OVERRIDE-MARKER" },
+    "oracle": { "model": "kimi-k3", "bogus_key": 1 }
+  }
+}
+```
+
+`loadOmoConfig` probe result:
+- `sisyphus.model` = `anthropic/claude-opus-5`  (SURVIVES)
+- `sisyphus.prompt_append` = `QA-OVERRIDE-MARKER`  (SURVIVES)
+- `oracle` present = false  (DROPPED)
+- diagnostics = exactly one validation diagnostic:
+  `Dropped invalid agents.oracle leaf: agents.oracle: Unrecognized key: "bogus_key"`,
+  path `agents.oracle`, issuePaths `["agents.oracle"]`
+
+### Isolation proof
+
+`opencode run` was executed inside `script/agent/qa-sandbox.sh` isolation
+(XDG_DATA_HOME/XDG_CONFIG_HOME/XDG_CACHE_HOME/XDG_STATE_HOME remapped to a
+`mktemp` sandbox). The run wrote its session to the sandbox DB
+(`/tmp/omo-qa-sandbox.*/data/opencode/opencode.db`, 1 session) — the real
+`~/.local/share/opencode/opencode.db` was never touched. `HOME` inside the
+sandbox is `/home/ubuntu` (NOT remapped), so the fixture was deliberately placed
+at a project layer `<tmp-project>/.omo/omo.jsonc` outside `$HOME`, per the
+amended B4 bullet.
+
+### Unit + typecheck
+
+- `bun test packages/omo-config-core`: 181 pass / 0 fail
+- `bun test packages/omo-opencode/src/config`: 163 pass / 0 fail
+- `tsgo --noEmit` (config-core + omo-opencode): clean
+- `bun run typecheck`: EXIT 0
+- codex-codegraph typecheck (consumes omo-config-core): clean after the
+  `@types/node` env fix
+
+### Schema freshness
+
+B1 added `permission`/`prompt_append` keys to the core agent schema; the
+generated `assets/omo.schema.json` was regenerated (`bun run build:omo-schema`)
+so `tests/omo-schema-freshness.test.ts` stays green (3 pass). The diff is only
+the expected `permission`/`prompt_append` additions.
+
+## WHY IT IS ENOUGH
+
+- The hard-invariant test (`loader-prune.test.ts`) and the direct `loadOmoConfig`
+  probe both prove the exact acceptance criterion: a bad `agents.oracle` leaf
+  never drops the healthy `agents.sisyphus`, and produces exactly one
+  per-key diagnostic.
+- The drift guard (`core-schema-parity.test.ts`) proves the core schema and the
+  OpenCode adapter schema stay in field parity for `permission`/`prompt_append`
+  (agents) and full category parity — the failure mode (future key addition on
+  one side without the other) fails CI.
+- The prune loop is bounded (`maxIterations = droppedGroups + 1`) AND total
+  (falls back to defaults when non-prunable paths remain), per the Global
+  Constraints.
+- Isolation is proven: the opencode run used the sandbox XDG paths; the real DB
+  was untouched.
+
+## WHAT WAS OMITTED
+
+- Root `bun test` 45 failures: all in modules unrelated to this change
+  (auto-update-checker network tests, codex/senpi installers, dist-bundle prompt
+  content, telemetry, skill-loader short-name resolution, claude-code-agent-loader,
+  codex-components doctor). These are pre-existing base-branch/environment
+  defects; none touch `omo-config-core` loader/schema or the adapter config
+  schema. The only failure in this change's blast radius (`omo schema
+  freshness`) was fixed by regenerating the schema.
+- `bun run test:codex` is blocked by a pre-existing dependency defect: the
+  committed `packages/omo-codex/plugin` lockfile does not install `@types/node`,
+  which the `ulw-loop`/`codegraph` components declare in devDependencies, so
+  their `tsc` build fails with TS2688 in a clean checkout. This is independent of
+  this change. Proof of attempt: `test:codex` run fails deterministically at the
+  `npm --prefix packages/omo-codex/plugin ci` → `components/ulw-loop build` step;
+  installing `@types/node --no-save` makes the codex-codegraph typecheck (the
+  part that consumes `omo-config-core` through the codex closure) pass. The
+  change's own gate (unit + typecheck + codex-closure typecheck) is green.
+- `opencode run` in the sandbox returned "Unexpected server error" because no
+  provider/model credentials are configured in the isolated environment to
+  answer a prompt. This is an environment limitation, not a code failure; the
+  loader's surgical-pruning behavior is deterministically proven by the unit
+  probe above.
+- Redacted: no secrets, credentials, or auth headers captured. Sandbox temp
+  paths are ephemeral and removed after QA.

--- a/.omo/evidence/20260824-config-chain-degrade/loader-probe-output.json
+++ b/.omo/evidence/20260824-config-chain-degrade/loader-probe-output.json
@@ -1,0 +1,15 @@
+{
+  "sisyphus_model": "anthropic/claude-opus-5",
+  "sisyphus_prompt_append": "QA-OVERRIDE-MARKER",
+  "oracle_dropped": true,
+  "diagnostics": [
+    {
+      "kind": "validation",
+      "message": "Dropped invalid agents.oracle leaf: agents.oracle: Unrecognized key: \"bogus_key\"",
+      "path": "agents.oracle",
+      "issuePaths": [
+        "agents.oracle"
+      ]
+    }
+  ]
+}

--- a/.omo/evidence/20260824-config-chain-degrade/omo-config-core-test.txt
+++ b/.omo/evidence/20260824-config-chain-degrade/omo-config-core-test.txt
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 181 pass
+ 0 fail
+ 469 expect() calls
+Ran 181 tests across 34 files. [304.00ms]

--- a/.omo/evidence/20260824-config-chain-degrade/omo-opencode-config-test.txt
+++ b/.omo/evidence/20260824-config-chain-degrade/omo-opencode-config-test.txt
@@ -1,0 +1,6 @@
+bun test v1.3.14 (0d9b296a)
+
+ 163 pass
+ 0 fail
+ 369 expect() calls
+Ran 163 tests across 24 files. [250.00ms]

--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -757,6 +757,88 @@
           },
           "disable": {
             "type": "boolean"
+          },
+          "permission": {
+            "type": "object",
+            "properties": {
+              "edit": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              },
+              "bash": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string",
+                      "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "webfetch": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              },
+              "task": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              },
+              "doom_loop": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              },
+              "external_directory": {
+                "type": "string",
+                "enum": [
+                  "ask",
+                  "allow",
+                  "deny"
+                ]
+              }
+            },
+            "additionalProperties": {
+              "type": "string",
+              "enum": [
+                "ask",
+                "allow",
+                "deny"
+              ]
+            }
+          },
+          "prompt_append": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -12467,6 +12549,88 @@
               },
               "disable": {
                 "type": "boolean"
+              },
+              "permission": {
+                "type": "object",
+                "properties": {
+                  "edit": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "bash": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "ask",
+                          "allow",
+                          "deny"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "webfetch": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "task": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "doom_loop": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "external_directory": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  }
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "enum": [
+                    "ask",
+                    "allow",
+                    "deny"
+                  ]
+                }
+              },
+              "prompt_append": {
+                "type": "string"
               }
             },
             "additionalProperties": false
@@ -14026,6 +14190,88 @@
               },
               "disable": {
                 "type": "boolean"
+              },
+              "permission": {
+                "type": "object",
+                "properties": {
+                  "edit": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "bash": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "ask",
+                          "allow",
+                          "deny"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "propertyNames": {
+                          "type": "string"
+                        },
+                        "additionalProperties": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "webfetch": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "task": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "doom_loop": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "external_directory": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  }
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "enum": [
+                    "ask",
+                    "allow",
+                    "deny"
+                  ]
+                }
+              },
+              "prompt_append": {
+                "type": "string"
               }
             },
             "additionalProperties": false
@@ -15591,6 +15837,88 @@
                 },
                 "disable": {
                   "type": "boolean"
+                },
+                "permission": {
+                  "type": "object",
+                  "properties": {
+                    "edit": {
+                      "type": "string",
+                      "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                      ]
+                    },
+                    "bash": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {
+                            "type": "string",
+                            "enum": [
+                              "ask",
+                              "allow",
+                              "deny"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    "webfetch": {
+                      "type": "string",
+                      "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                      ]
+                    },
+                    "task": {
+                      "type": "string",
+                      "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                      ]
+                    },
+                    "doom_loop": {
+                      "type": "string",
+                      "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                      ]
+                    },
+                    "external_directory": {
+                      "type": "string",
+                      "enum": [
+                        "ask",
+                        "allow",
+                        "deny"
+                      ]
+                    }
+                  },
+                  "additionalProperties": {
+                    "type": "string",
+                    "enum": [
+                      "ask",
+                      "allow",
+                      "deny"
+                    ]
+                  }
+                },
+                "prompt_append": {
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -27082,6 +27410,88 @@
                     },
                     "disable": {
                       "type": "boolean"
+                    },
+                    "permission": {
+                      "type": "object",
+                      "properties": {
+                        "edit": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        "bash": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "ask",
+                                "allow",
+                                "deny"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              },
+                              "additionalProperties": {
+                                "type": "string",
+                                "enum": [
+                                  "ask",
+                                  "allow",
+                                  "deny"
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        "webfetch": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        "task": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        "doom_loop": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        "external_directory": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        }
+                      },
+                      "additionalProperties": {
+                        "type": "string",
+                        "enum": [
+                          "ask",
+                          "allow",
+                          "deny"
+                        ]
+                      }
+                    },
+                    "prompt_append": {
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false
@@ -28641,6 +29051,88 @@
                     },
                     "disable": {
                       "type": "boolean"
+                    },
+                    "permission": {
+                      "type": "object",
+                      "properties": {
+                        "edit": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        "bash": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "ask",
+                                "allow",
+                                "deny"
+                              ]
+                            },
+                            {
+                              "type": "object",
+                              "propertyNames": {
+                                "type": "string"
+                              },
+                              "additionalProperties": {
+                                "type": "string",
+                                "enum": [
+                                  "ask",
+                                  "allow",
+                                  "deny"
+                                ]
+                              }
+                            }
+                          ]
+                        },
+                        "webfetch": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        "task": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        "doom_loop": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        },
+                        "external_directory": {
+                          "type": "string",
+                          "enum": [
+                            "ask",
+                            "allow",
+                            "deny"
+                          ]
+                        }
+                      },
+                      "additionalProperties": {
+                        "type": "string",
+                        "enum": [
+                          "ask",
+                          "allow",
+                          "deny"
+                        ]
+                      }
+                    },
+                    "prompt_append": {
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false

--- a/packages/omo-config-core/src/loader/loader-prune.test.ts
+++ b/packages/omo-config-core/src/loader/loader-prune.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+import { loadOmoConfig } from "../index"
+
+function writeJsonc(path: string, content: string): void {
+  mkdirSync(join(path, ".."), { recursive: true })
+  writeFileSync(path, content)
+}
+
+function makeFixture(): { readonly homeDir: string; readonly cwd: string } {
+  const root = mkdtempSync(join(tmpdir(), "omo-config-prune-"))
+  const homeDir = join(root, "home")
+  const cwd = join(homeDir, "project", "child")
+  mkdirSync(cwd, { recursive: true })
+  return { homeDir, cwd }
+}
+
+describe("loadOmoConfig surgical pruning", () => {
+  test("#given valid agents.sisyphus plus invalid key in agents.oracle #when loading #then sisyphus survives and oracle is dropped with one diagnostic", () => {
+    // given
+    const fixture = makeFixture()
+    writeJsonc(
+      join(fixture.homeDir, "project", ".omo", "omo.jsonc"),
+      `{
+        "agents": {
+          "sisyphus": { "model": "anthropic/claude-opus-5" },
+          "oracle": { "model": "kimi-k3", "bogus_key": 1 }
+        }
+      }`,
+    )
+
+    // when
+    const result = loadOmoConfig({
+      cwd: fixture.cwd,
+      env: { HOME: fixture.homeDir },
+      platform: "linux",
+    })
+
+    // then
+    expect(result.config.agents?.sisyphus?.model).toBe("anthropic/claude-opus-5")
+    expect(result.config.agents?.oracle).toBeUndefined()
+    const dropped = result.diagnostics.filter((d) => d.kind === "validation" && d.path === "agents.oracle")
+    expect(dropped).toHaveLength(1)
+    expect(dropped[0]?.issuePaths).toContain("agents.oracle")
+  })
+
+  test("#given multiple invalid agent entries across different names #when loading #then all are pruned with one diagnostic each", () => {
+    // given
+    const fixture = makeFixture()
+    writeJsonc(
+      join(fixture.homeDir, "project", ".omo", "omo.jsonc"),
+      `{
+        "agents": {
+          "sisyphus": { "model": "anthropic/claude-opus-5" },
+          "oracle": { "bogus_key": 1 },
+          "explore": { "bogus_key": 2 }
+        }
+      }`,
+    )
+
+    // when
+    const result = loadOmoConfig({
+      cwd: fixture.cwd,
+      env: { HOME: fixture.homeDir },
+      platform: "linux",
+    })
+
+    // then
+    expect(result.config.agents?.sisyphus?.model).toBe("anthropic/claude-opus-5")
+    expect(result.config.agents?.oracle).toBeUndefined()
+    expect(result.config.agents?.explore).toBeUndefined()
+    const dropped = result.diagnostics.filter((d) => d.kind === "validation" && d.path?.startsWith("agents."))
+    expect(dropped).toHaveLength(2)
+  })
+
+  test("#given a bad categories leaf #when loading #then categories pruning is symmetric and other categories survive", () => {
+    // given
+    const fixture = makeFixture()
+    writeJsonc(
+      join(fixture.homeDir, "project", ".omo", "omo.jsonc"),
+      `{
+        "categories": {
+          "quick": { "model": "gpt-5.6" },
+          "deep": { "bogus_key": 1 }
+        }
+      }`,
+    )
+
+    // when
+    const result = loadOmoConfig({
+      cwd: fixture.cwd,
+      env: { HOME: fixture.homeDir },
+      platform: "linux",
+    })
+
+    // then
+    expect(result.config.categories?.quick?.model).toBe("gpt-5.6")
+    expect(result.config.categories?.deep).toBeUndefined()
+    const dropped = result.diagnostics.filter((d) => d.kind === "validation" && d.path === "categories.deep")
+    expect(dropped).toHaveLength(1)
+  })
+
+  test("#given config broken beyond record leaves #when loading #then defaults are returned with a validation diagnostic", () => {
+    // given
+    const fixture = makeFixture()
+    writeJsonc(
+      join(fixture.homeDir, "project", ".omo", "omo.jsonc"),
+      `{
+        "agents": { "oracle": { "model": "kimi-k3", "bogus_key": 1 } },
+        "task": { "default_concurrency": "not-a-number" }
+      }`,
+    )
+
+    // when
+    const result = loadOmoConfig({
+      cwd: fixture.cwd,
+      env: { HOME: fixture.homeDir },
+      platform: "linux",
+    })
+
+    // then
+    expect(result.config.agents?.oracle).toBeUndefined()
+    expect(result.config.task?.default_concurrency).toBe(5)
+    expect(result.diagnostics.some((d) => d.kind === "validation")).toBe(true)
+  })
+})

--- a/packages/omo-config-core/src/loader/loader.ts
+++ b/packages/omo-config-core/src/loader/loader.ts
@@ -3,6 +3,7 @@ import { parse, printParseErrorCode } from "jsonc-parser/lib/esm/main.js"
 import { OmoCodegraphSettingsSchema, OmoConfigLayerSchema, OmoConfigSchema, resolveOmoTaskSettings, type OmoConfig } from "../schema"
 import { mergeOmoConfigRecords } from "./merge"
 import { resolveOmoConfigPaths } from "./paths"
+import { pruneInvalidConfigLeaves } from "./prune-invalid-leaves"
 import { resolveOmoConfigView, resolveOmoProfileName } from "./resolution"
 import {
   DEFAULT_READ_FILE_SYSTEM,
@@ -64,6 +65,16 @@ function validationDiagnostic(path: string, issues: readonly { readonly path: re
   }
 }
 
+function isRecordLeafIssue(issue: { readonly path: readonly PropertyKey[] }): boolean {
+  const segments = issue.path.map((segment) => String(segment))
+  if (segments.length < 2) return false
+  return segments[0] === "agents" || segments[0] === "categories"
+}
+
+function hasOnlyRecordLeafIssues(issues: readonly { readonly path: readonly PropertyKey[] }[]): boolean {
+  return issues.length > 0 && issues.every(isRecordLeafIssue)
+}
+
 function toRecord(value: unknown): Record<string, unknown> | null {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return null
   const record: Record<string, unknown> = {}
@@ -110,7 +121,7 @@ function readConfigSource(
   }
 
   const validation = OmoConfigLayerSchema.safeParse(parsed.data)
-  if (!validation.success) {
+  if (!validation.success && !hasOnlyRecordLeafIssues(validation.error.issues)) {
     return {
       diagnostic: validationDiagnostic(path, validation.error.issues),
       source: { exists: true, loaded: false, path, scope },
@@ -173,9 +184,33 @@ export function loadOmoConfig(options: LoadOmoConfigOptions = {}): LoadOmoConfig
     }
   }
 
+  // Surgical degradation: prune offending record leaves, keep healthy siblings.
+  const pruned = pruneInvalidConfigLeaves(
+    resolved.config,
+    finalConfig.error.issues,
+    (candidate) => {
+      const parsed = OmoConfigSchema.safeParse(mergeOmoConfigRecords(DEFAULT_RAW_CONFIG, candidate))
+      if (!parsed.success) return { success: false, issues: parsed.error.issues }
+      return { success: true }
+    },
+  )
+
+  if (pruned.config !== null && Object.keys(pruned.config).length > 0) {
+    const prunedConfig = OmoConfigSchema.safeParse(mergeOmoConfigRecords(DEFAULT_RAW_CONFIG, pruned.config))
+    if (prunedConfig.success) {
+      return {
+        config: stripResolutionControlKeys(prunedConfig.data),
+        diagnostics: [...diagnostics, ...resolved.diagnostics, ...pruned.dropped],
+        layers,
+        ...(resolved.profile === undefined ? {} : { profile: resolved.profile }),
+        sources,
+      }
+    }
+  }
+
   return {
     config: stripResolutionControlKeys(OmoConfigSchema.parse(DEFAULT_RAW_CONFIG)) satisfies OmoConfig,
-    diagnostics: [...diagnostics, ...resolved.diagnostics, validationDiagnostic("(merged omo config)", finalConfig.error.issues)],
+    diagnostics: [...diagnostics, ...resolved.diagnostics, ...pruned.dropped, validationDiagnostic("(merged omo config)", finalConfig.error.issues)],
     layers,
     ...(resolved.profile === undefined ? {} : { profile: resolved.profile }),
     sources,

--- a/packages/omo-config-core/src/loader/prune-invalid-leaves.ts
+++ b/packages/omo-config-core/src/loader/prune-invalid-leaves.ts
@@ -1,0 +1,118 @@
+import type * as z from "zod"
+
+import { mergeOmoConfigRecords } from "./merge"
+import type { OmoConfigDiagnostic } from "./types"
+
+/**
+ * Bounded surgical pruning of invalid config leaves.
+ *
+ * The loader must never wholesale-fallback to `DEFAULT_RAW_CONFIG` when a
+ * single bad agent/category leaf makes the whole merged document unparseable.
+ * Instead we prune only the offending record leaves (`agents.<name>` /
+ * `categories.<name>`), keep every healthy sibling, and re-validate until the
+ * document parses or the bounded loop is exhausted. If the bound is hit and the
+ * document still fails, the caller falls back to defaults (old totality
+ * preserved as the last resort, never the first).
+ */
+
+const RECORD_LEAF_PREFIXES: readonly string[] = ["agents.", "categories."]
+
+export type PruneResult = {
+  readonly config: Record<string, unknown>
+  readonly dropped: readonly OmoConfigDiagnostic[]
+}
+
+export type PruneValidator = (
+  candidate: Record<string, unknown>,
+) => { readonly success: boolean; readonly issues?: readonly z.core.$ZodIssue[] }
+
+function isRecordLeafPath(path: readonly PropertyKey[]): string | null {
+  const segments = path.map((segment) => String(segment))
+  if (segments.length < 2) return null
+  const section = segments[0]
+  if (section === undefined) return null
+  const prefix = `${section}.`
+  if (!RECORD_LEAF_PREFIXES.some((candidate) => candidate === prefix)) return null
+  return section
+}
+
+function dropLeaf(
+  config: Record<string, unknown>,
+  section: string,
+  name: string,
+): Record<string, unknown> {
+  const sectionValue = config[section]
+  if (sectionValue === null || typeof sectionValue !== "object" || Array.isArray(sectionValue)) {
+    return config
+  }
+  const record = sectionValue as Record<string, unknown>
+  if (!(name in record)) return config
+  const next = { ...record }
+  delete next[name]
+  return { ...config, [section]: next }
+}
+
+function diagnosticFor(section: string, name: string, issuePath: string, message: string): OmoConfigDiagnostic {
+  const key = `${section}.${name}`
+  return {
+    kind: "validation",
+    message: `Dropped invalid ${key} leaf: ${issuePath}: ${message}`,
+    path: key,
+    issuePaths: [issuePath],
+  }
+}
+
+/**
+ * Prune invalid record leaves out of `config`, re-validating through `validate`
+ * after each prune pass. The loop is bounded by `droppedGroups + 1`; if it
+ * still fails after the bound, `config` is returned empty and the caller falls
+ * back to defaults (old totality preserved).
+ */
+export function pruneInvalidConfigLeaves(
+  config: Record<string, unknown>,
+  issues: readonly z.core.$ZodIssue[],
+  validate: PruneValidator,
+): PruneResult {
+  const dropped: OmoConfigDiagnostic[] = []
+  let candidate = mergeOmoConfigRecords({}, config)
+  const droppedGroups = new Set<string>()
+
+  for (const issue of issues) {
+    const section = isRecordLeafPath(issue.path)
+    if (section === null) continue
+    const name = String(issue.path[1])
+    const key = `${section}.${name}`
+    if (droppedGroups.has(key)) continue
+    droppedGroups.add(key)
+    candidate = dropLeaf(candidate, section, name)
+    const issuePath = issue.path.map((segment) => String(segment)).join(".")
+    dropped.push(diagnosticFor(section, name, issuePath, issue.message))
+  }
+
+  if (droppedGroups.size === 0) return { config: candidate, dropped }
+
+  let current = candidate
+  let iteration = 0
+  const maxIterations = droppedGroups.size + 1
+  while (iteration < maxIterations) {
+    const parsed = validate(mergeOmoConfigRecords({}, current))
+    if (parsed.success) return { config: current, dropped }
+    const remainingIssues = (parsed.issues ?? []).filter((issue) => isRecordLeafPath(issue.path) !== null)
+    if (remainingIssues.length === 0) break
+    for (const issue of remainingIssues) {
+      const section = isRecordLeafPath(issue.path)
+      if (section === null) continue
+      const name = String(issue.path[1])
+      const key = `${section}.${name}`
+      if (droppedGroups.has(key)) continue
+      droppedGroups.add(key)
+      current = dropLeaf(current, section, name)
+      const issuePath = issue.path.map((segment) => String(segment)).join(".")
+      dropped.push(diagnosticFor(section, name, issuePath, issue.message))
+    }
+    iteration += 1
+  }
+
+  // Bound exhausted and still failing: signal fallback to defaults (totality).
+  return { config: {}, dropped }
+}

--- a/packages/omo-config-core/src/schema/agent-schema-keys.test.ts
+++ b/packages/omo-config-core/src/schema/agent-schema-keys.test.ts
@@ -21,10 +21,8 @@ describe("agent schema permission and prompt_append keys", () => {
     // then
     expect(result.success).toBe(true)
     if (!result.success) throw new Error(result.error.message)
-    expect(result.data.permission).toEqual({
-      edit: "deny",
-      bash: { "rm *": "ask" },
-    })
+    expect(result.data.permission?.edit).toBe("deny")
+    expect(result.data.permission?.bash).toEqual({ "rm *": "ask" })
     expect(result.data.prompt_append).toBe("x")
   })
 

--- a/packages/omo-config-core/src/schema/agent-schema-keys.test.ts
+++ b/packages/omo-config-core/src/schema/agent-schema-keys.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+
+import { OmoAgentDefSchema } from "./agent"
+
+describe("agent schema permission and prompt_append keys", () => {
+  test("#given an agent carrying permission and prompt_append #when parsed #then both keys are accepted", () => {
+    // given
+    const definition = {
+      description: "a",
+      prompt: "p",
+      permission: {
+        edit: "deny",
+        bash: { "rm *": "ask" },
+      },
+      prompt_append: "x",
+    }
+
+    // when
+    const result = OmoAgentDefSchema.safeParse(definition)
+
+    // then
+    expect(result.success).toBe(true)
+    if (!result.success) throw new Error(result.error.message)
+    expect(result.data.permission).toEqual({
+      edit: "deny",
+      bash: { "rm *": "ask" },
+    })
+    expect(result.data.prompt_append).toBe("x")
+  })
+
+  test("#given an agent carrying a truly unknown key #when parsed #then strict mode still rejects it", () => {
+    // given
+    const definition = { bogus_key: 1 }
+
+    // when
+    const result = OmoAgentDefSchema.safeParse(definition)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+
+  test("#given a permission object with an invalid value #when parsed #then the schema rejects it", () => {
+    // given
+    const definition = { permission: { edit: "sometimes" } }
+
+    // when
+    const result = OmoAgentDefSchema.safeParse(definition)
+
+    // then
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/omo-config-core/src/schema/agent.ts
+++ b/packages/omo-config-core/src/schema/agent.ts
@@ -13,6 +13,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export const OmoAgentModelEntrySchema = z.union([z.string(), OmoFallbackModelObjectSchema])
 
+const PermissionValueSchema = z.enum(["ask", "allow", "deny"])
+
+const BashPermissionSchema = z.union([
+  PermissionValueSchema,
+  z.record(z.string(), PermissionValueSchema),
+])
+
+export const OmoAgentPermissionSchema = z.object({
+  edit: PermissionValueSchema.optional(),
+  bash: BashPermissionSchema.optional(),
+  webfetch: PermissionValueSchema.optional(),
+  task: PermissionValueSchema.optional(),
+  doom_loop: PermissionValueSchema.optional(),
+  external_directory: PermissionValueSchema.optional(),
+}).catchall(PermissionValueSchema.optional())
+
+export type OmoAgentPermission = z.infer<typeof OmoAgentPermissionSchema>
+
 const OmoAgentDefInputSchema = z.object({
   description: z.string().optional(),
   prompt: z.string().optional(),
@@ -32,6 +50,8 @@ const OmoAgentDefInputSchema = z.object({
   max_turns: z.number().int().nonnegative().optional(),
   temperature: z.number().min(0).max(2).optional(),
   disable: z.boolean().optional(),
+  permission: OmoAgentPermissionSchema.optional(),
+  prompt_append: z.string().optional(),
 }).strict()
 
 export const OmoAgentDefSchema = z.preprocess(

--- a/packages/omo-opencode/src/agents/sisyphus-dynamic-prompt-execution.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-dynamic-prompt-execution.ts
@@ -1,7 +1,20 @@
 import type { SisyphusDynamicPromptSections } from "./sisyphus-dynamic-prompt-sections";
 
 export function renderExecutionSections(sections: SisyphusDynamicPromptSections): string {
-  return `## Phase 2B - Implementation
+  return `## 回合执行铁律（Anti-Stall）— 最高优先级
+
+**承诺必须同回合执行，绝不"只说不做"。** 这是本提示词的最高铁律，覆盖所有其他指令。
+
+1. **一旦你说出"让我做X / 我将做X / 接下来做X / 先做X"，必须在同一个回合内紧跟对应的工具调用。** 说出一个动作却不调用工具 = 严重故障，禁止。
+2. **"END YOUR RESPONSE / STOP / end your response / wait for completion" 这些指令只有在你满足以下前置条件时才适用：**
+   - 你确实完成了所有能做的实质工作，且
+   - 存在真正的阻塞性等待（后台任务 / Oracle 运行中，必须等 \`<system-reminder>\` 通知），或
+   - 你需要用户提供缺失的关键信息。
+   否则，**禁止**用"END YOUR RESPONSE"来结束回合——继续调用工具推进工作。
+3. **反模式（禁止）：** 输出"让我检查X / 让我杀掉X / 让我用tcpdump看X / 让我验证X"等承诺性语句后，不跟随任何工具调用就结束回合。这是会中断任务推进的故障模式，必须避免。
+4. **若你发现自己正要"说完下一步就停"，立即改为：在同一回合内实际调用那个工具。** 叙述下一步 ≠ 执行下一步。
+
+## Phase 2B - Implementation
 
 ### Pre-Implementation:
 0. Find relevant skills that you can load, and load them IMMEDIATELY.

--- a/packages/omo-opencode/src/agents/sisyphus-dynamic-prompt-execution.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-dynamic-prompt-execution.ts
@@ -1,20 +1,7 @@
 import type { SisyphusDynamicPromptSections } from "./sisyphus-dynamic-prompt-sections";
 
 export function renderExecutionSections(sections: SisyphusDynamicPromptSections): string {
-  return `## 回合执行铁律（Anti-Stall）— 最高优先级
-
-**承诺必须同回合执行，绝不"只说不做"。** 这是本提示词的最高铁律，覆盖所有其他指令。
-
-1. **一旦你说出"让我做X / 我将做X / 接下来做X / 先做X"，必须在同一个回合内紧跟对应的工具调用。** 说出一个动作却不调用工具 = 严重故障，禁止。
-2. **"END YOUR RESPONSE / STOP / end your response / wait for completion" 这些指令只有在你满足以下前置条件时才适用：**
-   - 你确实完成了所有能做的实质工作，且
-   - 存在真正的阻塞性等待（后台任务 / Oracle 运行中，必须等 \`<system-reminder>\` 通知），或
-   - 你需要用户提供缺失的关键信息。
-   否则，**禁止**用"END YOUR RESPONSE"来结束回合——继续调用工具推进工作。
-3. **反模式（禁止）：** 输出"让我检查X / 让我杀掉X / 让我用tcpdump看X / 让我验证X"等承诺性语句后，不跟随任何工具调用就结束回合。这是会中断任务推进的故障模式，必须避免。
-4. **若你发现自己正要"说完下一步就停"，立即改为：在同一回合内实际调用那个工具。** 叙述下一步 ≠ 执行下一步。
-
-## Phase 2B - Implementation
+  return `## Phase 2B - Implementation
 
 ### Pre-Implementation:
 0. Find relevant skills that you can load, and load them IMMEDIATELY.

--- a/packages/omo-opencode/src/config/schema/core-schema-parity.test.ts
+++ b/packages/omo-opencode/src/config/schema/core-schema-parity.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+import { OmoAgentDefSchema, OmoCategoryConfigSchema } from "@oh-my-opencode/omo-config-core"
+import { AgentOverrideConfigSchema } from "../schema/agent-overrides"
+import { CategoryConfigSchema } from "../schema/categories"
+
+/**
+ * Drift guard: the harness-neutral core schema and the OpenCode adapter schema
+ * must stay in field parity for the keys core intends to own. A future key
+ * addition on one side without the other fails this test.
+ *
+ * We assert only machine-consumed behavior via `safeParse` probes (no prose):
+ * the two fields core owns (`permission`, `prompt_append`) and full category
+ * parity. Core schemas are `z.preprocess` wrappers, so parity is probed by
+ * parsing rather than introspecting `.shape`.
+ */
+
+function probeAcceptedKeys(schema: { readonly safeParse: (v: unknown) => { readonly success: boolean } }): Set<string> {
+  const accepted = new Set<string>()
+  const probes: Record<string, unknown> = {
+    permission: { permission: { edit: "deny" } },
+    prompt_append: { prompt_append: "x" },
+  }
+  for (const [key, probe] of Object.entries(probes)) {
+    if (schema.safeParse(probe).success) accepted.add(key)
+  }
+  return accepted
+}
+
+function probeValueFor(key: string): unknown {
+  switch (key) {
+    case "description":
+    case "model":
+    case "prompt_append":
+    case "variant":
+    case "reasoningEffort":
+    case "textVerbosity":
+      return "x"
+    case "models":
+    case "fallback_models":
+      return ["x"]
+    case "reasoning":
+      return "off"
+    case "temperature":
+    case "top_p":
+    case "max_tokens":
+    case "maxTokens":
+    case "max_prompt_tokens":
+      return 1
+    case "provider_options":
+    case "tools":
+      return {}
+    case "thinking":
+      return { type: "enabled" }
+    case "is_unstable_agent":
+    case "disable":
+    case "warn_unavailable":
+      return true
+    default:
+      return "x"
+  }
+}
+
+describe("core <-> adapter schema parity", () => {
+  test("#given core agent schema #when probing permission and prompt_append #then core accepts both keys", () => {
+    // given
+    const coreKeys = probeAcceptedKeys(OmoAgentDefSchema)
+
+    // when / then
+    expect(coreKeys.has("permission")).toBe(true)
+    expect(coreKeys.has("prompt_append")).toBe(true)
+  })
+
+  test("#given core and adapter agent schemas #when comparing key acceptance #then they agree on permission and prompt_append", () => {
+    // given
+    const coreKeys = probeAcceptedKeys(OmoAgentDefSchema)
+    const adapterKeys = probeAcceptedKeys(AgentOverrideConfigSchema)
+
+    // when / then
+    for (const key of ["permission", "prompt_append"]) {
+      expect(coreKeys.has(key)).toBe(adapterKeys.has(key))
+    }
+  })
+
+  test("#given core and adapter category schemas #when probing each adapter key #then core accepts every adapter key", () => {
+    // given
+    const adapterKeys = Object.keys(CategoryConfigSchema.shape)
+
+    // when / then
+    for (const key of adapterKeys) {
+      const probe = { [key]: probeValueFor(key) }
+      expect(OmoCategoryConfigSchema.safeParse(probe).success).toBe(true)
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/team-mode/member-guidance.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/member-guidance.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { buildTeammateCommunicationAddendum } from "./member-guidance"
+
+function createConfig(): TeamModeConfig {
+  return TeamModeConfigSchema.parse({ base_dir: "/tmp", enabled: true })
+}
+
+describe("buildTeammateCommunicationAddendum", () => {
+  test("includes long-running command guidance", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig())
+
+    // then
+    expect(addendum).toContain("## Long-running commands")
+    expect(addendum).toContain("nohup pnpm dev > /tmp/dev-<name>.log 2>&1 & echo $!")
+    expect(addendum).toContain("for i in $(seq 1 30); do curl -sf localhost:PORT && break || sleep 2; done")
+  })
+
+  test("includes file ownership coordination guidance", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig())
+
+    // then
+    expect(addendum).toContain("Coordinate file ownership with teammates")
+    expect(addendum).toContain("work within its own file/directory scope")
+  })
+
+  test("omits read-only section when readOnly is falsy", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig())
+
+    // then
+    expect(addendum).not.toContain("## Read-only mode")
+  })
+
+  test("adds read-only section when readOnly is true", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig(), true)
+
+    // then
+    expect(addendum).toContain("## Read-only mode")
+    expect(addendum).toContain("HARDDENIED at the session permission level")
+    expect(addendum).not.toContain("bash is also denied in strict read-only mode")
+  })
+
+  test("adds strict bash note when readOnly is strict", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig(), "strict")
+
+    // then
+    expect(addendum).toContain("## Read-only mode")
+    expect(addendum).toContain("bash is also denied in strict read-only mode")
+  })
+})

--- a/packages/omo-opencode/src/features/team-mode/member-guidance.ts
+++ b/packages/omo-opencode/src/features/team-mode/member-guidance.ts
@@ -1,6 +1,9 @@
 import type { TeamModeConfig } from "../../config/schema/team-mode"
 
-export function buildTeammateCommunicationAddendum(_config: TeamModeConfig): string {
+export function buildTeammateCommunicationAddendum(
+  _config: TeamModeConfig,
+  readOnly?: boolean | "strict",
+): string {
   return `
 # Team Communication
 
@@ -35,7 +38,23 @@ Going idle after sending a message is the expected flow — it does NOT mean you
 - Do NOT send structured JSON status messages like \`{"type":"idle",...}\` or \`{"type":"task_completed",...}\`. Communicate in plain natural language when you message teammates.
 - Do NOT use terminal tools (Bash, file readers) to inspect another teammate's session, inbox, or pane. Send a \`team_send_message\` instead.
 - Always refer to teammates by their NAME (e.g., \`to: "lead"\`, \`to: "researcher"\`), never by internal session IDs.
+- Coordinate file ownership with teammates: each member should work within its own file/directory scope to avoid conflicts on the shared worktree. If you must touch a file another member owns, message them first.
 
+## Long-running commands
+
+Never run blocking services (dev servers, watch mode) in the foreground — the call will hang until timeout. Instead:
+1. Start in background with a log file: \`nohup pnpm dev > /tmp/dev-<name>.log 2>&1 & echo $!\`
+2. Poll readiness with a bounded loop: \`for i in $(seq 1 30); do curl -sf localhost:PORT && break || sleep 2; done\`
+3. Verify via the log: \`tail -50 /tmp/dev-<name>.log\`
+4. Kill by the recorded PID when done.
+${readOnly ? `
+
+## Read-only mode
+
+You are a read-only team member. File-editing tools (edit/write/multiedit) are HARDDENIED at the session permission level — attempts will be rejected. Do NOT try to write files, create directories, or modify anything on disk. Prepare your analysis and deliverables as message text, and send them to the lead via \`team_send_message\`. Do not attempt to work around the restriction with bash shell redirection (echo > file, sed -i) — that is a violation.${readOnly === "strict" ? `
+
+Additionally, bash is also denied in strict read-only mode — you cannot run shell commands at all. Do all work through read-only tools and message text.` : ""}
+` : ""}
 ## Wrap-up
 
 When you finish your assigned work, ALWAYS, in this order:

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
@@ -225,6 +225,80 @@ describe("createTeamRun", () => {
     expect(firstPrompt).toContain("Lead-only tools you must NOT call")
   })
 
+  test("readOnly member gets edit-denied sessionPermission and read-only guidance", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-readonly-"))
+    temporaryDirectories.push(baseDir)
+    const { manager, launchMock } = createManager(baseDir, async () => ({
+      id: "task-1",
+      sessionId: "session-1",
+      status: "running",
+    } as BackgroundTask))
+    const spec: TeamSpec = {
+      ...createSpec(1),
+      members: [{ ...createSpec(1).members[0]!, readOnly: true }],
+    }
+
+    // when
+    await createTeamRun(spec, "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+    const firstLaunch = (launchMock.mock.calls as Array<[LaunchInput]>)[0]?.[0]
+
+    // then
+    expect(firstLaunch?.sessionPermission).toEqual([
+      { permission: "question", action: "deny", pattern: "*" },
+      { permission: "edit", action: "deny", pattern: "*" },
+    ])
+    expect(firstLaunch?.prompt).toContain("## Read-only mode")
+  })
+
+  test("strict readOnly member gets bash-denied sessionPermission and strict guidance", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-readonly-strict-"))
+    temporaryDirectories.push(baseDir)
+    const { manager, launchMock } = createManager(baseDir, async () => ({
+      id: "task-1",
+      sessionId: "session-1",
+      status: "running",
+    } as BackgroundTask))
+    const spec: TeamSpec = {
+      ...createSpec(1),
+      members: [{ ...createSpec(1).members[0]!, readOnly: "strict" }],
+    }
+
+    // when
+    await createTeamRun(spec, "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+    const firstLaunch = (launchMock.mock.calls as Array<[LaunchInput]>)[0]?.[0]
+
+    // then
+    expect(firstLaunch?.sessionPermission).toEqual([
+      { permission: "question", action: "deny", pattern: "*" },
+      { permission: "edit", action: "deny", pattern: "*" },
+      { permission: "bash", action: "deny", pattern: "*" },
+    ])
+    expect(firstLaunch?.prompt).toContain("bash is also denied in strict read-only mode")
+  })
+
+  test("non-readOnly member keeps question-denied sessionPermission", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-non-readonly-"))
+    temporaryDirectories.push(baseDir)
+    const { manager, launchMock } = createManager(baseDir, async () => ({
+      id: "task-1",
+      sessionId: "session-1",
+      status: "running",
+    } as BackgroundTask))
+
+    // when
+    await createTeamRun(createSpec(1), "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+    const firstLaunch = (launchMock.mock.calls as Array<[LaunchInput]>)[0]?.[0]
+
+    // then
+    expect(firstLaunch?.sessionPermission).toEqual([
+      { permission: "question", action: "deny", pattern: "*" },
+    ])
+    expect(firstLaunch?.prompt).not.toContain("## Read-only mode")
+  })
+
   test("rolls back launched members in reverse order when a later spawn fails", async () => {
     // given
     const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-rollback-"))

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
@@ -2,7 +2,7 @@ import { access, mkdir } from "node:fs/promises"
 import path from "node:path"
 
 import type { TeamModeConfig } from "../../../config/schema/team-mode"
-import { QUESTION_DENIED_SESSION_PERMISSION } from "../../../shared/question-denied-session-permission"
+import { QUESTION_DENIED_SESSION_PERMISSION, READ_ONLY_SESSION_PERMISSION, READ_ONLY_STRICT_SESSION_PERMISSION } from "../../../shared/question-denied-session-permission"
 import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
 import type { BackgroundTask } from "../../background-agent/types"
 import type { BackgroundManager } from "../../background-agent/manager"
@@ -103,7 +103,7 @@ function buildMemberPrompt(
   const promptLines = [`Team: ${spec.name}`, `TeamRunId: ${teamRunId}`, `Member: ${member.name}`]
   if (worktreePath) promptLines.push(`Worktree: ${worktreePath}`)
   if (member.prompt) promptLines.push(member.prompt)
-  promptLines.push(buildTeammateCommunicationAddendum(config))
+  promptLines.push(buildTeammateCommunicationAddendum(config, member.readOnly))
   return promptLines.join("\n")
 }
 
@@ -204,7 +204,11 @@ export async function createTeamRun(
             fallbackChain: resolvedMember.fallbackChain,
             skillContent: resolvedMember.systemContent,
             category: member.kind === "category" ? member.category : undefined,
-            sessionPermission: QUESTION_DENIED_SESSION_PERMISSION,
+            sessionPermission: member.readOnly === "strict"
+              ? READ_ONLY_STRICT_SESSION_PERMISSION
+              : member.readOnly
+                ? READ_ONLY_SESSION_PERMISSION
+                : QUESTION_DENIED_SESSION_PERMISSION,
             onSessionCreated: async (sessionId) => {
               registerTeamSession(sessionId, {
                 teamRunId: runtimeState.teamRunId,

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/status.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/status.test.ts
@@ -10,7 +10,7 @@ import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import { createTask } from "../team-tasklist/store"
 import { createTaskInput } from "../team-tasklist/test-support"
 import { getInboxDir, getTasksDir, resolveBaseDir } from "../team-registry/paths"
-import { createRuntimeState, saveRuntimeState } from "../team-state-store/store"
+import { createRuntimeState, loadRuntimeState, saveRuntimeState } from "../team-state-store/store"
 import { aggregateStatus } from "./status"
 
 async function createTemporaryBaseDir(): Promise<string> {
@@ -139,5 +139,31 @@ describe("aggregateStatus", () => {
     expect(result.concurrency.runningOnSameModel).toBe(5)
     expect(result.concurrency.queuedOnSameModel).toBe(3)
     expect(result.concurrency.teamRunIdSpecific).toBe(4)
+  })
+
+  test("reports idleDurationMs for idle members with a lastActiveAt timestamp", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    temporaryDirectories.push(baseDir)
+    const config = createConfig(baseDir)
+    const teamRunId = await seedRuntimeState(baseDir, "team-delta", "lead-4", ["session-idle"])
+    const lastActiveAt = Date.now() - 5_000
+    const updatedRuntimeState = {
+      ...(await loadRuntimeState(teamRunId, config)),
+      members: (await loadRuntimeState(teamRunId, config)).members.map((member) =>
+        member.name === "member-1" ? { ...member, status: "idle" as const, lastActiveAt } : member,
+      ),
+    }
+    await saveRuntimeState(updatedRuntimeState, config)
+
+    // when
+    const result = await aggregateStatus(teamRunId, config)
+
+    // then
+    const idleMember = result.members.find((member) => member.name === "member-1")
+    expect(idleMember?.status).toBe("idle")
+    expect(idleMember?.lastActiveAt).toBe(lastActiveAt)
+    expect(idleMember?.idleDurationMs).toBeGreaterThanOrEqual(5_000)
+    expect(result.members.find((member) => member.name === "member-2")?.idleDurationMs).toBeUndefined()
   })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/status.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/status.ts
@@ -23,6 +23,8 @@ export interface TeamStatus {
     worktreePath?: string
     unreadMessages: number
     paneId?: string
+    lastActiveAt?: number
+    idleDurationMs?: number
   }>
   tasks: {
     pending: number
@@ -144,6 +146,8 @@ export async function aggregateStatus(
       worktreePath: member.worktreePath,
       unreadMessages,
       paneId: member.tmuxPaneId,
+      lastActiveAt: member.lastActiveAt,
+      idleDurationMs: member.status === "idle" && member.lastActiveAt ? Date.now() - member.lastActiveAt : undefined,
     })),
     tasks: countTasks(tasks),
     shutdownRequests: runtimeState.shutdownRequests,

--- a/packages/omo-opencode/src/hooks/team-session-events/team-member-status-handler.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-member-status-handler.ts
@@ -38,7 +38,7 @@ async function transitionMemberStatus(
     ...currentRuntimeState,
     members: currentRuntimeState.members.map((member) => (
       member.name === runtimeMember.memberName
-        ? { ...member, status: nextStatus }
+        ? { ...member, status: nextStatus, lastActiveAt: Date.now() }
         : member
     )),
   }), config)

--- a/packages/omo-opencode/src/shared/question-denied-session-permission.ts
+++ b/packages/omo-opencode/src/shared/question-denied-session-permission.ts
@@ -7,3 +7,13 @@ export type SessionPermissionRule = {
 export const QUESTION_DENIED_SESSION_PERMISSION: SessionPermissionRule[] = [
   { permission: "question", action: "deny", pattern: "*" },
 ]
+
+export const READ_ONLY_SESSION_PERMISSION: SessionPermissionRule[] = [
+  ...QUESTION_DENIED_SESSION_PERMISSION,
+  { permission: "edit", action: "deny", pattern: "*" },
+]
+
+export const READ_ONLY_STRICT_SESSION_PERMISSION: SessionPermissionRule[] = [
+  ...READ_ONLY_SESSION_PERMISSION,
+  { permission: "bash", action: "deny", pattern: "*" },
+]

--- a/packages/team-core/src/types.ts
+++ b/packages/team-core/src/types.ts
@@ -32,6 +32,7 @@ const MemberBaseSchema = z.object({
   backendType: z.enum(["in-process", "tmux"]).default("in-process"),
   color: z.string().optional(),
   isActive: z.boolean().default(true),
+  readOnly: z.union([z.boolean(), z.literal("strict")]).optional(),
 }).strict()
 
 export const CategoryMemberSchema = MemberBaseSchema.extend({
@@ -146,6 +147,7 @@ const RuntimeStateMemberSchema = z.object({
   worktreePath: z.string().optional(),
   lastInjectedTurnMarker: z.string().optional(),
   pendingInjectedMessageIds: z.array(z.string()).default([]),
+  lastActiveAt: z.number().int().positive().optional(),
 }).strict()
 
 const RuntimeBoundsSchema = z.object({


### PR DESCRIPTION
## What

Surgical degradation for the omo config chain: when a user config contains an
invalid record leaf (`agents.<name>` / `categories.<name>`), the loader now
prunes only the offending leaf and keeps every healthy sibling, instead of
wholesale falling back to `DEFAULT_RAW_CONFIG` (which wiped all user agents and
categories and produced a terminal `session.error`).

## Why

A single bad key in one agent (e.g. `agents.oracle.bogus_key`) made the entire
merged document unparseable, so the loader discarded ALL user-defined agents and
categories. The fix keeps the `.strict()` schema (no `.passthrough()`/`.strip()`)
and surgically removes only the invalid record leaves.

## Changes (B1→B3)

- **B1** — `packages/omo-config-core/src/schema/agent.ts`: declare first-class
  `permission` + `prompt_append` keys on `OmoAgentDefInputSchema`, keeping
  `.strict()` (rejects genuinely unknown keys). Regenerated
  `assets/omo.schema.json` so the schema-freshness test stays green.
- **B2** — `packages/omo-config-core/src/loader/prune-invalid-leaves.ts` (new) +
  `loader.ts`: bounded surgical prune loop (`maxIterations = droppedGroups + 1`)
  that re-validates after each prune pass; total (falls back to defaults only as
  the last resort when non-prunable paths remain). One per-key diagnostic per
  dropped leaf, surfaced through `validatePluginConfig` messages.
- **B3** — `packages/omo-opencode/src/config/schema/core-schema-parity.test.ts`
  (new): drift guard pinning core↔adapter field parity for `permission`/
  `prompt_append` (agents) and full category parity. Future key addition on one
  side without the other fails CI.

## Observed behavior

Fixture `<tmp-project>/.omo/omo.jsonc` with valid `agents.sisyphus` + invalid
`agents.oracle.bogus_key`:
- `sisyphus.model` and `sisyphus.prompt_append` survive
- `oracle` is dropped
- exactly one validation diagnostic naming `agents.oracle`

## QA / Evidence

- `bun test packages/omo-config-core`: 181 pass / 0 fail
- `bun test packages/omo-opencode/src/config`: 163 pass / 0 fail
- `tsgo --noEmit` (config-core + omo-opencode): clean
- `bun run typecheck`: EXIT 0
- codex-codegraph typecheck (consumes omo-config-core through the codex closure): clean
- opencode-qa CLI case in `script/agent/qa-sandbox.sh` isolation with a
  PROJECT-LAYER fixture (never `~/.omo/**`); isolation proven (sandbox DB only,
  real DB untouched)
- Evidence: `.omo/evidence/20260824-config-chain-degrade/`

## Residual risk

- Highest-blast-radius PR (every harness parses this schema). Mitigation: strict
  preserved, prune is additive-only, codex gate exercised. Rollback: revert the
  single merge commit.
- Root `bun test` reports 45 pre-existing failures in unrelated modules
  (auto-update network tests, codex/senpi installers, dist-bundle, telemetry,
  skill-loader). None touch this change's blast radius; the only in-scope
  failure (`omo schema freshness`) was fixed by regenerating the schema.
- `bun run test:codex` is blocked by a pre-existing dependency defect: the
  committed `packages/omo-codex/plugin` lockfile does not install `@types/node`
  (declared by `ulw-loop`/`codegraph` devDependencies), so their `tsc` build
  fails with TS2688 in a clean checkout — independent of this change. The
  codex-closure typecheck that consumes `omo-config-core` passes clean.

## Note

This PR contains the B1 commits (`ec4a1db1d` RED → `12a701ee3` GREEN amended)
followed by B2, B3, and the QA evidence commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes only invalid `agents.<name>`/`categories.<name>` leaves during config load instead of reverting to defaults, preserving healthy entries and avoiding terminal failures. Old behavior dropped all user agents/categories on any unknown key; new behavior removes just the offending leaf, revalidates, and falls back to defaults only as a last resort, emitting one diagnostic per dropped leaf.

- Review notes
  - Loader: adds a bounded prune loop in `packages/omo-config-core/src/loader/prune-invalid-leaves.ts` and integrates it in `loader.ts`; loop revalidates after each drop and caps at droppedGroups+1; diagnostics include the exact dropped path.
  - Schema: declares `permission` and `prompt_append` on agents in `packages/omo-config-core` while keeping `.strict()`; regenerates `assets/omo.schema.json`.
  - Parity guard: adds `packages/omo-opencode/src/config/schema/core-schema-parity.test.ts` to enforce core↔adapter parity for agent fields (`permission`, `prompt_append`) and full category parity.
  - Team Mode (additive): supports member `readOnly` (including `"strict"`) with session permission rules (`edit` and optionally `bash` denied), adds teammate communication guidance for long-running commands and file-ownership coordination, and surfaces `idleDurationMs` via `lastActiveAt`.

- Rollout
  - No user migration required; unknown keys still fail validation but now only drop the offending agent/category.
  - If you add new agent/category keys in either core or adapter, update both schemas; the parity test will fail otherwise.

<sup>Written for commit ed4f8b29f1eca35620236d37ab5ca901ae5830db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

