### PR TITLE
ci: parallelize the Linux and macOS root-test legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,21 +194,28 @@ jobs:
         run: npm test
         working-directory: packages/lsp-daemon
 
-      # Git Bash sets SHELL/MSYSTEM on Windows, which makes process-platform
-      # tests observe sh instead of the native PowerShell/cmd execution path.
+      # Same shape as Windows shard 2: the shared serial quarantine
+      # (script/root-test-serial-quarantine.ts) runs in one process first, then
+      # the remainder runs with --parallel. test-env.ts gives every worker its
+      # own XDG dirs and test-setup.ts its own HOME, which is what makes the
+      # parallel pass safe.
       - name: Run tests
         if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
-        run: bun --config=bunfig.root.toml test
+        run: |
+          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts packages/senpi-task/src/dag/scheduler.test.ts
+          bun --config=bunfig.root.parallel.toml test --parallel
 
       - name: Run tests
         if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '1/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun test packages/omo-opencode packages/memory-core
 
+      # Git Bash sets SHELL/MSYSTEM on Windows, which makes process-platform
+      # tests observe sh instead of the native PowerShell/cmd execution path.
       - name: Run tests
         if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '2/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         shell: pwsh
         run: |
-          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/omo-native/test/payload.test.ts packages/omo-codex/src/install/install-codex.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts packages/senpi-task/src/dag/scheduler.test.ts
+          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/utils/src/codegraph-provision-upgrade.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts packages/senpi-task/src/dag/scheduler.test.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bun --config=bunfig.win2.parallel.toml test --parallel
 
@@ -221,7 +228,7 @@ jobs:
           JOB_SUMMARY_DETAILS: |
             - Builds vendored LSP packages before tests.
             - Runs `npm test` for `packages/lsp-daemon`.
-            - Runs all non-Senpi root tests on Linux and macOS via bunfig.root.toml.
+            - Runs all non-Senpi root tests on Linux and macOS: the shared serial quarantine first, then the remainder in parallel via bunfig.root.parallel.toml.
             - Splits Windows by measured package groups so global zauc mock bootstraps stay with their consumers.
           JOB_SUMMARY_NEXT: Open the first failing test or package-build step; matrix failures are usually OS-specific.
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,7 +316,7 @@ Digest-verified centrality (refs unmeasured unless noted):
 - **Runtime:** Bun only (1.4.0, pinned identically in CI and `.devcontainer/Dockerfile`). Never npm/yarn/pnpm. (Exceptions: `packages/lsp-tools-mcp` + `packages/lsp-daemon` are Node-targeted, vendored, and built with `npm` + vitest/biome.)
 - **TypeScript:** strict mode, ESNext, bundler moduleResolution, `bun-types` (never `@types/node`).
 - **Tests:** Bun test (`bun:test`), co-located `*.test.ts`, given/when/then style — nested `describe` with `#given`/`#when`/`#then` prefixes, or inline `// given` / `// when` / `// then` comments. Never Arrange-Act-Assert comments.
-- **CI tests:** `bun test` runs the root Bun suite in one process; `script/ci-fast-path.mjs` (`classifyCiMode`) runs the full OS matrix only when platform-sensitive paths change or the `ci:full-matrix` label is set. No split isolation runner. `bun run test:fast` partitions locally (opencode-memory → senpi → root-rest via `bunfig.win2.toml`).
+- **CI tests:** every root-test leg runs the shared serial quarantine (`script/root-test-serial-quarantine.ts`) in one process, then parallelizes the remainder — Linux/macOS via `bunfig.root.parallel.toml`, Windows shard 2 via `bunfig.win2.parallel.toml`. `script/ci-fast-path.mjs` (`classifyCiMode`) runs the full OS matrix only when platform-sensitive paths change or the `ci:full-matrix` label is set. `bun run test:fast` partitions locally (opencode-memory → senpi → root-rest via `bunfig.win2.toml`).
 - **Test setup:** `test-setup.ts` preloaded via `bunfig.toml` resets session/cache state between tests.
 - **Factory pattern:** `createXXX()` for all tools, hooks, agents.
 - **File naming:** kebab-case for files and directories.

