### PR TITLE
test(omo-senpi): lock omo-task pi-tui warm-up (#7355)

### DIFF
--- a/packages/omo-senpi/src/bundle-lazy-barrel.test.ts
+++ b/packages/omo-senpi/src/bundle-lazy-barrel.test.ts
@@ -39,6 +39,12 @@ const LAZY_BARRELS: readonly LazyBarrel[] = [
 ]
 
 describe("built bundles keep their lazy barrels loadable", () => {
+  it("keeps omo-task's pi-tui warm-up in the published artifact (#7355)", () => {
+    const taskBundle = readBundle("omo-task.js")
+    expect(countDynamicImports(taskBundle, "@earendil-works/pi-tui")).toBeGreaterThan(0)
+    expect(findUnconditionalGuard(taskBundle, LAZY_BARRELS[0].guardMessage)).toBeUndefined()
+  })
+
   for (const barrel of LAZY_BARRELS) {
     it(`#given a built bundle reaching the ${barrel.label} barrel #when the artifact is inspected #then its dynamic import survived minification`, () => {
       const reaching = readBundlesReaching(barrel.guardMessage)
@@ -65,12 +71,16 @@ describe("built bundles keep their lazy barrels loadable", () => {
   }
 })
 
+function readBundle(file: string): string {
+  const path = join(extensionsDir, file)
+  expect(existsSync(path), `missing built bundle at ${path}; run build:senpi-plugin first`).toBe(true)
+  return readFileSync(path, "utf8")
+}
+
 function readBundlesReaching(guardMessage: string): readonly { file: string; source: string }[] {
   const reaching: { file: string; source: string }[] = []
   for (const file of BUNDLE_FILES) {
-    const path = join(extensionsDir, file)
-    expect(existsSync(path), `missing built bundle at ${path}; run build:senpi-plugin first`).toBe(true)
-    const source = readFileSync(path, "utf8")
+    const source = readBundle(file)
     if (source.includes(guardMessage)) reaching.push({ file, source })
   }
   return reaching


### PR DESCRIPTION
## Root cause

The published `omo-task.js` regression occurred when bundling removed the `loadPiTui()` dynamic import while leaving the synchronous `piTui()` accessor as an unconditional throw. The registration entry point now awaits `loadPiTui()`, and the built artifact retains the dynamic import. This PR adds an artifact-specific regression assertion so `omo-task.js` cannot ship without that warm-up or with an unconditional barrel guard.

## RED

Reproduced against the pre-fix artifact (`14f4eef10^`):

```text
RED: Error: The @earendil-works/pi-tui barrel was accessed before it was loaded. Await loadPiTui() at the registration entry point before reading pi-tui values synchronously.
    at eval (eval at <anonymous> (file:///.../[eval1]:5:18), <anonymous>:3:25)
```

The pre-fix bundle had `dynamic_imports 0` for `import("@earendil-works/pi-tui")`.

## GREEN

After rebuilding:

```text
GREEN bundle bytes: 605585
GREEN dynamic import count: 1
```

The focused artifact test passes:

```text
5 pass
0 fail
```

## Verification

```bash
bun install --frozen-lockfile
bun run build:senpi-plugin
bun test packages/omo-senpi/src/bundle-lazy-barrel.test.ts
bun test packages/omo-senpi/src/components/task/status-ui-render-fault.test.ts packages/omo-senpi/src/components/task/dag-status-ui-render-fault.test.ts packages/omo-senpi/src/components/task/index.test.ts
python3 - <<'PY'
from pathlib import Path
p=Path('packages/omo-senpi/plugin/extensions/omo-task.js').read_text()
needle='The @earendil-works/pi-tui barrel was accessed before it was loaded'
i=p.find(needle)
print('GREEN bundle bytes:',len(p))
print('GREEN dynamic import count:',p.count('import("@earendil-works/pi-tui")'))
print('GREEN guard context:',p[i-80:i+len(needle)+30])
PY
git diff --check
git status --short
```

All targeted tests passed (18 tests, 0 failures), and `git diff --check` was clean. The branch is intentionally test-only because the production fix is already present on `dev`; this PR locks the published-bundle contract to prevent recurrence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test that locks the published `omo-task.js` bundle so it keeps the `pi-tui` dynamic import and drops the unconditional barrel guard.

- The production fix is already on `dev`; this PR is test-only to prevent recurrence.
- The new test fails against pre-fix artifacts and passes after a rebuild.
- Refactors bundle reading into a shared helper.

<sup>Written for commit 90bce0d82244d239cb1259698d741631e2f906ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

