### PR TITLE
fix(devcontainer): pin Bun to 1.4.0 to match CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Dev container image for oh-my-openagent.
 # Node 24 (npm builds the vendored lsp-tools-mcp / lsp-daemon / git-bash-mcp +
-# codex plugin) + Bun 1.3.12 (the workspace runtime, pinned to CI) + tmux
+# codex plugin) + Bun 1.4.0 (the workspace runtime, pinned to CI) + tmux
 # (interactive_bash + team-mode). git ships with the base image.
 FROM mcr.microsoft.com/devcontainers/javascript-node:24-bookworm
 
@@ -8,9 +8,9 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends tmux \
  && rm -rf /var/lib/apt/lists/*
 
-# Pin Bun to match CI (oven-sh/setup-bun bun-version: 1.3.12).
+# Pin Bun to match CI (oven-sh/setup-bun bun-version: 1.4.0).
 ENV BUN_INSTALL=/usr/local
-RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.12" \
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.4.0" \
  && bun --version
 
 USER node

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,7 +2,7 @@
 
 This dev container backs GitHub Codespaces, VS Code Dev Containers, and plain
 Docker (via [`script/agent/docker-dev.sh`](../script/agent/docker-dev.sh)). It
-builds [`Dockerfile`](./Dockerfile) (Node 24 + Bun 1.3.12 + tmux) and runs
+builds [`Dockerfile`](./Dockerfile) (Node 24 + Bun 1.4.0 + tmux) and runs
 [`script/agent/setup.sh`](../script/agent/setup.sh) on create. This guide covers
 getting your credentials and per-harness config INTO the container so OpenCode,
 Codex, and Claude Code all work inside it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,7 +313,7 @@ Digest-verified centrality (refs unmeasured unless noted):
 
 ## CONVENTIONS
 
-- **Runtime:** Bun only (1.4.0 in CI; `.devcontainer/Dockerfile` still pins 1.3.12 — that pin is drift, CI is authoritative). Never npm/yarn/pnpm. (Exceptions: `packages/lsp-tools-mcp` + `packages/lsp-daemon` are Node-targeted, vendored, and built with `npm` + vitest/biome.)
+- **Runtime:** Bun only (1.4.0, pinned identically in CI and `.devcontainer/Dockerfile`). Never npm/yarn/pnpm. (Exceptions: `packages/lsp-tools-mcp` + `packages/lsp-daemon` are Node-targeted, vendored, and built with `npm` + vitest/biome.)
 - **TypeScript:** strict mode, ESNext, bundler moduleResolution, `bun-types` (never `@types/node`).
 - **Tests:** Bun test (`bun:test`), co-located `*.test.ts`, given/when/then style — nested `describe` with `#given`/`#when`/`#then` prefixes, or inline `// given` / `// when` / `// then` comments. Never Arrange-Act-Assert comments.
 - **CI tests:** `bun test` runs the root Bun suite in one process; `script/ci-fast-path.mjs` (`classifyCiMode`) runs the full OS matrix only when platform-sensitive paths change or the `ci:full-matrix` label is set. No split isolation runner. `bun run test:fast` partitions locally (opencode-memory → senpi → root-rest via `bunfig.win2.toml`).
@@ -384,7 +384,7 @@ Cross-harness, one-command dev setup. The **single source of truth** is [`script
 
 | Harness | Committed wiring | Runs |
 |---------|------------------|------|
-| GitHub Codespaces / VS Code Dev Containers | [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) + [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile) (Node 24 + Bun 1.3.12 + tmux; CI pins 1.4.0, so this image lags) | `postCreateCommand` runs `setup.sh` on container create |
+| GitHub Codespaces / VS Code Dev Containers | [`.devcontainer/devcontainer.json`](.devcontainer/devcontainer.json) + [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile) (Node 24 + Bun 1.4.0 + tmux, matching CI) | `postCreateCommand` runs `setup.sh` on container create |
 | Plain Docker | [`script/agent/docker-dev.sh`](script/agent/docker-dev.sh) | builds the same Dockerfile, opens a shell |
 | Cursor cloud agents | [`.cursor/environment.json`](.cursor/environment.json) | `install` runs `setup.sh` on environment creation |
 | Claude Code | [`.claude/settings.json`](.claude/settings.json) | `SessionStart` runs `setup.sh`, `SessionEnd` launches `cleanup-hook.sh` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ If English isn't your first language, don't worry! We value your contributions r
 
 ### Prerequisites
 
-- **Bun** 1.3.12 (CI-pinned) - The only package manager for the workspace itself
+- **Bun** 1.4.0 (CI-pinned) - The only package manager for the workspace itself
 - **Node** 24 - Required for vendored packages (lsp-tools-mcp, lsp-daemon, git-bash-mcp) and the Codex plugin build via npm
 - **git** - Version control
 - **tmux** (optional) - Enables the `interactive_bash` tool and Team Mode visualization
@@ -132,7 +132,7 @@ All harnesses delegate to these scripts:
 
 | Harness | Wiring |
 | ------- | ------ |
-| GitHub Codespaces / VS Code Dev Containers | `.devcontainer/devcontainer.json` runs `postCreateCommand: script/agent/setup.sh` on `.devcontainer/Dockerfile` (Node 24 + Bun 1.3.12 + tmux) |
+| GitHub Codespaces / VS Code Dev Containers | `.devcontainer/devcontainer.json` runs `postCreateCommand: script/agent/setup.sh` on `.devcontainer/Dockerfile` (Node 24 + Bun 1.4.0 + tmux) |
 | Plain Docker | `script/agent/docker-dev.sh` builds the Dockerfile and opens a shell |
 | Cursor cloud agents | `.cursor/environment.json` `install` runs setup on environment creation |
 | Claude Code | `.claude/settings.json` `SessionStart` hook runs setup; `SessionEnd` hook launches cleanup |

--- a/script/agent-env.test.ts
+++ b/script/agent-env.test.ts
@@ -30,9 +30,32 @@ describe("agent dev-environment scripts", () => {
       expect(body).toContain("OMO_AGENT_FORCE_BUILD") // idempotent skip-build guard
       expect(body).toContain(".env") // credential sourcing
       expect(body).toContain("--ignore-scripts")
-      expect(body).toContain("1.3.12")
+      expect(body).toMatch(/expected_bun="\d+\.\d+\.\d+"/) // drift warning is version-pinned
       expect(body).toContain("submodule update --init") // provenance submodules
       expect(body).toContain("materialize-frontend-refs") // frontend ref materialize
+    })
+
+    test("#given the CI-pinned Bun version #when setup.sh, the devcontainer image, and CI are compared #then all three pin the same version", () => {
+      // given
+      const setupPin = readFileSync(setup, "utf8").match(/expected_bun="([^"]+)"/)?.[1]
+      const dockerfilePin = readFileSync(join(REPO_ROOT, ".devcontainer", "Dockerfile"), "utf8").match(
+        /bash -s "bun-v([^"]+)"/,
+      )?.[1]
+      const ciPins = [
+        ...readFileSync(join(REPO_ROOT, ".github", "workflows", "ci.yml"), "utf8").matchAll(
+          /bun-version:\s*"([^"]+)"/g,
+        ),
+      ].map((match) => match[1])
+
+      // then
+      expect(setupPin, "setup.sh must declare expected_bun").toBeDefined()
+      expect(dockerfilePin, ".devcontainer/Dockerfile must pin an explicit bun-v<version>").toBeDefined()
+      expect(ciPins.length, "ci.yml must pin bun-version").toBeGreaterThan(0)
+      // The devcontainer image and the setup.sh drift warning must both track CI.
+      for (const ciPin of new Set(ciPins)) {
+        expect(ciPin, "every ci.yml bun-version must match the devcontainer pin").toBe(dockerfilePin as string)
+      }
+      expect(setupPin).toBe(dockerfilePin as string)
     })
   })
 

--- a/script/agent/setup.sh
+++ b/script/agent/setup.sh
@@ -45,7 +45,7 @@ fi
 log "bun $(bun --version) / node $(node --version) / $(git --version)"
 
 # Warn (do not fail) when the local toolchain drifts from the CI-pinned versions.
-expected_bun="1.3.12"
+expected_bun="1.4.0"
 expected_node_major="24"
 bun_version="$(bun --version 2>/dev/null || echo unknown)"
 node_major="$(node --version 2>/dev/null | sed -E 's/^v?([0-9]+).*/\1/')"


