### PR TITLE
fix(omo-senpi): stabilize Windows senpi compatibility

### DIFF
--- a/packages/omo-senpi/src/components/memory/commands/memfs-extra.test.ts
+++ b/packages/omo-senpi/src/components/memory/commands/memfs-extra.test.ts
@@ -89,7 +89,9 @@ describe("/memfs backup", () => {
 })
 
 describe("/memfs restore", () => {
-  test("#given a named backup #when restore runs #then repo content is replaced and a safety backup is kept", async () => {
+  test(
+    "#given a named backup #when restore runs #then repo content is replaced and a safety backup is kept",
+    async () => {
     // given
     const { identityRoot, repoDir, pi, ctx } = await harness()
     await invoke(pi, "memfs", "backup", ctx)
@@ -104,7 +106,8 @@ describe("/memfs restore", () => {
     expect(restored).toContain("seeded persona")
     expect(text).toContain("restored")
     expect((await backupNames(identityRoot)).length).toBe(2)
-  })
+  },
+  15000)
 
   test("#given no backups #when restore runs #then an actionable error is returned", async () => {
     // given

--- a/packages/omo-senpi/src/components/skill-pointers/index.ts
+++ b/packages/omo-senpi/src/components/skill-pointers/index.ts
@@ -128,7 +128,7 @@ function ulwLoopCliShimPath(): string {
 }
 
 function ulwLoopCliShimSentence(): string {
-  const abs = ulwLoopCliShimPath()
+  const abs = ulwLoopCliShimPath().replaceAll("\\", "/")
   return ` The resolved ulw-loop CLI shim is at ${abs} — invoke every ulw-loop command as \`${abs} ulw-loop <subcommand>\`.`
 }
 


### PR DESCRIPTION
Fixes dev CI failures on windows-latest senpi-compatibility (run 32963420267).

**Root cause:**
- `skill-pointers` ulw-loop CLI shim path used `fileURLToPath` which yields backslashes on Windows (`D:\...\runtime\agent-toolkit\omo-agent-toolkit`) but test expects forward slashes `runtime/agent-toolkit/omo-agent-toolkit` — failed at skill-pointers.test.ts:201.
- `memfs restore` named backup test timed out at 5594ms (>5000ms) on windows runner.

**Fix:**
1. `fix(omo-senpi): normalize ulw-loop CLI shim path for Windows` — `.replaceAll("\\","/")` before embedding in prompt.
2. `fix(omo-senpi): stabilize memfs restore test on Windows` — increase test timeout 5s → 15s.

**Verification:** dev head 9c62b627 had 2278 pass 14 skip 2 fail; after fix windows senpi should pass. ubuntu exit 143 was infra timeout (0 test fails), not code — will clear on rerun.

Fixes dev-parity failures blocking #7361 #7359 #7362 #7364 #7366 #7367 #7370 #7343 etc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows CI failures in `omo-senpi` where the ulw-loop shim path contained backslashes and the memfs restore test timed out.

- Replaces backslashes with forward slashes in the shim path before embedding it in the orchestrator prompt.
- Increases the named-backup restore test timeout from 5s to 15s to account for slower Windows runners.

<sup>Written for commit f52c67829fc6ed5e8601eaea29e7e4f1c99a10a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

