### PR TITLE
fix(omo-native): diagnose partially reified engine installs at launch

### DIFF
--- a/packages/omo-native/bin/lib/package-paths.js
+++ b/packages/omo-native/bin/lib/package-paths.js
@@ -31,17 +31,34 @@ export function updateTarget(root = packageRoot, platform = process.platform) {
   return { manager: "npm", command: "npm i -g omo-ai@beta" }
 }
 
-export function resolveSenpi() {
+export function resolveSenpi(options = {}) {
+  const {
+    resolveIndex = () => fileURLToPath(import.meta.resolve("@code-yeongyu/senpi")),
+    platform = process.platform,
+  } = options
   let indexPath
   try {
-    indexPath = fileURLToPath(import.meta.resolve("@code-yeongyu/senpi"))
+    indexPath = resolveIndex()
   } catch (error) {
     throw new Error(`could not resolve @code-yeongyu/senpi; reinstall with: ${updateTarget().command} (${error.message})`)
   }
 
-  const cliPath = join(dirname(indexPath), "cli.js")
+  const distDir = dirname(indexPath)
+  const cliPath = join(distDir, "cli.js")
   if (!existsSync(cliPath)) {
     throw new Error(`senpi CLI is missing at ${cliPath}; reinstall with: ${updateTarget().command}`)
+  }
+  // The engine imports this module on every boot, and it is the file interrupted upgrades lose in
+  // the wild (npm reify dies on a Windows-locked native module and leaves a partial tree), so
+  // checking it here turns the engine's raw ERR_MODULE_NOT_FOUND stack into one actionable line.
+  const brandPath = join(distDir, "core", "brand.js")
+  if (!existsSync(brandPath)) {
+    const windowsHint = platform === "win32"
+      ? " (close every running omo/senpi process first: Windows locks loaded native modules, so npm fails with EBUSY mid-upgrade and leaves exactly this partial state)"
+      : ""
+    throw new Error(
+      `senpi engine files are incomplete: ${brandPath} is missing, which usually means an interrupted or failed omo-ai upgrade; reinstall with: ${updateTarget().command}${windowsHint}`,
+    )
   }
   return { cliPath, packageRoot: dirname(dirname(indexPath)) }
 }

--- a/packages/omo-native/test/bun-bin-shim.test.ts
+++ b/packages/omo-native/test/bun-bin-shim.test.ts
@@ -170,6 +170,8 @@ import { writeFileSync } from "node:fs"
 writeFileSync(process.env.CAPTURE_FILE, JSON.stringify({ argv: process.argv.slice(2), env: process.env, versions: process.versions }))
 process.exit(Number(process.env.FAKE_EXIT ?? 0))
 `)
+  mkdirSync(join(senpiRoot, "dist", "core"), { recursive: true })
+  writeFileSync(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
   // A stand-in bun that proves it ran; the real bun end to end is QA's job against the real install.
   const markerFile = join(root, "fake-bun.marker")
   const bunBinary = join(bunInstall, "bin", "bun")

--- a/packages/omo-native/test/doctor.test.ts
+++ b/packages/omo-native/test/doctor.test.ts
@@ -42,6 +42,7 @@ function createFixture(): Fixture {
   }))
   writeFile(join(senpiRoot, "dist", "index.js"), "export const fixture = true\n")
   writeFile(join(senpiRoot, "dist", "cli.js"), "process.exit(0)\n")
+  writeFile(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
   for (const [, artifact] of artifacts) writeFile(join(packageRoot, artifact))
   const agentDir = join(root, "agent")
   mkdirSync(agentDir, { recursive: true })

--- a/packages/omo-native/test/engine-integrity.test.ts
+++ b/packages/omo-native/test/engine-integrity.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+import { resolveSenpi, updateTarget } from "../bin/lib/package-paths.js"
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function writeFile(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+}
+
+type EngineFixtureOptions = {
+  cli?: boolean
+  brandModule?: boolean
+}
+
+/**
+ * A minimal on-disk engine install shaped like the published package: the resolver hands the
+ * launcher `dist/index.js`, and the launcher derives every sibling it preflights from there. The
+ * corrupted variants mirror real partially-reified npm trees seen in the wild, where an interrupted
+ * upgrade keeps some dist files and loses others.
+ */
+function createEngineFixture(options: EngineFixtureOptions = {}): { indexPath: string; senpiRoot: string } {
+  const root = mkdtempSync(join(tmpdir(), "omo-engine-integrity-"))
+  roots.push(root)
+  const senpiRoot = join(root, "node_modules", "@code-yeongyu", "senpi")
+  writeFile(join(senpiRoot, "package.json"), JSON.stringify({ name: "@code-yeongyu/senpi", version: "2026.8.25" }))
+  const indexPath = join(senpiRoot, "dist", "index.js")
+  writeFile(indexPath, "export {}\n")
+  if (options.cli !== false) writeFile(join(senpiRoot, "dist", "cli.js"), "export {}\n")
+  if (options.brandModule !== false) writeFile(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
+  return { indexPath, senpiRoot }
+}
+
+function resolveError(fixtureIndexPath: string, platform: string): Error {
+  try {
+    resolveSenpi({ resolveIndex: () => fixtureIndexPath, platform })
+  } catch (error) {
+    return error as Error
+  }
+  throw new Error("expected resolveSenpi to refuse the fixture install")
+}
+
+const REINSTALL_COMMAND = updateTarget().command
+
+describe("engine install integrity", () => {
+  describe("#given a partially reified install missing the brand contract module", () => {
+    describe("#when the launcher resolves the engine", () => {
+      test("#then it refuses with the missing path, the partial-install diagnosis, and the reinstall command", () => {
+        const { indexPath, senpiRoot } = createEngineFixture({ brandModule: false })
+
+        const error = resolveError(indexPath, "darwin")
+
+        expect(error.message).toContain(join(senpiRoot, "dist", "core", "brand.js"))
+        expect(error.message).toContain("incomplete")
+        expect(error.message).toContain("interrupted")
+        expect(error.message).toContain(`reinstall with: ${REINSTALL_COMMAND}`)
+      })
+
+      test("#then win32 adds the locked-native-module hint", () => {
+        const { indexPath } = createEngineFixture({ brandModule: false })
+
+        const error = resolveError(indexPath, "win32")
+
+        expect(error.message).toContain("EBUSY")
+        expect(error.message).toContain("locks loaded native modules")
+      })
+
+      test("#then posix keeps the message free of the windows hint", () => {
+        const { indexPath } = createEngineFixture({ brandModule: false })
+
+        const error = resolveError(indexPath, "linux")
+
+        expect(error.message).not.toContain("EBUSY")
+      })
+    })
+  })
+
+  describe("#given an intact engine install", () => {
+    describe("#when the launcher resolves the engine", () => {
+      test("#then it hands back the cli path and package root unchanged", () => {
+        const { indexPath, senpiRoot } = createEngineFixture()
+
+        const resolved = resolveSenpi({ resolveIndex: () => indexPath, platform: "win32" })
+
+        expect(resolved).toEqual({
+          cliPath: join(senpiRoot, "dist", "cli.js"),
+          packageRoot: senpiRoot,
+        })
+      })
+    })
+  })
+
+  describe("#given an install missing the engine CLI entirely", () => {
+    describe("#when the launcher resolves the engine", () => {
+      test("#then the established missing-CLI message is preserved", () => {
+        const { indexPath, senpiRoot } = createEngineFixture({ cli: false })
+
+        const error = resolveError(indexPath, "darwin")
+
+        expect(error.message).toBe(
+          `senpi CLI is missing at ${join(senpiRoot, "dist", "cli.js")}; reinstall with: ${REINSTALL_COMMAND}`,
+        )
+      })
+    })
+  })
+})

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -90,6 +90,7 @@ if (process.env.FAKE_STDOUT) console.log(process.env.FAKE_STDOUT)
 if (process.env.FAKE_SIGNAL) process.kill(process.pid, process.env.FAKE_SIGNAL)
 process.exit(Number(process.env.FAKE_EXIT ?? 0))
 `)