### PR DESCRIPTION
## Summary

The devcontainer image installed **Bun 1.3.12** while every CI workflow pins **1.4.0**, so anyone using Codespaces, VS Code Dev Containers, or `script/agent/docker-dev.sh` was building and testing on a different runtime than CI. The Dockerfile comment even claimed the image was "pinned to CI", which had silently stopped being true. `AGENTS.md` already tracked this as known drift ("that pin is drift, CI is authoritative").

This pins the image to 1.4.0, fixes the `setup.sh` drift warning that fired falsely on every container create, and replaces the test that hardcoded `"1.3.12"` — that assertion was locking the stale pin in place rather than catching drift.

## Changes

- **Devcontainer image** (`.devcontainer/Dockerfile`) — installs `bun-v1.4.0`; both comments now name the version CI actually pins.
- **Bootstrap warning** (`script/agent/setup.sh`) — `expected_bun` is `1.4.0`. Previously a correct 1.4.0 container was told it "differs from CI-pinned 1.3.12" on every create.
- **Drift guard** (`script/agent-env.test.ts`) — the old `expect(body).toContain("1.3.12")` is replaced by a check that `setup.sh`, the Dockerfile, and all `ci.yml` `bun-version` entries resolve to one version. A future CI bump that misses the image now fails the suite instead of going unnoticed.
- **Docs** (`AGENTS.md`, `CONTRIBUTING.md`, `.devcontainer/README.md`) — drop the obsolete drift note and list 1.4.0. `AGENTS.md` requires these to be updated alongside the Dockerfile and setup.sh.

