### PR TITLE
chore(shared-skills): shallow-clone vendored upstream submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "packages/shared-skills/upstreams/open-design"]
 	path = packages/shared-skills/upstreams/open-design
 	url = https://github.com/nexu-io/open-design
+	shallow = true
 [submodule "packages/shared-skills/upstreams/taste-skill"]
 	path = packages/shared-skills/upstreams/taste-skill
 	url = https://github.com/Leonxlnx/taste-skill
+	shallow = true
 [submodule "packages/shared-skills/upstreams/ui-ux-pro-max"]
 	path = packages/shared-skills/upstreams/ui-ux-pro-max
 	url = https://github.com/nextlevelbuilder/ui-ux-pro-max-skill
+	shallow = true
 [submodule "packages/shared-skills/upstreams/designpowers"]
 	path = packages/shared-skills/upstreams/designpowers
 	url = https://github.com/Owl-Listener/designpowers
+	shallow = true

--- a/.omo/evidence/20260825-gitdir-worktree-module-bloat/REPORT.md
+++ b/.omo/evidence/20260825-gitdir-worktree-module-bloat/REPORT.md
@@ -1,0 +1,83 @@
+# .git 102GB autopsy and cleanup (mengmotaHost, 2026-08-25)
+
+## What was tested / measured
+
+Autopsy of the main checkout's `.git` (102GB reported vs 700MB src) on mengmotaHost
+(`/Volumes/mengmotaStorage/local-workspaces/omo`), followed by cleanup and verification.
+
+All numbers below were captured live with `du -sh`, `git count-objects -vH`,
+`git worktree list --porcelain`, and per-worktree `git status --porcelain` /
+`git rev-list --count HEAD --not --remotes=origin`.
+
+## Root cause
+
+The repository history is healthy. The bloat was worktree submodule duplication:
+
+| component | before | note |
+|---|---|---|
+| `.git/worktrees` | **100GB** | 85 linked worktrees x ~1.8GB admin dir each |
+| `.git/modules` | 1.7GB | single shared submodule store (expected) |
+| `.git/rr-cache` | 461MB | stale rerere entries |
+| `.git/objects` | 423MB | main history - healthy |
+
+Every linked worktree that ran `git submodule update --init` received its own FULL
+clone of the vendored upstreams under `.git/worktrees/<id>/modules/`, dominated by
+`open-design` (~1.7GB of objects per copy; upstream repo itself is ~1.8GB on GitHub).
+85 worktrees x 1.8GB = ~100GB. No history-embedded binaries, no loose-object explosion.
+
+## Actions
+
+1. Classified all 85 linked worktrees: dirty state, unpushed commits, locks.
+   - 55 removed via `git worktree remove --force`: all were fully pushed with a clean
+     tree, or dirty ONLY with regenerated build artifacts (codegraph `dist/*`,
+     `install-local.mjs` bundle drift, re-minified `plugin/extensions/*.js` - verified
+     by diff content: hash-header + symbol-rename only). Branches were NOT deleted.
+   - 30 kept: all locked worktrees (bip-*, parallelism-v3, perf/omo-launcher),
+     worktrees with real uncommitted source/test changes, worktrees with unpushed
+     commits, main checkout, and omo-thread-tools.
+   - 11MB of opengateway QA evidence in a removed worktree's `.local-ignore` was
+     salvaged to the sisyphuslabs evidence lane before removal.
+2. Deduplicated surviving worktree submodule stores: wrote
+   `objects/info/alternates` -> main `.git/modules/.../<name>/objects`, then
+   `git repack -a -d -l` + `prune-packed` (84 module dirs, 0 failures). Fetched
+   upstream into the main open-design module first so newer commits held only by
+   recent worktrees also deduplicated (99MB -> 4MB residue per worktree).
+3. `git rerere gc` with 7-day windows: 461MB -> 86MB.
+4. `git gc` on the main repo: objects now a single healthy 206MB pack.
+5. Prevention: `.gitmodules` marks all four vendored upstream submodules
+   `shallow = true`, so future worktree/CI submodule clones fetch depth-1 instead of
+   full history (open-design full history alone is ~1.7GB per clone).
+
+## Observed result
+
+- `.git`: **102GB -> 2.3GB** (modules 1.8GB shared store + objects 221MB +
+  worktrees 139MB + rr-cache 86MB).
+- Volume usage dropped ~200GB total including the removed checkouts' node_modules
+  and submodule working copies.
+- `git fsck --no-dangling`: clean.
+- Survivor worktrees verified working: `git submodule status` healthy and submodule
+  `git log` resolves through alternates (checked bip-7023, omo-thread-tools).
+- Spot-checked removed worktrees' branches still present in the main repo
+  (`fix/ci-real-sharding`, `feat/telemetry-surface-attribution`, `release/20260824-beta18`).
+
+## Why this is enough
+
+The change in this PR is metadata-only (`.gitmodules` clone-depth hint). It alters no
+code reaching OpenCode/Codex/Senpi runtime; existing initialized submodules are
+unaffected (shallow applies to fresh clones only), and `git submodule update` falls
+back to fetching the exact pinned SHA when the shallow tip does not contain it
+(GitHub serves reachable-SHA fetches).
+
+## What was omitted
+
+Raw command transcripts (they contain only sizes/paths already summarized above).
+No secrets were involved.
+
+## Residual risk / follow-up
+
+- Worktree admin dirs still grow ~4MB per worktree for submodule residue; acceptable.
+- If a surviving worktree later force-gc's the main open-design module store,
+  alternates-borrowed objects could dangle; the store is a full upstream clone and is
+  not routinely gc'd, and `repack -l` kept every locally-unique object.
+- The stale-worktree accumulation itself (55 dead worktrees) suggests the worktree
+  sweeper is not being run after PR merges; worth wiring into the release/merge flow.


