### PR TITLE
fix(omo-native): gate POSIX shim tests off Windows

### DIFF
--- a/packages/omo-native/test/bun-bin-shim.test.ts
+++ b/packages/omo-native/test/bun-bin-shim.test.ts
@@ -106,6 +106,12 @@ function nodeInterpreter(): string | undefined {
 
 const NODE = nodeInterpreter()
 const POSIX_ONLY = process.platform === "win32" || !NODE
+// The unit surface drives the module with `platform: "linux"`, so the module spells its paths with
+// posix.join while the fixtures below spell theirs with the HOST's path.join. On Windows those two
+// spellings never meet - `/home/dev/.bun/bin/bun` against `\home\dev\.bun\bin\bun` - and every
+// lookup misses. Mirroring the module's own darwin/linux gate is the honest fix: the repair itself
+// returns `skipped-platform` on Windows, so there is no Windows behaviour here left to cover.
+const NON_POSIX_HOST = process.platform === "win32"
 
 type Fixture = {
   root: string
@@ -234,7 +240,7 @@ describe("bun launcher bin shim", () => {
     })
   })
 
-  describe("#given a stock bun bin symlink pointing at this install", () => {
+  describe.skipIf(NON_POSIX_HOST)("#given a stock bun bin symlink pointing at this install", () => {
     test("#then it is replaced by an executable shim through an atomic rename", () => {
       // given
       const scriptPath = bunTreePackage(join(POSIX_HOME, ".bun"))
@@ -287,7 +293,7 @@ describe("bun launcher bin shim", () => {
     })
   })
 
-  describe("#given the bin path is not ours to touch", () => {
+  describe.skipIf(NON_POSIX_HOST)("#given the bin path is not ours to touch", () => {
     test("#then a symlink into another package is left alone", () => {
       // given
       const scriptPath = bunTreePackage(join(POSIX_HOME, ".bun"))
@@ -378,7 +384,7 @@ describe("bun launcher bin shim", () => {
     })
   })
 
-  describe("#given the repair path fails", () => {
+  describe.skipIf(NON_POSIX_HOST)("#given the repair path fails", () => {
     test("#then the failure is swallowed and never breaks the launch", () => {
       // given
       const scriptPath = bunTreePackage(join(POSIX_HOME, ".bun"))


### PR DESCRIPTION
## Summary

Test-only hotfix. `dev` CI is red on the Windows shard and blocking open PRs; this gates the POSIX-only `bun launcher bin shim` unit tests off Windows, mirroring the shim module's own `darwin`/`linux` platform gate. Zero behaviour change — the shim implementation is untouched.

## Root cause

dev run [32814116856](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/32814116856) (`c7094b8`, merge of #7273) fails `test (windows-latest, 2/2)` with **8 failing tests**, all under `bun launcher bin shim`:

- `#given a stock bun bin symlink pointing at this install` — atomic rename, already-current shim, older-generator rewrite
- `#given the bin path is not ours to touch` — foreign link, foreign file, absent bin
- `#given the repair path fails` — fail-open, `OMO_DEBUG` narration

Every one fails identically: `Expected {action: "repaired" | "foreign-link" | ...}`, `Received {action: "skipped-no-bun"}`.

The unit surface drives `ensureBunBinShim` with an injected `platform: "linux"`, so the module resolves its paths through `posix.join` and looks for `/home/dev/.bun/bin/bun`. The test fixtures build their injected `exists` allowlist with the **host's** `node:path.join`, which on a Windows runner emits `\home\dev\.bun\bin\bun`. The two spellings never meet, `findBunBinary` misses, and the module short-circuits to `skipped-no-bun` before any of the behaviour under test can run.

Posix-joining the fixtures does not rescue this: `ensureBunBinShim` computes its own `binPath` with `node:path.join`, which on Windows normalises even a posix input back to backslashes (`/home/dev/.bun` + `bin/omo` -> `\home\dev\.bun\bin\omo`). Making these tests run honestly on Windows would require changing the implementation — out of scope for a red-CI hotfix, and pointless: `ensureBunBinShim` returns `skipped-platform` on Windows by design, so there is no Windows behaviour here to cover.

`dev` was green at `81e07a3` (pre-merge); this is the first red.

## Fix

`describe.skipIf(process.platform === "win32")` on the three describes whose fixtures depend on POSIX path spelling. Coverage kept everywhere else:

- `#given the generated shim script` (pure string generation) — still runs on Windows
- `#given the launch context rules the repair out` (`skipped-platform`, `skipped-runtime`, `skipped-install`, `skipped-no-bun`) — still runs on Windows, and includes the explicit "Windows never repairs" assertion
- `#given a real synthetic bun global tree driven by node` — already gated by the pre-existing `POSIX_ONLY`

No POSIX coverage is lost: all 19 tests still execute on macOS/Linux.

## QA

- `bun test packages/omo-native/test/bun-bin-shim.test.ts` on macOS — **19 pass, 0 fail** (nothing skipped on POSIX)
- `bunx tsgo --noEmit -p packages/omo-native/tsconfig.json` — clean
- Pre-existing, unrelated local-env failures in `doctor` / `setup-detect` / `setup-import` reproduce identically on pristine `origin/dev` (13 fail both before and after); not touched by this change and green on CI's POSIX shards
- The Windows shard on this PR is the real gate


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates POSIX-only `omo-native` bin-shim tests on Windows to unblock red CI. Previously these suites failed on `windows-latest` due to POSIX vs Windows path spelling; they now skip on win32, matching the module’s darwin/linux gate, with no runtime behavior change.

- Skips three path-sensitive suites on win32 via describe.skipIf; mirrors the module’s platform guard.
- Keeps script-generation and short-circuit tests running on all platforms.
- No changes to implementation; POSIX coverage unchanged; Windows CI unblocked.

<sup>Written for commit 234304d0623e5a3dad6cf2f18cb8e82decdff65d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

