### PR TITLE
fix(senpi-task): resume DAG runs without blocking

### DIFF
--- a/packages/senpi-task/changes.md
+++ b/packages/senpi-task/changes.md
@@ -1,3 +1,9 @@
+## 2026-08-25 — Resume DAG runs without waiting for surviving children
+
+DAG recovery now marks a claimed run resumed after non-blocking reconciliation work and watches surviving pending/running child tasks through the new scheduler instance. Their terminal outcomes are folded asynchronously, so durable result reuse and operator controls remain live while a reattached child continues executing.
+
+Keep surviving task owners externally owned during scheduler re-entry; never dispatch them a second time or revive the prior scheduler instance.
+
 ## 2026-08-20 — Export the canonical notice-box visual contract
 
 The package now exports one `buildNoticeBox` helper and `NoticeSpec`-shaped types for Senpi-coupled adapters. It reproduces Senpi's canonical `Box(1, 1, customMessageBg)` contract while the pinned host package does not export its own builder.

--- a/packages/senpi-task/src/dag/recovery.test.ts
+++ b/packages/senpi-task/src/dag/recovery.test.ts
@@ -236,6 +236,46 @@ describe("DAG crash recovery", () => {
     expect(events(store).some((event) => event.type === "dag.run.resumed")).toBe(true)
   })
 
