### PR TITLE
fix(atlas): bound session lifecycle retention

### DIFF
--- a/.omo/evidence/20260825-atlas-memory-leak/verification.md
+++ b/.omo/evidence/20260825-atlas-memory-leak/verification.md
@@ -1,0 +1,25 @@
+# Atlas Memory Leak Verification
+
+## Failing-first proof
+
+`bun test packages/omo-opencode/src/hooks/atlas/index.test.ts --test-name-pattern "releases Atlas-owned state on disposal"`
+
+Before the implementation, this failed because `createAtlasHook()` did not expose `dispose`.
+
+## Passing checks
+
+`bun test packages/omo-opencode/src/hooks/atlas/index.test.ts packages/omo-opencode/src/hooks/atlas/atlas-lifecycle-store.test.ts packages/omo-opencode/src/plugin-dispose.test.ts`
+
+Observed: 79 passing tests and 130 assertions.
+
+`bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
+
+Observed: exit status 0.
+
+## Manual hook-surface QA
+
+`opencode serve --pure --port 47891` was launched with every XDG path under a `mktemp` sandbox. A Node `fetch` observed `200 {"healthy":true,"version":"1.18.22"}` from `/global/health`; the process was terminated and the sandbox removed. This proves isolated OpenCode server startup but does not prove an Atlas event because the pure server intentionally loaded no plugin.
+
+## Diagnostics
+
+The configured LSP daemon was unavailable at `/home/viprix/.omo/lsp-daemon/v0.1.0/daemon.sock`; package typechecking is the available static diagnostic result.

--- a/packages/omo-opencode/src/create-hooks.ts
+++ b/packages/omo-opencode/src/create-hooks.ts
@@ -19,6 +19,7 @@ export type DisposableCreatedHooks = {
   claudeCodeHooks?: DisposableHook
   commentChecker?: DisposableHook
   runtimeFallback?: DisposableHook
+  atlasHook?: DisposableHook
   todoContinuationEnforcer?: DisposableHook
   autoSlashCommand?: DisposableHook
   anthropicContextWindowLimitRecovery?: DisposableHook
@@ -28,6 +29,7 @@ export function disposeCreatedHooks(hooks: DisposableCreatedHooks): void {
   hooks.claudeCodeHooks?.dispose?.()
   hooks.commentChecker?.dispose?.()
   hooks.runtimeFallback?.dispose?.()
+  hooks.atlasHook?.dispose?.()
   hooks.todoContinuationEnforcer?.dispose?.()
   hooks.autoSlashCommand?.dispose?.()
   hooks.anthropicContextWindowLimitRecovery?.dispose?.()

--- a/packages/omo-opencode/src/hooks/atlas/atlas-hook.ts
+++ b/packages/omo-opencode/src/hooks/atlas/atlas-hook.ts
@@ -1,42 +1,39 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { createAtlasEventHandler } from "./event-handler"
+import { AtlasLifecycleStore } from "./atlas-lifecycle-store"
 import { createToolExecuteAfterHandler } from "./tool-execute-after"
 import { createToolExecuteBeforeHandler } from "./tool-execute-before"
-import type { AtlasHookOptions, PendingTaskRef, SessionState } from "./types"
+import type { AtlasHookOptions, SessionState } from "./types"
 
 export function createAtlasHook(ctx: PluginInput, options?: AtlasHookOptions) {
-  const sessions = new Map<string, SessionState>()
-  const pendingFilePaths = new Map<string, string>()
-  const pendingTaskRefs = new Map<string, PendingTaskRef>()
-  const pendingPlanSnapshots = new Map<string, string>()
+  const lifecycle = new AtlasLifecycleStore()
   const autoCommit = options?.autoCommit ?? true
 
   function getState(sessionID: string): SessionState {
-    let state = sessions.get(sessionID)
-    if (!state) {
-      state = { promptFailureCount: 0 }
-      sessions.set(sessionID, state)
-    }
-    return state
+    return lifecycle.getOrCreateState(sessionID)
   }
 
   return {
-    handler: createAtlasEventHandler({ ctx, options, sessions, getState }),
+    handler: createAtlasEventHandler({ ctx, options, sessions: lifecycle.sessions, getState, cleanupSession: (sessionID) => lifecycle.cleanupSession(sessionID) }),
     "tool.execute.before": createToolExecuteBeforeHandler({
       ctx,
-      pendingFilePaths,
-      pendingTaskRefs,
-      pendingPlanSnapshots,
+      pendingFilePaths: lifecycle.pendingFilePaths,
+      pendingTaskRefs: lifecycle.pendingTaskRefs,
+      pendingPlanSnapshots: lifecycle.pendingPlanSnapshots,
+      trackFileCall: (callID, sessionID, filePath) => lifecycle.trackFileCall(callID, sessionID, filePath),
+      trackTaskCall: (callID, sessionID, task) => lifecycle.trackTaskCall(callID, sessionID, task),
+      trackPlanSnapshot: (callID, snapshot) => lifecycle.trackPlanSnapshot(callID, snapshot),
       isCallerOrchestrator: options?.isCallerOrchestrator,
     }),
     "tool.execute.after": createToolExecuteAfterHandler({
       ctx,
-      pendingFilePaths,
-      pendingTaskRefs,
-      pendingPlanSnapshots,
+      pendingFilePaths: lifecycle.pendingFilePaths,
+      pendingTaskRefs: lifecycle.pendingTaskRefs,
+      pendingPlanSnapshots: lifecycle.pendingPlanSnapshots,
       autoCommit,
       getState,
       isCallerOrchestrator: options?.isCallerOrchestrator,
     }),
+    dispose: () => lifecycle.dispose(),
   }
 }

--- a/packages/omo-opencode/src/hooks/atlas/atlas-lifecycle-store.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/atlas-lifecycle-store.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test"
+import { AtlasLifecycleStore } from "./atlas-lifecycle-store"
+
+describe("AtlasLifecycleStore", () => {
+  test("keeps pending work until its matching after event or terminal session boundary", () => {
+    // given
+    const store = new AtlasLifecycleStore()
+    store.trackTaskCall("call-1", "session-1", { kind: "skip", reason: "explicit_resume" })
+
+    // when
+    store.cleanupSession("session-1")
+
+    // then
+    expect(store.sizes).toEqual({ sessions: 0, pendingCalls: 0, sessionIndexes: 0, hasPruneInterval: false })
+  })
+
+  test("does not allocate session state for pending calls", () => {
+    // given
+    const store = new AtlasLifecycleStore()
+
+    // when
+    store.trackFileCall("call-1", "session-1", "plan.md")
+
+    // then
+    expect(store.sizes.sessions).toBe(0)
+  })
+
+  test("cleans only the terminal session pending calls", () => {
+    // given
+    const store = new AtlasLifecycleStore()
+    store.trackFileCall("call-1", "session-1", "plan-a.md")
+    store.trackTaskCall("call-2", "session-2", { kind: "skip", reason: "explicit_resume" })
+
+    // when
+    store.cleanupSession("session-1")
+
+    // then
+    expect(store.pendingFilePaths.has("call-1")).toBeFalse()
+    expect(store.pendingTaskRefs.has("call-2")).toBeTrue()
+  })
+
+  test("disposal clears stores and makes a pending retry callback harmless", () => {
+    // given
+    const store = new AtlasLifecycleStore()
+    const state = store.getOrCreateState("session-1")
+    state.pendingRetryTimer = setTimeout(() => store.getOrCreateState("session-1"), 60_000)
+    store.trackFileCall("call-1", "session-1", "plan.md")
+
+    // when
+    store.dispose()
+
+    // then
+    store.getOrCreateState("session-1")
+    expect(store.sizes).toEqual({ sessions: 0, pendingCalls: 0, sessionIndexes: 0, hasPruneInterval: false })
+  })
+})

--- a/packages/omo-opencode/src/hooks/atlas/atlas-lifecycle-store.ts
+++ b/packages/omo-opencode/src/hooks/atlas/atlas-lifecycle-store.ts
@@ -1,0 +1,135 @@
+import type { PendingTaskRef, SessionState } from "./types"
+
+export const ATLAS_SESSION_STATE_TTL_MS = 10 * 60 * 1000
+export const ATLAS_SESSION_PRUNE_INTERVAL_MS = 2 * 60 * 1000
+
+type PendingAtlasCall =
+  | { readonly kind: "file"; readonly sessionID?: string; readonly filePath: string; readonly planSnapshot?: string }
+  | { readonly kind: "task"; readonly sessionID?: string; readonly task: PendingTaskRef }
+
+export class AtlasLifecycleStore {
+  readonly sessions = new Map<string, SessionState>()
+  readonly pendingFilePaths = new Map<string, string>()
+  readonly pendingTaskRefs = new Map<string, PendingTaskRef>()
+  readonly pendingPlanSnapshots = new Map<string, string>()
+  readonly pendingCalls = new Map<string, PendingAtlasCall>()
+  readonly sessionCallIDs = new Map<string, Set<string>>()
+  private readonly lastAccessedAt = new Map<string, number>()
+  private pruneInterval: ReturnType<typeof setInterval> | undefined
+  private disposed = false
+  private readonly disposedState: SessionState = { promptFailureCount: 0 }
+
+  getExistingState(sessionID: string): SessionState | undefined {
+    const tracked = this.sessions.get(sessionID)
+    if (!tracked) return undefined
+    this.lastAccessedAt.set(sessionID, Date.now())
+    return tracked
+  }
+
+  getOrCreateState(sessionID: string): SessionState {
+    if (this.disposed) return this.disposedState
+    const existing = this.getExistingState(sessionID)
+    if (existing) return existing
+    const state = { promptFailureCount: 0, lifecycleActive: true }
+    this.sessions.set(sessionID, state)
+    this.lastAccessedAt.set(sessionID, Date.now())
+    this.ensurePruneInterval()
+    return state
+  }
+
+  trackFileCall(callID: string, sessionID: string | undefined, filePath: string): void {
+    this.pendingFilePaths.set(callID, filePath)
+    this.replaceCall(callID, { kind: "file", sessionID, filePath })
+  }
+
+  trackTaskCall(callID: string, sessionID: string | undefined, task: PendingTaskRef): void {
+    this.pendingTaskRefs.set(callID, task)
+    this.replaceCall(callID, { kind: "task", sessionID, task })
+  }
+
+  trackPlanSnapshot(callID: string, snapshot: string): void {
+    this.pendingPlanSnapshots.set(callID, snapshot)
+  }
+
+  consumeFileCall(callID: string | undefined): Extract<PendingAtlasCall, { kind: "file" }> | undefined {
+    const pending = this.pendingCalls.get(callID ?? "")
+    if (!pending || pending.kind !== "file") return undefined
+    this.clearPendingCall(callID)
+    return pending
+  }
+
+  consumeTaskCall(callID: string | undefined): Extract<PendingAtlasCall, { kind: "task" }> | undefined {
+    const pending = this.pendingCalls.get(callID ?? "")
+    if (!pending || pending.kind !== "task") return undefined
+    this.clearPendingCall(callID)
+    return pending
+  }
+
+  clearPendingCall(callID: string | undefined): void {
+    if (!callID) return
+    const pending = this.pendingCalls.get(callID)
+    if (!pending) return
+    this.pendingCalls.delete(callID)
+    this.pendingFilePaths.delete(callID)
+    this.pendingTaskRefs.delete(callID)
+    this.pendingPlanSnapshots.delete(callID)
+    if (pending.sessionID) this.removeSessionCallID(pending.sessionID, callID)
+  }
+
+  cleanupSession(sessionID: string): void {
+    const state = this.sessions.get(sessionID)
+    if (state) state.lifecycleActive = false
+    if (state?.pendingRetryTimer) clearTimeout(state.pendingRetryTimer)
+    this.sessions.delete(sessionID)
+    this.lastAccessedAt.delete(sessionID)
+    for (const callID of this.sessionCallIDs.get(sessionID) ?? []) this.clearPendingCall(callID)
+    this.sessionCallIDs.delete(sessionID)
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    if (this.pruneInterval) clearInterval(this.pruneInterval)
+    this.pruneInterval = undefined
+    for (const sessionID of this.sessions.keys()) this.cleanupSession(sessionID)
+    this.pendingCalls.clear()
+    this.pendingFilePaths.clear()
+    this.pendingTaskRefs.clear()
+    this.pendingPlanSnapshots.clear()
+    this.sessionCallIDs.clear()
+  }
+
+  get sizes(): { readonly sessions: number; readonly pendingCalls: number; readonly sessionIndexes: number; readonly hasPruneInterval: boolean } {
+    return { sessions: this.sessions.size, pendingCalls: this.pendingCalls.size, sessionIndexes: this.sessionCallIDs.size, hasPruneInterval: this.pruneInterval !== undefined }
+  }
+
+  private replaceCall(callID: string, call: PendingAtlasCall): void {
+    this.clearPendingCall(callID)
+    this.pendingCalls.set(callID, call)
+    if (!call.sessionID) return
+    const callIDs = this.sessionCallIDs.get(call.sessionID) ?? new Set<string>()
+    callIDs.add(callID)
+    this.sessionCallIDs.set(call.sessionID, callIDs)
+  }
+
+  private removeSessionCallID(sessionID: string, callID: string): void {
+    const callIDs = this.sessionCallIDs.get(sessionID)
+    if (!callIDs) return
+    callIDs.delete(callID)
+    if (callIDs.size === 0) this.sessionCallIDs.delete(sessionID)
+  }
+
+  private ensurePruneInterval(): void {
+    if (this.pruneInterval || this.disposed) return
+    this.pruneInterval = setInterval(() => this.prune(), ATLAS_SESSION_PRUNE_INTERVAL_MS)
+    this.pruneInterval.unref()
+  }
+
+  private prune(): void {
+    const now = Date.now()
+    for (const sessionID of this.sessions.keys()) {
+      const lastAccessedAt = this.lastAccessedAt.get(sessionID)
+      if (lastAccessedAt !== undefined && now - lastAccessedAt > ATLAS_SESSION_STATE_TTL_MS) this.cleanupSession(sessionID)
+    }
+  }
+}

--- a/packages/omo-opencode/src/hooks/atlas/event-handler.ts
+++ b/packages/omo-opencode/src/hooks/atlas/event-handler.ts
@@ -4,6 +4,7 @@ import { resolveMessageEventSessionID, resolveSessionEventID } from "../../share
 import { HOOK_NAME } from "./hook-name"
 import { isAbortError } from "./is-abort-error"
 import { handleAtlasSessionIdle } from "./idle-event"
+import { resolveActiveBoulderSession } from "./resolve-active-boulder-session"
 import type { AtlasHookOptions, SessionState } from "./types"
 
 export function createAtlasEventHandler(input: {
@@ -11,8 +12,9 @@ export function createAtlasEventHandler(input: {
   options?: AtlasHookOptions
   sessions: Map<string, SessionState>
   getState: (sessionID: string) => SessionState
+  cleanupSession: (sessionID: string) => void
 }): (arg: { event: { type: string; properties?: unknown } }) => Promise<void> {
-  const { ctx, options, sessions, getState } = input
+  const { ctx, options, sessions, getState, cleanupSession } = input
 
   return async ({ event }): Promise<void> => {
     const props = event.properties as Record<string, unknown> | undefined
@@ -21,15 +23,23 @@ export function createAtlasEventHandler(input: {
       const sessionID = resolveSessionEventID(props)
       if (!sessionID) return
 
-      const state = getState(sessionID)
       const isAbort = isAbortError(props?.error)
-      state.lastEventWasAbortError = isAbort
 
       log(`[${HOOK_NAME}] session.error`, { sessionID, isAbort })
-      if (!isAbort) {
-        const previousInjectedAt = state.lastContinuationInjectedAt
+      if (isAbort) {
+        const activeBoulderSession = await resolveActiveBoulderSession({
+          client: ctx.client,
+          directory: ctx.directory,
+          sessionID,
+        })
+        if (activeBoulderSession) getState(sessionID).lastEventWasAbortError = true
+      } else {
+        const previousInjectedAt = sessions.get(sessionID)?.lastContinuationInjectedAt
         await handleAtlasSessionIdle({ ctx, options, getState, sessionID })
+        const state = sessions.get(sessionID)
         if (
+          state
+          &&
           state.lastContinuationInjectedAt !== undefined
           && state.lastContinuationInjectedAt !== previousInjectedAt
         ) {
@@ -93,12 +103,7 @@ export function createAtlasEventHandler(input: {
     if (event.type === "session.deleted") {
       const sessionID = resolveSessionEventID(props)
       if (sessionID) {
-        const deletedState = sessions.get(sessionID)
-        if (deletedState?.pendingRetryTimer) {
-          clearTimeout(deletedState.pendingRetryTimer)
-          deletedState.pendingRetryTimer = undefined
-        }
-        sessions.delete(sessionID)
+        cleanupSession(sessionID)
         log(`[${HOOK_NAME}] Session deleted: cleaned up`, { sessionID })
       }
       return
@@ -107,12 +112,7 @@ export function createAtlasEventHandler(input: {
     if (event.type === "session.compacted") {
       const sessionID = resolveSessionEventID(props)
       if (sessionID) {
-        const compactedState = sessions.get(sessionID)
-        if (compactedState?.pendingRetryTimer) {
-          clearTimeout(compactedState.pendingRetryTimer)
-          compactedState.pendingRetryTimer = undefined
-        }
-        sessions.delete(sessionID)
+        cleanupSession(sessionID)
         log(`[${HOOK_NAME}] Session compacted: cleaned up`, { sessionID })
       }
     }

--- a/packages/omo-opencode/src/hooks/atlas/idle-continuation.ts
+++ b/packages/omo-opencode/src/hooks/atlas/idle-continuation.ts
@@ -40,6 +40,7 @@ export async function injectContinuation(input: {
   worktreePath?: string
   idleSettleMs?: number
 }): Promise<void> {
+  if (input.sessionState.lifecycleActive === false) return
   const remaining = input.progress.total - input.progress.completed
   if (input.sessionState.isInjectingContinuation) {
     scheduleRetry({
@@ -161,6 +162,7 @@ export function scheduleRetry(input: {
   options?: AtlasHookOptions
 }): void {
   const { ctx, sessionID, sessionState, options } = input
+  if (sessionState.lifecycleActive === false) return
   if (sessionState.pendingRetryTimer) {
     return
   }
@@ -168,6 +170,8 @@ export function scheduleRetry(input: {
   sessionState.pendingRetryTimer = setTimeout(async () => {
     try {
       sessionState.pendingRetryTimer = undefined
+
+      if (sessionState.lifecycleActive === false) return
 
       if (sessionState.promptFailureCount >= MAX_CONSECUTIVE_PROMPT_FAILURES) return
       if (sessionState.stalledContinuationReason) return

--- a/packages/omo-opencode/src/hooks/atlas/idle-event.ts
+++ b/packages/omo-opencode/src/hooks/atlas/idle-event.ts
@@ -31,7 +31,6 @@ export async function handleAtlasSessionIdle(input: {
 }): Promise<void> {
   const { ctx, options, getState, sessionID } = input
   const normalizedSessionID = normalizeSessionId(sessionID)
-  const sessionState = getState(sessionID)
 
   log(`[${HOOK_NAME}] session.idle`, { sessionID })
 
@@ -44,6 +43,8 @@ export async function handleAtlasSessionIdle(input: {
     log(`[${HOOK_NAME}] Skipped: session not registered in active boulder`, { sessionID })
     return
   }
+
+  const sessionState = getState(sessionID)
 
   const { boulderState, progress, appendedSession } = activeBoulderSession
   if (sessionState.waitingForFinalWaveApproval) {

--- a/packages/omo-opencode/src/hooks/atlas/index.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/index.test.ts
@@ -2682,5 +2682,15 @@ session_id: ses_untrusted_999
         expect(mockInput._promptMock).toHaveBeenCalledTimes(1)
       })
     })
+
+    test("releases Atlas-owned state on disposal", () => {
+      // given - an Atlas hook instance owns session state and retry handles
+      const mockInput = createMockPluginInput()
+      const hook = createTestAtlasHook(mockInput)
+
+      // when - the plugin lifecycle disposes the hook
+      // then - Atlas exposes its lifecycle cleanup contract
+      expect(hook).toHaveProperty("dispose")
+    })
   })
 })

--- a/packages/omo-opencode/src/hooks/atlas/tool-execute-after.ts
+++ b/packages/omo-opencode/src/hooks/atlas/tool-execute-after.ts
@@ -24,8 +24,16 @@ export function createToolExecuteAfterHandler(input: {
   const collectGitDiffStatsImpl = input.collectGitDiffStats ?? collectGitDiffStats
   const formatFileChangesImpl = input.formatFileChanges ?? formatFileChanges
   return async (toolInput, toolOutput): Promise<void> => {
+    const clearPendingCall = (): void => {
+      if (!toolInput.callID) return
+      pendingFilePaths.delete(toolInput.callID)
+      pendingPlanSnapshots?.delete(toolInput.callID)
+      pendingTaskRefs.delete(toolInput.callID)
+    }
+
     // Guard against undefined output (e.g., from /review command - see issue #1035)
     if (!toolOutput) {
+      clearPendingCall()
       return
     }
 
@@ -34,6 +42,7 @@ export function createToolExecuteAfterHandler(input: {
     }
 
     if (!(await resolveIsCallerOrchestrator(toolInput.sessionID))) {
+      clearPendingCall()
       return
     }
 

--- a/packages/omo-opencode/src/hooks/atlas/tool-execute-before.ts
+++ b/packages/omo-opencode/src/hooks/atlas/tool-execute-before.ts
@@ -60,16 +60,21 @@ export function createToolExecuteBeforeHandler(input: {
   pendingFilePaths: Map<string, string>
   pendingTaskRefs: Map<string, PendingTaskRef>
   pendingPlanSnapshots?: Map<string, string>
+  trackFileCall?: (callID: string, sessionID: string | undefined, filePath: string) => void
+  trackTaskCall?: (callID: string, sessionID: string | undefined, task: PendingTaskRef) => void
+  trackPlanSnapshot?: (callID: string, snapshot: string) => void
   isCallerOrchestrator?: (sessionID: string | undefined) => Promise<boolean>
 }): (
   toolInput: { tool: string; sessionID?: string; callID?: string },
   toolOutput: { args: Record<string, unknown>; message?: string }
 ) => Promise<void> {
-  const { ctx, pendingFilePaths, pendingTaskRefs, pendingPlanSnapshots } = input
+  const { ctx, pendingFilePaths, pendingTaskRefs, pendingPlanSnapshots, trackFileCall, trackTaskCall, trackPlanSnapshot } = input
   const resolveIsCallerOrchestrator = input.isCallerOrchestrator ?? ((sessionID) => isCallerOrchestrator(sessionID, ctx.client))
 
-  function trackTask(callID: string, task: TrackedTopLevelTaskRef): void {
-    pendingTaskRefs.set(callID, { kind: "track", task })
+  function trackTask(callID: string, sessionID: string | undefined, task: TrackedTopLevelTaskRef): void {
+    const pending = { kind: "track", task } as const
+    pendingTaskRefs.set(callID, pending)
+    trackTaskCall?.(callID, sessionID, pending)
   }
 
   return async (toolInput, toolOutput): Promise<void> => {
@@ -87,6 +92,7 @@ export function createToolExecuteBeforeHandler(input: {
 
       // Store filePath for use in tool.execute.after
       pendingFilePaths.set(toolInput.callID, filePath)
+      trackFileCall?.(toolInput.callID, toolInput.sessionID, filePath)
 
       const sessionID = toolInput.sessionID
       const sessionWork = sessionID
@@ -103,6 +109,7 @@ export function createToolExecuteBeforeHandler(input: {
         try {
           if (existsSync(planPath)) {
             pendingPlanSnapshots.set(toolInput.callID, readFileSync(planPath, "utf-8"))
+            trackPlanSnapshot?.(toolInput.callID, readFileSync(planPath, "utf-8"))
           }
         } catch (error) {
           if (!(error instanceof Error)) {
@@ -129,10 +136,12 @@ export function createToolExecuteBeforeHandler(input: {
       if (toolInput.callID) {
         const requestedSessionId = toolOutput.args.session_id as string | undefined
         if (requestedSessionId) {
-          pendingTaskRefs.set(toolInput.callID, {
+          const pending = {
             kind: "skip",
             reason: "explicit_resume",
-          })
+          } as const
+          pendingTaskRefs.set(toolInput.callID, pending)
+          trackTaskCall?.(toolInput.callID, toolInput.sessionID, pending)
         } else {
           const prompt = typeof toolOutput.args.prompt === "string" ? toolOutput.args.prompt : ""
           const taskFromPrompt = parseTrackedTaskFromPrompt(prompt)
@@ -164,18 +173,20 @@ export function createToolExecuteBeforeHandler(input: {
             ))
 
             if (hasExistingClaim) {
-              pendingTaskRefs.set(toolInput.callID, {
+              const pending = {
                 kind: "skip",
                 reason: "ambiguous_task_key",
                 task: trackedTask,
-              })
+              } as const
+              pendingTaskRefs.set(toolInput.callID, pending)
+              trackTaskCall?.(toolInput.callID, toolInput.sessionID, pending)
               log(`[${HOOK_NAME}] Skipping task session persistence for ambiguous task key`, {
                 sessionID: toolInput.sessionID,
                 callID: toolInput.callID,
                 taskKey: trackedTask.key,
               })
             } else {
-              trackTask(toolInput.callID, trackedTask)
+              trackTask(toolInput.callID, toolInput.sessionID, trackedTask)
             }
           }
         }

--- a/packages/omo-opencode/src/hooks/atlas/types.ts
+++ b/packages/omo-opencode/src/hooks/atlas/types.ts
@@ -38,6 +38,7 @@ export type PendingTaskRef =
   | { kind: "skip"; reason: "ambiguous_task_key"; task: TrackedTopLevelTaskRef }
 
 export interface SessionState {
+  lifecycleActive?: boolean
   lastEventWasAbortError?: boolean
   skipNextIdleAfterRuntimeErrorRetry?: boolean
   lastContinuationInjectedAt?: number

--- a/packages/omo-opencode/src/plugin-dispose.test.ts
+++ b/packages/omo-opencode/src/plugin-dispose.test.ts
@@ -59,6 +59,9 @@ describe("createPluginDispose", () => {
     const runtimeFallback = {
       dispose: (): void => {},
     }
+    const atlasHook = {
+      dispose: (): void => {},
+    }
     const todoContinuationEnforcer = {
       dispose: (): void => {},
     }
@@ -68,6 +71,7 @@ describe("createPluginDispose", () => {
     const claudeCodeHooksDisposeSpy = spyOn(claudeCodeHooks, "dispose")
     const commentCheckerDisposeSpy = spyOn(commentChecker, "dispose")
     const runtimeFallbackDisposeSpy = spyOn(runtimeFallback, "dispose")
+    const atlasHookDisposeSpy = spyOn(atlasHook, "dispose")
     const todoContinuationEnforcerDisposeSpy = spyOn(todoContinuationEnforcer, "dispose")
     const autoSlashCommandDisposeSpy = spyOn(autoSlashCommand, "dispose")
     const dispose = createPluginDispose({
@@ -82,6 +86,7 @@ describe("createPluginDispose", () => {
           claudeCodeHooks,
           commentChecker,
           runtimeFallback,
+          atlasHook,
           todoContinuationEnforcer,
           autoSlashCommand,
         })
@@ -95,6 +100,7 @@ describe("createPluginDispose", () => {
     expect(claudeCodeHooksDisposeSpy).toHaveBeenCalledTimes(1)
     expect(commentCheckerDisposeSpy).toHaveBeenCalledTimes(1)
     expect(runtimeFallbackDisposeSpy).toHaveBeenCalledTimes(1)
+    expect(atlasHookDisposeSpy).toHaveBeenCalledTimes(1)
     expect(todoContinuationEnforcerDisposeSpy).toHaveBeenCalledTimes(1)
     expect(autoSlashCommandDisposeSpy).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## Summary
- add an Atlas-owned lifecycle store for session/timer disposal
- gate idle/error state creation on active Boulder relevance
- clear pending tool state on undefined output and eligibility early exits

## Verification
- `bun test packages/omo-opencode/src/hooks/atlas/atlas-lifecycle-store.test.ts packages/omo-opencode/src/hooks/atlas/index.test.ts packages/omo-opencode/src/plugin-dispose.test.ts` (80 pass)
- `bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json`
- isolated OpenCode server health smoke; plugin event-on-wire coverage remains constrained by harness dependency availability and is documented in evidence

Fixes #6319

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds Atlas session lifecycle to stop memory leaks and stray retries. Previously session and tool-call state could outlive their sessions; now Atlas owns its state, prunes it, and cleans up on session end.

- Creates an `AtlasLifecycleStore` that tracks pending calls, indexes them by session, prunes idle state on a TTL, and cleans up on `session.deleted`/`session.compacted`.
- Only creates idle/error state when a relevant active Boulder session exists, reducing spurious continuations.
- Clears pending tool state when output is undefined or the caller is not the orchestrator to avoid orphaned entries.
- Exposes `dispose` on the Atlas hook and wires it into plugin disposal to release timers and maps.

<sup>Written for commit 2debb1ae16e79540b066e157632d190dd74057e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

