### PR TITLE
feat(senpi-onboarding): teach ulw keyword, mass-ulw, and init-deep mass-ulw attribution

### DIFF
--- a/packages/omo-senpi/plugin/skills/onboarding/SKILL.md
+++ b/packages/omo-senpi/plugin/skills/onboarding/SKILL.md
@@ -49,8 +49,14 @@ The baked catalog:
   selected omo harness exposes that surface.
 - **Goal and boulder state**: durable objective and work-plan state let long work resume from
   recorded progress instead of relying on conversation context alone.
-- **Ultrawork and ulw workflows**: planning, research, execution loops, fan-out decisions, and
-  evidence-bound continuation keep autonomous work moving until its observable goal is proven.
+- **Ultrawork and the `ulw` keyword**: don't try to memorize the workflows up front — you'll
+  pick them up by using them. For now, remember one word: `ulw`. Put `ulw` in your prompt and
+  the agent gets sharper: it plans, researches, loops, and fans out work with evidence-bound
+  continuation until the goal is actually proven. Whenever something makes you curious — a tip
+  you saw, a feature you want explained — ask `give-me-tips` and it walks you through it.
+- **Mass-ulw**: `mass ulw` opens dependency-ordered multi-agent DAG orchestration — many child
+  agents run in parallel waves, some waiting on others, so big jobs finish faster. Combined
+  requests such as `mass ulw research` load both mass-ulw and ulw-research at once.
 - **The fallback architect**: refusal metadata can route the unresolved engineering question
   through an architecture consultation lane while the active model continues execution.
 - **Memory**: dedicated memory tools record durable user and project facts so later sessions begin
@@ -58,7 +64,9 @@ The baked catalog:
 - **Telemetry**: privacy-bounded anonymous lifecycle signals and local preview commands make omo
   behavior measurable and auditable, with documented opt-outs.
 - **Init-deep**: hierarchical `AGENTS.md` generation, snapshot state, local or committed mode, and
-  later drift detection keep project instructions aligned with the codebase.
+  later drift detection keep project instructions aligned with the codebase. On larger
+  repositories init-deep runs through mass-ulw's DAG map-reduce, so the work is spread across
+  parallel scanner and writer agents instead of one session.
 - **Tips with a live source of truth**: run `senpi --list-tips` during the tour, then read and
   follow `give-me-tips` for any visible tip the user wants explained from the implementation.
 - **Interactive UI primitives**: real pickers, confirms, inputs, notifications, editors, custom
@@ -223,3 +231,9 @@ If all gates pass, ask in the user's language: "want me to set up AGENTS.md for 
 This is opt-in. On yes, read the `init-deep` skill at its SKILL.md path and follow it. On no,
 record the decline through the memory tools and finish the conversation gracefully: a short
 send-off in their language, an invitation to come back with `senpi --onboard`, and nothing more.
+
+After init-deep finishes, tell the user in their language that init-deep ran through mass-ulw's
+DAG orchestration — the work was spread across parallel child agents in dependency-ordered
+waves rather than done by one session. Then introduce mass-ulw: `mass ulw` is how you bring that
+same multi-agent orchestration to any big job, and combined requests such as `mass ulw
+research`, `mass ulw loop`, and `mass ulw plan` load mass-ulw alongside each of those workflows.

--- a/packages/omo-senpi/skills/onboarding/SKILL.md
+++ b/packages/omo-senpi/skills/onboarding/SKILL.md
@@ -49,8 +49,14 @@ The baked catalog:
   selected omo harness exposes that surface.
 - **Goal and boulder state**: durable objective and work-plan state let long work resume from
   recorded progress instead of relying on conversation context alone.
-- **Ultrawork and ulw workflows**: planning, research, execution loops, fan-out decisions, and
-  evidence-bound continuation keep autonomous work moving until its observable goal is proven.
+- **Ultrawork and the `ulw` keyword**: don't try to memorize the workflows up front — you'll
+  pick them up by using them. For now, remember one word: `ulw`. Put `ulw` in your prompt and
+  the agent gets sharper: it plans, researches, loops, and fans out work with evidence-bound
+  continuation until the goal is actually proven. Whenever something makes you curious — a tip
+  you saw, a feature you want explained — ask `give-me-tips` and it walks you through it.
+- **Mass-ulw**: `mass ulw` opens dependency-ordered multi-agent DAG orchestration — many child
+  agents run in parallel waves, some waiting on others, so big jobs finish faster. Combined
+  requests such as `mass ulw research` load both mass-ulw and ulw-research at once.
 - **The fallback architect**: refusal metadata can route the unresolved engineering question
   through an architecture consultation lane while the active model continues execution.
 - **Memory**: dedicated memory tools record durable user and project facts so later sessions begin
@@ -58,7 +64,9 @@ The baked catalog:
 - **Telemetry**: privacy-bounded anonymous lifecycle signals and local preview commands make omo
   behavior measurable and auditable, with documented opt-outs.
 - **Init-deep**: hierarchical `AGENTS.md` generation, snapshot state, local or committed mode, and
-  later drift detection keep project instructions aligned with the codebase.
+  later drift detection keep project instructions aligned with the codebase. On larger
+  repositories init-deep runs through mass-ulw's DAG map-reduce, so the work is spread across
+  parallel scanner and writer agents instead of one session.
 - **Tips with a live source of truth**: run `senpi --list-tips` during the tour, then read and
   follow `give-me-tips` for any visible tip the user wants explained from the implementation.
 - **Interactive UI primitives**: real pickers, confirms, inputs, notifications, editors, custom