--- a/bunfig.root.parallel.toml
+++ b/bunfig.root.parallel.toml
@@ -1,0 +1,26 @@
+[test]
+preload = ["./test-env.ts", "./test-setup.ts"]
+# bunfig.root.toml plus the shared serial quarantine from
+# script/root-test-serial-quarantine.ts. The Linux/macOS legs run that
+# quarantine serially first, then parallelize everything left here.
+pathIgnorePatterns = [
+  "dist/**",
+  "packages/web/**",
+  "packages/lsp-tools-mcp/**",
+  "packages/lsp-daemon/**",
+  "packages/omo-codex/plugin/**",
+  "packages/omo-codex/scripts/**",
+  "packages/shared-skills/upstreams/**",
+  "packages/omo-senpi/**",
+  "packages/senpi-task/src/runners/rpc-process.windows.test.ts",
+  "packages/utils/src/codegraph-provision-upgrade.test.ts",
+  "packages/senpi-task/src/__adversarial__/chaos-bench.test.ts",
+  "packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts",
+  "script/codex-installer-version.test.ts",
+  "packages/shared-skills/provenance-gate.test.ts",
+  "packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts",
+  "packages/senpi-task/src/dag/scheduler.test.ts",
+]
+
+[loader]
+".md" = "text"

