### PR TITLE
feat(omo-native,omo-senpi): inject brand command for resume hints

### DIFF
--- a/packages/omo-native/bin/lib/launcher.js
+++ b/packages/omo-native/bin/lib/launcher.js
@@ -30,6 +30,7 @@ function brandProfile() {
   const update = updateTarget()
   return {
     name: "OmO",
+    command: "omo",
     displayVersion: packageManifest().version,
     configDir: ".omo",
     // Engine state lives at the canonical `~/.omo/agent`, never directly under the config

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -211,6 +211,7 @@ describe("omo launcher", () => {
 
         const brand = JSON.parse(capture(fixture).env.SENPI_BRAND ?? "{}")
         expect(brand.name).toBe("OmO")
+        expect(brand.command).toBe("omo")
         expect(brand.configDir).toBe(".omo")
         expect(brand.flatLayout).toBe(false)
         expect(brand.envPrefix).toBe("OMO")

--- a/packages/omo-senpi/changes.md
+++ b/packages/omo-senpi/changes.md
@@ -1,3 +1,10 @@
+## 2026-08-25 — Name the executable in the local-launcher brand profile
+
+The sibling-store local launcher now injects `command: "omo"` on the `SENPI_BRAND`
+profile it hands the engine, matching the published omo-ai launcher. Senpi can
+render resume hints with the real executable name instead of guessing; unknown
+fields stay ignored on older engines.
+
 ## 2026-08-22 — One exception-free keyword table for every ULW skill pointer
 
 The mass-ulw and ulw-skill-pointers components were the same mechanism written twice, and the

--- a/packages/omo-senpi/plugin/scripts/install.mjs
+++ b/packages/omo-senpi/plugin/scripts/install.mjs
@@ -54,6 +54,7 @@ function localLauncherCmdPath(homeDir = homedir2()) {
 function renderLocalLauncher(options) {
   const brand = {
     name: "OmO",
+    command: "omo",
     displayVersion: options.version ?? "local",
     configDir: ".omo",
     flatLayout: false,

--- a/packages/omo-senpi/src/install/local-launcher.test.ts
+++ b/packages/omo-senpi/src/install/local-launcher.test.ts
@@ -20,6 +20,7 @@ describe("local omo launcher", () => {
 
         expect(brand).toEqual({
           name: "OmO",
+          command: "omo",
           displayVersion: "9.9.9",
           configDir: ".omo",
           flatLayout: false,

--- a/packages/omo-senpi/src/install/local-launcher.ts
+++ b/packages/omo-senpi/src/install/local-launcher.ts
@@ -33,6 +33,7 @@ export function localLauncherCmdPath(homeDir: string = homedir()): string {
 export function renderLocalLauncher(options: LocalLauncherOptions): string {
   const brand = {
     name: "OmO",
+    command: "omo",
     displayVersion: options.version ?? "local",
     configDir: ".omo",
     // Engine state lives at the canonical `~/.omo/agent`; a flat home would disagree with the


### PR DESCRIPTION
## Summary

Every `SENPI_BRAND` injection site now carries `command: "omo"` so senpi can render resume hints with the real executable name instead of guessing. Current engines ignore unknown fields, so this is forward-compatible with the parallel engine-side `BrandProfile.command` change.

## Changes

- `packages/omo-native/bin/lib/launcher.js` — published launcher `brandProfile()` includes `command: "omo"`.
- `packages/omo-senpi/src/install/local-launcher.ts` — sibling-store local launcher injects the same field.
- `packages/omo-senpi/plugin/scripts/install.mjs` — regenerated, not hand-edited. Source is `packages/omo-senpi/src/install/cli-local.ts`, which pulls in `renderLocalLauncher` through the installer. Build command: `node packages/omo-senpi/plugin/scripts/build-install.mjs` (wired from root `build:senpi-plugin:stage`; `bun build --target node --format esm`). The bundle is checked in and published via the plugin `files` list (`scripts/install.mjs`).
- Tests pin the new field (RED then GREEN).
- `packages/omo-senpi/changes.md` dated entry. omo-native has no `changes.md`.

## QA & Evidence

- **RED** (tests flipped first, implementation absent):
  - `bun test packages/omo-senpi/src/install/local-launcher.test.ts` — expected `command: "omo"`, received object without it. `/tmp/omo-brand-command-evidence/red-local-launcher.txt`
  - `bun test packages/omo-native/test/launcher.test.ts` — `brand.command` was `undefined`. `/tmp/omo-brand-command-evidence/red-launcher.txt`
- **GREEN** after adding the field and regenerating the installer:
  - local-launcher: 6 pass / 0 fail. `/tmp/omo-brand-command-evidence/green-local-launcher.txt`
  - launcher: 37 pass / 0 fail. `/tmp/omo-brand-command-evidence/green-launcher.txt`

## Risks & Residuals

Older senpi builds ignore unknown brand fields, so this PR stands alone. Resume-hint wording changes only after the engine-side consumer merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects command: "omo" into every `SENPI_BRAND` profile from `omo-native` and `omo-senpi` so senpi can show resume hints with the real executable name. Previously hints guessed the executable; current engines ignore unknown brand fields, so behavior is unchanged until the engine reads `BrandProfile.command`.

<sup>Written for commit 7fd850e295bd8e4ec1feaba7e2bcc5e9efe614be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