@@ -223,3 +231,9 @@ If all gates pass, ask in the user's language: "want me to set up AGENTS.md for 
 This is opt-in. On yes, read the `init-deep` skill at its SKILL.md path and follow it. On no,
 record the decline through the memory tools and finish the conversation gracefully: a short
 send-off in their language, an invitation to come back with `senpi --onboard`, and nothing more.
+
+After init-deep finishes, tell the user in their language that init-deep ran through mass-ulw's
+DAG orchestration — the work was spread across parallel child agents in dependency-ordered
+waves rather than done by one session. Then introduce mass-ulw: `mass ulw` is how you bring that
+same multi-agent orchestration to any big job, and combined requests such as `mass ulw
+research`, `mass ulw loop`, and `mass ulw plan` load mass-ulw alongside each of those workflows.


### PR DESCRIPTION
## What changed

The Omo Native onboarding feature tour now teaches the **one keyword a new user should remember**, introduces **mass-ulw**, and makes **init-deep attribute its DAG execution to mass-ulw**.

Three edits to `packages/omo-senpi/skills/onboarding/SKILL.md` (authoritative native source) plus its synced plugin copy:

1. **`ulw` keyword bullet** (replaces the generic "Ultrawork and ulw workflows" bullet). New framing: don't try to memorize the workflows up front — you'll pick them up by using them. Remember one word: `ulw`. Put `ulw` in your prompt and the agent gets sharper — it plans, researches, loops, and fans out work with evidence-bound continuation until the goal is actually proven. When curious, ask `give-me-tips`.

2. **New `Mass-ulw` bullet**. `mass ulw` opens dependency-ordered multi-agent DAG orchestration — many child agents run in parallel waves, some waiting on others, so big jobs finish faster. Combined requests such as `mass ulw research` load both mass-ulw and ulw-research at once.

3. **Init-deep attribution**. The Init-deep tour bullet now says larger repositories run init-deep through mass-ulw's DAG map-reduce (work spread across parallel scanner and writer agents instead of one session). Lane 6 (the first-session init-deep proposal) now instructs the agent to tell the user — in their language — that init-deep ran through mass-ulw's DAG orchestration, and then introduces `mass ulw` as the way to bring that same orchestration to any big job, with combined forms `mass ulw research`, `mass ulw loop`, and `mass ulw plan`.

## Why

A prior research audit (ulw-research DAG, `.omo/ulw-research/20260825-123612/`) confirmed onboarding already explained Omo and init-deep, but:
- `mass ulw` and mass-prefixed combinations were **ABSENT** from onboarding prose even though the runtime skill-pointer already supported them.
- `ulw`/`ultrawork` was only a conceptual mention, not a "put this one word in your prompt" teaching.
- Init-deep never told the user the work was done through mass-ulw's DAG orchestration.

This PR closes those gaps in the one surface a new user actually sees: the feature-tour catalog and the lane-6 proposal.

## What it does NOT do

- No runtime trigger change. The `ultrawork` matcher (`/(?:ultrawork|ulw)/i`) and `skill-pointers` keyword table are untouched — the runtime already supported every form this PR now documents.
- No new test. Per the repo's `test-discipline.md` rule, skill content is **prose** and is not pinned by a test; a text grep would be pretend-coverage. This ships on review + QA-by-read.
- No behavior change. The onboarding component, init-deep-advisor runtime, and skill-pointer injection logic are all unchanged.

## QA evidence

All checks run in the task-owned worktree `omo-wt-onboarding-ulw` at commit `9e0ff4880`:

| Check | Command | Result |
|-------|---------|--------|
| Onboarding frontmatter + no token-cost warnings | `bash packages/omo-senpi/skills/onboarding/qa-validator.sh` | exit 0 |
| Savings fixture | `bash packages/omo-senpi/skills/onboarding/qa-savings-fixture.sh` | `qa-savings-fixture: OK` |
| Source matches generated plugin copy | `diff -q packages/omo-senpi/skills/onboarding/SKILL.md packages/omo-senpi/plugin/skills/onboarding/SKILL.md` | exit 0 (identical) |
| Skill-sync audit gate (foreign-harness token scan, verbatim native sync, roster) | `bun test packages/omo-senpi/src/skills-sync.test.ts` | 11 pass, 0 fail |
| No foreign harness tokens in new prose | `rg -i 'codex\|multi_agent\|spawn_agent\|update_plan\|call_omo_agent\|background_output\|team_\*' packages/omo-senpi/skills/onboarding/SKILL.md` | exit 1 (no matches) |

## Residual risk

Low. Pure-prose edit to a native skill source that ships verbatim. The only machine-consumed contract the new text must obey is the onboarding `qa-validator.sh` pin on `name: onboarding` and the token-cost-warning ban, both verified green. The skills-sync test additionally scans for foreign-harness tokens and confirms the native skill ships verbatim modulo blank-line normalization.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teaches the `ulw` keyword, introduces `mass ulw`, and explains that init-deep on larger repos runs via mass-ulw’s DAG orchestration in the onboarding tour. This helps new users invoke ultrawork directly, discover combined forms like `mass ulw research`, and understand how init-deep scales.

**Review notes**
- Prose-only updates in `packages/omo-senpi/skills/onboarding/SKILL.md`; synced copy in `packages/omo-senpi/plugin/skills/onboarding/SKILL.md`.
- Replaces the generic ultrawork bullet with an explicit `ulw` instruction and `give-me-tips` hint; adds a `mass ulw` bullet; updates init-deep text and adds a post-init message that attributes mass-ulw DAG execution and introduces combined forms.
- No runtime change; existing `ulw`/`ultrawork` matcher and skill-pointer keywords already support these forms.
- Validators and skill-sync tests pass.

<sup>Written for commit 9e0ff4880ff2ffefd79f90066c1e4cdcd3c2a01c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