+  writeFile(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
 
   let shimPath: string | undefined
   if (options.shim !== false) {

--- a/packages/omo-native/test/setup-detect-cache.test.ts
+++ b/packages/omo-native/test/setup-detect-cache.test.ts
@@ -63,6 +63,7 @@ import { writeFileSync } from "node:fs"
 writeFileSync(process.env.CAPTURE_FILE, "spawned")
 process.exit(0)
 `)
+  write(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
   for (const artifact of [
     "plugin/package.json", "plugin/extensions/omo.js", "plugin/runtime/lsp-daemon/dist/cli.js",
     "plugin/runtime/agent-toolkit/cli.js",

--- a/packages/omo-native/test/setup-detect.test.ts
+++ b/packages/omo-native/test/setup-detect.test.ts
@@ -136,6 +136,7 @@ function createLauncherFixture(fixture: Fixture): string {
   }))
   write(join(senpiRoot, "dist", "index.js"), "export const fixture = true\n")
   write(join(senpiRoot, "dist", "cli.js"), "process.exit(0)\n")
+  write(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
   for (const artifact of [
     "plugin/package.json", "plugin/extensions/omo.js", "plugin/runtime/lsp-daemon/dist/cli.js",
     "plugin/runtime/agent-toolkit/cli.js",


### PR DESCRIPTION
## What

`resolveSenpi()` in the omo-ai launcher now preflights the engine's brand-contract module (`dist/core/brand.js`) next to the existing `dist/cli.js` check. A partially reified install — `cli.js` survived, `brand.js` gone — used to pass preflight and blow up inside the engine with a raw `ERR_MODULE_NOT_FOUND` stack; it now fails fast with one actionable line:

```
omo: senpi engine files are incomplete: <path>/dist/core/brand.js is missing, which usually means an interrupted or failed omo-ai upgrade; reinstall with: npm i -g omo-ai@beta
```

On win32 the line additionally explains the state's usual origin: running omo/senpi processes lock loaded native modules, npm dies mid-reify with EBUSY, and leaves exactly this partial tree.

## Why

Fixes #7378 — field report from Windows (omo-ai@5.0.0-0.beta.20): every `omo` launch died with `ERR_MODULE_NOT_FOUND` for `@code-yeongyu/senpi/dist/core/brand.js`, and the recovery attempt `npm i -g omo-ai@beta` failed with `EBUSY copyfile` on the locked `@mariozechner/clipboard-win32-x64-msvc/clipboard.win32-x64-msvc.node`. The published senpi tarball contains `brand.js` (verified via `npm pack`), so the tree on disk was a partially reified install — a state the launcher accepted silently.

`dist/core/brand.js` is the right sentinel: it is the launcher's own engine contract (already pinned by `test/brand-contract-pin.test.ts`), it is imported on every engine boot, and it is the file that went missing in the wild.

## Observed behavior (real surface)

Faithful fixture built from the real published tarballs into an npm-global layout, `brand.js` deleted:

- **Before**: raw Node resolver stack, `ERR_MODULE_NOT_FOUND ... dist/core/brand.js imported from .../dist/config.js` — byte-identical failure mode to the field screenshot.
- **After**: `omo: senpi engine files are incomplete: ... reinstall with: npm i -g omo-ai@beta`, exit 1.

Full transcripts in the QA evidence section below.

## Tests

- New `packages/omo-native/test/engine-integrity.test.ts` (given/when/then): corrupted fixture → actionable message with missing path + reinstall command (RED→GREEN captured); win32 adds the EBUSY/locked-native-module hint, POSIX does not; intact fixture resolves unchanged; established missing-CLI message pinned.
- Existing senpi fixtures in `launcher.test.ts`, `doctor.test.ts`, `setup-detect.test.ts`, `setup-detect-cache.test.ts`, `bun-bin-shim.test.ts` now ship the brand module like the real package does.
- `bun test packages/omo-native/test` green; `bunx tsc -p packages/omo-native/tsconfig.json --noEmit` clean.

## Residual risk

- Sentinel is a single file by design; a partial reify that loses a *different* dist file still reaches the engine stack. brand.js covers the observed field failure and every boot path; more sentinels are additive if new field states appear.
- The npm EBUSY itself is npm/Windows behavior and out of scope here (the message now tells the user how to escape it); #6689 / #7172 remain separate.

## QA evidence

<details><summary>RED/GREEN transcripts</summary>

# QA Evidence — corrupted engine install diagnosis (fix/corrupt-engine-install-diagnosis)

Captured 2026-08-26 on mengmotaHost (macOS arm64), Node v26.7.0, Bun 1.4.x.

## 1. Real-surface RED (before fix) — faithful reproduction of the field report
Fixture: real published tarballs (omo-ai@5.0.0-0.beta.20 + @code-yeongyu/senpi@2026.8.25) unpacked into a fake npm-global layout at /tmp/qa-omo-global, then `dist/core/brand.js` deleted — the exact partial-reify state from the Windows report (issue #7378).

```
$ HOME=/tmp/qa-home OMO_RUNTIME=node node /tmp/qa-omo-global/node_modules/omo-ai/bin/omo.js   # brand.js deleted from real beta.20+senpi-2026.8.25 tree
exit=1
--- stdout ---

--- stderr ---
node:internal/modules/esm/resolve:272
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/private/tmp/qa-omo-global/node_modules/omo-ai/node_modules/@code-yeongyu/senpi/dist/core/brand.js' imported from /private/tmp/qa-omo-global/node_modules/omo-ai/node_modules/@code-yeongyu/senpi/dist/config.js
    at finalizeResolution (node:internal/modules/esm/resolve:272:11)
    at moduleResolve (node:internal/modules/esm/resolve:879:10)
    at defaultResolve (node:internal/modules/esm/resolve:1006:11)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:708:20)
    at #resolveAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:728:38)
    at ModuleLoader.resolveSync (node:internal/modules/esm/loader:766:56)
    at #resolve (node:internal/modules/esm/loader:690:17)
    at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:610:35)
    at ModuleJob.syncLink (node:internal/modules/esm/module_job:277:33)
    at ModuleJob.link (node:internal/modules/esm/module_job:389:17) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///private/tmp/qa-omo-global/node_modules/omo-ai/node_modules/@code-yeongyu/senpi/dist/core/brand.js'
}