No runtime/product source is touched.

## QA & Evidence

- **What was tested:** the Dockerfile's exact install line executed in a clean `debian:bookworm-slim` container, before and after.
  **Observed result:** before → `installed bun --version = 1.3.12`; after → `installed bun --version = 1.4.0`.
  **Artifact:** `RED-container-bun-version.txt`, `GREEN-container-bun-version.txt`
  **Why sufficient:** proves the real install behavior changed, not just the file text.

- **What was tested:** full `docker build -f .devcontainer/Dockerfile`, then running the built image.
  **Observed result:** build succeeded; the image's own `bun --version` layer printed `1.4.0`; runtime check reported `bun: 1.4.0`, `node: v24.19.0`, `tmux 3.3a`, `bun` at `/usr/local/bin/bun`.
  **Artifact:** `GREEN-image-build.txt`, `GREEN-image-runtime.txt`
  **Why sufficient:** exercises the actual surface a Codespaces user receives, including that Node/tmux are unaffected.

- **What was tested:** the `setup.sh` drift warning, evaluated inside the built 1.4.0 image.
  **Observed result:** with the old constant → `[setup] WARN: Bun 1.4.0 differs from CI-pinned 1.3.12`; with the new constant → no warning.
  **Artifact:** `GREEN-drift-warning-behavior.txt`
  **Why sufficient:** direct before/after on the user-visible symptom.

- **What was tested:** falsifiability of the new guard — Dockerfile temporarily reverted to `bun-v1.3.12`.
  **Observed result:** the new test failed (`Expected: "1.3.12" / Received: "1.4.0"`); passes once restored.
  **Artifact:** `RED-guard-test.txt`, `RED-new-guard-falsifiable.txt`
  **Why sufficient:** proves the guard can actually fail, so it will catch a reintroduced pin.

- **What was tested:** `bun test` on all four affected suites, plus `bun run typecheck`.
  **Observed result:** 23 pass / 0 fail; typecheck exit 0. Re-ran green after rebasing onto latest `dev`.
  **Artifact:** `GREEN-targeted-tests.txt`, `GREEN-typecheck.txt`, `GREEN-post-rebase.txt`

## Risks & Residuals

- **Runtime behavior change:** none — no product source is modified; CI already ran 1.4.0, so this makes local containers match what CI has been validating all along.
- **Full-suite failures:** a local `bun test` run showed 16573 pass / 21 fail, all in `dist`/bundle/installer suites. Pre-existing and environmental: the worktree was installed with `--ignore-scripts`, so `dist/index.js` was never built. Verified by stashing these changes and reproducing the same failures on the pristine tree. Unrelated to this diff; CI builds `dist` normally.
- **Stale `1.3.12` strings elsewhere:** remaining hits are historical QA evidence under `.omo/evidence/`, archived plans, `bun-types` in vendored `package-lock.json` files, and a `ci.yml` comment explaining *why* 1.3.12 was abandoned. Intentionally left as historical record.