### PR TITLE
fix(omo-senpi): warm the task chunk's pi-tui runtime

### DIFF
--- a/packages/omo-senpi/plugin/scripts/build-extension.test.mjs
+++ b/packages/omo-senpi/plugin/scripts/build-extension.test.mjs
@@ -222,6 +222,7 @@ describe("checkExtensionCurrent", () => {
     const manifest = JSON.parse(await readFile(join(pluginRoot, "package.json"), "utf8"))
 
     expect(main).toContain('import("#omo-task-runtime")')
+    expect(task).toContain('import("@earendil-works/pi-tui")')
     expect(task).toMatch(/^\/\/ omo:[A-Za-z0-9_-]{43}:[A-Za-z0-9_-]{43}/)
     expect(manifest.imports).toEqual({ "#omo-task-runtime": "./extensions/omo-task.js" })
   })

--- a/packages/omo-senpi/src/components/task/index.ts
+++ b/packages/omo-senpi/src/components/task/index.ts
@@ -1,5 +1,6 @@
 import { loadSenpiOmoConfig } from "../config-resolution"
 import {
+  loadPiTui,
   TEAM_LEAD_SENTINEL,
   buildLeadTeamTools,
   createLeadDeliveryJournal,
@@ -63,6 +64,9 @@ export function createTaskComponent(options: TaskComponentOptions = {}): OmoSenp
       // Unconditional omo process hygiene (T16): fires on session_start before any
       // flag/capability gate can skip the rest of the component.
       wireSessionStartProcessSweep(pi, ctx)
+      // The task runtime is built into its own chunk, so compose's main-bundle warm-up does not
+      // initialize this chunk's private lazy pi-tui namespace.
+      await loadPiTui()
 
       registerTaskFlags(pi)
       if (pi.getFlag(TASK_ENABLED_FLAG) === false) {


### PR DESCRIPTION
## Summary
- await `loadPiTui()` from the independently bundled task runtime before task renderers are registered
- preserve the existing main-bundle warm-up while fixing the task chunk's distinct module instance
- assert that generated `omo-task.js` retains its pi-tui dynamic import

## Root cause
`omo.js` and `omo-task.js` are separate bundles. The compose-level warm-up initializes only `omo.js`'s private lazy-module state, leaving the sidecar accessor permanently cold.

## Verification
- `bun test packages/omo-senpi/plugin/scripts/build-extension.test.mjs`
  - 12 passed, 0 failed

Fixes #7340