### PR TITLE
fix(senpi): stop orphaned hold-lock fixtures (#7335)

### DIFF
--- a/packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts
+++ b/packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts
@@ -1,6 +1,7 @@
 // Live lock holder for concurrency tests: acquires the given lock path with THIS process's
-// identity and blocks forever, so lock recovery (which only reclaims proven-dead owners)
-// cannot reclaim it. The test kills the child; readiness is signalled on stdout, never timed.
+// identity and waits for its parent to close stdin, so lock recovery (which only reclaims proven-dead
+// owners) cannot reclaim it while the test is running. The test normally kills the child; readiness is
+// signalled on stdout, never timed.
 
 import { acquireLock, createLockRecord } from "@oh-my-opencode/memory-core"
 
@@ -10,4 +11,18 @@ if (lockPath === undefined) throw new Error("lock path is required")
 const record = await createLockRecord("facts-finalize", { runId: "hold-lock-fixture" })
 await acquireLock(lockPath, record, { waitTimeoutMs: 10_000, retryDelayMs: 10 })
 process.stdout.write("held\n")
-await new Promise<never>(() => {})
+
+// A killed test runner closes the child's stdin, but keep a PPID watchdog as a fallback for runtimes
+// that do not deliver the pipe close event after reparenting.
+const parentPid = process.ppid
+const watchdog = setInterval(() => {
+  if (process.ppid === 1 || process.ppid !== parentPid) process.exit(0)
+}, 1_000)
+watchdog.unref()
+
+await new Promise<void>((resolve) => {
+  process.stdin.once("end", resolve)
+  process.stdin.once("close", resolve)
+  process.stdin.resume()
+})
+clearInterval(watchdog)


### PR DESCRIPTION
## Root cause

The `hold-lock.ts` test fixture acquired its marker lock and awaited a permanently unresolved promise. If the test runner was killed before cleanup, the fixture was reparented to PID 1 and continued running indefinitely (and could consume substantial CPU). The fixture now waits on its parent-owned stdin control pipe, with a 1-second PPID watchdog fallback. A killed parent closes stdin; reparenting to PID 1 also terminates the fixture even if the pipe close event is not delivered.

## RED proof (before the fix)

Command:

```sh
bun /tmp/holdlock-parent-wrapper.ts packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts "$lock" "$pidfile" "$readyfile"
```

Output:

```text
RED setup: parent=14829 child=14837 ready=yes
RED FAIL (expected before fix): fixture still alive after parent death
14837     1 R    /Users/yeongyu/.bun/bin/bun packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts /var/folders/.../held.lock
```

The wrapper was SIGKILLed and the fixture remained alive with PPID 1.

## GREEN proof (after the fix)

Command:

```sh
bun /tmp/holdlock-parent-wrapper.ts packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts "$lock" "$pidfile" "$readyfile"
```

Output:

```text
GREEN setup: parent=24610 child=24616 ready=yes
GREEN PASS: fixture exited after parent death in <=0s
```

## Verification

```sh
bun install --frozen-lockfile
bun /tmp/holdlock-parent-wrapper.ts packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts "$lock" "$pidfile" "$readyfile"
bun test packages/omo-senpi/src/components/memory/facts-run-prune.test.ts
bun run --cwd packages/omo-senpi typecheck
git diff --check
```

Targeted test output: `12 pass, 0 fail`.
Typecheck completed successfully. LSP diagnostics reported no diagnostics for the touched fixture.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the `hold-lock.ts` fixture from running forever as an orphaned process when the test runner is killed, which previously reparented it to PID 1 and could consume substantial CPU. The fixture now exits when its parent's stdin closes, with a 1-second PPID watchdog as a fallback.

<sup>Written for commit 8417a0d32f3f0348d811ec2057ff63e26d2b0507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