### PR DESCRIPTION
## What changed

`.gitmodules` marks the four vendored upstream skill submodules (`open-design`, `taste-skill`, `ui-ux-pro-max`, `designpowers`) as `shallow = true`, plus an evidence report of the `.git` bloat autopsy that motivated it.

## Why

The mengmotaHost main checkout's `.git` had grown to **102GB** with only ~700MB of src. Autopsy showed the history is healthy (206MB pack after gc); the bloat was `.git/worktrees` = **100GB**: each of 85 linked worktrees that ran `git submodule update --init` got its own FULL clone of the vendored upstreams under its admin dir, dominated by `open-design` (~1.7GB objects per copy - the upstream repo itself is that big).

With `shallow = true`, fresh submodule clones (new worktrees, CI recursive clones) fetch depth-1 instead of full history. Existing initialized modules are unaffected. When the pinned SHA is not the shallow tip, `git submodule update` falls back to fetching the exact SHA, which GitHub serves.

## Observed behavior / QA evidence

Metadata-only change; no OpenCode/Codex/Senpi runtime surface is touched. The accompanying evidence file `.omo/evidence/20260825-gitdir-worktree-module-bloat/REPORT.md` records the live cleanup performed alongside this change:

- 55 stale worktrees removed (all fully pushed and clean, or dirty only with regenerated build artifacts verified by diff content); branches preserved.
- 30 surviving worktrees deduplicated via `objects/info/alternates` -> shared `.git/modules` store + `repack -a -d -l` (84 module dirs, 0 failures), verified with `git submodule status` and submodule `git log` through alternates.
- `rerere gc` (461MB -> 86MB), main `git gc`, `git fsck --no-dangling` clean.
- Net: `.git` **102GB -> 2.3GB**; ~200GB freed on the volume.

## Residual risk

- Shallow submodule clones occasionally need the exact-SHA fallback fetch (extra round trip, still served by GitHub).
- Stale-worktree accumulation itself (55 dead worktrees) suggests the worktree sweeper is not running after merges; follow-up candidate, noted in the evidence report.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shallow-clones the four vendored upstream skill submodules to cut per-worktree disk usage and speed up CI. Previously each worktree downloaded full submodule history; now new inits fetch depth-1, and Git auto-fetches the pinned commit if it isn’t on the shallow tip; no runtime or build behavior changes.

• Migration
- CI and new worktrees clone these submodules shallow by default.
- To get full history in a submodule, run `git -C <submodule-path> fetch --unshallow` or remove and re-init the submodule.
- If using offline mirrors, ensure pinned SHAs are available or allow network fetch during `git submodule update`.

<sup>Written for commit c6751d269126db663ae87f87199b2e5ca8c16093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