+  test("R1: resume emits dag.run.resumed and reuses completed nodes while a reattached child is still running", async () => {
+    const projectDir = tempProject()
+    const store = createDagFileStore({ project_dir: projectDir })
+    const manager = new RecoveryTaskManager()
+    const observedEvents = deferred<void>()
+    const seenTypes = new Set<string>()
+    const observedStore = {
+      ...store,
+      appendEvent(event: DagRunEvent) {
+        store.appendEvent(event)
+        seenTypes.add(event.type)
+        if (seenTypes.has("dag.node.reused") && seenTypes.has("dag.run.resumed")) observedEvents.resolve()
+      },
+    }
+    const input = definition([node("running"), node("done"), node("next", ["done"])])
+    store.writeCheckpoint(runId, recoverableRecord(input, {
+      running: { state: "running", taskId: "task-running", attempt: 1 },
+      done: { state: "completed", taskId: "task-done", attempt: 1 },
+      next: { state: "pending" },
+    }, { previousLeaseHolderPid: 9001 }))
+    store.writeResult(runId, "done", "durable done output")
+    manager.add(taskRecord(owner("running"), "running", "task-running"))
+
+    const resume = createDagRecovery({
+      store: observedStore,
+      taskManager: manager,
+      hostPid: 101,
+      isProcessAlive: () => false,
+    }).resumePausedRuns(parentSessionId)
+    await observedEvents.promise
+
+    expect(seenTypes).toContain("dag.node.reused")
+    expect(seenTypes).toContain("dag.run.resumed")
+    expect(manager.startOwnedCalls).toContain("next")
+    expect(manager.startOwnedCalls).not.toContain("running")
+
+    manager.complete("task-running")
+    await resume
+  }, 10_000)
+
   test("#given no injected liveness probe #when a paused run's previous holder is this live process #then the default probe skips it as a live lease", async () => {
     // given - the default probe is the lifecycle port's signal-0 existence check, so THIS pid reads alive
     const projectDir = tempProject()

--- a/packages/senpi-task/src/dag/recovery.ts
+++ b/packages/senpi-task/src/dag/recovery.ts
@@ -149,7 +149,7 @@ async function resumeClaimedRun(context: RecoveryContext, claimed: RecoverableRe
   const journal = recoveryJournal(context, claimed, pendingErrors, pendingTerminalResults)
   const reusedOutputs = new Map<DagNodeId, string>()
   try {
-    await reconcileNodes(context, journal, reusedOutputs, pendingErrors, pendingTerminalResults)
+    const reattachedTasks = await reconcileNodes(context, journal, reusedOutputs, pendingErrors, pendingTerminalResults)
     const generation = journal.snapshot().generation + 1
     journal.append(dagRunResumedEvent({ generation }))
     const scheduler = createDagScheduler({
@@ -158,6 +158,7 @@ async function resumeClaimedRun(context: RecoveryContext, claimed: RecoverableRe
       initialRecord: journal.snapshot(),
       ...(context.subscriberRing === undefined ? {} : { subscriberRing: context.subscriberRing }),
       ...(context.nodeSpawnPolicy === undefined ? {} : { nodeSpawnPolicy: context.nodeSpawnPolicy }),
+      ...(reattachedTasks.length === 0 ? {} : { reattachedTasks }),
       now: context.now,
     })
     const record = await scheduler.run()
@@ -173,7 +174,8 @@ async function reconcileNodes(
   reusedOutputs: Map<DagNodeId, string>,
   pendingErrors: Map<DagNodeId, DagNodeError>,
   pendingTerminalResults: Map<DagNodeId, RecoveryPendingTerminalResult>,
-): Promise<void> {
+): Promise<readonly { readonly nodeId: DagNodeId; readonly taskId: string }[]> {
+  const reattachedTasks: { readonly nodeId: DagNodeId; readonly taskId: string }[] = []
   for (const observed of journal.snapshot().nodes) {
     if (observed.state === "completed") {
       const result = readDagNodeResult({ store: context.store, runId: journal.snapshot().runId, nodeId: observed.id })
@@ -238,10 +240,12 @@ async function reconcileNodes(
 
     if (task.status === "pending" || task.status === "running") {
       context.reattach?.(journal.snapshot().runId, task.task_id)
-      task = await context.taskManager.waitFor(task.task_id)
+      reattachedTasks.push({ nodeId: observed.id, taskId: task.task_id })
+      continue
     }
     foldTaskOutcome(context, journal, observed.id, task, pendingErrors, pendingTerminalResults)
   }
+  return reattachedTasks
 }
 
 function attachStartedOrFail(

--- a/packages/senpi-task/src/dag/scheduler.ts
+++ b/packages/senpi-task/src/dag/scheduler.ts
@@ -59,6 +59,8 @@ export type DagSchedulerOptions = {
   readonly ancestry?: { readonly depth: number }
   readonly subscriberRing?: number
   readonly nodeSpawnPolicy?: DagNodeSpawnPolicy
+  /** Tasks that survived a scheduler restart and remain owned by the task manager. */
+  readonly reattachedTasks?: readonly { readonly nodeId: DagNodeId; readonly taskId: string }[]
   // Skill materialization for a retry that carries a prompt override (it re-runs the amend path).
   readonly materializeSkills?: DagMaterializeSkills
   // Lease identity for the control verbs: a run leased by a DIFFERENT live process is not ours to
@@ -219,6 +221,12 @@ export function createDagScheduler(options: DagSchedulerOptions): DagScheduler {
         ? watchRevivedInScheduler(context, revivedNodeId, taskId)
         : undefined,
     ),
+  }
+  for (const reattached of options.reattachedTasks ?? []) {
+    const node = nodeById(journal.snapshot(), reattached.nodeId)
+    if (TERMINAL_NODE_STATES.has(node.state)) continue
+    context.attachedTaskIds.set(reattached.nodeId, reattached.taskId)
+    attachTaskSettlement(context, reattached.nodeId, reattached.taskId)
   }
   for (const observer of schedulerObservers.get(options.taskManager) ?? []) observer(scheduler)
   return scheduler
@@ -444,6 +452,11 @@ async function runWaves(context: SchedulerContext): Promise<DagRunRecordV1> {
       context.journal.append(dagWaveStartedEvent({ waveIndex: wave.index, nodeIds: runnable }))
       if (!await admitAndSettleWave(context, runnable)) return cancelledSnapshot(context)
       context.journal.append(dagWaveCompletedEvent({ waveIndex: wave.index, nodeIds: runnable }))
+      // Reattached tasks belong to the already-open wave. They are externally owned, but the
+      // strict barrier still waits for them before advancing to a later wave.
+      while (context.attachedTasks.size > 0) {
+        if (!await settleOne(context)) return cancelledSnapshot(context)
+      }
     }
 
     applyDependentSkipCascade(context)


### PR DESCRIPTION
## Defect

Restart recovery reconciled surviving pending/running DAG children by awaiting `TaskManager.waitFor()` inline. A single long-running child therefore kept the claimed run checkpoint paused, froze journal sequencing, delayed reuse events for later nodes, and left amend/retry controls unavailable.

Observed in the 2026-08-25 `dag_530ad299` incident and reproduced by the supplied R1 evidence fixture.

## Fix design

- Recovery now performs only non-blocking reconciliation before appending `dag.run.resumed`.
- Surviving child identities are passed into the newly-created scheduler as externally-owned reattachments.
- The new scheduler registers normal settlement watchers for those children and folds each terminal outcome through its existing pending-terminal-result/reducer path.
- Reattached children are never sent through `startOwned`, so they cannot be double-admitted.
- The previous scheduler instance is never resumed; cancellation/admission latches remain single-shot.
- Strict wave barriers are preserved: reattached children still settle before a later wave advances.

The secondary `dag-runtime.ts` snapshot seam was not changed. Store mutation listeners already re-emit recovery mutations, and a cheap isolated adapter test seam was not available in this focused fix.

## RED -> GREEN proof

RED on unchanged code after porting R1:

```text
Expected to contain: "dag.node.reused"
Received: []
(fail) DAG crash recovery > R1: resume emits dag.run.resumed and reuses completed nodes while a reattached child is still running
14 pass, 1 fail
```

GREEN after the fix:

```text
(pass) DAG crash recovery > R1: resume emits dag.run.resumed and reuses completed nodes while a reattached child is still running
```

The final regression subscribes to exact WAL appends instead of using a timing sleep. It also asserts a ready node is admitted and the surviving running node is not redispatched.

## Verification

- `bun test packages/senpi-task/src/dag` — **244 pass, 0 fail**
- `bun run --cwd packages/senpi-task typecheck` — pass
- `tsgo --noEmit -p packages/omo-senpi/tsconfig.json` — pass
- `node packages/omo-senpi/scripts/qa/drive.mjs --self-test` — pass
- Real isolated Senpi driver — **PASS**, `realSenpiUntouched: true`

Broader `bun run test:senpi` was attempted and reached an unrelated existing failure in `packages/omo-senpi/src/components/telemetry/product-identity.test.ts`: the fixture expected its temporary explicit agent directory but resolved `/Users/yeongyu/.omo/agent`. The touched DAG package suite and both scoped typechecks pass.

R2 from the evidence bundle was intentionally excluded because it conflicts with the pinned strict barrier test and is out of scope.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resumes DAG runs in `senpi-task` without blocking on surviving pending/running children. Previously recovery awaited `TaskManager.waitFor()` inline, pausing the run and freezing WAL sequencing; now recovery emits `dag.run.resumed` immediately and folds outcomes asynchronously so reuse and controls stay available.

- Perform non-blocking reconciliation before appending `dag.run.resumed`.
- Reattach surviving tasks to the new scheduler via `reattachedTasks` and register settlement watchers.
- Skip `startOwned` for reattached tasks to prevent double dispatch; do not revive the previous scheduler.
- Keep strict wave barriers; later waves still wait for reattached tasks to settle.
- Add a regression test that asserts reuse and resume while a reattached child continues running.

<sup>Written for commit b124f69c865052527d5f10eb020b5ddd58555b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