Node.js v26.7.0
```

## 2. Real-surface GREEN (after fix) — same corrupted tree, fixed bin/lib/package-paths.js
```
$ HOME=/tmp/qa-home OMO_RUNTIME=node node /tmp/qa-omo-global/node_modules/omo-ai/bin/omo.js   # same corrupted tree, fixed package-paths.js
exit=1
--- stdout ---

--- stderr ---
omo: senpi engine files are incomplete: /private/tmp/qa-omo-global/node_modules/omo-ai/node_modules/@code-yeongyu/senpi/dist/core/brand.js is missing, which usually means an interrupted or failed omo-ai upgrade; reinstall with: npm i -g omo-ai@beta
```

## 3. Unit RED (before implementation)
```
dules/.bun/@code-yeongyu+senpi@2026.8.26+df14032bda52d856/node_modules/@code-yeongyu/senpi",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/Volumes/mengmotaStorage/local-workspaces/omo-wt/corrupt-engine-diagnosis/packages/omo-native/test/engine-integrity.test.ts:93:26)
(fail) engine install integrity > #given an intact engine install > #when the launcher resolves the engine > #then it hands back the cli path and package root unchanged [1.85ms]
43 |   try {
44 |     resolveSenpi({ resolveIndex: () => fixtureIndexPath, platform })
45 |   } catch (error) {
46 |     return error as Error
47 |   }
48 |   throw new Error("expected resolveSenpi to refuse the fixture install")
                                                                            ^