--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -55,6 +55,7 @@ Co-located per script (`build-binaries.test.ts`, `stats.test.ts`, `sync-lazycode
 | `codex-install-bundle-freshness.test.ts` | The COMMITTED Codex installer bundle matches its sources: reads the bundle from the git index (`git show :packages/omo-codex/scripts/install-dist/install-local.mjs`), checks the build marker is present and self-consistent, and asserts the current source digest matches it |
 | `agent-command-string-audit.test.ts` (+ `agent-command-string-scan.test.ts`) | Bare/unsafe agent command strings in tracked sources must be allowlisted (`agent-command-string-audit.allowlist.json`, categorized) |
 | `ci-root-test-partition.test.ts` / `root-test-config.test.ts` | `ci.yml` root test job and the `bunfig.*.toml` partition stay in sync |
+| `root-test-serial-quarantine.ts` | Single source of truth for the test files every parallel CI leg runs serially first, with the documented reason per entry; pinned into both parallel bunfigs and both leg commands by `ci-root-test-partition.test.ts` |
 | `test-environment-isolation.test.ts` | The test preload strips `OPENCODE_SERVER_PASSWORD` so credentials never reach tests |
 
 ## TSCONFIG

--- a/script/ci-fast-path.full-matrix.test.ts
+++ b/script/ci-fast-path.full-matrix.test.ts
@@ -156,6 +156,8 @@ describe("full-matrix classification", () => {
       ["ci workflow", ".github/workflows/ci.yml"],
       ["classifier itself", "script/ci-fast-path.mjs"],
       ["windows shard bunfig", "bunfig.win2.parallel.toml"],
+      ["posix parallel bunfig", "bunfig.root.parallel.toml"],
+      ["shared serial quarantine", "script/root-test-serial-quarantine.ts"],
     ])("#then %s forces the full matrix", (_name, changedPath) => {
       // given / when
       const mode = classify({

--- a/script/ci-fast-path.mjs
+++ b/script/ci-fast-path.mjs
@@ -13,6 +13,8 @@ const platformSensitiveExactPaths = new Set([
   ".github/workflows/ci.yml",
   "script/ci-fast-path.mjs",
   "bunfig.win2.parallel.toml",
+  "bunfig.root.parallel.toml",
+  "script/root-test-serial-quarantine.ts",
 ])
 
 function parseArguments(argv) {

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -1,10 +1,23 @@
 import { describe, expect, test } from "bun:test"
 import { existsSync, readFileSync } from "node:fs"
+import {
+  ROOT_TEST_SERIAL_QUARANTINE_PATHS,
+  serialQuarantineCommand,
+} from "./root-test-serial-quarantine.ts"
 
 const workflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8")
 const rootConfig = readFileSync(new URL("../bunfig.root.toml", import.meta.url), "utf8")
+const rootParallelConfigPath = new URL("../bunfig.root.parallel.toml", import.meta.url)
 const win2ConfigPath = new URL("../bunfig.win2.toml", import.meta.url)
 const win2ParallelConfigPath = new URL("../bunfig.win2.parallel.toml", import.meta.url)
+
+function quarantinedTestPaths(config: string): readonly string[] {
+  return [...config.matchAll(/"([^"]+\.test\.ts)"/g)].map((match) => match[1] ?? "")
+}
+
+function escapeForRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
 
 function rootTestJob(): string {
   const start = workflow.indexOf("  test:\n")
@@ -37,33 +50,61 @@ describe("root test CI partition", () => {
     const job = rootTestJob()
 
     expect(job).toContain("bun test packages/omo-opencode packages/memory-core")
-    expect(job).toContain("bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts")
-    expect(job).toContain("packages/utils/src/codegraph-provision-upgrade.test.ts")
-    expect(job).toContain("packages/senpi-task/src/__adversarial__/chaos-bench.test.ts")
-    expect(job).toContain("packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts")
-    expect(job).toContain("script/codex-installer-version.test.ts")
-    expect(job).toContain("packages/shared-skills/provenance-gate.test.ts")
-    expect(job).toContain("packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts")
     expect(job).toContain("bun --config=bunfig.win2.parallel.toml test --parallel")
     expect(existsSync(win2ConfigPath)).toBe(true)
     expect(existsSync(win2ParallelConfigPath)).toBe(true)
     expect(quotedPatterns(readFileSync(win2ConfigPath, "utf8"))).toContain("packages/omo-opencode/**")
     expect(quotedPatterns(readFileSync(win2ConfigPath, "utf8"))).toContain("packages/memory-core/**")
-    const parallelConfig = readFileSync(win2ParallelConfigPath, "utf8")
-    expect(parallelConfig).toContain("packages/senpi-task/src/runners/rpc-process.windows.test.ts")
-    expect(parallelConfig).toContain("packages/utils/src/codegraph-provision-upgrade.test.ts")
-    expect(parallelConfig).toContain("packages/senpi-task/src/__adversarial__/chaos-bench.test.ts")
-    expect(parallelConfig).toContain("packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts")
-    expect(parallelConfig).toContain("script/codex-installer-version.test.ts")
-    expect(parallelConfig).toContain("packages/shared-skills/provenance-gate.test.ts")
-    expect(parallelConfig).toContain("packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts")
+  })
+
+  test("#given the shared quarantine module #when a parallel leg is rendered #then its serial command lists exactly those files", () => {
+    const job = rootTestJob()
+    const serialCommand = serialQuarantineCommand()
+
+    expect(ROOT_TEST_SERIAL_QUARANTINE_PATHS.length).toBeGreaterThan(0)
+    // Both parallel legs (POSIX and Windows shard 2) run the same serial list,
+    // so a file added to or dropped from the module must move both legs.
+    expect([...job.matchAll(new RegExp(escapeForRegExp(serialCommand), "g"))]).toHaveLength(2)
+  })
+
+  test("#given the shared quarantine module #when the parallel bunfigs are read #then each ignores exactly the quarantined files", () => {
+    expect(existsSync(rootParallelConfigPath)).toBe(true)
+    expect(existsSync(win2ParallelConfigPath)).toBe(true)
+
+    for (const configPath of [rootParallelConfigPath, win2ParallelConfigPath]) {
+      expect(quarantinedTestPaths(readFileSync(configPath, "utf8"))).toEqual([
+        ...ROOT_TEST_SERIAL_QUARANTINE_PATHS,
+      ])
+    }
+  })
+
+  test("#given bunfig.root.parallel.toml #when the POSIX leg parallelizes #then it keeps every bunfig.root.toml exclusion", () => {
+    const parallelPatterns = quotedPatterns(readFileSync(rootParallelConfigPath, "utf8"))
+
+    for (const pattern of quotedPatterns(rootConfig)) {
+      expect(parallelPatterns).toContain(pattern)
+    }
+  })
+
+  test("#given the Linux and macOS legs #when root tests run #then the quarantine precedes the parallel remainder", () => {
+    const job = rootTestJob()
+    const posixStep = job.slice(
+      job.indexOf("runner.os != 'Windows'"),
+      job.indexOf("matrix.shard == '1/2'"),
+    )
+
+    expect(posixStep).toContain(serialQuarantineCommand())
+    expect(posixStep).toContain("bun --config=bunfig.root.parallel.toml test --parallel")
+    expect(posixStep.indexOf(serialQuarantineCommand())).toBeLessThan(
+      posixStep.indexOf("bun --config=bunfig.root.parallel.toml test --parallel"),
+    )
   })
 
   test("#given the dedicated Senpi compatibility job #when root tests run #then omo-senpi is excluded on every OS", () => {
-    const job = rootTestJob()
-
-    expect(job).toContain("bun --config=bunfig.root.toml test")
     expect(quotedPatterns(rootConfig)).toContain("packages/omo-senpi/**")
+    expect(quotedPatterns(readFileSync(rootParallelConfigPath, "utf8"))).toContain(
+      "packages/omo-senpi/**",
+    )
     expect(quotedPatterns(readFileSync(win2ConfigPath, "utf8"))).toContain("packages/omo-senpi/**")
   })
 

--- a/script/root-test-config.test.ts
+++ b/script/root-test-config.test.ts
@@ -43,7 +43,7 @@ describe("root test Bun config", () => {
 
   test("#given bun 1.3.x test argv #when CI selects the dedicated config #then --config= is passed before test", () => {
     const workflow = readFileSync(workflowPath, "utf8")
-    expect(workflow).toContain("bun --config=bunfig.root.toml test")
+    expect(workflow).toContain("bun --config=bunfig.root.parallel.toml test --parallel")
     expect(workflow).not.toContain("bun test -c")
     expect(workflow).not.toContain("format('-c {0}'")
     expect(workflow).not.toContain("--path-ignore-patterns=")

--- a/script/root-test-serial-quarantine.ts
+++ b/script/root-test-serial-quarantine.ts
@@ -1,0 +1,63 @@
+// Single source of truth for the root-test files that must run in one serial
+// process before the rest of the suite runs under `bun test --parallel`.
+//
+// Every CI leg that parallelizes the root suite runs this exact list serially
+// first, then parallelizes the remainder with a bunfig whose pathIgnorePatterns
+// contain these same paths. Three legs (Windows shard 2, Linux, macOS) consume
+// the list, so it lives here instead of being pasted into each one; the
+// contract test in script/ci-root-test-partition.test.ts pins the workflow
+// commands and both bunfig configs against this array.
+//
+// Entries are removed only when the underlying isolation requirement is fixed
+// at its root, never to make a leg faster.
+
+export interface SerialQuarantineEntry {
+  /** Repo-relative test path, exactly as bun test and pathIgnorePatterns spell it. */
+  readonly path: string
+  /** Why this file cannot share a process pool with the rest of the suite. */
+  readonly reason: string
+}
+
+export const ROOT_TEST_SERIAL_QUARANTINE: readonly SerialQuarantineEntry[] = [
+  {
+    path: "packages/senpi-task/src/runners/rpc-process.windows.test.ts",
+    reason: "spawns a real console probe process and asserts on its exclusive console handles",
+  },
+  {
+    path: "packages/utils/src/codegraph-provision-upgrade.test.ts",
+    reason: "provisions a shared codegraph install directory that concurrent workers would clobber",
+  },
+  {
+    path: "packages/senpi-task/src/__adversarial__/chaos-bench.test.ts",
+    reason: "a saturation benchmark whose timings degrade once workers compete for the same cores",
+  },
+  {
+    path: "packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts",
+    reason: "purges legacy agent state from a shared installer root",
+  },
+  {
+    path: "script/codex-installer-version.test.ts",
+    reason: "reads the single installer version stamp the other installer suites rewrite",
+  },
+  {
+    path: "packages/shared-skills/provenance-gate.test.ts",
+    reason: "walks the whole shared-skills tree and is starved by concurrent filesystem load",
+  },
+  {
+    path: "packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts",
+    reason: "hit its timeout under real --parallel on the manifest cache path (run 32053350172)",
+  },
+  {
+    path: "packages/senpi-task/src/dag/scheduler.test.ts",
+    reason: "wave-ordering assertions are timing sensitive under a saturated scheduler",
+  },
+] as const
+
+/** Quarantined paths in workflow/bunfig order. */
+export const ROOT_TEST_SERIAL_QUARANTINE_PATHS: readonly string[] =
+  ROOT_TEST_SERIAL_QUARANTINE.map((entry) => entry.path)
+
+/** The serial `bun test` argument list each parallel leg runs before its parallel pass. */
+export function serialQuarantineCommand(): string {
+  return `bun test ${ROOT_TEST_SERIAL_QUARANTINE_PATHS.join(" ")}`
+}


### PR DESCRIPTION
## What changed

Linux and macOS root tests ran the whole suite in one process while Windows shard 2 already ran a serial quarantine first and parallelized the remainder. Both POSIX legs now use that same shape.

### Per leg

| Leg | Before | After |
|---|---|---|
| `ubuntu-latest` | `bun --config=bunfig.root.toml test` (serial, whole suite) | serial quarantine, then `bun --config=bunfig.root.parallel.toml test --parallel` |
| `macos-latest` | same as Linux | same as Linux |
| `windows-latest` shard 2 | serial list (10 files) then `bunfig.win2.parallel.toml --parallel` | serial list (8 files) then unchanged parallel pass |

Windows shard 2 loses two entries from its **command line** only: `packages/omo-native/test/payload.test.ts` and `packages/omo-codex/src/install/install-codex.test.ts`. #7379 removed both from `bunfig.win2.parallel.toml` but left them on the command line, so each was running twice per shard. No quarantine entry is removed from any parallel config — the remaining 8 all keep their documented non-race reasons.

Timeouts and the `runner.os`/`matrix.shard` conditions on every leg are unchanged.

### Config source of truth

`script/root-test-serial-quarantine.ts` holds the list once, with the reason each file cannot share a worker pool. Three legs consume it, so pasting a third copy was the alternative.

`bunfig.root.parallel.toml` = `bunfig.root.toml` + those paths. `script/ci-root-test-partition.test.ts` derives its expectations from the module rather than repeating the list, so:

- both parallel bunfigs must ignore *exactly* the quarantined paths (`toEqual`, not `toContain` — an extra or missing entry fails)
- the serial command must appear in the workflow exactly twice, once per parallel leg
- `bunfig.root.parallel.toml` must keep every `bunfig.root.toml` exclusion
- the POSIX leg's quarantine must precede its parallel pass

Verified the pin has teeth: deleting one entry from `bunfig.root.parallel.toml` fails the contract test.

`script/ci-fast-path.mjs` treats the new config and the module as platform-sensitive, since either changes how the macOS and Windows runners partition.

## Local validation (macOS, Bun 1.4.0)

GitHub Actions billing is broken account-wide today, so CI cannot run; local was the gate. All suites run under `env -u OMO_CODING_AGENT_DIR -u SENPI_CODING_AGENT_DIR -u PI_CODING_AGENT_DIR`.

| Check | Result |
|---|---|
| Serial quarantine subset, exactly as the leg runs it | exit 0 — 57 pass, 1 skip, 21.4s |
| Parallel remainder, run 1 | exit 0 — 14279 pass, 6 skip, 0 fail, 313s |
| Parallel remainder, run 2 (consecutive) | exit 0 — 14279 pass, 6 skip, 0 fail, 309s |
| `bun test script/ci-root-test-partition.test.ts` | exit 0 — 10 pass |
| `bun test script/` (full) | exit 0 — 344 pass, 1 skip |
| `bun run typecheck` | exit 0 (baseline on this tree before any edit: also exit 0) |
| `git status --porcelain` after the runs | clean |

### One caveat worth recording

The first two parallel runs on this host failed — but with **disjoint** failure sets (2 failures, then 7 unrelated ones), every one a timeout or a subprocess-starvation assertion, and every failing file passing serially. The host was at load average 56-75 on 14 cores from other concurrent agents, and `--parallel` defaults to CPU-core-count workers, so it spawned 14 workers onto an already-4x-oversubscribed box. Re-running bounded to `--parallel=4` (a realistic runner width) gave two clean consecutive passes.

The workflow intentionally keeps `--parallel` unbounded, matching the Windows leg that already ships that way and passes in CI: GitHub runners have 2-4 cores and no competing load, so the default resolves to roughly the bounded width validated here. Non-overlapping failure sets across runs are the signature of load-induced timeouts, not of shared-state races.

Evidence logs: `/tmp/bun14-fix-omo-ci-parallel/` (`00`-`10`, each ending in its exit code).