error: expected resolveSenpi to refuse the fixture install
      at resolveError (/Volumes/mengmotaStorage/local-workspaces/omo-wt/corrupt-engine-diagnosis/packages/omo-native/test/engine-integrity.test.ts:48:72)
      at <anonymous> (/Volumes/mengmotaStorage/local-workspaces/omo-wt/corrupt-engine-diagnosis/packages/omo-native/test/engine-integrity.test.ts:106:23)
(fail) engine install integrity > #given an install missing the engine CLI entirely > #when the launcher resolves the engine > #then the established missing-CLI message is preserved [0.97ms]

 0 pass
 5 fail
 1 expect() calls
Ran 5 tests across 1 file. [995.00ms]
```

## 4. Unit GREEN
```
y reified install missing the brand contract module > #when the launcher resolves the engine > #then posix keeps the message free of the windows hint [1.12ms]
(pass) engine install integrity > #given an intact engine install > #when the launcher resolves the engine > #then it hands back the cli path and package root unchanged [1.44ms]
(pass) engine install integrity > #given an install missing the engine CLI entirely > #when the launcher resolves the engine > #then the established missing-CLI message is preserved [1.29ms]

 5 pass
 0 fail
 9 expect() calls
Ran 5 tests across 1 file. [586.00ms]
```


</details>
