### PR TITLE
test(senpi-task): cover fallback waiter guards

### DIFF
--- a/.omo/evidence/20260827-dag-fallback-waiter-guard/README.md
+++ b/.omo/evidence/20260827-dag-fallback-waiter-guard/README.md
@@ -1,0 +1,3 @@
+# F2 regression coverage
+
+Adds manager tests covering terminal waiter behavior and fallback abort terminalization for PR #7413. Outputs are captured under this directory. The existing package suite remains the authoritative gate.

--- a/.omo/evidence/20260827-dag-fallback-waiter-guard/full-suite.txt
+++ b/.omo/evidence/20260827-dag-fallback-waiter-guard/full-suite.txt
@@ -1,0 +1,2282 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/senpi-task/src/luna-deepseek-chain-policy.test.ts:
+(pass) Senpi Luna and DeepSeek chain policy > quick places non-reasoning DeepSeek V4 Flash immediately after Luna [0.55ms]
+(pass) Senpi Luna and DeepSeek chain policy > explore places max-reasoning DeepSeek V4 Flash immediately after Luna [0.08ms]
+(pass) Senpi Luna and DeepSeek chain policy > librarian places max-reasoning DeepSeek V4 Flash immediately after Luna [0.07ms]
+
+packages/senpi-task/src/progress.test.ts:
+(pass) child task progress > #given a task summary #when progress is composed #then the activity identity is the summary [1.29ms]
+(pass) child task progress > #given child events #when progress is composed #then activity carries target, model, turn and tool counts [0.38ms]
+(pass) child task progress > #given a human description #when progress is composed #then the activity leads with what the task is, not its id [0.13ms]
+(pass) child task progress > #given a running tool #when composed #then the activity names the tool and pluralizes tool counts [0.13ms]
+(pass) child task progress > #given runtime fallback events #when progress is composed #then the active model and fallback count update [0.09ms]
+(pass) child task progress > #given no events yet #when composed #then activity has no turn-zero noise beyond the base status [0.08ms]
+(pass) child task progress > #given unknown details #when read #then only the local progress shape is accepted [0.11ms]
+
+packages/senpi-task/src/run-stats-eval.test.ts:
+(pass) eval nested tool accounting > #given one eval with two nested calls #when the eval ends #then outer and nested calls total three [0.16ms]
+(pass) eval nested tool accounting > #given an eval without nested calls #when it ends #then the eval still counts once [0.11ms]
+(pass) eval nested tool accounting > #given an eval control call #when its result repeats prior nested calls #then only the control call is new [0.07ms]
+(pass) eval nested tool accounting > #given an input-only eval control call #when its result repeats prior nested calls #then only the control call is new [0.07ms]
+(pass) eval nested tool accounting > #given malformed eval tool summaries #when the eval ends #then only valid tool calls are counted [0.07ms]
+(pass) eval nested tool accounting > #given a non-eval tool result with details #when it ends #then the top-level tool counts once [0.07ms]
+(pass) eval nested tool accounting > #given a duplicated eval end #when both arrive #then nested calls are counted only once [0.08ms]
+
+packages/senpi-task/src/run-stats-tokens.test.ts:
+(pass) run stats token totals and data-quality statuses > #given assistant turns reporting input/cacheRead/cacheWrite #when snapshot is taken #then input_tokens, cache_read_tokens and cache_write_tokens are summed and omitted when unreported [12.89ms]
+(pass) run stats token totals and data-quality statuses > #given every assistant turn reporting usage #when snapshot is taken #then token_status is complete [0.11ms]
+(pass) run stats token totals and data-quality statuses > #given one turn with usage and one without #when snapshot is taken #then token_status is partial [0.08ms]
+(pass) run stats token totals and data-quality statuses > #given no turn reporting usage #when snapshot is taken #then token_status is unavailable [0.07ms]
+(pass) run stats token totals and data-quality statuses > #given a provider-reported zero cost #when snapshot is taken #then cost_usd is 0 with cost_status reported while an absent cost is unavailable [0.10ms]
+(pass) run stats token totals and data-quality statuses > #given a tracker measuring the live run #when snapshot is taken #then duration_status is monotonic [0.07ms]
+
+packages/senpi-task/src/senpi-static-import-guard.test.ts:
+(pass) senpi-task static import guard > #given senpi-task source #when scanned #then no runtime static import of the senpi or pi-tui barrels remains [24.16ms]
+(pass) senpi-task static import guard > #given the guard scanner #when fed runtime and type-only clauses #then only runtime clauses are flagged [0.22ms]
+
+packages/senpi-task/src/notice-box.test.ts:
+(pass) buildNoticeBox > #given a notice spec #when rendered collapsed #then every full-width line uses the custom-message background and Box padding [1.98ms]
+(pass) buildNoticeBox > #given an expanded notice #when rendered #then the gated detail is dim inside the same background block [10.24ms]
+
+packages/senpi-task/src/completion.test.ts:
+(pass) task completion fallback reporting > #given a rerouted task #when terminal completion renders #then it reports model fallback once at terminal completion [0.54ms]
+(pass) task completion fallback reporting > #given no model reroute #when fallback notification rendering runs #then existing completion output stays unchanged [0.10ms]
+
+packages/senpi-task/src/status-line.test.ts:
+(pass) taskIdentityLabel > #given a task summary #when labelled #then the delegated-work summary wins over description, name and id [0.17ms]
+(pass) taskIdentityLabel > #given a blank task summary #when labelled #then it falls back to the description [0.07ms]
+(pass) taskIdentityLabel > #given a description #when labelled #then the human description wins over name and id [0.07ms]
+(pass) taskIdentityLabel > #given no description #when labelled #then the stable name is used [0.07ms]
+(pass) taskIdentityLabel > #given neither description nor name #when labelled #then the id remains as the last-resort handle [0.07ms]
+(pass) taskIdentityLabel > #given blank labels #when labelled #then whitespace-only values are ignored [0.06ms]
+(pass) taskIdentityLabel > #given an overlong description #when labelled #then it is excerpted for one status row [0.15ms]
+(pass) formatStatusTarget > #given a category and resolved model #when formatted #then model metadata qualifies the category [0.07ms]
+(pass) formatStatusTarget > #given only an agent type #when formatted #then the agent target shares the category grammar [0.06ms]
+(pass) formatStatusTarget > #given an agent type and resolved model #when formatted #then model metadata qualifies the agent exactly like a category [0.07ms]
+(pass) formatStatusTarget > #given an agent type with only a raw model #when formatted #then the raw model qualifies the agent target [0.06ms]
+(pass) formatStatusTarget > #given resolved model metadata with effort and variant #when formatted #then reasoning effort wins in the status target [0.07ms]
+(pass) formatStatusTarget > #given resolved model metadata with variant only #when formatted #then the variant is rendered [0.07ms]
+(pass) formatStatusTarget > #given resolved model metadata with reasoning effort only #when formatted #then the reasoning effort is rendered [0.07ms]
+(pass) formatStatusTarget > #given resolved model metadata without effort or variant #when formatted #then the model name is rendered without a suffix [0.07ms]
+(pass) formatStatusTarget > #given model metadata with terminal controls #when formatted #then every part is normalized [0.07ms]
+(pass) formatStatusTarget > #given a category but only a raw model #when formatted #then the sanitized raw model qualifies the target [0.08ms]
+(pass) formatStatusTarget > #given no target facts #when formatted #then nothing is emitted [0.06ms]
+(pass) composeStatusLine > #given full live facts #when composed #then tokens follow the canonical identity-first grammar [0.07ms]
+(pass) composeStatusLine > #given cost and cache facts #when composed #then only cost sits immediately before tps [0.07ms]
+(pass) composeStatusLine > #given a cache hit rate without cost #when composed #then no spend token renders [0.06ms]
+(pass) composeStatusLine > #given a single tool call #when composed #then the tool noun is singular [0.07ms]
+(pass) composeStatusLine > #given no stats #when composed #then only known tokens are emitted [0.06ms]
+
+packages/senpi-task/src/task-summary.test.ts:
+(pass) clampTaskSummary > #given undefined #when clamped #then undefined is returned [0.17ms]
+(pass) clampTaskSummary > #given a blank summary #when clamped #then it collapses to undefined [0.07ms]
+(pass) clampTaskSummary > #given a multi-line summary #when clamped #then whitespace collapses to one status row [0.06ms]
+(pass) clampTaskSummary > #given a summary at the limit #when clamped #then it passes through unchanged [0.06ms]
+(pass) clampTaskSummary > #given an over-limit summary #when clamped #then the harness force-truncates to the schema limit with an ellipsis [0.07ms]
+
+packages/senpi-task/src/run-stats.test.ts:
+(pass) run stats tracker > #given assistant turns with usage #when snapshotted #then totals and tps derive from generation time [36.48ms]
+(pass) run stats tracker > #given non-assistant messages and missing usage #when snapshotted #then only counted facts appear [2.64ms]
+(pass) run stats tracker > #given snake_case usage fields #when accumulated #then they are read as a fallback [0.18ms]
+(pass) run stats tracker > #given a sub-10 tps run #when snapshotted #then tps keeps one decimal [0.10ms]
+(pass) run stats tracker > #given message_start before message_end #when snapshotted #then the window is the arrival-clock gap [0.09ms]
+(pass) run stats tracker > #given bursty delivery collapsing the only generation window #when snapshotted #then tps is omitted as unverifiable [0.08ms]
+(pass) run stats tracker > #given multiple cache-bearing turns #when snapshotted #then latest-request and whole-run cache hit rates stay distinct [0.11ms]
+(pass) run stats tracker > #given cost as an object with a total #when snapshotted #then the total is summed [0.09ms]
+(pass) run stats tracker > #given usage without cache or cost facts #when snapshotted #then both fields are omitted [0.08ms]
+(pass) run stats tracker > #given snake_case cache fields and zero cache reads #when snapshotted #then the rate is zero not omitted [0.08ms]
+(pass) run stats tracker > #given non-finite cost and negative cache inputs #when snapshotted #then unsafe values cannot poison persisted stats [0.10ms]
+(pass) run stats tracker > #given an object cost with a non-finite total #when snapshotted #then cost is omitted [0.09ms]
+(pass) run stats tracker > #given finite values that overflow cumulative totals #when snapshotted #then non-finite metrics are omitted [0.10ms]
+(pass) run stats tracker > #given a later assistant turn without a cacheable denominator #when snapshotted #then the latest valid request rate is retained [0.10ms]
+(pass) run stats tracker > #given one measured window and one token-bearing collapsed window #when snapshotted #then tps is omitted as unverifiable [0.09ms]
+
+packages/senpi-task/src/senpi-api-tripwire.test.ts:
+(pass) pinned Senpi API surface > #given the senpi-task root import #when curated agent exports are used #then values and result types resolve [0.91ms]
+(pass) pinned Senpi API surface > #given senpi root exports #when type checked #then task adapter can pass session construction seams [0.43ms]
+(pass) pinned Senpi API surface > #given the pinned senpi barrel #when defineTool is applied #then it is the identity helper [0.07ms]
+(pass) pinned Senpi API surface > #given agent dir marker extension #when session boots with minimal loader #then marker factory is not invoked [503.44ms]
+(pass) pinned Senpi API surface > #given minimal resource loader source #when audited #then fake marker factory option is absent [0.14ms]
+(pass) pinned Senpi API surface > #given pinned artifact #when package metadata and rpc entry are checked #then expected public contract exists [0.40ms]
+
+packages/senpi-task/src/category/available-categories.test.ts:
+(pass) resolveAvailableCategoryNames > #given no user categories and a registry exposing the architect gate model > #when the runtime category list is resolved > #then the builtin architect category is exposed [1.24ms]
+(pass) resolveAvailableCategoryNames > #given no user categories and a registry without the architect gate model > #when the runtime category list is resolved > #then the builtin architect category is not exposed [0.12ms]
+(pass) resolveAvailableCategoryNames > #given a user-declared architect category > #when the registry lacks the gate model > #then the explicit declaration still exposes architect [0.09ms]
+(pass) resolveAvailableCategoryNames > #given a registry whose getAvailable throws > #when the runtime category list is resolved > #then it degrades to the ungated list instead of throwing [0.08ms]
+
+packages/senpi-task/src/category/anthropic-categories.test.ts:
+(pass) anthropic builtin categories > #given the architect category > #when a caller reads the description before delegating > #then it names the model that answers the consultation [0.10ms]
+(pass) anthropic builtin categories > #given the architect category > #when a caller reads the description before delegating > #then it names the content that model is sensitive about [0.06ms]
+(pass) anthropic builtin categories > #given the architect category > #when a caller reads the description before delegating > #then it prescribes the refusal recovery: split indirectly, reason yourself [21.56ms]
+(pass) anthropic builtin categories > #given the architect category > #when the resolver routes it > #then it still requires fable 5 at the xhigh variant [0.14ms]
+
+packages/senpi-task/src/category/resolve-category.test.ts:
+(pass) resolveCategory > #given a builtin category and omo overlay #when resolved #then user config wins and prompt text is appended [0.93ms]
+(pass) resolveCategory > #given a disabled omo category overlay #when resolved #then a disabled result explains the reason [0.10ms]
+(pass) resolveCategory > #given primary model is unavailable and omo fallback exists #when resolved #then delegate-core fallback reaches the registry model [0.25ms]
+(pass) resolveCategory > #given configured runtime fallback preserves requested and resolved models #when resolved #then the ordered runtime chain is retained [0.15ms]
+(pass) resolveCategory > #given a canonical models chain with per-entry reasoning #when resolved #then the canonical chain and reasoning reach the resolved model [0.14ms]
+(pass) resolveCategory > #given a canonical models chain plus a conflicting legacy fallback_models #when resolved #then canonical models wins [0.11ms]
+(pass) resolveCategory > #given a simple category with canonical reasoning and no chain #when resolved #then the canonical thinking level reaches the resolved model [0.12ms]
+(pass) resolveCategory > #given quick primary is unavailable and the quotio rung is available #when resolved #then delegate-core fallback chain reaches gpt-5.6-luna-fast [0.12ms]
+(pass) resolveCategory > #given writing's Kimi for Coding default is available #when resolved #then its canonical Kimi K3 id is selected [0.09ms]
+(pass) resolveCategory > #given writing's provider default is unavailable and Kimi K3 is available #when resolved #then the K3 fallback is selected [0.10ms]
+(pass) resolveCategory > #given visual-engineering primary is unavailable and the ZAI GLM rung is available #when resolved #then delegate-core fallback chain preserves the max variant [0.12ms]
+(pass) resolveCategory > #given only transformed Vercel GPT-5.6 models #when deep categories resolve #then each keeps its native top rung [0.20ms]
+(pass) resolveCategory > #given transformed Vercel and Copilot GPT-5.6 models #when deep categories resolve #then the first available rung provider wins [0.19ms]
+(pass) resolveCategory > #given only Copilot GPT-5.6 models #when deep categories resolve #then each uses its copilot rung [0.15ms]
+(pass) resolveCategory > #given GPT-5.6 is unavailable #when deep resolves with Copilot GPT-5.5 #then the retired rung is not selected [0.07ms]
+(pass) resolveCategory > #given no category or fallback model resolves and a system default is available #when resolved #then delegate-core reaches the system default [0.11ms]
+(pass) resolveCategory > #given selected model is absent from registry #when resolved #then unavailable result names attempted and available models [0.09ms]
+(pass) resolveCategory > #given category params in omo overlay #when resolved #then child spec carries generation params and prompt append [0.11ms]
+(pass) resolveCategory > #given a custom category description #when resolved #then the resolved result preserves it [0.08ms]
+(pass) builtin category defaults > #given ported builtin defaults #when inspected #then machine routing fields stay pinned without prose wording [0.08ms]
+
+packages/senpi-task/src/category/fallback-chains.test.ts:
+(pass) CATEGORY_FALLBACK_CHAINS > #given the builtin chains #when listing keys #then exactly the 9 category names are present [14.22ms]
+(pass) CATEGORY_FALLBACK_CHAINS > #given the mirrored fallback table #when compared with the independent transcription #then every provider model variant and order is pinned [2.19ms]
+(pass) CATEGORY_FALLBACK_CHAINS > #given the builtin chains #when scanning providers #then no rung lists vercel or quotio-openai [0.12ms]
+(pass) CATEGORY_FALLBACK_CHAINS > #given the builtin chains #when a rung lists openai #then openai-codex rides alongside [0.08ms]
+
+packages/senpi-task/src/category/resolve-category-boundary.test.ts:
+(pass) resolveCategory boundary parsing > #given a registry model with legal headers #when resolved #then the header-bearing model is accepted [0.30ms]
+(pass) resolveCategory boundary parsing > #given a malformed registry entry #when resolved #then category resolution returns sanitized model_unavailable instead of throwing [0.11ms]
+(pass) resolveCategory boundary parsing > #given getAvailable returns a throwing-accessor model #when resolved #then category resolution returns sanitized model_unavailable [0.16ms]
+(pass) resolveCategory boundary parsing > #given malformed truthy find results #when resolved #then category resolution returns sanitized model_unavailable [0.19ms]
+(pass) resolveCategory boundary parsing > #given find returns a throwing-accessor model #when resolved #then category resolution returns sanitized model_unavailable [0.11ms]
+(pass) resolveCategory boundary parsing > #given find returns an empty or mismatched identity #when resolved #then category resolution rejects the registry result [0.13ms]
+(pass) resolveCategory boundary parsing > #given inherited model identity fields #when resolved #then category resolution rejects them without leaking prototype data [0.09ms]
+(pass) resolveCategory boundary parsing > #given non-array registry availability #when resolved #then category resolution returns sanitized model_unavailable instead of throwing [0.08ms]
+(pass) resolveCategory boundary parsing > #given prototype-shaped category names #when resolved #then they return not_found instead of inherited object values [0.09ms]
+
+packages/senpi-task/src/category/gating.test.ts:
+(pass) category activation gating > #given a builtin category gated on claude-fable-5 > #when the registry offers only cross-family models #then architect is unavailable and never falls back [0.17ms]
+(pass) category activation gating > #given a builtin category gated on claude-fable-5 > #when the registry offers claude-fable-5 #then architect resolves at xhigh [0.15ms]
+(pass) category activation gating > #given a builtin category gated on claude-fable-5 > #when the gate model is absent but omo.json configures the category #then the explicit entry bypasses the gate [0.11ms]
+(pass) category activation gating > #given a builtin category gated on claude-fable-5 > #when the gate model is absent and omo.json only sets a description #then the gate is bypassed and the category stays listed [0.07ms]
+(pass) category activation gating > #given a builtin category gated on gpt-5.6-sol > #when the registry offers only cross-family models #then ultrabrain is unavailable and never falls back [0.07ms]
+(pass) category activation gating > #given a builtin category gated on gpt-5.6-sol > #when the registry offers gpt-5.6-sol #then ultrabrain resolves at max [0.10ms]
+(pass) category activation gating > #given a builtin category gated on gpt-5.6-sol > #when only Copilot carries gpt-5.6-sol #then the gate is satisfied and the copilot rung applies [0.10ms]
+(pass) category activation gating > #given a builtin category gated on gpt-5.6-sol via the deep chain > #when the registry offers only cross-family models #then deep is unavailable and never falls back [0.07ms]
+(pass) category activation gating > #given a builtin category gated on gpt-5.6-sol via the deep chain > #when the registry offers gpt-5.6-sol #then deep resolves at medium [0.08ms]
+(pass) category activation gating > #given a builtin category gated on gpt-5.6-sol via the deep chain > #when the gate model is absent but omo.json configures the category #then the explicit entry bypasses the gate [0.08ms]
+(pass) category activation gating > #given a retargeted fallback fixture > #when visual-engineering resolves on a kimi-only registry #then it is a REAL chain fallback, not a primary hit [0.10ms]
+(pass) category activation gating > #given a retargeted fallback fixture > #when artistry resolves on a fable-only registry #then it is a PRIMARY hit, which is why it cannot prove fallback [0.08ms]
+(pass) category activation gating > #given a registry model whose last path segment collides with a gate model > #when architect resolves #then an unrelated vendor model must not open the fable gate [0.06ms]
+(pass) category activation gating > #given a registry model whose last path segment collides with a gate model > #when ultrabrain resolves #then an unrelated vendor model must not open the sol gate [0.06ms]
+(pass) category activation gating > #given a registry model whose last path segment collides with a gate model > #when a real vercel gateway id is present #then the gate still opens [0.08ms]
+(pass) category activation gating > #given an ungated builtin category > #when the registry offers only a chain rung #then the pre-gating fallback behavior is unchanged [0.10ms]
+(pass) category activation gating > #given an ungated builtin category > #when a gated category is unmet #then other categories stay listed as available [0.08ms]
+
+packages/senpi-task/src/category/dead-chain.test.ts:
+(pass) dead-chain category disabling > #given a builtin category whose chain has no resolvable rung > #when spawned #then it fails model_unavailable with attempted_chain and missing_providers [0.26ms]
+(pass) dead-chain category disabling > #given a builtin category whose chain has no resolvable rung > #when the gated category list is computed #then the dead-chain builtin is excluded [0.08ms]
+(pass) dead-chain category disabling > #given a builtin category whose chain has no resolvable rung > #when other builtins still have a live rung #then they stay listed [0.08ms]
+(pass) dead-chain category disabling > #given a builtin category whose chain has no resolvable rung > #when a gated builtin's chain is also dead #then the gate failure carries the chain details [0.07ms]
+(pass) dead-chain category disabling > #given a registry with one kimi-coding model > #when a chain rung needs the kimi transform #then the transformed id keeps the category alive [0.18ms]
+(pass) dead-chain category disabling > #given a gateway-prefixed registry id > #when the unwrapped id matches a rung #then the category stays available [0.11ms]
+(pass) dead-chain category disabling > #given a user-configured category with an explicit model > #when the builtin chain is dead #then the category is never gated and still resolves [0.10ms]
+(pass) dead-chain category disabling > #given a user-configured category with an explicit model > #when the explicit model is missing #then the failure is a plain miss without chain details [0.10ms]
+(pass) dead-chain category disabling > #given disabled and unknown targets > #when the category is disabled #then the result still returns the gated list [0.08ms]
+(pass) dead-chain category disabling > #given disabled and unknown targets > #when the category is unknown #then the result still returns the gated list [0.08ms]
+
+packages/senpi-task/src/category/category-routing-policy.test.ts:
+(pass) Senpi category routing policy > uses the requested primary model and effort for routed categories [2.81ms]
+(pass) Senpi category routing policy > unspecified-low fallback chain is grok-4.6 xhigh first and excludes luna [0.10ms]
+
+packages/senpi-task/src/category/gpt-5.6-sol-routing.test.ts:
+(pass) GPT-5.6 Sol category routing > #given only OpenCode Sol #when ultrabrain resolves #then it uses the migrated GPT-5.6 rung [27.39ms]
+(pass) GPT-5.6 Sol category routing > #given only OpenCode Sol #when deep resolves #then it uses the migrated GPT-5.6 rung [0.22ms]
+(pass) GPT-5.6 Sol category routing > #given only OpenCode Sol #when unspecified-low resolves #then it is unavailable because sol left its chain [0.12ms]
+(pass) GPT-5.6 Sol category routing > #given only xAI grok-4.6 #when unspecified-low resolves #then it uses the xhigh first rung [0.15ms]
+(pass) GPT-5.6 Sol category routing > #given only Vercel Terra #when unspecified-low resolves #then it uses the high gateway rung [0.13ms]
+
+packages/senpi-task/src/config/settings.test.ts:
+(pass) task settings > #given no residency override #when settings parse #then defaults residency cap to max of eight and cpu times three [0.60ms]
+
+packages/senpi-task/src/dag/store.test.ts:
+(pass) createDagFileStore event WAL > #given five durable events #when reading two at a time #then sinceSeq is exclusive and hasMore flips [2.89ms]
+(pass) createDagFileStore event WAL > #given mixed events beyond a catch-up boundary #when filtering a bounded page #then lane type and throughSeq all apply [1.58ms]
+(pass) createDagFileStore event WAL > #given an existing event seq #when a distinct event reuses it #then the WAL rejects the duplicate [1.06ms]
+(pass) createDagFileStore event WAL > #given default store durability #when one event is appended #then the WAL descriptor is fsynced [0.94ms]
+(pass) createDagFileStore event WAL > #given fsync is disabled #when WAL, lock, and checkpoint writes run #then ordering remains without durability barriers [2.06ms]
+(pass) createDagFileStore event WAL > #given a WAL ending in a torn fragment #when a new store opens #then valid events remain and the tail is diagnosed and discarded [1.35ms]
+(pass) createDagFileStore event WAL > #given a future-schema event file #when a store opens #then it fails closed with a journal_corrupt diagnostic [1.03ms]
+(pass) createDagFileStore checkpoints and layout > #given POSIX checkpoint persistence #when an existing checkpoint is replaced #then readers see the old complete file until rename and both file and directory are fsynced [1.22ms]
+(pass) createDagFileStore checkpoints and layout > #given Windows checkpoint persistence #when directory fsync would fail with EPERM #then the atomic checkpoint still succeeds [0.97ms]
+(pass) createDagFileStore checkpoints and layout > #given a future-schema checkpoint #when it is opened #then it fails closed with a journal_corrupt diagnostic [0.94ms]
+(pass) createDagFileStore checkpoints and layout > #given an existing node result #when it is replaced #then readers see the old complete file until rename and both file and directory are fsynced [1.28ms]
+(pass) createDagFileStore checkpoints and layout > #given a one-run session limit #when a second run checkpoint is created #then the configured limit rejects it without an orphan [2.53ms]
+(pass) createDagFileStore checkpoints and layout > #given a parent session and run key #when writing the key #then its filename is the exact nul-delimited sha256 [1.36ms]
+(pass) createDagFileStore locks and retention > #given a lock held by a dead pid #when the run lock is acquired #then the stale lock is reclaimed [2.60ms]
+(pass) createDagFileStore locks and retention > #given Windows lock publication #when hard links are rejected with EPERM #then the lock is still acquired and released [1.56ms]
+(pass) createDagFileStore locks and retention > #given a Windows lock already held by a live process #when a second acquirer races #then it observes the holder instead of crashing [1.27ms]
+(pass) createDagFileStore locks and retention > #given a concurrent observer watches stale reclamation #when ownership changes #then the canonical lock path is never vacant [22.45ms]
+(pass) createDagFileStore locks and retention > #given two reclaimers validate one stale holder #when they contend at publication #then reclamation stays exclusive [4.03ms]
+(pass) createDagFileStore locks and retention > #given a second reclaimer observes sentinel initialization #when the first is preempted after open #then no ownerless sentinel is visible [15.73ms]
+(pass) createDagFileStore locks and retention > #given a crashed reclaimer left its sentinel #when another process reclaims the stale holder #then the sentinel cannot wedge acquisition [14.07ms]
+(pass) createDagFileStore locks and retention > #given a contender probes every reclamation transition #when a stale lock is replaced #then only the reclaimer concludes it holds the lock [2.89ms]
+(pass) createDagFileStore locks and retention > #given a fresh holder acquires between stale inspection and removal #when the run lock retries #then the fresh lock survives and the reclaimer never enters [2.24ms]
+(pass) createDagFileStore locks and retention > #given a contender replaces the observed stale holder before atomic takeover #when validation runs #then the contender wins and the reclaimer never enters [2.35ms]
+(pass) createDagFileStore locks and retention > #given an acquired lock path is replaced before release #when the original holder exits #then it never unlinks the replacement [1.43ms]
+(pass) createDagFileStore locks and retention > #given a dead holder is replaced before reclamation #when the run lock retries #then it never deletes the fresh holder [2.13ms]
+(pass) createDagFileStore locks and retention > #given expired terminal artifacts and equally old live artifacts #when retention runs #then only the terminal run is pruned [4.79ms]
+(pass) createDagFileStore locks and retention > #given expired terminal and equally old live skill sidecars #when retention runs #then only the terminal sidecar is pruned [2.89ms]
+
+packages/senpi-task/src/dag/scheduler.test.ts:
+(pass) DAG scheduler owner conflict adoption > #given a live task owned by another DAG attempt #when its node is admitted #then the scheduler adopts its completion and admits the dependent [19.70ms]
+(pass) DAG scheduler terminal result persistence > #given only the senpi-task scheduler #when a node completes #then output and run stats are persisted without an adapter [11.42ms]
+(pass) DAG scheduler subscriber backpressure > #given a non-default subscriber ring #when a scheduler listener falls behind #then overflow occurs at the configured bound [12.49ms]
+(pass) DAG scheduler execution mode dispatch > #given task.default_execution_mode #when a DAG node is dispatched #then the scheduler resolves through the existing chain [10.02ms]
+(pass) DAG scheduler failure semantics > #given every terminal task status #when folded #then each maps to its exact node outcome and error code [52.16ms]
+(pass) DAG scheduler failure semantics > #given every start denial #when admission fails #then each maps to its exact node error code [13.08ms]
+(pass) DAG scheduler failure semantics > #given a failed root with a descendant chain #when failure cascades #then every descendant skip is persisted separately [13.38ms]
+(pass) DAG scheduler failure semantics > #given graph-ordered failures finish out of order #when independent work settles #then the run uses the first wave and declaration failure [27.20ms]
+(pass) DAG scheduler cancellation > #given durable waiters armed before and during cancellation #when the scheduler cancels through a separate journal path #then every wait and re-attach settles cancelled [171.45ms]
+(pass) DAG scheduler cancellation > #given a running wave and pending descendants #when cancelled #then admitted tasks cancel, frontier admission stops, and waiters resolve cancelled [25.45ms]
+(pass) DAG scheduler cancellation > #given one startOwned rejects after a sibling starts #when cancellation follows #then admission clears and the sibling is attached and cancelled [10.41ms]
+(pass) DAG scheduler cancellation > #given an AbortError returned by task cancellation #when the run is cancelled #then durable cancellation settles and the rejection still surfaces [10.40ms]
+(pass) DAG scheduler cancellation > #given a genuine task cancellation failure #when a wave is cancelled #then the run settles cancelled and the failure still surfaces [13.87ms]
+(pass) DAG scheduler cancellation > #given a paused unclaimed run #when cancelled #then it ends cancelled without task cancellation [5.91ms]
+(pass) DAG scheduler dependency-frontier admission > #given a linear three-wave DAG #when run #then nodes and wave events still settle in order [24.42ms]
+(pass) DAG scheduler dependency-frontier admission > #given a diamond DAG #when run #then the fan-out shares one admission pass and the join waits for both [26.80ms]
+(pass) DAG scheduler dependency-frontier admission > #given an unrelated sibling still running #when a dependent's dependencies are all terminal #then the dependent is admitted without waiting for the sibling [257.14ms]
+(pass) DAG scheduler dependency-frontier admission > #given a dependency still running #when the scheduler is active #then its dependent is not admitted before terminal [29.68ms]
+(pass) DAG scheduler dependency-frontier admission > #given one waitFor rejects while a sibling is running #when the wave settles #then the rejection becomes one node failure and the sibling completes [15.80ms]
+(pass) DAG scheduler dependency-frontier admission > #given one root start fails #when its wave is admitted #then siblings and the independent branch still run [20.13ms]
+(pass) DAG scheduler dependency-frontier admission > #given startOwned queues a scheduled node #when attached #then its queue position is journaled [11.89ms]
+(pass) DAG scheduler dependency-frontier admission > #given a same-wave node is residency denied #when an attached sibling frees a slot #then admission retries without failing it [18.63ms]
+(pass) DAG scheduler dependency-frontier admission > #given a wave wider than residency capacity #when tasks settle #then all nodes are admitted in batches without a second concurrency limit [32.23ms]
+(pass) DAG scheduler node spawn policy > #given a policy that denies an agent-routed node #when the wave admits #then the node fails with the denial message and startOwned is never called [8.59ms]
+(pass) DAG scheduler node spawn policy > #given a policy that forces the prompt #when the node starts #then the child receives the forced prompt [10.73ms]
+(pass) DAG scheduler node spawn policy > #given category-routed nodes #when the wave admits #then the policy is never consulted [48.31ms]
+(pass) DAG scheduler node controls > #given a completed node #when retry is requested #then it refuses with node_not_retryable [2.98ms]
+(pass) DAG scheduler node controls > #given a cancelled node child #when send is requested #then it refuses with node_not_continuable and names retry [3.46ms]
+(pass) DAG scheduler node controls > #given a failed node with skipped dependents #when retried #then execAttempt increments, dependents unblock, and the run re-enters to completion [21.88ms]
+(pass) DAG scheduler node controls > #given a retried node #when it is admitted again #then the owner fingerprint folds the new execAttempt [36.49ms]
+(pass) DAG scheduler node controls > #given an explicit retry of only the failed ancestor #when re-entered #then its skipped dependents are restored to blocked [127.33ms]
+(pass) DAG scheduler node controls > #given a skipped node whose failed ancestor stays failed #when retried alone #then it refuses and names the ancestor [2.78ms]
+(pass) DAG scheduler node controls > #given a running run #when retry is requested #then it refuses with run_still_active and journals nothing [2.72ms]
+(pass) DAG scheduler node controls > #given a foreign pid holds the lease and is alive #when retry is requested for THIS run #then it refuses with run_not_owned naming that pid [2.82ms]
+(pass) DAG scheduler node controls > #given the lease pid is dead #when retry is requested #then the guard lets it through and the node re-runs [16.60ms]
+(pass) DAG scheduler node controls > #given a running node #when send delivers a steer #then the node stays running and the journal records delivery steer [15.11ms]
+(pass) DAG scheduler node controls > #given a failed node whose child is still resident #when send revives it #then the node runs again and its new outcome settles exactly once [6.98ms]
+(pass) DAG scheduler node controls > #given the full send outcome vocabulary #when a node child is messaged #then each outcome maps to its exact result or refusal [2.95ms]
+(pass) DAG scheduler node controls > #given a single explicit node and a prompt override #when retried #then the amendment is journaled before the retry and the new prompt runs [22.31ms]
+(pass) DAG scheduler node controls > #given a prompt override the definition compiler rejects #when retried #then the refusal is total: invalid_arguments, nothing journaled, no task started [3.03ms]
+(pass) DAG scheduler node controls > #given a prompt override with more than one target #when retried #then it refuses with invalid_arguments [2.29ms]
+(pass) applyDagSchedulerEvent resume reducer > #given a settled run record #when a resume is applied #then status runs again and the stale completedAt is cleared [0.14ms]
+(pass) applyDagSchedulerEvent resume reducer > #given a retried event #when applied through the scheduler reducer #then the shared record mutation runs [0.12ms]
+(pass) DAG scheduler control-event replay > #given a retried and revived run #when the checkpoint is rebuilt from the WAL alone #then it matches the live record [22.33ms]
+
+packages/senpi-task/src/dag/journal.test.ts:
+(pass) createDagJournal WAL ordering and replay > #given three mutations #when appended #then subscribers see durable events in order and checkpoint seq reaches three [4.96ms]
+(pass) createDagJournal WAL ordering and replay > #given checkpoint replacement crashes after WAL append #when reopened on the same store #then replay never reaches the previous journal subscriber [4.19ms]
+(pass) createDagJournal WAL ordering and replay > #given a queued node transition #when appended #then the journal preserves its queue position [2.60ms]
+(pass) createDagJournal WAL ordering and replay > #given a durable checkpoint and WAL #when reopened #then sequence numbers continue from the greater persisted tail [4.65ms]
+(pass) createDagJournal subscribers > #given a durable commit subscription #when it is removed before another journal commits #then no phantom delivery remains [3.06ms]
+(pass) createDagJournal subscribers > #given a subscriber blocked on its first event #when its ring overflows #then it receives one coalesced overflow with the last delivered recovery seq [6.95ms]
+(pass) createDagJournal subscribers > #given a viewer recovering a subscriber overflow #when it catches up from the recovery cursor #then every WAL seq is applied once without gaps [7.60ms]
+(pass) createDagJournal subscribers > #given a slow async listener #when another mutation is appended #then the mutation completes before the listener catches up [3.57ms]
+(pass) createDagJournal subscribers > #given an active subscription #when it is removed #then later events are not delivered [3.26ms]
+(pass) createDagJournal new event replay > #given a WAL with dag.node.retried, dag.node.steered, and dag.definition.amended #when the checkpoint is rebuilt from the WAL #then replayed checkpoint equals the original [14.60ms]
+(pass) createDagJournal new event replay > #given a checkpoint crash on a new boundary event #when reopened #then replay recovers the uncheckpointed tail and seq continues [4.76ms]
+(pass) createDagJournal new event replay > #given a subscriber #when new boundary events are appended #then it receives them with monotonic seq [3.61ms]
+
+packages/senpi-task/src/dag/manager.test.ts:
+(pass) createDagManager start > #given a valid two node definition #when started #then a run, a key file, and one created event are persisted [4.56ms]
+(pass) createDagManager start > #given a run created from a definition #when the identical definition is resubmitted #then the existing run is reused without new writes [4.76ms]
+(pass) createDagManager start > #given a run created from a definition #when the same key is resubmitted with an edited prompt #then definition_conflict is thrown and the run is untouched [5.92ms]
+(pass) createDagManager start > #given a key file whose run record was pruned #when a changed definition reuses the key #then a fresh run is created instead of a conflict [7.05ms]
+(pass) createDagManager start > #given a definition with a cyclic dependency #when started #then invalid_definition is thrown and nothing is persisted [1.04ms]
+(pass) createDagManager start > #given a configured node ceiling #when a definition exceeds it #then invalid_definition names the configured bound [0.91ms]
+(pass) createDagManager start > #given the same run key in two different sessions #when both start #then each session owns its own run [12.50ms]
+(pass) createDagManager skill materialization seam > #given a materializeSkills hook #when a run is created #then per node effectivePrompt slots are persisted without entering the fingerprint [8.39ms]
+(pass) createDagManager attach, snapshot, and history > #given a run owned by one session #when another session attaches #then run_not_owned is thrown [4.59ms]
+(pass) createDagManager attach, snapshot, and history > #given an unknown run id #when attached or snapshotted #then run_not_found is thrown [0.84ms]
+(pass) createDagManager attach, snapshot, and history > #given a run owned by one session #when a foreign session reads history #then run_not_owned is thrown and no events leak [4.30ms]
+(pass) createDagManager attach, snapshot, and history > #given journaled events #when history pages with an exclusive since and a through bound #then the store paging contract is delegated [4.54ms]
+(pass) createDagManager list > #given runs across two sessions #when listed #then only this session's runs appear sorted by updatedAt desc then runId asc [13.83ms]
+(pass) createDagManager list > #given more runs than the requested limit #when listed #then the limit is clamped to at most 256 and defaults to 100 [11.08ms]
+(pass) createDagManager amend > #given a completed diamond #when B's prompt is amended #then only B and D are invalidated and cached siblings survive [8.26ms]
+(pass) createDagManager amend > #given changed or invalid graph members #when amended #then running nodes and dangling removals are typed refusals while leaf removal is legal [6.69ms]
+(pass) createDagManager amend > #given a completed run #when a node is added #then compiled projections are replaced so the new node is admissible [79.56ms]
+(pass) createDagManager amend > #given a materialized run #when changed and added nodes are amended #then skills rematerialize once for only those nodes [6.72ms]
+(pass) createDagManager amend > #given invalid selectors or a missing run #when amended #then invalid_arguments and run_not_found are returned [0.91ms]
+(pass) createDagManager amend > #given amended and retried WAL events #when replayed from the old checkpoint #then the shared reducer rebuilds the identical checkpoint [8.50ms]
+(pass) createDagManager amend > #given a durable amendment whose preconditions no longer hold #when the WAL is replayed #then replay no-ops instead of wedging the run forever [8.61ms]
+(pass) createDagManager concurrent starts > #given two OS processes starting the same run key #when both are released together #then exactly one run file exists and the loser reuses it [192.19ms]
+(pass) createDagManager concurrent starts > #given two OS processes racing the same key with different prompts #when both are released together #then one run is created and the conflicting submission mutates nothing [156.60ms]
+
+packages/senpi-task/src/dag/events.test.ts:
+(pass) dagEventLane > #given all 14 journaled event types > #then every one classifies as boundary without throwing [0.19ms]
+(pass) dagEventLane > #given an unknown type string > #when classified #then it throws (exhaustiveness guard) [0.09ms]
+(pass) dag event builders > #given run fields #when dagRunCreatedEvent #then spec-shaped payload [0.07ms]
+(pass) dag event builders > #given a generation #when dagRunStartedEvent #then spec-shaped payload [0.06ms]
+(pass) dag event builders > #given a reason #when dagRunPausedEvent #then spec-shaped payload [0.07ms]
+(pass) dag event builders > #given no reason #when dagRunPausedEvent #then reason omitted [0.06ms]
+(pass) dag event builders > #given a generation #when dagRunResumedEvent #then spec-shaped payload [0.05ms]
+(pass) dag event builders > #given counts #when dagRunCompletedEvent #then spec-shaped payload [0.05ms]
+(pass) dag event builders > #given an error and counts #when dagRunFailedEvent #then spec-shaped payload [0.06ms]
+(pass) dag event builders > #given a reason and counts #when dagRunCancelledEvent #then spec-shaped payload [0.06ms]
+(pass) dag event builders > #given a wave #when dagWaveStartedEvent #then spec-shaped payload [0.07ms]
+(pass) dag event builders > #given a wave #when dagWaveCompletedEvent #then spec-shaped payload [0.07ms]
+(pass) dag event builders > #given a transition #when dagNodeTransitionedEvent #then spec-shaped payload [0.19ms]
+(pass) dag event builders > #given a task attach #when dagNodeTaskAttachedEvent #then spec-shaped payload [0.07ms]
+(pass) dag event builders > #given a reuse source #when dagNodeReusedEvent #then spec-shaped payload [0.07ms]
+(pass) dag event builders > #given a retry #when dagNodeRetriedEvent #then spec-shaped payload [0.06ms]
+(pass) dag event builders > #given a retry without prior task #when dagNodeRetriedEvent #then priorTaskId omitted [0.05ms]
+(pass) dag event builders > #given a steer delivery #when dagNodeSteeredEvent #then spec-shaped payload [0.05ms]
+(pass) dag event builders > #given a revive delivery #when dagNodeSteeredEvent #then spec-shaped payload [0.07ms]
+(pass) dag event builders > #given an amendment #when dagDefinitionAmendedEvent #then spec-shaped payload [0.06ms]
+(pass) dag event builders > #given a diagnostic #when dagDiagnosticAddedEvent #then spec-shaped payload [0.06ms]
+(pass) dag event builders > #given an overflow #when dagStreamOverflowEvent #then spec-shaped payload [0.06ms]
+(pass) dag event builders > #given any builder output #when inspected #then no envelope seq or at is assigned here [0.11ms]
+
+packages/senpi-task/src/dag/skills.test.ts:
+(pass) createDagSkillMaterializer at run creation > #given a node requesting a present skill #when materialized #then the skill block precedes the original prompt [2.49ms]
+(pass) createDagSkillMaterializer at run creation > #given a resolved skill #when materialized #then the manifest records the requested names, the sha256 digest, and the pinned cwd [1.89ms]
+(pass) createDagSkillMaterializer at run creation > #given a node requesting an absent skill #when materialized #then a missing_skill diagnostic is recorded and the prompt still dispatches [2.28ms]
+(pass) createDagSkillMaterializer at run creation > #given a materialized run #when SKILL.md is rewritten on disk #then the persisted effectivePrompt still carries the creation-time content [1.69ms]
+(pass) createDagSkillMaterializer at run creation > #given a node without load_skills #when materialized #then the effective prompt is the untouched original [1.24ms]
+(pass) createDagSkillMaterializer wired into DagManager.start > #given a run created with a materializer #when the cwd loses the skill afterwards #then the persisted definition keeps the creation-time effectivePrompt [5.93ms]
+(pass) createDagSkillMaterializer wired into DagManager.start > #given a missing skill #when the run is created #then the run exists with a missing_skill diagnostic and no failure [5.08ms]
+(pass) createDagSkillMaterializer wired into DagManager.start > #given a materialized run #when the same definition is submitted again #then the fingerprint ignores the skill content entirely [9.02ms]
+
+packages/senpi-task/src/dag/types.test.ts:
+(pass) dag domain types > #given the journaled payload union #when its type tags are enumerated #then it has exactly 14 members and excludes live activity [0.17ms]
+(pass) dag domain types > #given a journaled dag event #when constructed #then type and seq are sibling top-level properties on the flat envelope-payload intersection [0.10ms]
+(pass) dag domain types > #given live activity telemetry #when inspected #then it is a separate unsequenced event on its own channel [0.08ms]
+(pass) dag domain types > #given a dag route #when kinds are enumerated #then category XOR agent holds and a pure model route is impossible [0.09ms]
+(pass) dag domain types > #given node-level user input #when field names are checked #then they mirror the task tool category XOR subagent_type contract [0.07ms]
+(pass) dag domain types > #given the settings block #when defaults resolve #then every documented default holds [0.07ms]
+(pass) dag domain types > #given the state vocabularies #when enumerated #then run statuses node states error codes and transition reasons match the contract [0.09ms]
+
+packages/senpi-task/src/dag/scheduler-spill.test.ts:
+(pass) DAG scheduler wave spill-through > #given a node whose primary lane is full #when a fallback lane has capacity #then the wave runs on the spilled model without stalling [19.90ms]
+
+packages/senpi-task/src/dag/handle.test.ts:
+(pass) createDagWaitSurface wait terminal projection > #given a two node run #when both nodes complete #then wait resolves with each node output and run stats [82.00ms]
+(pass) createDagWaitSurface wait terminal projection > #given a failed node with a dependent #when the run ends failed #then wait resolves with the node error and the dependency skip [3.82ms]
+(pass) createDagWaitSurface wait terminal projection > #given a cancelled run #when wait is pending #then it resolves rather than rejects and carries the cancellation reason [4.03ms]
+(pass) createDagWaitSurface wait terminal projection > #given a run that is already terminal #when wait is called #then it resolves without any further journal event [4.23ms]
+(pass) createDagWaitSurface wait terminal projection > #given a run terminalizes during live subscription setup #when wait registers #then the final checkpoint read resolves without an event callback [2.50ms]
+(pass) createDagWaitSurface attach > #given an attached handle #when done resolves #then it equals the wait result and snapshot tracks the live record [4.08ms]
+(pass) createDagWaitSurface attach > #given an attached handle #when cancel is called #then the injected cancellation runs for the owned run only [2.64ms]
+(pass) createDagWaitSurface detach safety > #given a caller that abandons its wait promise #when the run later completes #then the run is untouched and a fresh attach still returns the result [3.90ms]
+(pass) createDagWaitSurface detach safety > #given many waiters on one run #when every waiter detaches but one #then the survivor still resolves and no journal subscription leaks [3.62ms]
+(pass) createDagWaitSurface pre-dispatch rejections > #given a run owned by a dead session #when a new session waits #then it rejects with run_not_owned instead of hanging [2.44ms]
+(pass) createDagWaitSurface pre-dispatch rejections > #given an unknown run id #when waited or attached #then run_not_found is raised before any subscription [2.33ms]
+(pass) createDagWaitSurface pre-dispatch rejections > #given malformed wait params #when waited #then invalid_arguments is raised and no run is touched [2.45ms]
+
+packages/senpi-task/src/dag/e2e-failure.test.ts:
+(pass) DAG failure, crash, and policy end to end > #given two failures whose completion order opposes graph order #when the real engine runs #then siblings and independent branches finish, dependents skip, and graph order selects the primary failure [69.11ms]
+(pass) DAG failure, crash, and policy end to end > #given a crash after an owned task spawns but before task attachment #when a fresh manager resumes #then startOwned recovers the existing task and spawn count remains exactly one [29.45ms]
+(pass) DAG failure, crash, and policy end to end > #given an existing run key #when its prompt changes #then definition_conflict leaves the original checkpoint, events, and task count untouched [16.01ms]
+(pass) DAG failure, crash, and policy end to end > #given spawn-capable parent tools #when an in-process DAG child resolves its real session options #then task, task_*, team_*, and dag are absent [16.68ms]
+(pass) DAG failure, crash, and policy end to end > #given inherited rpc extensions #when DAG and non-DAG children spawn #then only the DAG child omits the leading omo-senpi entry [19.06ms]
+(pass) DAG failure, crash, and policy end to end > #given a missing requested skill #when the real run starts #then a missing_skill diagnostic is retained and the node still completes [62.24ms]
+(pass) DAG failure, crash, and policy end to end > #given a corrupt trailing JSONL fragment #when the store reopens #then the tail is discarded, diagnosed, and earlier events remain authoritative [17.30ms]
+(pass) DAG failure, crash, and policy end to end > #given a SIGKILL at a randomized fsync-backed mutation boundary #when the store reopens #then the checkpoint is whole and every journaled event replays [389.10ms]
+(pass) DAG failure, crash, and policy end to end > #given a wave wider than residency_max_children #when admission frees slots in batches #then every node completes without a residency failure [61.96ms]
+(pass) DAG failure, crash, and policy end to end > #given expired terminal artifacts and equally old live artifacts #when retention runs #then events, results, and skills are pruned only for the terminal run [4.14ms]
+(pass) DAG retry, amend, and revive end to end > #given a failed node in a completed-upstream run #when retried #then the run completes and every upstream task id is reused untouched [49.16ms]
+(pass) DAG retry, amend, and revive end to end > #given a node that fails twice #when retried twice #then each attempt owns a distinct child and the last one settles the run [39.70ms]
+(pass) DAG retry, amend, and revive end to end > #given a node failed by the residency cap #when retried after the storm clears #then it runs and the run completes [22.47ms]
+(pass) DAG retry, amend, and revive end to end > #given a failed node #when its prompt is amended #then only it and its dependents re-run on re-entry [249.36ms]
+(pass) DAG retry, amend, and revive end to end > #given a settled run #when an amendment adds a node #then the added node executes on re-entry [30.03ms]
+(pass) DAG retry, amend, and revive end to end > #given a live wave with one failed node revived before its sibling settles #when the sibling completes #then the run awaits the revival and schedules their dependent [39.54ms]
+(pass) DAG retry, amend, and revive end to end > #given a failed node whose child is still resident #when send revives it #then the child continues in place and the node reaches completed once [25.27ms]
+
+packages/senpi-task/src/dag/fingerprint.test.ts:
+(pass) dagFingerprint canonicalization > #given key order differs #when fingerprinted #then identical hashes [0.23ms]
+(pass) dagFingerprint canonicalization > #given undefined fields #when fingerprinted #then omitted as if absent [0.07ms]
+(pass) dagFingerprint canonicalization > #given arrays with different order #when fingerprinted #then different hashes [0.08ms]
+(pass) dagFingerprint canonicalization > #given strings differing by whitespace only #when fingerprinted #then different hashes [0.06ms]
+(pass) dagDefinitionFingerprint > #given reordered dependsOn #when fingerprinted #then identical fingerprints [0.09ms]
+(pass) dagDefinitionFingerprint > #given reordered node list #when fingerprinted #then identical fingerprints [0.09ms]
+(pass) dagDefinitionFingerprint > #given a one-character change in the original prompt #when fingerprinted #then different fingerprints [0.07ms]
+(pass) dagDefinitionFingerprint > #given semantically identical definitions built independently #when fingerprinted #then identical [0.09ms]
+(pass) dagDefinitionFingerprint > #given the same submitted definition across a skill file change on disk #when fingerprinted twice #then identical [0.50ms]
+(pass) dagDefinitionFingerprint > #given optional node fields present #when fingerprinted #then included in the hash [0.08ms]
+(pass) nodeFingerprintInput > #given a node input with unsorted dependsOn #when normalized #then sorts dependsOn and keeps the original prompt [0.07ms]
+(pass) ownerFingerprintInput > #given execAttempt is 0 #when fingerprinted #then matches the pinned legacy hash [0.07ms]
+(pass) ownerFingerprintInput > #given execAttempt is omitted #when fingerprinted #then matches the pinned legacy hash [0.06ms]
+(pass) ownerFingerprintInput > #given execAttempt is 1 #when fingerprinted #then differs from the legacy hash [0.06ms]
+(pass) diffNodeFingerprints > #given changed/unchanged/added/removed nodes #when diffed #then classifies each bucket correctly [0.11ms]
+
+packages/senpi-task/src/dag/scheduler-frontier.test.ts:
+(pass) DAG scheduler dependency-frontier admission > #given a dependent whose dependsOn completed #when an unrelated sibling keeps running #then the dependent is admitted at once (dag_530ad299) [21.73ms]
+(pass) DAG scheduler dependency-frontier admission > #given a dependency still running #when the scheduler is active #then its dependent is not admitted before terminal [23.65ms]
+(pass) DAG scheduler dependency-frontier admission > #given frontier admission under the residency cap #when a slot frees #then the oldest denial is retried before newer ready nodes [20.93ms]
+(pass) DAG scheduler dependency-frontier admission > #given frontier admission #when the run settles #then every wave index reports exactly one completed grouping with full membership [27.24ms]
+
+packages/senpi-task/src/dag/recovery-nonblocking.test.ts:
+(pass) DAG resume without blocking on a reattached child > #given a paused run whose first node is still running #when the session resumes #then reuse and dag.run.resumed land while that child keeps running [33.31ms]
+(pass) DAG resume without blocking on a reattached child > #given a scheduler built with pre-attached tasks #when a node is retried #then the fresh instance does not re-attach the settled child [12.89ms]
+
+packages/senpi-task/src/dag/execution-mode.test.ts:
+(pass) resolveDagNodeExecutionMode > #given no sources at all #when resolved #then the default is in-process [0.60ms]
+(pass) resolveDagNodeExecutionMode > #given an omo.json task.default_execution_mode #when resolved #then the config mode is honored [0.07ms]
+(pass) resolveDagNodeExecutionMode > #given a per-agent executionMode #when resolved #then the agent mode wins over config [0.07ms]
+(pass) resolveDagNodeExecutionMode > #given a curated read-only agent configured for process #when resolved #then it is forced in-process [14.19ms]
+(pass) dag execution mode config surface > #given a config carrying task.dag.default_execution_mode #when parsed #then the strict schema rejects it [1.11ms]
+
+packages/senpi-task/src/dag/graph.test.ts:
+(pass) compileDag structure > #given a 4-node diamond #when compiled #then waves follow fan-out then join [0.19ms]
+(pass) compileDag structure > #given a diamond #when compiled #then edges derive from dependsOn only [35.94ms]
+(pass) compileDag structure > #given nodes with routes and labels #when compiled #then nodes carry pending state and the submitted prompt [0.49ms]
+(pass) compileDag structure > #given a downstream node #when compiled #then the prompt is never templated with upstream ids [60.30ms]
+(pass) compileDag ordering determinism > #given same-wave nodes declared out of id order #when compiled #then wave order follows declaration index then id [0.52ms]
+(pass) compileDag ordering determinism > #given identical graphs declared in different node order #when compiled #then wave membership is identical [0.59ms]
+(pass) compileDag critical path > #given a longest chain #when compiled #then the critical path is that chain in dependency order [0.20ms]
+(pass) compileDag critical path > #given two equally long chains #when compiled #then the tie breaks lexicographically on the full id sequence [0.34ms]
+(pass) compileDag bottlenecks > #given a diamond #when compiled #then bottlenecks count transitive descendants sorted by blocked count then id [0.51ms]
+(pass) compileDag bottlenecks > #given a deep chain #when compiled #then transitive descendants are counted, not direct dependents [0.25ms]
+(pass) compileDag validation > #given duplicate node ids #when compiled #then rejected naming the duplicate id and no graph produced [0.33ms]
+(pass) compileDag validation > #given an unknown dependency #when compiled #then rejected naming the missing id [0.25ms]
+(pass) compileDag validation > #given a self dependency #when compiled #then rejected as a self dependency, not a cycle [0.19ms]
+(pass) compileDag validation > #given a cyclic 3-node graph #when compiled #then rejected listing the exact cycle members deterministically [0.47ms]
+(pass) compileDag validation > #given the same cyclic graph declared in a different order #when compiled #then the cycle listing is identical [0.33ms]
+(pass) compileDag size bounds > #given 65 nodes #when compiled with default settings #then rejected on max_nodes_per_run [0.39ms]
+(pass) compileDag size bounds > #given 64 nodes #when compiled with default settings #then accepted [0.29ms]
+(pass) compileDag size bounds > #given a prompt over max_prompt_bytes #when compiled #then rejected naming the node [0.13ms]
+(pass) compileDag size bounds > #given a multibyte prompt #when measured #then bytes are counted, not code units [0.10ms]
+(pass) compileDag size bounds > #given a dependsOn fan-out over max_nodes_per_run #when compiled #then rejected on fan-out [0.11ms]
+(pass) compileDag purity > #given the same definition compiled twice #when serialized #then output is byte-identical [0.11ms]
+
+packages/senpi-task/src/dag/e2e-happy.test.ts:
+(pass) DAG happy-path end to end > #given a linear three-node definition #when the real engine runs #then every event, output, snapshot, and artifact is wave ordered [85.28ms]
+(pass) DAG happy-path end to end > #given a diamond fan-out and join #when the real engine runs #then the middle nodes share one admission pass [36.90ms]
+(pass) DAG happy-path end to end > #given eight mixed-route nodes across four waves #when the real engine runs #then routes, membership, events, and outputs stay intact [79.03ms]
+(pass) DAG happy-path end to end > #given a completed run key #when the identical definition starts again #then the same run is reused without a second run file or event [15.66ms]
+(pass) DAG happy-path end to end > #given the shipped SDK builder #when define, node, start, and wait call the real engine #then wait returns a terminal DagRunResult with node outputs [90.64ms]
+(pass) DAG happy-path end to end > #given all first-wave starts hit the resident child cap #when the shipped SDK waits #then it returns the terminal residency failures instead of hanging [21.69ms]
+(pass) DAG node control end to end > #given a running node #when a message is sent #then the live child receives it and the node keeps running to completion [20.87ms]
+(pass) DAG node control end to end > #given a settled run #when retry is followed immediately by wait #then wait blocks until the NEW settle [69.31ms]
+
+packages/senpi-task/src/dag/recovery.test.ts:
+(pass) DAG crash recovery > #given a paused run after wave one #when the session restarts #then completed work is reused, the running child folds, and the incomplete wave resumes [17.67ms]
+(pass) DAG crash recovery > #given no injected liveness probe #when a paused run's previous holder is this live process #then the default probe skips it as a live lease [16.40ms]
+(pass) DAG crash recovery > #given no injected liveness probe #when a paused run's previous holder pid does not exist #then the default probe claims the run [12.51ms]
+(pass) DAG crash recovery > #given scheduled nodes with and without durable owners #when resumed #then the owner is attached and only never-dispatched work starts [10.82ms]
+(pass) DAG crash recovery > #given an attached node whose task, owner, result, and transcript vanished #when resumed #then it fails closed without dispatch [7.92ms]
+(pass) DAG crash recovery > #given reconcile marked an in-process child lost #when its paused DAG resumes #then task_lost is folded and never re-dispatched [7.84ms]
+(pass) DAG crash recovery > #given a paused run owned by a dead foreign session #when recovery adopts it #then the resume is journaled on the run's own ledger [13.31ms]
+(pass) DAG crash recovery > #given two managers race a paused run #when the first claim holder is live #then exactly one resumes and the other observes the live lease [8.25ms]
+(pass) DAG crash recovery > #given a crash after a terminal transition reaches the WAL but before its reducer #when recovery reopens #then output artifact metadata and run stats are rebuilt [12.15ms]
+(pass) DAG crash recovery > #given a crash after a recovered task transition reaches the WAL #when the engine reopens #then artifact metadata is rebuilt from the durable copy [11.70ms]
+(pass) DAG crash recovery > #given a live run #when shutdown pause starts #then admission stops before pause persistence and its lease is released [28.56ms]
+(pass) DAG recovery attempt-scoped ownership > #given a pre-change checkpoint with legacy owner fingerprints #when resumed #then it completes and the legacy fingerprint is reused verbatim [10.94ms]
+(pass) DAG recovery attempt-scoped ownership > #given a reattach whose observed taskId differs #when resumed #then the display attempt bumps without a new execution and the owner fingerprint still matches [8.72ms]
+(pass) DAG recovery attempt-scoped ownership > #given a retried pending node with execAttempt #when resumed #then it starts fresh under the attempt-scoped fingerprint [31.99ms]
+(pass) resumePausedRuns adoption > #given a foreign paused run with a dead lease holder #when a new session resumes #then it adopts, re-homes, and completes the run [16.57ms]
+(pass) resumePausedRuns adoption > #given a foreign paused run whose lease holder is alive #when another session resumes #then the run is left untouched [2.63ms]
+(pass) resumePausedRuns adoption > #given a foreign paused run with no recorded lease holder #when another session resumes #then abandonment is unproven and the run is left untouched [2.53ms]
+(pass) resumePausedRuns adoption > #given a foreign paused run whose lease holder is this process #when it resumes #then self-adoption is safe and the run completes [17.97ms]
+
+packages/senpi-task/src/dag/results.test.ts:
+(pass) persistDagNodeResult durable node artifacts > #given a terminal node record #when persisted #then the response file carries the sha256 and byte count of the copy [24.60ms]
+(pass) persistDagNodeResult durable node artifacts > #given run stats on the terminal record #when persisted #then a stats sidecar holds them with its own digest [3.88ms]
+(pass) persistDagNodeResult durable node artifacts > #given a persisted node #when the TaskRecord is deleted #then resume reuse still reads the output and stats [2.00ms]
+(pass) persistDagNodeResult durable node artifacts > #given an unwritable result path #when persisting #then a journal_corrupt diagnostic is returned instead of throwing [2.07ms]
+(pass) persistDagNodeResult durable node artifacts > #given a node with no persisted artifact #when reuse reads it #then it reports nothing rather than falling back to the record [1.64ms]
+(pass) persistDagNodeResult durable node artifacts > #given a terminal record without run stats #when persisted #then no sidecar is written and reuse reports undefined stats [1.63ms]
+(pass) persistDagNodeResult durable node artifacts > #given a persisted node #when persisted again with a different body #then the second body replaces the first and the stats sidecar is replaced [2.53ms]
+(pass) persistDagNodeResult durable node artifacts > #given a fault mid-write during re-persist #then the prior artifact body remains intact and no orphan temp file is left [2.53ms]
+
+packages/senpi-task/src/lifecycle/residency.test.ts:
+(pass) admitResident (residency cap + LRU eviction) > #given residents below the cap #when admitting #then it is admitted with no eviction [1.18ms]
+(pass) admitResident (residency cap + LRU eviction) > #given a full session with terminal residents #when admitting #then the OLDEST idle terminal is evicted [1.81ms]
+(pass) admitResident (residency cap + LRU eviction) > #given the oldest terminal has a pending send #when admitting #then it is skipped and the next terminal is evicted [1.44ms]
+(pass) admitResident (residency cap + LRU eviction) > #given a full session with ALL residents running #when admitting #then it is rejected naming the residents, no eviction [1.04ms]
+(pass) admitResident (residency cap + LRU eviction) > #given other-session residents fill the cap #when admitting for a fresh session #then it is admitted (cap is per parent session) [0.86ms]
+(pass) admitResident (residency cap + LRU eviction) > #given lost residents pin every slot #when admitting #then the oldest lost resident is evicted (residency-leak regression) [1.45ms]
+(pass) admitResident (residency cap + LRU eviction) > #given a cancelled resident at the cap #when admitting #then it is evicted like any other terminal [1.45ms]
+
+packages/senpi-task/src/lifecycle/admission-lease.test.ts:
+(pass) acquireSessionAdmissionLease > #given no lease on disk #when acquiring #then the lease file appears with the acquirer's token and release removes it [47.86ms]
+(pass) acquireSessionAdmissionLease > #given a holder renewing on virtual time #when several stale windows pass before a waiter contends #then the holder is NOT reclaimed and the waiter yields contended [134.65ms]
+(pass) acquireSessionAdmissionLease > #given a crashed holder whose renewal stopped #when the lease goes stale #then a waiter takes over and the crashed holder's late release cannot delete the successor [135.74ms]
+(pass) acquireSessionAdmissionLease > #given one stale lease and two racing waiters #when both attempt the takeover CAS #then exactly one wins and the loser never deletes the winner's lease [23.63ms]
+
+packages/senpi-task/src/lifecycle/reconcile-revival.test.ts:
+(pass) reconcileOnSessionStart scoped revival > #given a suspended in-process child of the resumed session #when session start reconciles #then it resumes through the in-process port [73.57ms]
+(pass) reconcileOnSessionStart scoped revival > #given a legacy crash orphan of another session #when this session resumes #then the global process reattach still runs [3.57ms]
+(pass) reconcileOnSessionStart scoped revival > #given a terminal record owned by a live sibling #when reconciled #then the early owner guard leaves it untouched [1.62ms]
+(pass) reconcileOnSessionStart scoped revival > #given a suspended child of another session #when this session resumes #then the other child is untouched [3.42ms]
+(pass) reconcileOnSessionStart scoped revival > #given two managers racing one suspended child #when both reconcile #then one claims and the other defers [30.03ms]
+(pass) reconcileOnSessionStart scoped revival > #given one in-process and one rpc child of this session plus another-session child #when reconciled #then only this session revives end to end [4.88ms]
+(pass) reconcileOnSessionStart scoped revival > #given terminal no-transcript disposal contends once #when admission follows #then the prompt is never relaunched and disposal defers [1.83ms]
+(pass) reconcileOnSessionStart scoped revival > #given model resolution is temporarily unavailable #when revival fails #then ownership rolls back and the outcome is deferred [2.76ms]
+(pass) reconcileOnSessionStart scoped revival > #given retryable respawn failure and rollback lock failure #when reconciled #then the outcome loudly names the failed rollback [7.28ms]
+(pass) reconcileOnSessionStart scoped revival > #given one record lock throws #when a batch reconciles #then only that record defers and the other revives [4.49ms]
+(pass) reconcileOnSessionStart scoped revival > #given cancelled and killed suspended records #when their session resumes #then neither is revived [2.85ms]
+(pass) reconcileOnSessionStart scoped revival > #given a pending child without a transcript and with durable steering #when resumed twice #then it launches once from its prompt and drains steering in order [7.69ms]
+(pass) reconcileOnSessionStart scoped revival > #given legacy records without transcript or v1 spec #when resumed #then non-terminal is lost and terminal is disposed with its result [3.71ms]
+(pass) reconcileOnSessionStart scoped revival > #given a terminal v1 record without transcript #when resumed #then it is disposed without rerunning its prompt [2.18ms]
+(pass) reconcileOnSessionStart scoped revival > #given an orphaned rpc child still alive #when reclaimed #then the old pid is proven dead before replacement spawn [32.94ms]
+(pass) reconcileOnSessionStart scoped revival > #given a killed orphaned resident at the cap #when reconciled #then it is disposed and its slot can be reused [8.04ms]
+(pass) reconcileOnSessionStart scoped revival > #given a same-process orphan and a full cap #when its session resumes #then reclamation bypasses capacity and revives it [4.73ms]
+(pass) reconcileOnSessionStart scoped revival > #given two OS processes observe one dead-owner resident #when their ownership CAS races #then exactly one respawns and the loser defers [327.02ms]
+(pass) reconcileOnSessionStart scoped revival > #given reattach and child resume are disabled #when suspended records exist #then they remain suspended with deferred outcomes [2.39ms]
+(pass) reconcileOnSessionStart scoped revival > #given ten suspended children and capacity eight #when resumed #then eight revive and overflow defers without loss [15.92ms]
+(pass) reconcileOnSessionStart scoped revival > #given the admission lease is held past the bounded wait #when the session resumes #then the batch defers without throwing [39.00ms]
+
+packages/senpi-task/src/lifecycle/batch-admission-race.test.ts:
+(pass) admitSuspendedBatch two-OS-process race > #given two OS processes over one store with 8 suspended and cap 5 #when both admit from a shared barrier #then total claims never exceed the cap and never duplicate [310.89ms]
+
+packages/senpi-task/src/lifecycle/shutdown.test.ts:
+(pass) suspendOnSessionShutdown > #given an in-process running resident #when its session shuts down #then it suspends persisted_only with forget before abort and run_epoch unchanged [12.69ms]
+(pass) suspendOnSessionShutdown > #given an rpc running resident #when its session shuts down #then it suspends rpc_detached retaining pid and clearing host_pid [1.69ms]
+(pass) suspendOnSessionShutdown > #given a resident of a different parent session #when this session shuts down #then it is untouched [0.72ms]
+(pass) suspendOnSessionShutdown > #given a resident owned by a foreign host pid #when this session shuts down #then it is untouched [0.74ms]
+(pass) suspendOnSessionShutdown > #given a cancelled resident #when its session shuts down #then it is disposed through the cancel family, not suspended [1.51ms]
+(pass) suspendOnSessionShutdown > #given a completed resident #when its session shuts down #then it suspends persisted_only preserving the completed status [1.57ms]
+(pass) suspendOnSessionShutdown > #given a pending record of this session with no handle #when its session shuts down #then it is dequeued and suspended with host_pid cleared and run_epoch unchanged [1.32ms]
+(pass) suspendOnSessionShutdown > #given a pending record of another session #when this session shuts down #then it is untouched and never dequeued [0.72ms]
+(pass) suspendOnSessionShutdown > #given a killed resident #when its session shuts down #then it is disposed with a destroyed event, never persisted_only [1.47ms]
+(pass) suspendOnSessionShutdown > #given resume_children false #when the session shuts down #then the legacy dispose path runs and pending records stay untouched [1.61ms]
+(pass) suspendOnSessionShutdown > #given one child whose dispose throws #when the session shuts down #then the other child still suspends and the failure is reported [1.60ms]
+(pass) suspendOnSessionShutdown > #given a child whose abort rejects #when the session shuts down #then suspension continues and no failure is recorded [1.68ms]
+(pass) suspendOnSessionShutdown > #given no children at all #when the session shuts down #then the summary is all zeros without throwing [0.52ms]
+
+packages/senpi-task/src/lifecycle/single-writer-audit.test.ts:
+(pass) single-writer destruction audit > #given package source #when scanning for destruction invocations #then none live outside the lifecycle port [6.02ms]
+(pass) single-writer destruction audit > #given the allowlist #when auditing the lifecycle port #then it is the only non-definition invoker [0.09ms]
+
+packages/senpi-task/src/lifecycle/destroy.test.ts:
+(pass) destroyResidentTask (the single-writer destruction port) > #given an in-process resident #when cancel-destroyed #then it aborts before dispose and marks disposed [3.81ms]
+(pass) destroyResidentTask (the single-writer destruction port) > #given an in-process DAG resident #when cancel-destroyed without abort #then it disposes without creating an abort promise [1.39ms]
+(pass) destroyResidentTask (the single-writer destruction port) > #given an in-process resident whose abort rejects #when cancel-destroyed #then dispose still runs and it ends disposed [1.31ms]
+(pass) destroyResidentTask (the single-writer destruction port) > #given a fallback handoff #when the old resident is torn down #then manager ownership metadata stays registered [0.72ms]
+(pass) destroyResidentTask (the single-writer destruction port) > #given an rpc resident #when destroyed #then it terminates (TERM->KILL) then detaches, never dispose-only [1.06ms]
+(pass) destroyResidentTask (the single-writer destruction port) > #given a terminal resident #when evicted #then residency becomes evicted and a JSONL evicted event lands [1.11ms]
+(pass) destroyResidentTask (the single-writer destruction port) > #given no resident handle #when destroyed twice #then it is idempotent and never throws [1.57ms]
+
+packages/senpi-task/src/lifecycle/ttl.test.ts:
+(pass) cleanupExpiredRecords (TTL) > #given an expired terminal record #when cleaning #then its record and log are deleted [26.05ms]
+(pass) cleanupExpiredRecords (TTL) > #given a fresh terminal record #when cleaning #then it is retained [1.01ms]
+(pass) cleanupExpiredRecords (TTL) > #given an old NON-terminal record #when cleaning #then it is retained [1.00ms]
+(pass) cleanupExpiredRecords (TTL) > #given a freshly claimed pending record #when the cutoff is far in the future #then it is retained [0.74ms]
+(pass) cleanupExpiredRecords (TTL) > #given an old lost RPC record with a LIVE pid #when cleaning #then it is retained (no pid-dead proof) [0.72ms]
+(pass) cleanupExpiredRecords (TTL) > #given an old lost RPC record with a DEAD pid #when cleaning #then it is deleted (pid-dead proven) [0.91ms]
+(pass) cleanupExpiredRecords (TTL) > #given an expired terminal record owned by a live resident handle #when cleaning #then it is retained until the handle is forgotten [1.07ms]
+(pass) cleanupExpiredRecords (TTL) cross-process ownership > #given an expired resident record owned by a LIVE foreign process #when cleaning #then it is retained [0.75ms]
+(pass) cleanupExpiredRecords (TTL) cross-process ownership > #given an expired resident record whose foreign owner is DEAD #when cleaning #then it is deleted [0.87ms]
+(pass) cleanupExpiredRecords (TTL) suspended-era artifacts > #given an expired terminal persisted_only record with child artifacts #when cleaning #then record, children dir, spill, and log are all deleted [1.89ms]
+(pass) cleanupExpiredRecords (TTL) suspended-era artifacts > #given an expired NON-terminal suspended record #when cleaning #then it and its child artifacts are retained [1.57ms]
+(pass) cleanupExpiredRecords (TTL) suspended-era artifacts > #given a record claimed by revival between the scan and the delete #when cleaning #then the claimed record is retained [1.38ms]
+(pass) cleanupExpiredRecords (TTL) suspended-era artifacts > #given an expired terminal record with an undelivered notify_on_terminal notification #when cleaning #then it is retained until the epoch is delivered [1.29ms]
+(pass) cleanupExpiredRecords (TTL) suspended-era artifacts > #given an expired legacy terminal record whose only marker is notification_failed_epoch #when cleaning #then it is retained until delivered [1.20ms]
+(pass) cleanupExpiredRecords (TTL) suspended-era artifacts > #given a sweep crashed after tombstoning #when the next sweep runs #then it finishes deleting the artifacts idempotently [2.07ms]
+(pass) cleanupExpiredRecords (TTL) suspended-era artifacts > #given an expired terminal rpc record with a LIVE orphan pid #when cleaning #then the orphan is destroyed BEFORE its artifacts are deleted [3.71ms]
+
+packages/senpi-task/src/lifecycle/reconcile.test.ts:
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a dead process and persisted sessions #when reconciled #then the newest session is respawned running at epoch plus one [22.65ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given injected reattach ports and a registered store fallback #when reconciled #then the injected ports take precedence [2.26ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a dead process without a session #when reconciled #then it remains lost without respawn [2.03ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a live foreign process and persisted session #when reconciled #then it is terminated before respawn reattach [5.51ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given an in-process record #when reconciled #then the previous-process task is lost and never respawned [7.57ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a live in-process resident visible in the registry snapshot #when reconciled #then it stays running and resident for completion delivery [0.99ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given an in-process record marked lost #when reconciled #then its residency claim is released so the slot is reclaimable [1.60ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a leaked {lost, resident} record from an earlier session #when reconciled #then it self-heals to disposed [1.37ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given an orphan whose reattach respawn then fails #when reconciled #then the true terminal reason replaces the first lost reason [3.84ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given reconcile reattach is disabled #when a durable session exists #then v1 lost behavior runs without respawn [2.66ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given this process already owns the live handle #when reconciled #then the record is skipped without signalling or respawn [1.44ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a completed resident daemon with a dead pid #when reconciled #then its process returns while the record stays terminal [2.40ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a completed resident daemon with a live foreign pid #when reconciled #then it is terminated before reattach [18.75ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given overlapping reconcile sweeps #when ownership claims race #then exactly one child respawns and the loser defers [14.38ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a process runner reports effective launch inputs #when persisted record is reloaded #then only safe spawn facts survive [3.85ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given switch_session is cancelled #when reconciled #then the fresh child is torn down and the record stays lost [9.24ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given one trusted launch resolver rejection #when reconciling multiple process tasks #then later tasks still reattach [15.28ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given a team member whose current runtime is missing #when reconciling #then it is lost without blocking later records [46.15ms]
+(pass) reconcileOnSessionStart reattach >  w2reattach #given one concurrency slot and two queued tasks #when a reattached task completes #then only the first queued task starts [19.46ms]
+(pass) reconcileOnSessionStart cross-process ownership > #given a running in-process record owned by a LIVE foreign process #when reconciled #then it is skipped and stays running [2.37ms]
+(pass) reconcileOnSessionStart cross-process ownership > #given a running process-mode record owned by a LIVE foreign process #when reconciled #then it is skipped with no signals and no loss [1.07ms]
+(pass) reconcileOnSessionStart cross-process ownership > #given a running process-mode record whose owner process is DEAD #when reconciled #then it is lost as before [6.26ms]
+(pass) reconcileOnSessionStart cross-process ownership > #given a process-mode record owned by THIS process #when reconciled #then it is not skipped as foreign and reattaches as before [22.94ms]
+(pass) reconcileOnSessionStart cross-process ownership > #given a legacy running process-mode record with no host_pid #when reconciled #then it is lost as before [13.54ms]
+(pass) reconcileOnSessionStart cross-process ownership > #given a running in-process record owned by THIS process with no live handle #when reconciled #then it is lost [12.78ms]
+
+packages/senpi-task/src/lifecycle/reconcile-multi-session.test.ts:
+(pass) reconcileOnSessionStart multi-session sibling sweep > #given a running in-process resident owned by THIS process for ANOTHER session #when this session reconciles #then it is deferred as a same-process sibling and never lost [10.38ms]
+(pass) reconcileOnSessionStart multi-session sibling sweep > #given a running in-process resident owned by a DEAD foreign process for ANOTHER session #when this session reconciles #then it is still lost (sweep still works) [9.22ms]
+
+packages/senpi-task/src/lifecycle/batch-admission.test.ts:
+(pass) admitSuspendedBatch (capacity-aware batch admission) > #given unlimited residency with existing residents #when suspended children resume #then every candidate is claimed [11.09ms]
+(pass) admitSuspendedBatch (capacity-aware batch admission) > #given 10 suspended (3 running, 7 completed) and 2 residents under cap 8 #when the batch admits #then 3 running + 3 MRU completed are claimed and 4 defer capacity [18.97ms]
+(pass) admitSuspendedBatch (capacity-aware batch admission) > #given cap 2 with 3 residents #when the batch admits #then nothing is revived and the residents are kept [3.18ms]
+(pass) admitSuspendedBatch (capacity-aware batch admission) > #given another session's, cancelled, and killed suspended records #when the batch admits #then only this session's revivable records are claimed [3.75ms]
+(pass) admitSuspendedBatch (capacity-aware batch admission) > #given lease acquisition reports contention #when a batch admission starts #then the whole batch defers lock_contended and nothing is claimed [1.92ms]
+(pass) admitSuspendedBatch (capacity-aware batch admission) > #given the lease is displaced mid-batch #when the holder re-reads it before each mutation #then it aborts the remaining claims [4.60ms]
+(pass) reclaimOrphanedResident (reclamation bypasses admission) > #given the cap fully consumed and an orphaned resident #when reclaiming the orphan #then it is claimed without touching the cap or the other residents [10.86ms]
+(pass) reclaimOrphanedResident (reclamation bypasses admission) > #given a reclaim raced and lost the expected-owner CAS #when retrying with the stale observation #then it reports not_claimable and touches nothing [1.72ms]
+
+packages/senpi-task/src/lifecycle/reconcile-capacity.test.ts:
+(pass) reconcile capacity reservations > #given legacy reconcile is at cap #when reattach is considered #then it defers without respawn [50.13ms]
+(pass) reconcile capacity reservations > #given reclamation reconcile is at cap #when revival is considered #then it rolls back and defers without respawn [2.36ms]
+
+packages/senpi-task/src/completion/notifier-reconcile-unnotified.test.ts:
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given a terminal notify_on_terminal record with an unnotified epoch w4notif #when the session reconciles twice #then exactly one notification is delivered [32.37ms]
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given an already-notified epoch w4notif #when the session reconciles #then the record is skipped [0.10ms]
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given a terminal unnotified record of another session w4notif #when this session reconciles #then the record is skipped [0.07ms]
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given a terminal unnotified record without opt-in or failed delivery w4notif #when the session reconciles #then the record is skipped [0.06ms]
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given a legacy failed-delivery record without notify_on_terminal w4notif #when the session reconciles #then the in-flight retry is preserved [0.10ms]
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given delivery fails during reconcile w4notif #when the enqueue throws #then notification_failed_epoch is recorded and the retry is scheduled [0.20ms]
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given a completion buffered behind a transient parent state w4notif #when the session reconciles before the flush #then reconcile skips it and the flush delivers exactly once [0.18ms]
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given a residency claim lands between read and notified-epoch persist w4notif #when the epoch is stamped #then the claim survives [0.09ms]
+(pass) createCompletionNotifier - reconcile unnotified terminal completions > #given a residency claim lands before a failed-delivery persist w4notif #when the failure epoch is stamped #then the claim survives [0.09ms]
+
+packages/senpi-task/src/completion/model-visibility.test.ts:
+(pass) task completion model visibility > #given a resolved category model #when completion is rendered #then the event names both [0.33ms]
+
+packages/senpi-task/src/completion/routing.test.ts:
+(pass) routeCompletion > #given idle parent #when routed #then always wakes with no config to consult [0.38ms]
+(pass) routeCompletion > #given streaming parent #when routed #then delivered into the running turn [0.18ms]
+(pass) routeCompletion > #given compacting parent #when routed #then buffered with compacting reason [0.14ms]
+(pass) routeCompletion > #given session_switching parent #when routed #then buffered with switching reason [0.12ms]
+(pass) routeCompletion > #given session_shutdown parent #when routed #then buffered with shutdown reason [0.12ms]
+(pass) shouldNotifyStatus > #given external terminals and completions/errors #when checked #then notifies [7.59ms]
+(pass) shouldNotifyStatus > #given parent-initiated terminals #when checked #then does not notify [0.22ms]
+(pass) shouldNotifyStatus > #given non-terminal statuses #when checked #then does not notify [0.33ms]
+
+packages/senpi-task/src/completion/notifier-retry.test.ts:
+(pass) createCompletionNotifier scheduled retries > #given two immediate failures w2notif #when the first timer fires #then delivery persists exactly once [0.49ms]
+(pass) createCompletionNotifier scheduled retries > #given a failed epoch w2notif #when revive advances the epoch before retry #then stale delivery drops [0.14ms]
+(pass) createCompletionNotifier scheduled retries > #given a pending retry w2notif #when the buffered entry flushes first #then the timer skips notified work [19.80ms]
+(pass) createCompletionNotifier scheduled retries > #given persistent enqueue failures w2notif #when eight timers exhaust #then the cycle caps and the count is cleaned so a later reconcile restarts fresh [0.33ms]
+(pass) createCompletionNotifier scheduled retries > #given failed records from mixed sessions w2notif #when reconciled twice #then only eligible work delivers once [0.15ms]
+(pass) createCompletionNotifier scheduled retries > #given a failed record w2notif #when reconciliation sees compaction #then it buffers normally [0.09ms]
+(pass) createCompletionNotifier scheduled retries > #given retries keep failing w2notif #when timers reschedule #then delays follow the capped ladder [0.19ms]
+(pass) createCompletionNotifier scheduled retries > #given a retry dropped for another session w2notif #when its session reconciles #then backoff restarts at the base delay [0.12ms]
+(pass) createCompletionNotifier scheduled retries > #given session A owns a failed retry w2notif #when session B is current #then retry drops until A reconciles [0.14ms]
+
+packages/senpi-task/src/completion/notifier-buffer-dedupe.test.ts:
+(pass) completion notifier buffered dedupe (W1-V F5) > #given the same (task,epoch) buffered twice #when flushed #then the parent is notified once [0.38ms]
+
+packages/senpi-task/src/completion/notifier.test.ts:
+(pass) createCompletionNotifier - exactly-once epoch contract > #given double terminal replay #when notified twice #then exactly one delivery [0.28ms]
+(pass) createCompletionNotifier - exactly-once epoch contract > #given revived task at epoch 1 #when second completion arrives #then it notifies again [0.10ms]
+(pass) createCompletionNotifier - exactly-once epoch contract > #given persisted notified_epoch #when notified after resume #then no re-notify [0.07ms]
+(pass) createCompletionNotifier - gating > #given synchronous foreground task #when it completes #then never notifies [0.06ms]
+(pass) createCompletionNotifier - gating > #given parent-initiated cancel or interrupt #when terminal #then never notifies [0.07ms]
+(pass) createCompletionNotifier - gating > #given still-running task #when notified #then skipped as non-terminal [0.06ms]
+(pass) createCompletionNotifier - routing table > #given idle parent #when delivered #then triggerTurn payload recorded unconditionally [0.09ms]
+(pass) createCompletionNotifier - routing table > #given streaming parent #when delivered #then triggerTurn payload recorded for the batched steer [0.07ms]
+(pass) createCompletionNotifier - routing table > #given compacting parent #when notified #then buffered without delivery [0.06ms]
+(pass) createCompletionNotifier - routing table > #given session_switching parent #when notified #then buffered without delivery [0.06ms]
+(pass) createCompletionNotifier - buffering, flush, batching > #given two buffered completions on one session #when flushed on idle #then one wake carries both [0.11ms]
+(pass) createCompletionNotifier - buffering, flush, batching > #given buffered completion #when the session was replaced #then it is dropped, not delivered [0.11ms]
+(pass) createCompletionNotifier - buffering, flush, batching > #given no buffered notifications #when flushed #then empty result [0.08ms]
+(pass) createCompletionNotifier - notifier failure contract > #given first enqueue throws but retry succeeds #when delivered #then one retry lands and epoch advances [0.13ms]
+(pass) createCompletionNotifier - notifier failure contract > #given enqueue throws twice #when delivered #then failure recorded and epoch not advanced [0.12ms]
+
+packages/senpi-task/src/completion/notification.test.ts:
+(pass) buildCompletionDetails > #given completed record #when details built #then core facts, full result, and duration are populated [0.22ms]
+(pass) buildCompletionDetails > #given a result longer than the former 700-char cap #when details built #then the full result is included [0.08ms]
+(pass) buildCompletionDetails > #given a result beyond transport capacity #when details built #then its full text is spilled to a local file [0.61ms]
+(pass) buildCompletionDetails > #given resident completed record #when details built #then continuation hint names task_send but never task_output [0.06ms]
+(pass) buildCompletionDetails > #given resident completed record #when details built #then task_send hint uses to and message params [0.06ms]
+(pass) buildCompletionDetails > #given error record #when details built #then error message feeds the full result [0.07ms]
+(pass) buildCompletionDetails > #given tokens provided #when details built #then tokens are attached [0.05ms]
+(pass) buildCompletionMessage > #given a complete result #when notification built #then the body contains it without a follow-up task_output instruction [0.12ms]
+(pass) buildCompletionMessage > #given a spilled result #when notification built #then the body names its local file [5.92ms]
+(pass) buildCompletionMessage > #given two details #when message built #then both completions appear in one content block [0.18ms]
+(pass) dag-owned completions > #given a dag-owned record #when details built #then the owning run and node are attached [0.09ms]
+(pass) dag-owned completions > #given a dag-owned detail #when message built #then the verification directive is appended once [0.11ms]
+(pass) dag-owned completions > #given a plain record #when details and message built #then no dag facts and no directive appear [0.08ms]
+(pass) dag-owned completions > #given one plain and two dag details #when message built #then the directive appears exactly once [0.09ms]
+(pass) completion run stats > #given a record with run stats #when details are built #then run stats and token fallback are attached [0.11ms]
+(pass) completion run stats > #given explicit tokens #when details are built #then the explicit value wins over run stats [0.06ms]
+
+packages/senpi-task/src/completion/unconditional-wake.test.ts:
+(pass) unconditional wake > #given an idle parent #when a background child completes #then it always wakes with triggerTurn [0.18ms]
+(pass) unconditional wake > #given an idle parent #when notified end to end #then a triggerTurn message is enqueued [0.29ms]
+(pass) unconditional wake > #given a streaming parent #when a background child completes #then delivery carries triggerTurn for the batched steer [0.11ms]
+
+packages/senpi-task/src/agents/invocation-guard.test.ts:
+(pass) AGENT_INVOCATION_CONDITIONS > #given the classification #when inspected #then metis and momus form the plan-gated tier with the ulw-plan/artifact/ulw-execute condition [0.21ms]
+(pass) AGENT_INVOCATION_CONDITIONS > #given a non-gated agent #when its condition is queried #then none is registered [0.08ms]
+(pass) evaluateInvocationGuard > #given a non-gated agent #when evaluated with an empty session #then it allows [0.12ms]
+(pass) evaluateInvocationGuard > #given momus and an empty session #when evaluated #then it denies and names the ulw-plan requirement [0.09ms]
+(pass) evaluateInvocationGuard > #given metis and an empty session #when evaluated #then it denies and names the ulw-plan requirement [0.07ms]
+(pass) evaluateInvocationGuard > #given only a SKILL.md-read invocation without a user request #when momus is evaluated #then it denies even with an artifact [0.06ms]
+(pass) evaluateInvocationGuard > #given a user request without a plan artifact #when momus is evaluated #then it denies naming the plan artifact [0.06ms]
+(pass) evaluateInvocationGuard > #given a user request and a plan artifact #when momus is evaluated #then it allows [0.06ms]
+(pass) evaluateInvocationGuard > #given a user request with artifact but ulw-execute invoked #when momus is evaluated #then it denies and names ulw-execute [0.07ms]
+(pass) evaluateInvocationGuard > #given momus with only ulw-execute invoked #when evaluated #then the forbidden denial takes precedence over the missing requirement [0.06ms]
+(pass) SkillInvocationState planArtifactReferences > #given the empty skill-invocation state #when plan references are queried #then it reports none and no artifact [0.06ms]
+(pass) SkillInvocationState planArtifactReferences > #given a state built with plan references #when queried #then the widened member returns them [0.06ms]
+(pass) evaluateInvocationGuard - denial names the real unlock path > #given a missing user request #when momus is evaluated #then the denial names the user-driven unlock [0.06ms]
+(pass) evaluateInvocationGuard - denial names the real unlock path > #given a missing plan artifact #when metis is evaluated #then the denial still names the plan-file requirement [0.06ms]
+(pass) evaluateInvocationGuard - denial names the real unlock path > #given ulw-execute already invoked #when momus is evaluated #then the terminal denial does not advertise an unlock [0.06ms]
+
+packages/senpi-task/src/agents/interaction-policy.test.ts:
+(pass) AGENT_INTERACTION_POLICIES > #given the registry #when inspected #then momus is the sole one-shot entry with the plan-review contract [0.17ms]
+(pass) AGENT_INTERACTION_POLICIES > #given the registry #when inspected #then only momus is present and metis is absent [0.09ms]
+(pass) ONE_SHOT_AGENT_NAMES > #given the one-shot set #when inspected #then it contains exactly momus [0.07ms]
+(pass) interactionPolicyForAgent > #given momus #when looked up #then its policy is returned [0.07ms]
+(pass) interactionPolicyForAgent > #given an unknown agent #when looked up #then undefined is returned [0.06ms]
+(pass) interactionPolicyForAgent > #given metis #when looked up #then undefined is returned (metis is not one-shot) [0.06ms]
+(pass) sendDenialReminder structure > #given the momus denial reminder #when inspected #then it is non-empty and wrapped in system-reminder sentinel tags [0.06ms]
+
+packages/senpi-task/src/agents/omo-config-agents.test.ts:
+(pass) mapOmoConfigAgents > #given an omo.json agent with the full field set #when mapped #then snake_case config keys land on the camelCase AgentDefinition with the record key as name [0.36ms]
+(pass) mapOmoConfigAgents > #given the omo.json tools record #when mapped #then each boolean entry becomes a pattern/allow rule [0.17ms]
+(pass) mapOmoConfigAgents > #given an agent with only a name-worth of config #when mapped #then absent optional keys stay absent [0.07ms]
+(pass) mapOmoConfigAgents > #given a config with no agents #when mapped #then the result is an empty record [0.06ms]
+
+packages/senpi-task/src/agents/agent-builtin-chain-tuning.test.ts:
+(pass) agent tuning on the builtin fallback chain > #given an agent with only top level effort #when the builtin chain resolves #then the effort still reaches the record [0.61ms]
+(pass) agent tuning on the builtin fallback chain > #given an agent with a top level variant #when a variant bearing chain rung resolves #then the configured variant wins [0.14ms]
+(pass) agent tuning on the builtin fallback chain > #given an agent with no configured tuning #when a variant bearing chain rung resolves #then the rung variant survives and no effort is invented [0.10ms]
+
+packages/senpi-task/src/agents/resolve-agent.test.ts:
+(pass) resolveAgent > #given an agent with disallowedTools #when resolved #then the denylist rides the persona as toolDenylist [0.43ms]
+(pass) resolveAgent > #given an agent without disallowedTools #when resolved #then no denylist is forced onto the persona [0.11ms]
+(pass) resolveAgent > #given an agent fallback chain and matching live model #when resolved #then it returns agent metadata and persona [0.12ms]
+(pass) resolveAgent > #given def.model and def.models are both available #when resolved #then def.model wins [0.14ms]
+(pass) resolveAgent > #given configured runtime fallback preserves requested and resolved models #when an agent resolves #then the ordered runtime chain is retained [0.11ms]
+(pass) resolveAgent > #given an unavailable primary and ordered def.models #when resolved #then the first available model wins [0.09ms]
+(pass) resolveAgent > #given def.models entries the machine has no credentials for #when resolved #then resolution falls through to the first available entry [0.11ms]
+(pass) resolveAgent > #given every configured model is keyless #when resolved #then the builtin fallback chain still resolves an available model [0.09ms]
+(pass) resolveAgent > #given a disabled agent #when resolved #then it is hidden as not_found [0.07ms]
+(pass) resolveAgent > #given an unknown agent name #when resolved #then it returns the active sorted roster [0.06ms]
+(pass) resolveAgent > #given no registry model matches #when resolved #then it returns model_unavailable without throwing [0.07ms]
+(pass) resolveAgent > #given a model override without a registry #when resolved #then it returns persona fields and filters the tool allowlist [0.09ms]
+
+packages/senpi-task/src/agents/tools.test.ts:
+(pass) tools pi-task contract shapes > #given a string-action record #when parsing and normalizing #then allow and deny map to boolean rules [0.48ms]
+(pass) tools pi-task contract shapes > #given a nested command-pattern map #when resolving #then last matching pattern wins [0.12ms]
+(pass) tools pi-task contract shapes > #given a reversed nested map #when resolving #then the trailing broad deny wins over the earlier allow [0.10ms]
+(pass) tools pi-task contract shapes > #given a mixed record of boolean string-action and nested map #when resolving #then every shape evaluates [0.10ms]
+(pass) tools pi-task contract shapes > #given an ask action #when resolving #then it is a non-grant and overrides a broader allow [0.11ms]
+(pass) tools pi-task contract shapes > #given the existing boolean-record shape #when normalizing #then it keeps working unchanged [0.08ms]
+(pass) tools pi-task contract shapes > #given the existing array shape #when normalizing #then bang-prefixed entries deny and plain entries allow [1.30ms]
+
+packages/senpi-task/src/agents/agent-model-effort.test.ts:
+(pass) agent model entries carrying effort > #given an omo agent whose models carry effort #when bridged #then the entry objects survive onto the definition [0.17ms]
+(pass) agent model entries carrying effort > #given an omo agent whose model entries carry canonical reasoning #when bridged #then the entry reasoning is preserved on the candidate [0.07ms]
+(pass) agent model entries carrying effort > #given an omo agent with plain string models #when bridged #then the legacy strings are preserved verbatim [0.08ms]
+(pass) agent model entries carrying effort > #given a canonicalized agent entry #when resolved through resolveAgent #then its canonical reasoning reaches the resolved model record [0.19ms]
+(pass) agent model entries carrying effort > #given a resolved agent model entry carrying effort #when resolved #then the effort reaches the resolved model record [0.09ms]
+(pass) agent model entries carrying effort > #given a model entry carrying an explicit variant #when resolved #then the variant reaches the resolved model record [0.07ms]
+(pass) agent model entries carrying effort > #given an agent whose top level effort applies to its primary model #when resolved #then the effort reaches the record [0.07ms]
+(pass) agent model entries carrying effort > #given a fallback entry with its own effort #when the primary is unavailable #then the fallback effort wins over the agent default [0.08ms]
+(pass) agent model entries carrying effort > #given a model entry with no effort of its own #when resolved #then no effort is invented [0.07ms]
+
+packages/senpi-task/src/agents/loader.test.ts:
+(pass) loadAgents > #given home and project files #when loading #then later configured locations override earlier names [8.90ms]
+(pass) loadAgents > #given markdown at a configured root #when loading #then only agent subdirectories are scanned [1.43ms]
+(pass) loadAgents > #given file and programmatic definitions #when loading #then registerAgent overrides file values [1.04ms]
+(pass) loadAgents > #given file programmatic and omo config definitions #when loading #then omo agents overlay wins last [3.99ms]
+(pass) loadAgents > #given malformed and valid frontmatter #when loading #then diagnostics are per file and valid agents still load [5.88ms]
+(pass) loadAgents > #given project scan root is a symlink #when loading #then external agents are blocked with a read diagnostic [2.69ms]
+(pass) loadAgents > #given configured location is a symlink #when loading #then later scan children do not escape [2.07ms]
+(pass) loadAgents > #given broken directory symlink and valid sibling #when loading #then read diagnostic is returned and valid agent loads [1.32ms]
+(pass) loadAgents > #given omo json path is a directory #when loading #then read diagnostic is returned and valid agents still load [1.19ms]
+(pass) loadAgents > #given repeated tool allow and deny rules #when resolving a tool #then the last matching rule wins [1.28ms]
+(pass) loadAgents > #given the pi-task documented tools frontmatter shape #when loading #then the agent is kept and rules evaluate [0.90ms]
+(pass) loadAgents > #given a string-action tools record #when loading #then the agent is not dropped with a validation diagnostic [0.75ms]
+(pass) loadAgents > #given activated Senpi agent overlays and model catalog aliases #when loading #then the Senpi profile view and concrete model chain win [1.63ms]
+(pass) loadAgents > #given snake case omo agent keys #when loading #then fields normalize to camelCase definitions [0.94ms]
+
+packages/senpi-task/src/state/record.test.ts:
+(pass) createTaskRecord durable notification and steering fields > #given notify_on_terminal true #when the record is created #then the intent lands on the record [0.21ms]
+(pass) createTaskRecord durable notification and steering fields > #given notify_on_terminal false #when the record is created #then the record carries false explicitly [0.07ms]
+(pass) createTaskRecord durable notification and steering fields > #given a pending steering queue #when the record is created #then the queue round-trips through JSON [0.12ms]
+(pass) createTaskRecord durable notification and steering fields > #given an empty pending steering queue #when the record is created #then the field is omitted [0.06ms]
+(pass) createTaskRecord durable notification and steering fields > #given no pending steering input #when the record is created #then the field stays absent [0.07ms]
+
+packages/senpi-task/src/state/store.test.ts:
+(pass) resolveStateDir > #given no task state override #when resolved #then project omo senpi-task directory is used [0.27ms]
+(pass) resolveStateDir > #given task state override #when resolved #then override directory wins [0.08ms]
+(pass) TaskRecordStore > #given completed task record #when saved and reloaded #then durable task facts are identical [3.85ms]
+(pass) TaskRecordStore > #given a task spawned with a description #when saved and reloaded #then the description survives the round trip [1.76ms]
+(pass) TaskRecordStore > #given sensitive event payload #when event is appended #then jsonl payload is redacted [2.12ms]
+(pass) TaskRecordStore > #given corrupt task json #when records are listed #then typed diagnostic is reported and corrupt record is skipped [8.69ms]
+(pass) TaskRecordStore > #given duplicate generated task id #when a different record is saved #then existing task file is not overwritten [0.97ms]
+(pass) TaskRecordStore > #given completed record #when illegal running transition is persisted #then transition is rejected and completion remains [12.69ms]
+
+packages/senpi-task/src/state/transitions-table.test.ts:
+(pass) transitionTaskRecord exhaustive lifecycle table > #given every status and normal transition #when applied #then allowed and rejected outcomes match the lifecycle table [0.47ms]
+
+packages/senpi-task/src/state/model.test.ts:
+(pass) messageability > #given every status and residency pair #when classified #then the table is exhaustive [31.59ms]
+(pass) messageability suspended residencies > #given any status #when residency is persisted_only or rpc_detached #then classification is not-continuable (no lazy revive-on-send) [0.40ms]
+(pass) transitionTaskRecord > #given a cancelled task #when late failure arrives #then cancelled remains terminal and failure is logged [0.15ms]
+
+packages/senpi-task/src/state/id.test.ts:
+(pass) task id primitives > #given a task id ending in ffff #when bumped #then it carries into the next hexadecimal group [0.18ms]
+(pass) task id primitives > #given a task id #when bumped #then the hexadecimal value increments [0.09ms]
+(pass) task id primitives > #given an isolated module process #when bump-exhaust executes #then it succeeds [64.37ms]
+(pass) task id primitives > #given an isolated module process #when create-exhaust executes #then it succeeds [155.39ms]
+(pass) task id primitives > #given an isolated module process #when floor-raise executes #then it succeeds [57.34ms]
+(pass) task id primitives > #given an isolated module process #when floor-never-lower executes #then it succeeds [20.86ms]
+(pass) task id primitives > #given an isolated module process #when nowms executes #then it succeeds [41.08ms]
+(pass) createTaskId > #given a deterministic clock #when ids are created #then ids are canonical and sortable [0.23ms]
+(pass) createTaskId > #given a same-millisecond burst #when more than one byte of ids are created #then every id is unique [0.33ms]
+(pass) createTaskId > #given an isolated deterministic clock #when ids are created #then the clock seam is repeatable [0.23ms]
+(pass) createTaskId > #given wrap pressure near the id ceiling #when ids are created #then ids never wrap or repeat [0.27ms]
+
+packages/senpi-task/src/state/transitions.test.ts:
+(pass) transitionTaskRecord lifecycle graph > #given pending task #when running-only terminals (complete/fail/interrupt) arrive before start #then they are rejected [0.35ms]
+(pass) transitionTaskRecord lifecycle graph > #given running task #when terminal transitions arrive #then the lifecycle terminal is applied [0.50ms]
+(pass) transitionTaskRecord lifecycle graph > #given a running rpc child killed by signal #when the fail transition carries killed #then the record persists killed:true [0.12ms]
+(pass) transitionTaskRecord lifecycle graph > #given a plain (non-signal) failure #when the fail transition omits killed #then killed stays absent (a record fact) [0.15ms]
+(pass) transitionTaskRecord lifecycle graph > #given pending or running task #when normal lose transition arrives #then lost is rejected [0.31ms]
+(pass) transitionTaskRecord lifecycle graph > #given pending or running task #when reconciliation marks lost #then lost is applied explicitly [0.16ms]
+(pass) transitionTaskRecord lifecycle graph > #given terminal task #when residency-only transition arrives #then status remains and residency changes [0.11ms]
+(pass) transitionTaskRecord lifecycle graph > #given every terminal status #when every residency transition arrives #then only residency changes [0.28ms]
+(pass) transitionTaskRecord lifecycle graph > #given interrupted task #when late completion arrives #then interrupted remains terminal [0.08ms]
+(pass) transitionTaskRecord cancel-from-pending >  w2trans #given pending task #when cancel transition arrives #then it is applied and status becomes cancelled [0.07ms]
+(pass) transitionTaskRecord cancel-from-pending >  w2trans #given pending task #when interrupt transition arrives #then it is rejected as invalid (running-only) [0.07ms]
+(pass) transitionTaskRecord cancel-from-pending >  w2trans #given running task #when cancel transition arrives #then it is still applied (regression) [0.07ms]
+(pass) transitionTaskRecord cancel-from-pending >  w2trans #given terminal task (completed or cancelled) #when cancel arrives #then it is rejected by terminal idempotence [0.08ms]
+(pass) transitionTaskRecord cancel-from-pending >  w2trans #given pending task #when cancel carries error_message #then the reason is stamped onto the cancelled record [0.50ms]
+(pass) transitionTaskRecord suspension residency > #given a running record with host and child pids #when persist_only arrives #then status and run epoch survive while both pids clear [0.33ms]
+(pass) transitionTaskRecord suspension residency > #given a running rpc record #when detach_rpc arrives #then the last pid is retained for orphan detection while host ownership clears [0.21ms]
+(pass) transitionTaskRecord suspension residency > #given a completed record with terminal fields and run stats #when persist_only arrives #then every terminal fact survives [0.23ms]
+(pass) transitionTaskRecord suspension residency > #given a suspended running record #when a late complete arrives #then terminal fields still land and residency stays suspended [0.16ms]
+
+packages/senpi-task/src/state/spawn-spec.test.ts:
+(pass) isSpawnSpecV1 > #given a legacy process-mode spawn spec #when classified #then it is not v1 [0.34ms]
+(pass) isSpawnSpecV1 > #given a legacy spec carrying extensions and member_env #when classified #then it stays the legacy variant [0.19ms]
+(pass) isSpawnSpecV1 > #given a v1 spawn spec #when classified #then it is v1 and narrows to the rebuildable fields [13.77ms]
+(pass) isSpawnSpecV1 > #given a malformed spec with an unknown version #when classified #then it is rejected as not v1 [0.13ms]
+
+packages/senpi-task/src/state/resolved-reasoning.test.ts:
+(pass) readResolvedReasoning > #given a canonical reasoning field #when read #then it wins over legacy spellings [0.16ms]
+(pass) readResolvedReasoning > #given a legacy reasoning_effort record #when read #then the legacy effort is used [0.07ms]
+(pass) readResolvedReasoning > #given only a legacy variant #when read #then the variant is used [0.07ms]
+(pass) readResolvedReasoning > #given no reasoning of any spelling #when read #then it is undefined [0.06ms]
+(pass) resolvedReasoningFields > #given a legacy effort record #when fields are built #then canonical and legacy mirror carry the effort [0.07ms]
+(pass) resolvedReasoningFields > #given no reasoning #when fields are built #then nothing is invented [0.06ms]
+
+packages/senpi-task/src/state/run-stats-record.test.ts:
+(pass) run stats on task records > #given a complete transition with run stats #when applied #then the terminal record carries them [0.24ms]
+(pass) run stats on task records > #given fail cancel and interrupt transitions #when applied with run stats #then they persist too [0.12ms]
+(pass) run stats on task records > #given a persisted record with run stats #when parsed #then the stats round-trip [0.17ms]
+(pass) run stats on task records > #given malformed run stats #when parsed #then parsing rejects the record [0.12ms]
+(pass) run stats on task records > #given a record with explicit latest-request and whole-run cache hit rates #when parsed #then both fields round-trip [0.08ms]
+(pass) run stats on task records > #given a legacy record with ambiguous cache_hit_rate #when parsed #then it is treated as the whole-run rate [0.08ms]
+(pass) run stats on task records > #given a non-numeric cost_usd #when parsed #then parsing rejects the record [0.07ms]
+
+packages/senpi-task/src/manager/manager-runtime-fallback.test.ts:
+(pass) TaskManager runtime fallback visibility > #given a running category child #when Senpi applies a fallback #then the task record exposes the actual model [19.63ms]
+(pass) TaskManager runtime fallback visibility > #given a builtin category child on a chain rung #when Senpi applies a fallback to the next rung #then the record advances and the remaining chain shrinks [11.52ms]
+
+packages/senpi-task/src/manager/concurrency.test.ts:
+(pass) TaskConcurrency > #given default settings #when nothing acquired #then a fresh model has a free slot [0.54ms]
+(pass) TaskConcurrency > #given limit reached #when checking free slot #then it reports full and exposes queue position [0.14ms]
+(pass) TaskConcurrency > #given a waiter enqueued #when the holder releases #then the waiter callback fires (FIFO handoff) [0.17ms]
+(pass) TaskConcurrency > #given two waiters #when slots free one at a time #then they are granted in FIFO order [0.10ms]
+(pass) TaskConcurrency > #given model and provider overrides #when resolving a key #then model override wins over provider [0.10ms]
+(pass) TaskConcurrency > #given a zero limit at each precedence level #when resolving the limit #then zero means unbounded [0.08ms]
+(pass) TaskConcurrency > #given a zero default limit #when many tasks acquire #then slots never fill and nothing queues [0.15ms]
+(pass) TaskConcurrency > #given different models #when both acquire under a shared default limit #then each keeps its own count [0.06ms]
+(pass) TaskConcurrency > remove (queued-task dequeue)  w2conc  >  w2conc  #given an enqueued waiter #when removed #then its queuePosition becomes undefined [0.13ms]
+(pass) TaskConcurrency > remove (queued-task dequeue)  w2conc  >  w2conc  #given three queued waiters #when the middle is removed #then survivors renumber (third drops 3 to 2) [0.07ms]
+(pass) TaskConcurrency > remove (queued-task dequeue)  w2conc  >  w2conc  #given head waiter removed #when release fires #then it grants the next survivor not the removed one [0.07ms]
+(pass) TaskConcurrency > remove (queued-task dequeue)  w2conc  >  w2conc  #given no such queued task #when remove called #then it returns false (safe no-op) [0.20ms]
+(pass) TaskConcurrency > remove (queued-task dequeue)  w2conc  >  w2conc  #given an acquired slot #when a queued waiter is removed #then getCount is unchanged [0.54ms]
+(pass) TaskConcurrency > remove (queued-task dequeue)  w2conc  >  w2conc  #given three waiters one removed #when release drains #then both survivors grant in FIFO and removed never grants [0.31ms]
+(pass) TaskConcurrency > #given a global cap of two #when two free lanes acquire #then a third lane is blocked [0.14ms]
+(pass) TaskConcurrency > #given global zero #when lanes acquire #then only lane limits apply [0.19ms]
+(pass) TaskConcurrency > #given an infinite lane and one global slot #when it acquires #then it consumes the slot [0.08ms]
+(pass) TaskConcurrency > #given a lane B waiter #when lane A releases the global slot #then B is granted [0.19ms]
+(pass) TaskConcurrency > #given queued lanes #when a slot frees #then the oldest eligible head wins [0.12ms]
+(pass) TaskConcurrency > #given a blocked head on A and an eligible head on B #when a slot frees #then B is granted [0.15ms]
+(pass) TaskConcurrency > #given a queued waiter #when removed #then lane and global counts stay unchanged [0.10ms]
+(pass) TaskConcurrency > #given a blocked acquisition #when tryAcquire fails #then counts remain unchanged [0.08ms]
+(pass) TaskConcurrency > #given a queued lane #when tryAcquire runs #then it refuses to bypass the queue [0.08ms]
+(pass) TaskConcurrency > #given a newer lease #when an older epoch releases #then the newer lease remains [0.07ms]
+(pass) TaskConcurrency > #given 64 waiters across 16 lanes #when each lane drains #then every grant is deterministic and empty [4.52ms]
+
+packages/senpi-task/src/manager/manager.test.ts:
+(pass) TaskManager unlimited residency > #given unlimited residency #when sixteen children start #then admits more than the default residency when configured unlimited [210.40ms]
+(pass) TaskManager.start > #given a valid spec #when started #then it returns a st_ id and running status with a persisted record [1.55ms]
+(pass) TaskManager.start > #given a child beyond max depth without allowance #when started #then DepthDenied is returned and zero records exist [0.52ms]
+(pass) TaskManager.start > #given a full model slot #when a further same-model task starts #then it queues FIFO and starts when a slot frees [5.57ms]
+(pass) TaskManager.start > #given two categories that resolve to different models #when both start under a shared limit of 1 #then both run [19.03ms]
+(pass) TaskManager.start > #given a runner whose start throws #when a task starts #then the slot is released, the record is error, and a failure event is logged [8.24ms]
+(pass) TaskManager.start > #given a requested name that collides in the same parent #when started #then a -2 suffix and a warning are returned [2.54ms]
+(pass) TaskManager.start > #given execution_mode process on the spec #when started #then the process runner is used [1.55ms]
+(pass) TaskManager.start > #given a resolved model plan #when started #then manager metadata surfaces persist resolved_model without prompt payloads [1.70ms]
+(pass) TaskManager.start > #given a resolved ultrabrain plan whose runner throws #when the real task mapping renders start_failed #then resolved context reaches the error row without the prompt [3.36ms]
+(pass) TaskManager.waitFor > #given a running task with an abortable wait w2waitfor #when the signal aborts #then the wait rejects and its waiter key is removed [2.03ms]
+(pass) TaskManager.waitFor > #given an abortable wait that resolves terminal w2waitfor #when the signal aborts afterwards #then abort is a no-op without an unhandled rejection [3.23ms]
+(pass) TaskManager.waitFor > #given a pre-aborted signal w2waitfor #when waitFor is called #then it rejects immediately without registering a waiter [1.90ms]
+(pass) TaskManager.waitFor > #given two concurrent waiters for one task w2waitfor #when one signal aborts #then the surviving waiter still resolves on settle [2.43ms]
+(pass) TaskManager.waitFor > #given a running task and a signal-less wait w2waitfor #when the task settles #then waitFor resolves as before [2.01ms]
+(pass) TaskManager child subscriptions > #given a pending task #when its concurrency slot is promoted #then the deferred child listener attaches to its managed handle [8.66ms]
+(pass) TaskManager pending cancellation > #given a queued task at the residency cap w2pend #when cancelled #then its wait settles cancelled and a later spawn is admitted [4.32ms]
+(pass) TaskManager pending cancellation > #given a grant whose start transition loses to cancel w2pend #when the slot transfers #then the runner is skipped and the slot is released [6.83ms]
+(pass) TaskManager pending cancellation > #given cancel lands while runner start awaits w2pend #when the handle arrives #then destruction tears it down, settles the wait, and releases the slot [11.71ms]
+(pass) TaskManager pending cancellation > #given a running task with one queued behind it w2pend #when the running task is cancelled #then the queued task receives the released slot [6.01ms]
+
+packages/senpi-task/src/manager/start-owned.test.ts:
+(pass) TaskManager.startOwned > #given a new DAG owner #when started #then the initial claim persists the owner before launch [3.80ms]
+(pass) TaskManager.startOwned > #given two overlapping starts for one owner #when creation is still awaiting launch #then the owner lock serializes the second start [15.02ms]
+(pass) TaskManager.startOwned > #given an existing owner with the same fingerprint #when started again #then it reuses one persisted task and never double-spawns [2.56ms]
+(pass) TaskManager.startOwned > #given a still-running owner with a different fingerprint #when started again #then it returns owner_conflict without another task [1.81ms]
+(pass) TaskManager.startOwned > #given a TERMINAL owner with a different fingerprint #when started again #then ownership is replaced and a fresh task runs [3.00ms]
+(pass) TaskManager.startOwned > #given caller journal knowledge is lost after dispatch #when a fresh manager starts the same owner #then recovery finds exactly one task [1.93ms]
+(pass) TaskManager.startOwned > #given depth, residency, and concurrency gates #when owned starts are attempted #then the existing manager outcomes remain authoritative [4.14ms]
+
+packages/senpi-task/src/manager/manager-revive-slot.test.ts:
+(pass) TaskManager revive concurrency slot > #given single concurrency #when a revived task completes #then it releases its slot and a queued task starts [10.45ms]
+(pass) TaskManager revive concurrency slot > #given single concurrency #when a task is interrupted #then its slot is released for the next task [3.26ms]
+
+packages/senpi-task/src/manager/manager-claim.test.ts:
+(pass) TaskManager claim characterization > #given no requested name #when started #then the fallback name is the task id [1.91ms]
+(pass) TaskManager claim characterization > #given a duplicate requested name in one parent #when started #then it receives a suffix and warning [2.80ms]
+(pass) TaskManager claim characterization > #given an id-shaped requested name #when an unnamed task claims its fallback #then every saved sibling name is unique [2.60ms]
+(pass) TaskManager claim characterization > #given a background spec #when started #then the manager tracks its task as background [1.53ms]
+(pass) TaskManager claim characterization > #given a runner that fails after persistence #when started and its name is requested again #then the record is terminal and the name remains reserved [5.64ms]
+(pass) TaskManager claim characterization > #given process execution mode #when started #then its record persists a spawn spec [2.19ms]
+(pass) TaskManager claim characterization > #given a blank requested name "" #when started #then it falls back to the task id [5.90ms]
+(pass) TaskManager claim characterization > #given a blank requested name "   " #when started #then it falls back to the task id [1.50ms]
+(pass) TaskManager claim characterization > #given an isolated manager process #when seed seeds from disk #then it succeeds [156.42ms]
+(pass) TaskManager claim characterization > #given an isolated manager process #when warm-cache seeds from disk #then it succeeds [391.76ms]
+(pass) TaskManager claim characterization > #given an isolated manager process #when diagnostics seeds from disk #then it succeeds [334.87ms]
+(pass) TaskManager claim characterization > #given a foreign winner for the first candidate #when started #then it claims the next id [6.28ms]
+(pass) TaskManager claim characterization > #given a requested name and a foreign winner #when started #then only the loser keeps the requested name [7.73ms]
+(pass) TaskManager claim characterization > #given a real manager under collision #when team members spawn #then no member start is rejected [5.97ms]
+(pass) TaskManager claim characterization > #given an allocation failure #when the requested name is retried #then its reservation was released [4.35ms]
+(pass) TaskManager claim characterization > #given bookkeeping fails after a claim #when process mode starts #then it records a terminal failure [5.14ms]
+(pass) TaskManager claim characterization > #given a whitespace requested name #when a collision is claimed #then the fallback follows the final id [3.98ms]
+
+packages/senpi-task/src/manager/manager-background-mode.test.ts:
+(pass) manager background_mode persistence > #given a foreground task promoted to background #when promoteToBackground runs #then background_mode becomes "promoted" and notify_on_terminal stays true [27.89ms]
+(pass) manager background_mode persistence > #given a background spawn #when promoteToBackground runs #then background_mode stays "background" [13.97ms]
+(pass) manager background_mode persistence > #given two spawns in one parent session #when both are started #then their task_seq ordinals count from zero in spawn order [12.79ms]
+
+packages/senpi-task/src/manager/manager-hygiene.test.ts:
+(pass) TaskManager release guard growth > #given a task revived multiple times #when each run completes #then the release guard keeps one entry per task, not per epoch [9.77ms]
+(pass) TaskManager release guard growth > #given a completed task #when it is forgotten #then the release guard entry is pruned [6.35ms]
+(pass) TaskManager transcript subscription ownership > #given a running task with a transcript subscription #when it is forgotten #then the subscription is torn down [2.09ms]
+
+packages/senpi-task/src/manager/manager-capacity-paths.test.ts:
+(pass) TaskManager capacity paths > #given runtime fallback capacity #when the primary fails #then its old lease is released and only the next rung launches [76.93ms]
+(pass) TaskManager capacity paths > #given a runtime fallback waiter #when it is cancelled before capacity frees #then it never launches later [51.81ms]
+(pass) TaskManager capacity paths > #given an old primary waiter #when fallback capacity frees #then a new spawn spills around it and primary release grants it first [19.95ms]
+(pass) TaskManager capacity paths > #given a released terminal task #when revived and completed #then it acquires once and releases once [4.96ms]
+(pass) TaskManager capacity paths > #given persistence fails after acquire #when spawning #then the lease is released and no child starts [13.45ms]
+
+packages/senpi-task/src/manager/manager-spawn-facts.test.ts:
+(pass) recordSpawnedPid > #given a running record and a real pid #when folded #then the pid is set on a copy [0.20ms]
+(pass) recordSpawnedPid > #given no pid (in-process child) #when folded #then nothing changes [0.07ms]
+(pass) recordSpawnedPid > #given a record that already went terminal #when folded #then it is left untouched [0.07ms]
+(pass) TaskManager spawn-fact persistence > #given member launch env #when a process task starts #then the generated task id is threaded into the child env [7.80ms]
+(pass) TaskManager spawn-fact persistence > #given a process runner whose child has a pid #when a process task starts #then the persisted record carries that pid [4.56ms]
+(pass) TaskManager spawn-fact persistence > #given an in-process runner with no pid #when a task starts #then the record has no pid [1.59ms]
+
+packages/senpi-task/src/manager/manager-respawn-cleanup.test.ts:
+(pass) TaskManager respawn terminate cleanup > #given cancelled respawn cleanup rejects #when respawn returns #then teardown failure is surfaced [1.06ms]
+(pass) TaskManager respawn dispose cleanup > #given cancelled respawn cleanup rejects #when respawn returns #then teardown failure is surfaced [0.59ms]
+(pass) TaskManager respawn launch trust boundary > #given persisted extension and member env inputs #when respawned #then neither reaches the current runner [1.65ms]
+(pass) TaskManager team-member respawn > #given a team member record #when respawned #then current trusted launch settings replace persisted extension and env [12.20ms]
+(pass) TaskManager respawn variant > #given a record whose resolved model carried a variant #when respawned #then the variant reaches the rpc runner spec [6.51ms]
+(pass) TaskManager in-process respawn > #given a claimed in-process record #when respawned #then resume receives the rebuilt persisted spec [6.16ms]
+(pass) TaskManager in-process respawn > #given resolveResumeContext cannot find the persisted model #when respawned #then failure is retryable and no child is spawned [2.39ms]
+(pass) TaskManager in-process respawn > #given an in-process record without v1 rebuild facts #when respawned #then it fails unrecoverably without spawning [0.65ms]
+(pass) TaskManager guarded reattach > #given no prior host ownership claim #when reattached #then the handle is rejected [1.02ms]
+(pass) TaskManager guarded reattach > #given a claimed non-terminal record with stale output #when reattached #then output clears and run_epoch bumps exactly once [1.23ms]
+(pass) TaskManager guarded reattach > #given a claimed terminal record #when reattached #then run_epoch is unchanged [3.65ms]
+(pass) TaskManager respawn continuation > #given a toolResult tail #when respawned #then the revived child gets a continuation followUp [2.42ms]
+(pass) TaskManager respawn continuation > #given an assistant toolCall tail #when respawned #then the revived child gets a continuation followUp [1.53ms]
+(pass) TaskManager respawn continuation > #given a trailing user message #when respawned #then the revived child gets exactly one continuation followUp [9.52ms]
+(pass) TaskManager respawn continuation > #given an aborted assistant tail #when respawned #then the revived child gets exactly one continuation followUp [3.32ms]
+(pass) TaskManager respawn continuation > #given a terminal record with a user tail #when respawned #then no continuation is sent [0.94ms]
+(pass) TaskManager respawn continuation > #given a completed assistant JSON line larger than 64 KiB #when respawned #then no preceding user false-positive continuation is sent [3.62ms]
+(pass) TaskManager respawn continuation > #given an assistant text-only tail #when respawned #then no continuation is sent [2.27ms]
+(pass) TaskManager respawn continuation > #given an unreadable session path #when respawned #then no continuation is sent and respawn still succeeds [0.82ms]
+
+packages/senpi-task/src/manager/names.test.ts:
+(pass) NameRegistry > #given a fresh name #when registered #then it is used verbatim with no warning [18.51ms]
+(pass) NameRegistry > #given a colliding name in the same parent #when registered #then a -2 suffix and a warning are returned [8.69ms]
+(pass) NameRegistry > #given two prior collisions #when registered again #then the suffix increments to -3 [0.12ms]
+(pass) NameRegistry > #given the same name under a different parent #when registered #then there is no collision [0.07ms]
+(pass) NameRegistry > #given no requested name #when registered #then an auto name is generated and reserved [0.22ms]
+(pass) NameRegistry > #given a registered name #when released and re-registered #then the bare name is available [0.17ms]
+(pass) NameRegistry > #given an unknown name #when released #then registration is unchanged [0.13ms]
+(pass) NameRegistry > #given names in separate parents #when one is released #then the other remains reserved [0.15ms]
+
+packages/senpi-task/src/manager/residency-unlimited.test.ts:
+
+packages/senpi-task/src/manager/continue-result.test.ts:
+(pass) toContinueResult > #given a one_shot_agent send outcome #when adapted #then it is not_continuable with the registry reminder as the reason [0.18ms]
+
+packages/senpi-task/src/manager/start-failure-security.test.ts:
+(pass) TaskManager start failure security > #given an unknown runner start error containing secrets #when the task tool reports the failure #then every public and persisted surface receives only the stable classification [14.94ms]
+(pass) TaskManager start failure security > #given a non-Error runner start throw containing secrets #when a team member spawn fails #then the team error contains only the stable classification [5.33ms]
+(pass) TaskManager start failure security > #given a spoofed RunnerError plain object #when the task starts #then it receives the generic unknown-error classification [14.87ms]
+(pass) TaskManager start failure security > #given a spoofed RunnerError ordinary Error #when the task starts #then it receives the generic unknown-error classification [6.92ms]
+(pass) TaskManager start failure security > #given a runner start Error with a hostile name accessor #when the task starts #then classification stays total and returns the generic failure [25.38ms]
+(pass) TaskManager start failure security > #given a runner start throw whose prototype lookup is hostile #when the task starts #then classification stays total and returns the generic failure [8.27ms]
+(pass) TaskManager start failure security > #given a depth-exceeded RunnerError containing secrets #when a named subagent start fails #then its stable classification preserves the resolved context [21.31ms]
+(pass) TaskManager start failure security > #given a session-create-failed RunnerError containing secrets #when a named subagent start fails #then its stable classification preserves the resolved context [13.61ms]
+(pass) TaskManager start failure security > #given a child-prompt-failed RunnerError containing secrets #when a named subagent start fails #then its stable classification preserves the resolved context [9.07ms]
+
+packages/senpi-task/src/manager/residency-zero.test.ts:
+(pass) TaskManager zero residency cap > #given a zero residency cap #when sixteen children start #then admits more than the default residency cap [88.01ms]
+
+packages/senpi-task/src/manager/rpc-terminal-outcome.test.ts:
+(pass) RPC terminal outcomes > #given prompt preflight rejection #when a process task starts #then its running record becomes a typed start failure without an unhandled rejection [105.43ms]
+(pass) RPC terminal outcomes > #given provider failure after prompt admission #when the RPC turn ends #then the durable task becomes child-turn-failed instead of completed [150.52ms]
+
+packages/senpi-task/src/manager/manager-status-facts.test.ts:
+(pass) manager status facts > #given a spec carrying a description #when the task starts #then the persisted record keeps it for status views [14.40ms]
+(pass) manager status facts > #given a live child mid-run #when run stats are read #then the manager exposes the in-flight accumulator [2.50ms]
+(pass) manager status facts > #given an unknown task id #when run stats are read #then nothing is reported [0.55ms]
+(pass) manager child subscription cleanup > #given a listener registered before promotion #when its cleanup runs #then the handle unsubscribes exactly once [3.15ms]
+
+packages/senpi-task/src/manager/manager-helpers.test.ts:
+(pass) buildRecordInput task_summary > #given a spawn spec with a task_summary #when the record input is built #then the summary is carried onto the record facts [0.17ms]
+(pass) buildRecordInput task_summary > #given no task_summary #when the record input is built #then the field stays absent [0.07ms]
+(pass) buildRecordInput background_mode > #given a spawn spec with run_in_background true #when the record is built #then background_mode is "background" and a foreground spawn yields "foreground" [0.07ms]
+(pass) buildRecordInput background_mode > #given a spawn spec carrying a task ordinal #when the record is built #then task_seq is carried onto the record facts [0.07ms]
+(pass) promotedBackgroundMode > #given a record spawned in the foreground #when promoted #then the mode becomes promoted [0.10ms]
+(pass) promotedBackgroundMode > #given a record spawned in the background #when promoted #then the mode stays background [0.06ms]
+(pass) promotedBackgroundMode > #given a legacy record with no mode but durable background intent #when promoted #then the mode is background, not promoted [0.06ms]
+(pass) TaskSequence > #given two parent sessions #when ordinals are drawn #then each session counts from zero independently [0.07ms]
+(pass) task_summary record roundtrip > #given a record input with a task_summary #when created and re-parsed from JSON #then the summary survives the persistence roundtrip [0.13ms]
+
+packages/senpi-task/src/manager/manager-steering-race.test.ts:
+(pass) steering single-writer over the in-process launch-outcome tracker > #given the launch tracker settles on abort #when interrupted #then the record stays interrupted with partial text [3.06ms]
+(pass) steering single-writer over the in-process launch-outcome tracker > #given the launch tracker settles on abort #when cancelled #then the record is cancelled and destruction runs exactly once [2.30ms]
+(pass) steering single-writer over the in-process launch-outcome tracker > #given an already-cancelled task #when cancelled again #then it is a no-op and destruction is not re-run [2.01ms]
+(pass) steering single-writer over the in-process launch-outcome tracker > #given an already-interrupted task #when interrupted again #then it is an idempotent no-op [1.98ms]
+(pass) steering single-writer over the rpc launch-outcome tracker > #given the launch tracker settles on abort #when interrupted #then the record stays interrupted with partial text [2.27ms]
+(pass) steering single-writer over the rpc launch-outcome tracker > #given the launch tracker settles on abort #when cancelled #then the record is cancelled and destruction runs exactly once [13.52ms]
+(pass) steering single-writer over the rpc launch-outcome tracker > #given an already-cancelled task #when cancelled again #then it is a no-op and destruction is not re-run [2.42ms]
+(pass) steering single-writer over the rpc launch-outcome tracker > #given an already-interrupted task #when interrupted again #then it is an idempotent no-op [2.19ms]
+
+packages/senpi-task/src/manager/manager-fallback.test.ts:
+(pass) TaskManager configured runtime fallback > #given a provider failure before any tool call #when the child terminates #then the same task hands off to the next configured model [2.57ms]
+(pass) TaskManager configured runtime fallback > #given a failed child already executed a tool #when it terminates #then manager fallback does not replay the task [2.17ms]
+(pass) TaskManager configured runtime fallback > #given every configured model fails before tools #when the chain exhausts #then attempted models remain in terminal diagnostics [8.14ms]
+(pass) TaskManager configured runtime fallback > #given native fallback already advanced once #when that model terminates #then manager handoff uses only the remaining rung [2.47ms]
+
+packages/senpi-task/src/manager/execution-mode.test.ts:
+(pass) resolveExecutionMode > #given a spec mode #when resolved #then the spec mode wins over every other source [0.30ms]
+(pass) resolveExecutionMode > #given no spec mode but an agent mode #when resolved #then the agent mode wins over config [11.77ms]
+(pass) resolveExecutionMode > #given only a config mode #when resolved #then the config mode is used [0.25ms]
+(pass) resolveExecutionMode > #given no source at all #when resolved #then it falls back to in-process [0.07ms]
+
+packages/senpi-task/src/manager/manager-wiring-seams.test.ts:
+(pass) manager wiring seams (W1-V F3/F7) > #given a launched task #when forget is called #then the live handle is pruned [7.59ms]
+(pass) manager wiring seams (W1-V F3/F7) > #given a background spawn #when queried #then wasBackground reflects the spec [3.02ms]
+(pass) manager wiring seams (W1-V F3/F7) > #given a foreground spawn #when promoted twice #then the first call flips live background state and the second is idempotent [5.21ms]
+(pass) manager wiring seams (W1-V F3/F7) > #given an admit gate that rejects #when starting #then start returns residency_denied and never launches [0.79ms]
+(pass) manager wiring seams (W1-V F3/F7) > #given an admit gate that evicts #when starting #then start proceeds [4.22ms]
+
+packages/senpi-task/src/manager/run-stats-wiring.test.ts:
+(pass) manager run stats wiring > #given a spawned child #when it completes #then the terminal record carries accumulated run stats [7.13ms]
+(pass) manager run stats wiring > #given a spawned child reporting cost and cache usage #when it completes #then cost and cache hit rate persist [3.97ms]
+(pass) manager run stats wiring > #given a live child with cost usage #when the snapshot is read mid-run #then cost and cache facts are already visible [2.46ms]
+(pass) manager run stats wiring > #given a spawned child #when it fails #then run stats persist on the error record [3.62ms]
+(pass) manager run stats wiring > #given a spawned child #when it is cancelled #then run stats persist on the cancelled record [2.27ms]
+(pass) manager run stats through steering transitions > #given a running child with usage #when cancelled through cancelTask #then the cancelled record carries run stats [2.48ms]
+(pass) manager run stats through steering transitions > #given a completed run revived then cancelled #when the revived run has no events #then no stale run stats survive [3.00ms]
+
+packages/senpi-task/src/manager/manager-respawn-spec.test.ts:
+(pass) spawn_spec v1 persistence > #given an in-process spawn with a planner append and member-scoped tools #when started #then the record persists spawn_spec v1 with the EFFECTIVE prompt and tool names [3.57ms]
+(pass) spawn_spec v1 persistence > #given a process-mode spawn carrying extensions and member env #when started #then the persisted v1 spec carries neither [2.77ms]
+(pass) spawn_spec v1 persistence > #given an rpc child echoing its launch spec #when spawn facts are recorded #then the v1 spawn_spec is not clobbered [4.98ms]
+(pass) buildRespawnManagedSpec > #given a spawned in-process record #when a respawn spec is built #then it matches the original start spec minus runtime-only objects [1.46ms]
+(pass) buildRespawnManagedSpec > #given a record without a spawn_spec #when a respawn spec is built #then a typed spawn_spec_unavailable error is returned [0.08ms]
+(pass) buildRespawnManagedSpec > #given a legacy {cwd} spawn_spec #when a respawn spec is built #then a typed spawn_spec_unavailable error is returned [0.07ms]
+(pass) buildRecordInput durable facts > #given a plan with a tool denylist #when the record input is built #then tool_deny rides the record facts [0.08ms]
+(pass) buildRecordInput durable facts > #given a plan without a denylist #when the record input is built #then tool_deny stays absent [0.06ms]
+(pass) buildRecordInput durable facts > #given run_in_background #when the record input is built #then notify_on_terminal is durable; foreground stays false [0.07ms]
+
+packages/senpi-task/src/manager/runner.test.ts:
+(pass) createInProcessManagedRunner > #given a managed spec #when started #then it maps to a ChildSpec and injects session context [7.75ms]
+(pass) createInProcessManagedRunner > #given a managed spec with a runtime fallback chain #when started #then the ordered chain reaches the child runner [0.39ms]
+(pass) createInProcessManagedRunner > #given a managed resume spec #when resumed #then it maps every persisted tool and model fact to ChildSpec [1.70ms]
+(pass) createRpcManagedRunner > #given a managed spec #when started #then it maps stateDir to state_dir and adapts the handle [0.34ms]
+(pass) createRpcManagedRunner > #given a managed spec with a model #when started #then the model is threaded onto the rpc spec for the detached child [0.11ms]
+(pass) variant threading > #given a managed spec with a variant #when the rpc adapter starts #then the variant reaches the rpc spec [0.10ms]
+(pass) variant threading > #given a managed spec without a variant #when the rpc adapter starts #then no variant is threaded [0.08ms]
+(pass) variant threading > #given a session context with a thinking level #when the in-process adapter starts #then the level reaches the child spec [0.09ms]
+
+packages/senpi-task/src/manager/child-handle.test.ts:
+(pass) adaptInProcessHandle > #given an in-process handle #when adapted #then pid is undefined and the outcome is forwarded [5.22ms]
+(pass) adaptInProcessHandle > #given an in-process handle #when disposed via the seam #then dispose resolves as a promise [0.44ms]
+(pass) adaptRpcHandle > #given an rpc terminal provider error on a resident process #when adapted #then the outcome is a child-turn error carrying the provider message [0.23ms]
+(pass) adaptRpcHandle > #given an rpc terminal non-user abort #when adapted #then the outcome is a child-turn error [0.33ms]
+(pass) adaptRpcHandle > #given an rpc turn explicitly aborted by the user #when adapted #then the outcome remains cancelled [0.31ms]
+(pass) adaptRpcHandle > #given an rpc clean turn with no assistant output #when adapted #then the outcome is a child-turn error [0.17ms]
+(pass) adaptRpcHandle > #given an rpc clean turn with assistant text #when adapted #then the outcome is completed [0.18ms]
+(pass) adaptRpcHandle > #given an rpc handle that crashed #when adapted #then the outcome is an error carrying the stderr tail [0.28ms]
+
+packages/senpi-task/src/manager/transcript-log.test.ts:
+(pass) logTranscriptEvent > #given an assistant message_end #when logged #then an assistant transcript event is appended with the text [0.17ms]
+(pass) logTranscriptEvent > #given a tool_execution_end #when logged #then a tool transcript event is appended with the tool name and error flag [0.07ms]
+(pass) logTranscriptEvent > #given a non-assistant message_end #when logged #then nothing is appended [0.07ms]
+(pass) logTranscriptEvent > #given a retry_fallback_exhausted event #when logged #then it is appended with the chain key and last error [0.12ms]
+(pass) logTranscriptEvent > #given an unrelated event type #when logged #then nothing is appended [0.09ms]
+(pass) subscribeTranscriptLog > #given a handle #when subscribed #then transcript events flow into the store and the unsubscribe is returned [0.10ms]
+(pass) logTranscriptEvent child errors > #given an assistant message_end carrying a stopReason error #when logged #then a child_error transcript event is appended with the diagnostic [0.28ms]
+
+packages/senpi-task/src/manager/depth-policy.test.ts:
+(pass) decideDepthPolicy > #given a top-level child within max depth #when decided #then it is allowed [0.15ms]
+(pass) decideDepthPolicy > #given a child beyond max depth with no allowance #when decided #then it is denied [0.08ms]
+(pass) decideDepthPolicy > #given a deeper child whose type is in allowed_subagents #when decided #then it is allowed [0.08ms]
+(pass) decideDepthPolicy > #given a deeper child whose type is NOT in allowed_subagents #when decided #then it is denied [0.06ms]
+
+packages/senpi-task/src/manager/manager-continue.test.ts:
+(pass) TaskManager.continueTask > #given a running resident child #when continued with steer #then the steer is delivered via the handle [5.04ms]
+(pass) TaskManager.continueTask > #given a running resident child #when continued with no delivery override #then followUp is the default [2.46ms]
+(pass) TaskManager.continueTask > #given a completed but resident child #when continued #then it is revived on the same handle with an incremented epoch [6.16ms]
+(pass) TaskManager.continueTask > #given a cancelled child #when continued #then it is not continuable and suggests task_output [2.13ms]
+(pass) TaskManager.continueTask > #given an unknown task id #when continued #then it is not continuable [0.62ms]
+(pass) TaskManager.sendToTask one-shot refusal > #given a momus child started through manager.start #when sent #then the outcome is one_shot_agent (guards the subagent_type -> agent_type rename) [1.63ms]
+(pass) TaskManager.list and get > #given tasks across two parents #when listing a parent scope #then only that parent's tasks appear [2.39ms]
+(pass) TaskManager.list and get > #given a queued task #when listing #then its queue position is exposed [1.79ms]
+(pass) TaskManager.list and get > #given a foreground task #when waiting for it #then waitFor resolves with the terminal record [1.74ms]
+
+packages/senpi-task/src/manager/manager-outcome.test.ts:
+(pass) TaskManager outcome guards > #given a nonterminal record #when an outcome tries to settle waiters and the record then becomes terminal #then the waiter remains armed until terminal settlement [76.73ms]
+(pass) TaskManager outcome guards > #given a running resident child #when suspension forgets its handle and the abort settles cancelled #then the record stays running+persisted_only and no waiter settles with a terminal [4.39ms]
+(pass) TaskManager outcome guards > #given a suspended child #when the abort settles as an error outcome #then no error terminal lands on the record [6.60ms]
+(pass) TaskManager outcome guards > #given a suspended child #when a misleading success outcome settles late #then the record keeps running with no final response [3.31ms]
+(pass) TaskManager outcome guards > #given a running child #when its outcome settles in the gap after forget but before persist_only lands #then the record is still untouched [3.89ms]
+(pass) TaskManager outcome guards > #given a record disposed while running with its handle still mapped #when the abort settles cancelled #then the late outcome terminalizes the drained record [5.89ms]
+(pass) TaskManager outcome guards > #given a running resident child #when it completes normally #then the record completes and the waiter settles with the terminal record [4.25ms]
+(pass) TaskManager background intent > #given a foreground child #when promoted to background #then notify_on_terminal round-trips through a store reload [5.65ms]
+(pass) TaskManager background intent > #given a persisted background record #when a fresh manager over the same store is asked #then wasBackground reads the record alone [1.55ms]
+(pass) TaskManager background intent > #given an unknown task id promoted in memory only #when queried #then wasBackground falls back to the in-memory set [0.58ms]
+
+packages/senpi-task/src/manager/manager-start-spill.test.ts:
+(pass) TaskManager spawn spill admission > #given a full primary and free fallback #when spawning #then every launch fact uses the fallback [2.85ms]
+(pass) TaskManager spawn spill admission > #given a full global cap and a locally free fallback #when spawning #then it queues on the primary [1.76ms]
+(pass) TaskManager spawn spill admission > #given provider-collapsed candidates #when the provider lane is full #then the fallback cannot bypass it [1.69ms]
+(pass) TaskManager spawn spill admission > #given a provider primary lane and exact-model fallback lane #when primary is full #then the exact fallback remains distinct [2.07ms]
+(pass) TaskManager spawn spill admission > #given revive capacity is full #when a terminal task is sent #then it defers without sending and retries after release [4.00ms]
+(pass) TaskManager spawn spill admission > #given two global permits are occupied on distinct lanes #when spawning on a free third lane #then it queues [2.58ms]
+
+packages/senpi-task/src/manager/parent-registry-context.test.ts:
+(pass) findModelReference > #given a canonical provider/modelId reference #when resolved #then find is called with the split parts [0.18ms]
+(pass) findModelReference > #given a modelId that itself contains slashes #when resolved #then only the FIRST slash splits provider from modelId [0.07ms]
+(pass) findModelReference > #given a reference without a usable slash boundary #when resolved #then it returns undefined without calling find [0.07ms]
+(pass) createParentRegistrySessionContext > #given no parent registry yet #when the context is built #then it stays empty so senpi keeps its default resolution [0.09ms]
+(pass) createParentRegistrySessionContext > #given a parent registry with a dynamically-registered provider #when a child spec names that model #then the registry, its auth storage, and the resolved Model are threaded [6.45ms]
+(pass) createParentRegistrySessionContext > #given a parent registry but no model on the spec #when the context is built #then registry and auth are threaded with no model override [3.06ms]
+(pass) createParentRegistrySessionContext > #given a spec carrying a valid resolved variant #when the context is built #then it maps to the senpi thinking level [3.06ms]
+(pass) createParentRegistrySessionContext > #given a spec carrying an unknown variant #when the context is built #then no thinking level is threaded [2.48ms]
+(pass) createParentRegistrySessionContext > #given a model reference absent from the parent registry #when the context is built #then registry is still threaded but no Model is set [1.96ms]
+(pass) resolveResumeContext > #given a spec whose resolved_model provider+model_id exist in the live registry #when resolved #then it returns ok with the exact model and registry context [1.75ms]
+(pass) resolveResumeContext > #given a spec whose resolved_model provider was removed from the live registry #when resolved #then it returns model_unavailable and never drifts to a substitute [1.71ms]
+(pass) resolveResumeContext > #given a spec whose display string differs from the canonical provider/model_id #when resolved #then it keys on provider+model_id, not display, and resolves correctly [1.64ms]
+(pass) resolveResumeContext > #given a spec whose provider+model_id match one model but display matches a DIFFERENT model in the registry #when resolved #then it resolves the provider+model_id match, never the display match [1.63ms]
+(pass) resolveResumeContext > #given no live parent registry available #when resolved #then it returns model_unavailable, never silently drifting to a default [0.06ms]
+(pass) resolveResumeContext > #given a spec with no resolved_model at all #when resolved #then it returns model_unavailable [1.64ms]
+
+packages/senpi-task/src/__adversarial__/chaos-bench.test.ts:
+[chaos] seed=senpi-task-w1-chaos base=2337725802 iterations=200
+(pass) W1-V chaos bench > #given 200 randomized event interleavings #when each is driven to quiescence #then all thirteen invariants hold [36974.95ms]
+
+packages/senpi-task/src/__adversarial__/chaos-lifecycle.test.ts:
+(pass) suspend/revive lifecycle chaos model > #given every new lifecycle action #when deterministic interleavings run #then all lifecycle invariants hold [129.97ms]
+(pass) suspend/revive lifecycle chaos model > #given the double_revive regression #when the invariant witness runs #then invariant 6 fails [11.52ms]
+(pass) suspend/revive lifecycle chaos model > #given the lose_recoverable regression #when the invariant witness runs #then invariant 7 fails [4.08ms]
+(pass) suspend/revive lifecycle chaos model > #given the suspension_bumps_epoch regression #when the invariant witness runs #then invariant 8 fails [4.14ms]
+(pass) suspend/revive lifecycle chaos model > #given the spawn_before_orphan_kill regression #when the invariant witness runs #then invariant 9 fails [2.04ms]
+(pass) suspend/revive lifecycle chaos model > #given the revive_forbidden regression #when the invariant witness runs #then invariant 10 fails [2.32ms]
+(pass) suspend/revive lifecycle chaos model > #given the over_admit regression #when the invariant witness runs #then invariant 11 fails [1.31ms]
+(pass) suspend/revive lifecycle chaos model > #given the capacity_gate_reclamation regression #when the invariant witness runs #then invariant 12 fails [0.92ms]
+(pass) suspend/revive lifecycle chaos model > #given the relaunch_terminal_without_session regression #when the invariant witness runs #then invariant 13 fails [2.29ms]
+
+packages/senpi-task/src/team/runtime-config.test.ts:
+(pass) toTeamCoreConfig > #given omo task.team bounds #when converted #then the team-core config carries the bounds and base dir [0.29ms]
+(pass) toTeamCoreConfig > #given defaults #when converted #then transport fields keep team-core defaults [0.08ms]
+(pass) toTeamCoreSpecSource > #given a project source #when mapped #then it stays project [0.07ms]
+(pass) toTeamCoreSpecSource > #given an omo-json source #when mapped #then it maps to the user slot [0.06ms]
+
+packages/senpi-task/src/team/runtime-delete.test.ts:
+(pass) deleteTeam > #given an active team #when deleted #then all member tasks are cancelled and the runtime dir is removed [53.31ms]
+(pass) deleteTeam > #given a team still in creating #when deleted #then an invalid-state error is thrown [1.39ms]
+(pass) deleteTeam > #given an already-deleted team #when deleted again #then it is a no-op [13.48ms]
+(pass) deleteTeam > #given a completed resident member #when deleted #then cancellation stays noop while lifecycle destroys it and the runtime is removed [12.14ms]
+(pass) deleteTeam > #given a member sidecar points at a foreign task #when deleted #then that task is untouched [10.45ms]
+(pass) deleteTeam > #given a completed resident member already disposed #when deleted #then destruction is not repeated [5.06ms]
+(pass) deleteTeam > #given a completed resident member revives between residency checks #when deleted #then destruction is skipped [18.38ms]
+(pass) deleteTeam > #given a resident member cancellation is in flight #when deleted #then deletion does not race its destruction [171.31ms]
+(pass) deleteTeam > #given two delete calls for one team #when invoked concurrently #then they share one cancellation and one destruction [20.20ms]
+
+packages/senpi-task/src/team/member-extensions.test.ts:
+(pass) assembleMemberExtensions > #given duplicated and ordered inherited extensions #when assembled #then member stays first and inherited order is stable [0.15ms]
+
+packages/senpi-task/src/team/member-projection.test.ts:
+(pass) projectMemberStatus > #given task status pending #when projected #then member status is pending [0.31ms]
+(pass) projectMemberStatus > #given task status running #when projected #then member status is running [1.06ms]
+(pass) projectMemberStatus > #given task status interrupted #when projected #then member status is idle [0.06ms]
+(pass) projectMemberStatus > #given task status completed #when projected #then member status is completed [0.05ms]
+(pass) projectMemberStatus > #given task status error #when projected #then member status is errored [0.06ms]
+(pass) projectMemberStatus > #given task status cancelled #when projected #then member status is errored [0.06ms]
+(pass) projectMemberStatus > #given task status lost #when projected #then member status is errored [0.05ms]
+(pass) refreshTeamMemberStatuses > #given a member task moved to completed #when refreshed #then the runtime member reflects completed [11.51ms]
+
+packages/senpi-task/src/team/runtime-create-failure.test.ts:
+(pass) createTeam failures > #given a spec exceeding max_members #when created #then it is rejected before any spawn [1.43ms]
+(pass) createTeam failures > #given the 2nd member spawn throws #when created #then the team fails and the 1st member is cancelled [3.66ms]
+(pass) createTeam failures > #given the member sidecar write throws #when created #then members are cancelled, the team is failed, and it never activates [91.31ms]
+(pass) createTeam failures > #given a create deadline already passed #when created #then it fails with a deadline error and no spawns [5.28ms]
+
+packages/senpi-task/src/team/shutdown-helpers.test.ts:
+(pass) shutdown helpers > #given the omo shutdown-helpers parity set #when DELETABLE_MEMBER_STATUSES is read #then it is exactly completed/shutdown_approved/errored [0.30ms]
+(pass) shutdown helpers > #given each member status #when isMemberDeletable is applied #then only terminal-safe statuses are deletable [0.14ms]
+
+packages/senpi-task/src/team/normalize.test.ts:
+(pass) normalizeSenpiTeamSpec > #given a multi-member spec with a category and an agent alias #when normalized #then it parses with the lead sentinel and no spawnable lead member [0.33ms]
+(pass) normalizeSenpiTeamSpec > #given a name-less omo.json team value #when normalized #then it takes the record key as its name [0.10ms]
+(pass) normalizeSenpiTeamSpec > #given a spec that already carries its own name #when normalized #then the explicit name is preserved [0.08ms]
+(pass) normalizeSenpiTeamSpec > #given a raw.lead field on the input #when normalized #then it is rejected with a typed diagnostic and zero members survive [0.13ms]
+(pass) normalizeSenpiTeamSpec > #given a member literally named 'lead' #when normalized #then it is rejected with a typed diagnostic [0.11ms]
+(pass) normalizeSenpiTeamSpec > #given the callerTeamLead option #when normalized #then it is rejected before any member is spawned [0.07ms]
+(pass) normalizeSenpiTeamSpec > #given a member with no resolvable kind fields #when normalized #then the schema rejects it as an invalid spec [0.25ms]
+(pass) normalizeSenpiTeamSpec lenient input > #given a JSON-stringified spec #when normalized #then it parses and normalizes like the object form [0.09ms]
+(pass) normalizeSenpiTeamSpec lenient input > #given a malformed JSON string spec #when normalized #then it rejects with the parse detail and the corrective shape [0.08ms]
+(pass) normalizeSenpiTeamSpec lenient input > #given a non-string non-object spec #when normalized #then the error names the received type and the corrective shape [0.07ms]
+(pass) normalizeSenpiTeamSpec lenient input > #given a single member object instead of an array #when normalized #then it is wrapped into a one-member array [0.07ms]
+(pass) normalizeSenpiTeamSpec task_summary > #given a member with a task_summary #when normalized #then the summary survives the schema parse [0.10ms]
+(pass) normalizeSenpiTeamSpec task_summary > #given an over-limit member task_summary #when normalized #then it is clamped instead of rejected [0.10ms]
+
+packages/senpi-task/src/team/member-map.test.ts:
+(pass) member task map sidecar > #given a written map #when read back #then the member -> task mapping round-trips [16.60ms]
+(pass) member task map sidecar > #given no sidecar file #when read #then an empty map is returned [5.44ms]
+(pass) member task map sidecar > #given a malformed sidecar #when read #then an empty map is returned [3.30ms]
+(pass) member task map sidecar > #given a completed write #when the directory is listed #then no temp file remains [1.32ms]
+
+packages/senpi-task/src/team/member-respawn.test.ts:
+(pass) createTeamMemberRespawnLaunchResolver > #given a persisted team member task #when resolved against current team runtime #then trusted extension and identity replace persisted launch inputs [7.27ms]
+(pass) createTeamMemberRespawnLaunchResolver > #given a team member task missing from the current task map #when resolved #then reattach is rejected [38.19ms]
+(pass) createTeamMemberRespawnLaunchResolver > #given a shutdown-approved team member #when resolved #then reattach is rejected as member_missing and no launch is produced [39.12ms]
+
+packages/senpi-task/src/team/tasks.test.ts:
+(pass) team tasklist orchestration > #given a task input #when createTeamTask runs #then it persists a pending task with an id [94.26ms]
+(pass) team tasklist orchestration > #given two tasks with a dependency #when the blocked task is claimed before its blocker completes #then it is rejected until the blocker is completed [21.12ms]
+(pass) team tasklist orchestration > #given a claimed task #when a non-owner updates its status #then a typed cross-owner error is raised [33.67ms]
+(pass) team tasklist orchestration > #given a completed task #when a reverse transition is requested #then a typed invalid-transition error is raised [10.91ms]
+(pass) team tasklist orchestration > #given an already-claimed task #when a second member claims it #then a typed already-claimed error is raised [24.38ms]
+(pass) team tasklist orchestration > #given several tasks #when listTeamTasks runs with an owner filter #then only that owner's tasks are returned in id order [4.10ms]
+
+packages/senpi-task/src/team/storage.test.ts:
+(pass) team storage layout > #given a project state dir config #when the base dir is resolved #then it lands under the senpi-task state dir [1.92ms]
+(pass) team storage layout > #given a team run id #when runtime dirs are resolved #then runtime and tasks dirs live under the base dir [0.27ms]
+(pass) team storage layout > #given the discovery-only project spec path #when resolved #then it maps to the omo-compatible .omo/teams path [0.25ms]
+(pass) team storage layout > #given a team run #when runtime dirs are ensured #then the directories are created at the right paths [1.14ms]
+
+packages/senpi-task/src/team/shutdown.test.ts:
+(pass) team shutdown protocol > #given an active member #when requestShutdown runs #then a pending request is recorded and a shutdown_request message is sent to the member [5.28ms]
+(pass) team shutdown protocol > #given a member with a pending request #when requestShutdown runs again #then it is idempotent (no duplicate record or message) [25.79ms]
+(pass) team shutdown protocol > #given an unknown member #when requestShutdown runs #then a typed unknown_member error is raised and nothing is sent [3.06ms]
+(pass) team shutdown protocol > #given a pending request #when approveShutdown runs #then the member becomes shutdown_approved, the task is cancelled, and the request is marked approved [26.44ms]
+(pass) team shutdown protocol > #given no pending request #when approveShutdown runs #then a typed no_pending_request error is raised and no task is cancelled [2.74ms]
+(pass) team shutdown protocol > #given a completed member with a pending request #when approveShutdown runs #then the completed status is preserved (not overwritten) [5.20ms]
+(pass) team shutdown protocol > #given a pending request #when rejectShutdown runs #then the member status is left running and the request records the reason [5.81ms]
+(pass) team shutdown protocol > #given no pending request #when rejectShutdown runs #then a typed no_pending_request error is raised [12.16ms]
+(pass) team shutdown protocol > #given a rejected request #when requestShutdown runs again #then a fresh pending request is allowed [3.59ms]
+
+packages/senpi-task/src/team/import-discipline.test.ts:
+(pass) team layer import discipline > #given the team layer source files #when their imports are scanned #then no forbidden team-core or opencode/tmux specifier is used [6.89ms]
+(pass) team layer import discipline > #given team-core imports #when scanned #then only exported subpaths are used [1.49ms]
+
+packages/senpi-task/src/team/registry.test.ts:
+(pass) loadTeamRegistry > #given an omo.json teams section with a category and agent-alias member #when loaded #then it round-trips into a team-core spec [2.65ms]
+(pass) loadTeamRegistry > #given a directory spec and an omo.json spec sharing a name #when loaded #then the project directory wins [8.85ms]
+(pass) loadTeamRegistry > #given a member with an unresolvable kind #when loaded #then an error is recorded and zero teams spawn [4.42ms]
+(pass) loadTeamRegistry > #given a team declaring a raw lead field #when loaded #then it is rejected and spawns zero members [6.06ms]
+(pass) loadTeamRegistry > #given no team sources #when loaded #then it returns empty teams and errors [1.38ms]
+
+packages/senpi-task/src/team/member-validator.test.ts:
+(pass) validateSenpiTeamMembers vocabulary hints > #given an unknown category with named ports #when validated #then the error lists the available categories [0.30ms]
+(pass) validateSenpiTeamMembers vocabulary hints > #given an unknown subagent_type with named ports #when validated #then the error lists the available agents [0.15ms]
+(pass) validateSenpiTeamMembers > #given resolvable members #when validated #then it passes without throwing [0.12ms]
+(pass) validateSenpiTeamMembers > #given an unresolvable category #when validated #then it throws naming the allowed kinds [0.12ms]
+(pass) validateSenpiTeamMembers > #given an unknown subagent_type #when validated #then it throws a typed diagnostic [0.09ms]
+(pass) validateSenpiTeamMembers > #given a curated read-only agent #when validated #then it is rejected before the known-agent check [0.09ms]
+(pass) validateSenpiTeamMembers one-shot invariant > #given a one-shot agent name #when used as a subagent_type #then it throws SenpiTeamSpecError [0.12ms]
+
+packages/senpi-task/src/team/member-revival.test.ts:
+(pass) team member revival across session resume > #given a completed resident member whose process died unexpectedly #when reattach is disabled #then reconcile records the killed residency instead of silently suspending it [49.51ms]
+(pass) team member revival across session resume > #given a suspended team member record #when the owning session reconciles #then it revives with launch inputs from the trusted resolver and keeps its mailbox identity [8.53ms]
+(pass) team member revival across session resume > #given a suspended member whose team run is no longer active #when the owning session reconciles #then it stays suspended with a deferred team_inactive outcome [12.94ms]
+(pass) team member revival across session resume > #given a suspended member whose team run was deleted #when the owning session reconciles #then it stays suspended with a deferred team_inactive outcome [9.23ms]
+
+packages/senpi-task/src/team/fallback-notification.test.ts:
+(pass) team fallback notification > #given duplicate lead lifecycle triggers #when fallback notification delivers #then the lead receives one factual reroute [0.42ms]
+
+packages/senpi-task/src/team/runtime.test.ts:
+(pass) createTeam > #given a member extension launch config #when a team member starts #then extension and durable identity env reach the manager spec [41.91ms]
+(pass) createTeam > #given a 3-member spec #when created #then the team is active with 3 mapped running members [61.15ms]
+(pass) createTeam > #given roles, prompts, and a resolved model #when created #then member views carry role, model, task id, and prompt excerpt [62.83ms]
+(pass) createTeam > #given member prompts #when members start #then every bootstrap teaches injection-driven work after the role [6.06ms]
+(pass) createTeam > #given the created team #when the sidecar is read #then it maps every member to its st_ id [7.01ms]
+(pass) createTeam > #given a member with a worktreePath #when created #then the cwd is passed and the directory is made [6.49ms]
+
+packages/senpi-task/src/team/spawn-members-task-summary.test.ts:
+(pass) spawnTeamMembers task_summary > #given a member with a task_summary #when spawned #then the manager start spec carries the summary [0.38ms]
+
+packages/senpi-task/src/lazy/pi-tui-shared-state.test.ts:
+(pass) pi-tui lazy boundary across duplicated module instances > #given loadPiTui awaited through one module copy #when a second copy reads piTui() #then it resolves without throwing [1.20ms]
+
+packages/senpi-task/src/lazy/senpi-barrel-shared-state.test.ts:
+(pass) senpi barrel lazy boundary across duplicated module instances > #given loadSenpiBarrel awaited through one module copy #when a second copy reads senpiBarrel() #then it resolves without throwing [3.66ms]
+
+packages/senpi-task/src/runners/rpc-process.test.ts:
+(pass) RpcProcessRunner > #given the default RPC child spawner #when started #then Windows hides the child console [67.85ms]
+(pass) RpcProcessRunner > #given a completing child #when started #then the handle reports final text and a clean exit [78.69ms]
+(pass) RpcProcessRunner > #given a busy child #when steered #then the steer is acked while the turn is in flight [111.84ms]
+(pass) RpcProcessRunner > #given a busy child #when followUp is sent #then it is routed as a prompt with followUp streaming behavior [40.20ms]
+(pass) RpcProcessRunner > #given a child killed by signal #when it exits #then the outcome is killed and maps to status error with killed:true [109.15ms]
+(pass) RpcProcessRunner > #given a child that exits nonzero before terminal #when it crashes #then the outcome carries the stderr tail [45.87ms]
+(pass) RpcProcessRunner > #given a resident child #when heartbeats poll #then lastSeen and sessionId are recorded [50.93ms]
+(pass) RpcProcessRunner > #given a spawn #when the descriptor is built #then the child gets an isolated session dir, not the real HOME [65.58ms]
+(pass) RpcProcessRunner > #given an idle resident child #when revived with a follow-up #then waitForIdle re-arms for the new turn instead of the consumed first idle [157.56ms]
+(pass) RpcProcessRunner > #given prior assistant text #when a revived turn produces no output #then the stale text cannot become a fresh success [51.25ms]
+(pass) RpcProcessRunner > #given inheritedExtensions and a spec without its own extensions #when started #then the child spec carries the inherited entries [76.95ms]
+(pass) RpcProcessRunner > #given a spec that already carries extensions #when started #then inheritedExtensions do NOT override them [106.71ms]
+
+packages/senpi-task/src/runners/in-process-model-runtime.test.ts:
+(pass) #given a parent model runtime #when the child session is constructed #then native providers remain executable [9.05ms]
+
+packages/senpi-task/src/runners/in-process.test.ts:
+(pass) InProcessRunner > #given a running child #when steered while the prompt is in flight #then the fake session receives it [1.85ms]
+(pass) InProcessRunner > #given a running child #when aborted mid-run #then outcome is cancelled and the session was aborted [0.41ms]
+(pass) InProcessRunner > #given an aborted child #when a follow-up revives it #then the revived turn completes with new final text [0.37ms]
+(pass) InProcessRunner > #given a completing child #when idle #then the last assistant text is extracted [0.26ms]
+(pass) InProcessRunner > #given shared and member-scoped tools #when a child is started #then only member-scoped tools cross the family exclusion [0.34ms]
+(pass) InProcessRunner > #given a tool allowlist and shared lsp tools #when a child is started #then options.tools equals the allowlist while customTools still carries the lsp tool [0.31ms]
+(pass) InProcessRunner > #given a curated child with bash allowed #when the session is constructed #then a restricted bash override replaces the builtin [0.32ms]
+(pass) InProcessRunner > #given a non-curated child #when the session is constructed #then no bash override is injected [0.23ms]
+(pass) InProcessRunner > #given a started child #when the session is constructed #then a persisted session manager rooted at the spec session dir is used [3.78ms]
+(pass) InProcessRunner > #given a completed child #when the runner finishes #then it never disposes and dispose stays idempotent [0.35ms]
+(pass) InProcessRunner > #given a depth over policy #when start is called #then it refuses to construct the session [0.29ms]
+(pass) InProcessRunner > #given a session that fails to construct #when start is called #then a typed session-create failure is thrown with cause [0.39ms]
+(pass) InProcessRunner > #given a prompt that throws #when the child runs #then a typed failure is recorded, the child stays resident, and no rejection escapes [11.91ms]
+(pass) InProcessRunner > #given a subscribed listener #when the child emits lifecycle events #then it observes agent_start before agent_end [0.62ms]
+(pass) InProcessRunner thinking level > #given a spec carrying a thinking level #when the child session is created #then the level reaches the senpi session options [0.26ms]
+(pass) InProcessRunner thinking level > #given a spec without a thinking level #when the child session is created #then no level is forced so senpi keeps its default [0.18ms]
+
+packages/senpi-task/src/runners/rpc-process.windows.test.ts:
+(skip) #given a console-less parent #when the default RPC child starts #then windowsHide suppresses its console
+
+packages/senpi-task/src/runners/dag-child-policy.test.ts:
+(pass) DAG child in-process tool policy > #given a DAG node child #when its session options are built #then no orchestration-capable shared tool reaches it [0.92ms]
+(pass) DAG child in-process tool policy > #given a persisted DAG node child #when resumed #then the shared orchestration filter is re-applied [5.51ms]
+(pass) DAG child in-process tool policy > #given plain and team-member children #when their tool sets are built #then existing sanctioned sets stay exact and dag is absent [2.89ms]
+
+packages/senpi-task/src/runners/in-process-resume.test.ts:
+(pass) InProcessRunner resume > #given a curated spec with allowlist, denylist, and member-scoped names #when resumed #then the tool surface matches the start surface exactly [5.57ms]
+(pass) InProcessRunner resume > #given a resumed child #when the handle is created #then no prompt is sent and the next follow-up starts a fresh tracked turn [4.82ms]
+(pass) InProcessRunner resume > #given a member-scoped name missing from the live parent tools #when resumed #then a typed tools_unavailable failure surfaces and no session is created [2.27ms]
+(pass) InProcessRunner resume > #given a duplicated member-scoped name #when resumed #then a typed tools_unavailable failure surfaces [1.15ms]
+(pass) InProcessRunner resume > #given a member-scoped name matching two live tools #when resumed #then a typed tools_unavailable failure surfaces [1.04ms]
+
+packages/senpi-task/src/runners/in-process-persistence.test.ts:
+(pass) InProcessRunner session persistence > #given a child spec with a resolved child session dir #when started #then the session manager persists under children/<taskId>/sessions/ [1.08ms]
+(pass) InProcessRunner session persistence > #given allow and deny tool lists #when the child session is constructed #then tools carries the allowlist and excludeTools carries the denylist [0.81ms]
+(pass) InProcessRunner session persistence > #given no tool denylist #when the child session is constructed #then excludeTools stays unset so senpi keeps its defaults [0.56ms]
+(pass) InProcessRunner session persistence > #given an unwritable session dir #when start is called #then a typed session-create failure surfaces with no in-memory fallback [1.16ms]
+(pass) InProcessRunner session persistence > #given a legacy spec without a sessionDir #when start is called #then a typed session-create failure surfaces instead of a silent default-dir fallback [0.34ms]
+(pass) InProcessRunner session persistence > #given the real default session manager #when one stubbed turn runs #then a jsonl transcript with the child messages appears under the session dir [1.55ms]
+
+packages/senpi-task/src/runners/in-process-runtime-fallback.test.ts:
+(pass) InProcessRunner runtime fallback > #given a selected model and ordered fallbacks #when the child session is created #then child-local runtime fallback settings preserve the chain [2.36ms]
+(pass) InProcessRunner runtime fallback > #given runtime fallback models with both reasoning effort and variant #when the child session is created #then reasoning effort wins over variant [0.31ms]
+(pass) InProcessRunner runtime fallback > #given a builtin category resolving to a chain rung #when the child session is created #then the remaining chain rungs land in retry fallback chains [0.73ms]
+(pass) InProcessRunner runtime fallback > #given no runtime fallbacks #when the child session is created #then global model fallback is disabled [0.24ms]
+
+packages/senpi-task/src/runners/in-process-access-terminated-error.test.ts:
+(pass) in-process access_terminated_error fallback > #given access_terminated_error makes the first category candidate unusable #when the child runs #then the next configured candidate produces the result [181.27ms]
+(pass) in-process access_terminated_error fallback > #given context overflow is deliberately non-fallback #when the child runs #then it stays terminal on the first candidate [45.01ms]
+
+packages/senpi-task/src/runners/in-process-resume-session.test.ts:
+(pass) InProcessRunner resume session file failures > #given a corrupt session file #when resumed #then a typed session_unavailable failure surfaces and no raw parse error escapes [6.33ms]
+(pass) InProcessRunner resume session file failures > #given a missing session file #when resumed #then a typed session_unavailable failure surfaces [36.43ms]
+(pass) InProcessRunner resume session file failures > #given a directory as the session path #when resumed #then a typed session_unavailable failure surfaces [0.88ms]
+(pass) InProcessRunner resume session file failures > #given a session file whose first entry is not a session header #when resumed #then a typed session_unavailable failure surfaces [0.54ms]
+(pass) InProcessRunner resume session file failures > #given a legacy spec without a sessionDir #when resumed #then a typed session-create failure surfaces instead of a silent default-dir fallback [15.04ms]
+(pass) InProcessRunner resume session file failures > #given a real persisted child transcript written by the start path #when resumed #then the same session file is reopened and a follow-up produces a tracked turn [15.35ms]
+
+packages/senpi-task/src/steering/engine.test.ts:
+(pass) steering engine over the in-process runner fake > #given a running resident child #when sent a steer #then the steer lands mid-run on the live handle [14.03ms]
+(pass) steering engine over the in-process runner fake > #given a completed resident child #when sent a message #then it revives on the SAME instance with an incremented epoch [10.08ms]
+(pass) steering engine over the in-process runner fake > #given a running resident child #when interrupted then sent #then interrupt keeps partial text and the later send revives [8.05ms]
+(pass) steering engine over the in-process runner fake > #given a running resident child #when cancelled then sent #then destruction runs once and the send is not continuable [2.07ms]
+(pass) steering engine over the in-process runner fake > #given a running child whose abort rejects #when cancelled #then destruction still runs exactly once and the cancel resolves [2.99ms]
+(pass) steering engine over the in-process runner fake > #given a cancelled child #when cancelled again #then it is an idempotent no-op and destruction is not re-run [12.21ms]
+(pass) steering engine over the in-process runner fake > #given a pending child #when two messages are sent #then they queue and deliver in order right after start [6.79ms]
+(pass) steering engine over the rpc runner fake > #given a running resident child #when sent a steer #then the steer lands mid-run on the live handle [2.66ms]
+(pass) steering engine over the rpc runner fake > #given a completed resident child #when sent a message #then it revives on the SAME instance with an incremented epoch [2.86ms]
+(pass) steering engine over the rpc runner fake > #given a running resident child #when interrupted then sent #then interrupt keeps partial text and the later send revives [3.67ms]
+(pass) steering engine over the rpc runner fake > #given a running resident child #when cancelled then sent #then destruction runs once and the send is not continuable [2.81ms]
+(pass) steering engine over the rpc runner fake > #given a running child whose abort rejects #when cancelled #then destruction still runs exactly once and the cancel resolves [10.73ms]
+(pass) steering engine over the rpc runner fake > #given a cancelled child #when cancelled again #then it is an idempotent no-op and destruction is not re-run [2.86ms]
+(pass) steering engine over the rpc runner fake > #given a pending child #when two messages are sent #then they queue and deliver in order right after start [8.57ms]
+(pass) steering engine scope + resolution guards > #given a task owned by another session #when sent without all_scope #then it is scope-denied naming the owning session [3.46ms]
+(pass) steering engine scope + resolution guards > #given a cross-session task #when sent with all_scope #then delivery is allowed [6.86ms]
+(pass) steering engine scope + resolution guards > #given an unknown selector #when sent #then it reports not_found [0.63ms]
+(pass) steering engine scope + resolution guards > #given a task resolved by name #when sent a steer #then the name resolves to the record [3.78ms]
+(pass) steering pending cancellation > #given a pending child with queued sends w2pend #when cancelled then notified started #then the queue is dropped without delivery [11.20ms]
+(pass) steering pending cancellation > #given a pending child w2pend #when interrupted #then it remains pending with a noop outcome [0.69ms]
+(pass) steering pending cancellation > #given a pending child with queued sends w2pend #when dropPending then notified started #then buffered messages are discarded [4.64ms]
+(pass) durable prelaunch steering > #given a pending child with two queued sends #when a fresh engine starts over the same store and the child launches #then both messages drain in persisted order [4.31ms]
+(pass) durable prelaunch steering > #given a pending child with queued sends #when cancelled #then the persisted queue is cleared and a post-restart start delivers nothing [18.92ms]
+(pass) durable prelaunch steering > #given a running child suspended to persisted_only #when sent #then it is not_continuable with the suspended reason copy and NO revive [3.21ms]
+(pass) durable prelaunch steering > #given a running child suspended to rpc_detached #when sent #then it is not_continuable with the suspended reason copy [2.92ms]
+(pass) durable prelaunch steering > #given a persisted queue with one malformed entry #when the child starts after a restart #then the bad entry is dropped with a parse warning and the rest deliver in order [10.66ms]
+
+packages/senpi-task/src/steering/engine-one-shot.test.ts:
+(pass) steering engine one-shot agent refusal > #given a running resident momus child #when sent #then the outcome is one_shot_agent with the registry reminder and nothing is delivered [1.69ms]
+(pass) steering engine one-shot agent refusal > #given a pending momus child #when sent #then the outcome is one_shot_agent and nothing is queued [0.81ms]
+(pass) steering engine one-shot agent refusal > #given a completed resident momus child #when sent #then the outcome is one_shot_agent and no revive occurs [3.03ms]
+(pass) steering engine one-shot refusal vs scope ordering > #given a foreign-owned momus child #when sent without all_scope #then the scope denial wins and the one-shot classification is not leaked [10.28ms]
+(pass) steering engine one-shot refusal vs scope ordering > #given a foreign-owned momus child #when sent with all_scope #then the one-shot refusal applies [1.34ms]
+
+packages/senpi-task/src/steering/engine-run-epoch.test.ts:
+(pass) steering event log run epochs > #given a steer delivered during run_epoch 2 #when the event is appended #then the payload carries run_epoch 2 and survives redaction [13.28ms]
+(pass) steering event log run epochs > #given a prelaunch send to a pending child #when queued #then the steer_queued payload carries the current run_epoch [1.56ms]
+(pass) steering event log run epochs > #given a queued prelaunch message drained at launch #when delivered #then the steered event carries the launching run_epoch [2.01ms]
+
+packages/senpi-task/src/senpi/thinking-level.test.ts:
+(pass) asSenpiThinkingLevel > #given every senpi thinking level #when validated #then it passes through verbatim [0.18ms]
+(pass) asSenpiThinkingLevel > #given the omo.json reasoningEffort none #when validated #then it maps to senpi off [0.06ms]
+(pass) asSenpiThinkingLevel > #given an unknown variant string #when validated #then it is rejected so the child keeps the harness default [0.07ms]
+(pass) asSenpiThinkingLevel > #given undefined #when validated #then it stays undefined [0.06ms]
+
+packages/senpi-task/src/store/record-parse-v1.test.ts:
+(pass) record-parse notify_on_terminal legacy default > #given a legacy record without notify_on_terminal #when listed #then the field defaults to false [83.97ms]
+(pass) record-parse notify_on_terminal legacy default > #given a record with notify_on_terminal true #when listed #then the field round-trips [3.98ms]
+(pass) record-parse spawn_spec v1 > #given a legacy {cwd} spawn_spec #when listed #then it parses as the legacy variant (isSpawnSpecV1 false) with extensions/member_env dropped [4.75ms]
+(pass) record-parse spawn_spec v1 > #given a v1 spawn_spec #when listed #then it round-trips with version, prompt, instructions, and member_scoped_tool_names [2.31ms]
+(pass) record-parse spawn_spec v1 > #given a v1 spawn_spec with only required fields #when listed #then it round-trips without optional fields [0.88ms]
+(pass) record-parse spawn_spec v1 > #given a spawn_spec missing cwd #when listed #then diagnostic is typed and record is skipped [0.89ms]
+(pass) record-parse spawn_spec v1 > #given a v1 spawn_spec missing prompt #when listed #then diagnostic is typed and record is skipped [8.17ms]
+(pass) record-parse pending_steering > #given a valid pending_steering array #when listed #then it round-trips [23.46ms]
+(pass) record-parse pending_steering > #given a malformed pending_steering entry #when listed #then the entry is dropped, siblings survive, AND the record remains in records with a parse_warning diagnostic [10.40ms]
+(pass) record-parse pending_steering > #given pending_steering that is not an array #when listed #then diagnostic is typed and record is skipped (whole-field corruption) [2.03ms]
+(pass) record-parse pending_steering > #given pending_steering that is an object not array #when listed #then diagnostic is typed and record is skipped [0.67ms]
+(pass) record-parse pending_steering > #given a record with only malformed pending_steering entries #when listed #then record stays in records with warnings and empty steering [0.66ms]
+(pass) record-parse pending_steering with sibling records > #given one record with bad steering and one clean record #when listed #then both records survive, only the bad one has a warning [0.71ms]
+
+packages/senpi-task/src/store/security.test.ts:
+(pass) TaskRecordStore task id boundary > #given hostile task ids #when public path entry points are called #then ids are rejected before writing [7.12ms]
+(pass) parseTaskRecord persisted boundary > #given an old persisted record without resolved model metadata #when listed #then the record remains valid [2.61ms]
+(pass) parseTaskRecord persisted boundary > #given persisted resolved model metadata #when listed #then structured metadata survives the parse round-trip [0.64ms]
+(pass) parseTaskRecord persisted boundary > #given persisted resolved model metadata containing reasoning effort only #when listed #then the field survives the parse round-trip [0.64ms]
+(pass) parseTaskRecord persisted boundary > #given persisted resolved model metadata with a future field #when listed #then known metadata is parsed and the future field is ignored [0.64ms]
+(pass) parseTaskRecord persisted boundary > #given malformed resolved model metadata #when listed #then diagnostic is typed and record is skipped [0.64ms]
+(pass) parseTaskRecord persisted boundary > #given malformed known resolved model fields #when listed #then diagnostic is typed and record is skipped [4.19ms]
+(pass) parseTaskRecord persisted boundary > #given persisted spawn extensions and member env #when listed #then untrusted launch inputs are discarded [0.66ms]
+(pass) parseTaskRecord persisted boundary > #given a persisted killed:true error record #when listed #then the killed FACT survives the parse round-trip [0.64ms]
+(pass) parseTaskRecord persisted boundary > #given a persisted non-boolean killed #when listed #then a typed diagnostic is reported [0.80ms]
+(pass) parseTaskRecord persisted boundary > #given malformed optional pid #when records are listed #then diagnostic is typed and record is skipped [1.76ms]
+(pass) parseTaskRecord persisted boundary > #given malformed optional tool allow #when records are listed #then diagnostic is typed and record is skipped [6.60ms]
+(pass) parseTaskRecord persisted boundary > #given invalid enum sentinel #when diagnostic is reported #then raw rejected value is redacted [3.23ms]
+(pass) createTaskRecord privacy boundary > #given runtime task input with prompt-shaped extras #when created and saved #then extras are not copied into the record or store [3.58ms]
+
+packages/senpi-task/src/store/record-store.test.ts:
+(pass) createTaskRecordStore caching > #given an agent-resolved record #when a fresh store reads it #then source agent round-trips without diagnostics [1.05ms]
+(pass) createTaskRecordStore caching > #given a persisted liveness delivery epoch #when a fresh store reads the task #then the epoch round-trips [1.30ms]
+(pass) createTaskRecordStore caching > #given unchanged records #when list() is called repeatedly #then results stay consistent [3.52ms]
+(pass) createTaskRecordStore caching > #given an externally mutated record #when list() runs #then the change is reflected [2.79ms]
+(pass) createTaskRecordStore caching > #given a record removed by another process #when list() runs #then it disappears from results [2.48ms]
+(pass) createTaskRecordStore caching > #given a concurrent lifecycle write #when a serialized conditional patch runs #then it re-reads fresh state and preserves every lifecycle field [2.49ms]
+(pass) createTaskRecordStore caching > #given a record replaced through the store #when list() runs #then the cache reflects the new value [2.06ms]
+(pass) createTaskRecordStore event append > #given a removed task #when appendEvent is called again #then the log file is recreated [5.14ms]
+(pass) createTaskRecordStore event append > #given a record save #when the file is read back #then it is compact JSON without pretty-print indentation [6.05ms]
+(pass) createTaskRecordStore remove artifacts > #given a record + event log + children dir + spill file #when remove is called #then ALL FOUR artifacts are deleted [3.13ms]
+(pass) createTaskRecordStore remove artifacts > #given a partially-cleaned task (children dir already gone) #when remove is called #then it still deletes log + record without throwing [2.11ms]
+(pass) createTaskRecordStore remove artifacts > #given a fully removed task #when remove is called again #then it is a no-op without throwing [3.19ms]
+(pass) createTaskRecordStore tombstone expunge > #given the retention predicate rejects the record #when tombstoneIfExpired runs #then the record is renamed to a tombstone invisible to load, list, and mutate [38.86ms]
+(pass) createTaskRecordStore tombstone expunge > #given the retention predicate keeps the record #when tombstoneIfExpired runs #then the record is untouched [2.93ms]
+(pass) createTaskRecordStore tombstone expunge > #given a missing record #when tombstoneIfExpired runs #then it reports missing without writing anything [1.41ms]
+(pass) createTaskRecordStore tombstone expunge > #given a tombstoned record with leftover artifacts #when completeExpunge runs #then children dir, spill, log, and tombstone are gone and a re-run is a no-op [3.84ms]
+
+packages/senpi-task/src/store/claim-race.test.ts:
+(pass) claimTaskRecord cross-process race > #given two processes in one frozen id bucket #when they claim task records concurrently #then every record is unique and collisions retry [140.02ms]
+
+packages/senpi-task/src/store/record-parse.test.ts:
+(pass) record-parse run_stats token totals > #given a persisted run_stats without the new token fields #when parsed #then the record round-trips and the new fields stay undefined [0.50ms]
+(pass) record-parse run_stats token totals > #given a run_stats with all four token totals and status fields #when parsed #then every value round-trips exactly [0.18ms]
+(pass) record-parse run_stats token totals > #given a run_stats carrying an unknown token_status #when parsed #then the record is rejected [0.47ms]
+(pass) record-parse run_stats token totals > #given a run_stats carrying non-numeric token totals #when parsed #then the record is rejected [0.25ms]
+(pass) record-parse task ordinals and background mode > #given a persisted record with task_seq, config_generation and background_mode #when parsed #then all three round-trip exactly [0.28ms]
+(pass) record-parse task ordinals and background mode > #given a persisted record with an unknown background_mode #when parsed #then the record is rejected [0.31ms]
+
+packages/senpi-task/src/store/claim.test.ts:
+(pass) claimTaskRecord > #given consecutive persisted records #when a colliding draft is claimed #then it saves the next available record [1.51ms]
+(pass) claimTaskRecord > #given more collisions than the attempt limit #when a draft is claimed #then the final collision propagates [1.31ms]
+(pass) claimTaskRecord > #given a name derived from its id #when the draft is bumped with nameFollowsId #then its name follows the claimed id [0.88ms]
+(pass) claimTaskRecord > #given an unavailable id-derived name #when a draft is claimed #then it skips to the next available id and name [0.83ms]
+(pass) claimTaskRecord > #given unavailable id-derived names exhaust the attempt budget #when a draft is claimed #then it throws task-id space exhaustion [0.33ms]
+(pass) claimTaskRecord > #given a task-id-shaped requested name #when the draft is bumped without nameFollowsId #then its name is preserved verbatim [0.82ms]
+(pass) claimTaskRecord > #given a store that raises a non-collision error #when a draft is claimed #then the error propagates unwrapped [0.24ms]
+(pass) claimTaskRecord > #given a claimed record in an isolated process #when a new id is created #then the id floor follows the claim [51.25ms]
+
+packages/senpi-task/src/store/runtime-fallback-record.test.ts:
+(pass) task record runtime fallback metadata > #given requested and ordered fallback models #when a task record round-trips #then the chain remains intact [0.95ms]
+
+packages/senpi-task/src/tools/output/renderers-run-stats.test.ts:
+(pass) task_output run stats rendering > #given a completed task with run stats #when the status row renders #then duration tool count and tps stay adjacent [0.61ms]
+
+packages/senpi-task/src/tools/output/renderers.test.ts:
+(pass) task_output renderers > #given task_output arguments #when rendering calls #then rows show target mode peek and only relevant tail lines [0.28ms]
+(pass) task_output renderers > #given a long multiline Korean and English target #when rendering with ANSI at width 72 #then target is normalized truncated and column-safe [0.69ms]
+(pass) task_output renderers > #given a width smaller than the fixed call tokens #when rendering task_output #then the complete ANSI row is clamped [0.12ms]
+(pass) task_output renderers > #given every result detail kind #when rendering compact rows #then rows are exhaustive and transcripts are not echoed [0.20ms]
+(pass) task_output renderers > #given a task_summary snapshot #when the status row renders #then the summary leads over the description [0.11ms]
+(pass) task_output renderers > #given a described task #when the status row renders #then the human label leads and the id trails [0.10ms]
+(pass) task_output renderers > #given long multiline Korean and English known tasks #when rendering not_found at width 96 #then known list is normalized truncated and column-safe [0.21ms]
+(pass) task_output renderers > #given resolved model details #when the status row renders #then the canonical target token is used [0.18ms]
+(pass) task_output renderers > #given injected controls in task_output model metadata #when the status row renders #then it is plain and sanitized [0.12ms]
+(pass) task_output renderers > #given injected controls in a task_output result #when rendered #then dynamic controls are removed before trusted theme styling [0.14ms]
+(pass) task_output run stats rendering > #given a terminal snapshot with run stats #when the status row renders #then runtime and tps are shown [0.11ms]
+(pass) task_output run stats rendering > #given run stats with cost and cache hits #when the status row renders #then the cost token sits immediately before tps [0.13ms]
+(pass) task_output run stats rendering > #given run stats with cost but no cache facts #when the status row renders #then only the cost is shown before tps [0.10ms]
+(pass) task_output run stats rendering > #given a snapshot without run stats #when the status row renders #then no runtime tokens appear [0.09ms]
+(pass) task_output suspended residency rendering > #given a persisted_only snapshot #when the status row renders #then it shows suspended [0.09ms]
+(pass) task_output suspended residency rendering > #given an rpc_detached snapshot #when the status row renders #then it shows suspended [0.09ms]
+(pass) task_output suspended residency rendering > #given a resident snapshot #when the status row renders #then the status label is unchanged (regression pin) [0.11ms]
+
+packages/senpi-task/src/tools/output/output-block.test.ts:
+(pass) runTaskOutput non-blocking peek > #given the task_output schema #when exposed to a model #then blocking controls are absent [0.15ms]
+(pass) runTaskOutput non-blocking peek > #given a running child #when task_output reads its status #then it returns its running snapshot without waiting [0.39ms]
+(pass) runTaskOutput non-blocking peek > #given a legacy block true param #when task_output runs #then it redirects to notification-driven peeks [3.15ms]
+(pass) runTaskOutput non-blocking peek > #given a legacy block false param #when task_output runs #then it redirects to notification-driven peeks [0.07ms]
+(pass) runTaskOutput non-blocking peek > #given a legacy blocking timeout param #when task_output runs #then it redirects to notification-driven peeks [0.07ms]
+
+packages/senpi-task/src/tools/output/output.test.ts:
+(pass) runTaskOutput > #given a completed task in tail mode #when read #then the last assistant text is present [24.03ms]
+(pass) runTaskOutput > #given a source-truncated transcript #when read #then the RPC-visible result reports truncation [0.14ms]
+(pass) runTaskOutput > #given default mode #when read #then a status snapshot with final_response is returned [0.20ms]
+(pass) runTaskOutput > #given a task with a resolved model #when read #then status uses display plus reasoning details [0.15ms]
+(pass) runTaskOutput > #given a task without a resolved model #when read #then status keeps raw model fallback [0.13ms]
+(pass) runTaskOutput > #given a lost task #when read #then a status view with a lost explanation and pid/session-dir breadcrumbs is returned without throwing [0.15ms]
+(pass) runTaskOutput > #given a task owned by another session #when read #then it is not found (fail-closed scope) [0.10ms]
+(pass) runTaskOutput > #given no caller session #when read #then it fails closed as not found [0.07ms]
+(pass) runTaskOutput > #given neither task_id nor name #when read #then invalid arguments are reported [0.07ms]
+(pass) runTaskOutput > #given a name instead of an id #when read #then the task is resolved by name [0.10ms]
+(pass) runTaskOutput > #given a persisted_only record #when read in status mode #then the status text states it is suspended [0.08ms]
+(pass) runTaskOutput > #given an rpc_detached record #when read in status mode #then the status text states it is suspended [0.09ms]
+(pass) runTaskOutput > #given a resident record #when read in status mode #then no suspended text appears (regression pin) [0.08ms]
+
+packages/senpi-task/src/tools/output/integration.test.ts:
+(pass) readEventLogTranscript > #given a committed team_message_waited event #when task_output reads the event log #then the recovered body is visible [0.94ms]
+(pass) readEventLogTranscript > #given a store event log with transcript events #when read #then assistant and tool entries are reconstructed in order [0.34ms]
+(pass) readEventLogTranscript > #given no log file #when read #then an empty list is returned without throwing [0.17ms]
+(pass) readSessionDirTranscript > #given a child session jsonl on disk #when read #then assistant text entries are extracted [0.62ms]
+(pass) defaultTranscriptReader > #given both sources present #when read #then the event log wins and the source is reported [0.54ms]
+(pass) defaultTranscriptReader > #given only a session dir #when read #then the session jsonl source is used [0.61ms]
+(pass) defaultTranscriptReader > #given neither source #when read #then the source is none [0.22ms]
+
+packages/senpi-task/src/tools/output/render.test.ts:
+(pass) renderTranscript > #given entries #when full mode #then every entry is rendered and not truncated [0.20ms]
+(pass) renderTranscript > #given a transcript with more lines than tailLines #when tail mode #then only the last tailLines lines remain [0.12ms]
+(pass) renderTranscript > #given a transcript longer than the cap #when rendered #then it is elided with a head/tail marker under the cap [0.14ms]
+(pass) renderTranscript > #given no entries #when rendered #then an empty-transcript notice is returned and not truncated [0.07ms]
+(pass) renderTranscript error entries > #given an error transcript entry #when rendered #then it is shown as an error line [0.07ms]
+
+packages/senpi-task/src/tools/output/factory.test.ts:
+(pass) output tool factories > #given the output factory #when built #then name, label, and TypeBox params are wired [24.53ms]
+
+packages/senpi-task/src/tools/team/messaging.test.ts:
+(pass) team messaging route > #given a message to the lead #when it is enqueued #then it reports the lead inbox result [0.35ms]
+(pass) team messaging route > #given a member-direction message #when enqueued #then it reports the recipient list [0.15ms]
+(pass) team messaging route > #given a recipient backpressure error #when send runs #then it surfaces recipient_backpressure [0.17ms]
+(pass) team messaging route > #given a non-lead broadcast #when send runs #then it surfaces broadcast_denied [0.12ms]
+(pass) member-routed team messaging > #given a member targeting a non-member #when send runs #then it surfaces invalid_recipient [0.11ms]
+
+packages/senpi-task/src/tools/team/lifecycle-collision.test.ts:
+(pass) team_create collision handling > #given a first-save collision #when the real team_create tool creates a team #then the team activates without a member rejection or raw collision [16.32ms]
+
+packages/senpi-task/src/tools/team/lifecycle-precedence.test.ts:
+(pass) team_create inline precedence > #given both team_name and inline_spec #when team_create runs #then inline_spec is authoritative [0.31ms]
+
+packages/senpi-task/src/tools/team/tasks.test.ts:
+(pass) task_create tool > #given a new task #when create runs #then it reports the created task [0.38ms]
+(pass) task_create tool > #given a blocked task #when create runs #then the text names the blockers [0.10ms]
+(pass) task_create tool > #given a subject with embedded newlines #when create runs #then the text collapses them onto one line [0.10ms]
+(pass) task_create tool > #given a subject with embedded newlines #when create runs #then the text collapses them onto one line [0.08ms]
+(pass) task_create tool > #given adversarial owner and blocked_by values #when list and get run #then the echoed fields are collapsed and bounded [0.32ms]
+(pass) task_create tool > #given the factory #when built #then it names the tool task_create [0.08ms]
+(pass) task_list tool > #given tasks #when list runs #then it reports them, forwarding the filter [0.12ms]
+(pass) task_list tool > #given the factory #when built #then it names the tool task_list [0.06ms]
+(pass) task_get tool > #given an existing task #when get runs #then it reports the task [0.09ms]
+(pass) task_get tool > #given a missing task #when get runs #then it reports not_found [0.13ms]
+(pass) task_get tool > #given the factory #when built #then it names the tool task_get [0.06ms]
+(pass) task_update tool > #given a status update #when update runs #then it reports the updated task [0.18ms]
+(pass) task_update tool > #given an already-claimed task #when claim runs #then it reports already_claimed [0.10ms]
+(pass) task_update tool > #given a blocked task #when claim runs #then it reports blocked_by [0.08ms]
+(pass) task_update tool > #given an illegal transition #when update runs #then it reports invalid_transition [0.08ms]
+(pass) task_update tool > #given a cross-owner update #when update runs #then it reports cross_owner [0.08ms]
+(pass) task_update tool > #given the factory #when built #then it names the tool task_update [0.06ms]
+
+packages/senpi-task/src/tools/team/shutdown.test.ts:
+(pass) shutdown request route > #given a member #when request runs #then it reports requested [8.77ms]
+(pass) shutdown request route > #given an unknown member #when request runs #then it reports unknown_member [0.22ms]
+(pass) shutdown approve route > #given a pending request #when approve runs #then it reports approved [0.17ms]
+(pass) shutdown approve route > #given no pending request #when approve runs #then it reports no_pending_request [0.10ms]
+(pass) shutdown reject route > #given a pending request #when reject runs #then it reports rejected with the reason [0.72ms]
+(pass) shutdown reject route > #given no pending request #when reject runs #then it reports no_pending_request [2.43ms]
+
+packages/senpi-task/src/tools/team/allowlist.test.ts:
+(pass) member child team-tool allowlist > #given the lead team tools w2lead #when built #then the injection-only surface has no blocking wait [0.20ms]
+(pass) member child team-tool allowlist > #given the lead team tools as shared parent tools #when filtered for a child #then all are excluded [0.09ms]
+(pass) member child team-tool allowlist > #given a member with the pre-scoped send #when child tools merge #then ONLY task_send survives [14.85ms]
+
+packages/senpi-task/src/tools/team/lifecycle.test.ts:
+(pass) team_create tool > #given the team_create schema #when inspected #then it exposes no model-supplied lead_session_id override [10.77ms]
+(pass) team_create tool > #given an inline spec #when team_create runs #then it reports the created run and members [7.79ms]
+(pass) team_create tool > #given members with roles, models, and prompts #when team_create runs #then the text lists every member informatively and keeps the first line stable [0.28ms]
+(pass) team_create tool > #given the inline member schema #when inspected #then task_summary sits right after prompt with the length limit [0.09ms]
+(pass) team_create tool > #given a member with a taskSummary #when team_create runs #then the member view carries task_summary [17.48ms]
+(pass) team_create tool > #given member model metadata variants and reasoning efforts #when team_create runs #then reasoning is labeled and reasoning effort wins over variant [3.81ms]
+(pass) team_create tool > #given neither team_name nor inline_spec #when team_create runs #then it rejects with invalid_arguments [0.17ms]
+(pass) team_create tool > #given a spec error #when team_create runs #then it surfaces spec_error with the code [0.17ms]
+(pass) team_create tool > #given a bounds runtime error #when team_create runs #then it surfaces runtime_error with the code [0.10ms]
+(pass) team_create tool > #given the factory #when built #then it names the tool team_create [0.06ms]
+(pass) team_delete tool > #given an active run #when team_delete runs #then it reports the deleted run + cancelled tasks [0.21ms]
+(pass) team_delete tool > #given cancelled member tasks #when team_delete runs #then the text names the cancelled task ids [0.10ms]
+(pass) team_delete tool > #given force #when team_delete runs #then it forwards force=true [0.09ms]
+(pass) team_delete tool > #given an illegal delete state #when team_delete runs #then it surfaces invalid_state [0.09ms]
+(pass) team_delete tool > #given the factory #when built #then it names the tool team_delete [0.05ms]
+(pass) team_create inline_spec schema shape > #given the team_create schema #when inline_spec is inspected #then it exposes an object shape with members (no bare Unknown) [0.10ms]
+(pass) team_create inline_spec schema shape > #given a JSON-stringified inline spec #when team_create runs #then the parsed object reaches the service [0.12ms]
+(pass) team_create inline_spec schema shape > #given the team_create schema #when a single-member-object inline spec is validated #then it passes [4.21ms]
+(pass) team_create inline_spec schema shape > #given an inline spec whose members is a single object #when team_create runs #then the service receives it [0.19ms]
+(pass) team_create inline_spec schema shape > #given a malformed JSON string inline spec #when team_create runs #then it rejects without calling the service [0.14ms]
+
+packages/senpi-task/src/tools/task/description-plan-gated.test.ts:
+(pass) buildTaskToolDescription plan-gated agents > #given gated and plain agents #when built #then plan-gated agents are classified separately with their invocation condition [0.37ms]
+(pass) buildTaskToolDescription plan-gated agents > #given gated and plain agents #when built #then the plain available-agents line excludes the gated names [0.12ms]
+(pass) buildTaskToolDescription plan-gated agents > #given only plain agents #when built #then no plan-gated section is rendered [0.08ms]
+
+packages/senpi-task/src/tools/task/renderers-run-stats.test.ts:
+(pass) taskResultLines run stats > #given terminal details with run stats #when rendered #then runtime and tps tokens are appended [83.07ms]
+(pass) taskResultLines run stats > #given terminal details with run stats #when the width-aware result renders #then runtime tools and tps follow the completed status [0.27ms]
+(pass) taskResultLines run stats > #given run stats with cost and cache hits #when rendered #then cost then ch then tps tokens appear in order [0.08ms]
+(pass) taskResultLines run stats > #given run stats with zero cost #when rendered #then the empty price is omitted [0.07ms]
+(pass) taskResultLines run stats > #given run stats without cost or cache facts #when rendered #then neither token appears [0.06ms]
+(pass) taskResultLines run stats > #given malformed persisted spend facts #when rendered #then impossible money and cache values are omitted [0.07ms]
+(pass) taskResultLines run stats > #given details without run stats #when rendered #then no runtime tokens appear [0.06ms]
+
+packages/senpi-task/src/tools/task/argument-normalization.test.ts:
+(pass) task argument normalization > #given a GPT-padded single spawn #when arguments are prepared #then serializer-only fields are removed [0.48ms]
+(pass) task argument normalization > #given a GPT-padded batch #when arguments are prepared #then blank top-level prompt and item overrides do not block fan-out [0.18ms]
+(pass) task argument normalization > #given an over-limit task_summary #when arguments are prepared #then the harness force-truncates it to the schema limit [0.11ms]
+(pass) task argument normalization > #given blank and item task_summary values #when arguments are prepared #then blanks drop and item summaries are clamped [0.10ms]
+(pass) task argument normalization > #given genuinely meaningful prompt and tasks #when arguments are prepared #then semantic ambiguity remains a hard error [0.09ms]
+
+packages/senpi-task/src/tools/task/description.test.ts:
+(pass) buildTaskToolDescription > #given a custom omo.json category #when the description is built #then it lists that category dynamically [0.25ms]
+(pass) buildTaskToolDescription > #given the description #when built #then it enforces the category XOR subagent_type contract [0.09ms]
+(pass) buildTaskToolDescription > #given the description #when built #then it describes spawn-only task and task_send continuation [0.08ms]
+(pass) buildTaskToolDescription > #given loaded agents #when built #then it lists available agent types [0.07ms]
+(pass) buildTaskToolDescription > #given the guidelines #when read #then task_summary usage is advertised to the model [0.07ms]
+(pass) buildTaskToolDescription > #given the prompt surfaces #when read #then snippet and guidelines are present [0.06ms]
+(pass) buildTaskToolDescription > #given task prompt surfaces #when responsibilities are inspected #then target selection belongs to the tool description only [0.13ms]
+(pass) buildTaskToolDescription > #given caller-directed category guidance #when description is built #then selection sentinels reach the caller [0.07ms]
+(pass) buildTaskToolDescription category+model exclusivity > #given the description #when built #then it forbids combining category with model and names the config escape hatch [0.07ms]
+(pass) buildTaskToolDescription category+model exclusivity > #given the prompt guidelines #when read #then they carry the category/model exclusivity rule [0.06ms]
+
+packages/senpi-task/src/tools/task/execute-plan-review-contract.test.ts:
+(pass) buildTaskExecute plan-review contract (momus) > #given a chatty no-path prompt and a session with plans A(x3)/B(x1) #when spawning momus #then the child prompt is the canonical contract for the most-referenced plan [0.58ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given an explicit single plan path in the prompt #when spawning momus #then the explicit path beats the most-referenced session plan [0.16ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given two plan paths in the prompt #when spawning momus #then it falls back to the most-referenced session plan [0.12ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given a synthetic inconsistent state (artifact true, zero references) and no path #when spawning momus #then the contract denies (unreachable via the real tool path - the plan gate fires first) [0.12ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given a session with no plan artifact #when spawning momus #then the plan gate denies before the contract runs [0.10ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given load_skills on the spawn #when spawning momus #then the skill prepend never reaches the child prompt [0.12ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given a model override and task summary #when spawning momus #then they survive the prompt substitution [0.10ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given a batch with a momus item and an explore item #when executed #then only the momus item prompt is forced [0.39ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given a caller-controlled prefixed path matching no recorded reference #when spawning momus #then the recorded most-referenced plan is used and the caller token never reaches the child [0.16ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given a traversal or absolute path matching no recorded reference #when spawning momus #then it falls back to the recorded most-referenced plan [0.10ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given a single unrecorded path and an empty reference list #when spawning momus #then the contract denies (synthetic state, unreachable via the real tool path) [0.10ms]
+(pass) buildTaskExecute plan-review contract (momus) > #given an explore spawn with a plan path in the prompt #when executed #then the contract does not apply [0.08ms]
+
+packages/senpi-task/src/tools/task/skills.test.ts:
+(pass) buildSkillPrepend > #given resolved skills #when prepended #then each SKILL.md is wrapped before the prompt [20.73ms]
+(pass) buildSkillPrepend > #given no skills #when prepended #then the prompt is returned unchanged [0.07ms]
+(pass) createFsSkillLoader > #given a project skill dir #when a skill is loaded #then its SKILL.md content is resolved and prepended [1.22ms]
+(pass) createFsSkillLoader > #given a missing skill #when loaded #then it is reported missing and prepend is empty [0.36ms]
+(pass) createFsSkillLoader > #given extra search dirs #when a skill lives there #then it resolves from the extra dir [0.80ms]
+(pass) createFsSkillLoader > #given Senpi native project user and package locations #when multiple skills load #then every name resolves in request order [10.59ms]
+(pass) createFsSkillLoader > #given a direct markdown skill with frontmatter #when loaded #then only its body and source location are injected [0.73ms]
+(pass) createFsSkillLoader > #given several indirect skill names #when loaded together #then every existing directory is discovered once [2.25ms]
+
+packages/senpi-task/src/tools/task/momus-policy.integration.test.ts:
+(pass) momus one-shot policy over the real TaskManager > #given an open plan session #when the full momus lifecycle is driven #then forcing, refusal, cancel, and re-spawn all hold [5.60ms]
+
+packages/senpi-task/src/tools/task/execute-spawn-validation.test.ts:
+(pass) buildTaskExecute spawn validation > #given both category and subagent_type #when executed #then it returns the XOR error result without spawning [4.08ms]
+(pass) buildTaskExecute spawn validation > #given an unknown category #when executed #then it returns the category-listing plan error [0.17ms]
+(pass) buildTaskExecute spawn validation > #given an injected ancestry #when spawning #then child depth and root derive from it [0.13ms]
+(pass) buildTaskExecute spawn validation > #given category with model #when executed #then it returns the exclusivity error without spawning [0.09ms]
+
+packages/senpi-task/src/tools/task/execute-batch.test.ts:
+(pass) buildTaskExecute batch fanout >  w2batch #given three sync items #when all complete #then details preserve input order with aggregate completed [2.24ms]
+(pass) buildTaskExecute batch fanout >  w2batch #given one runner error #when the sync batch settles #then both successes remain and aggregate status is error [1.48ms]
+(pass) buildTaskExecute batch fanout >  w2batch #given an oversized batch #when executed #then it rejects before starting any item [0.20ms]
+(pass) buildTaskExecute batch fanout >  w2batch #given a thrown middle start #when later items can start #then every item outcome is preserved [0.92ms]
+(pass) buildTaskExecute batch fanout >  w2batch #given a parent abort during three waits #when the batch settles #then every non-terminal child is cancelled [0.82ms]
+(pass) buildTaskExecute batch fanout >  w2batch #given one tasks item #when compared with a legacy prompt #then the single-spawn result is identical [0.46ms]
+(pass) buildTaskExecute batch fanout >  w2batch #given one denied item #when other sync items complete #then denial has an empty id and aggregate error [0.21ms]
+(pass) buildTaskExecute batch fanout >  w2batch #given a model_unavailable start failure #when executed #then the error names valid category names with the omo.json config hint [0.19ms]
+
+packages/senpi-task/src/tools/task/tool.test.ts:
+(pass) createTaskTool > #given deps #when the tool is created #then it exposes the senpi ToolDefinition surface [0.49ms]
+(pass) createTaskTool > #given a custom omo.json category #when the description is read #then it lists that category (dynamic snapshot) [0.23ms]
+(pass) createTaskTool > #given the assembled tool #when parameters are read #then the shared TypeBox schema leaves prompt/tasks optional (XOR enforced in validateBatchShape) [0.16ms]
+(pass) createTaskTool > #given the real task call renderer #when rendered at 72 columns #then actual prompt and italic background mode are visible [0.75ms]
+(pass) createTaskTool > #given a category task call #when rendered #then the call row is prompt-only without category or model [0.34ms]
+(pass) createTaskTool > #given an agent task call #when rendered #then the call row is prompt-only without the agent target [0.21ms]
+(pass) createTaskTool > #given a partial child progress result #when rendered #then only the last-line row renders (status lives in senpi's progress line) [0.19ms]
+(pass) createTaskTool > #given a partial result with empty content #when rendered #then no extra rows render below the call line [0.10ms]
+(pass) createTaskTool > #given the real task result renderer #when a category result is rendered #then resolved context and italic foreground mode are visible [0.22ms]
+(pass) createTaskTool > #given an ultrabrain background result #when rendered at 72 columns #then every required context token remains complete [0.17ms]
+
+packages/senpi-task/src/tools/task/execute-spawn.test.ts:
+(pass) buildTaskExecute spawn > #given run_in_background true #when executed #then it returns immediately WITHOUT awaiting child completion [0.34ms]
+(pass) buildTaskExecute spawn > #given a background task #when the start result is rendered #then it directs the parent to yield instead of polling [0.13ms]
+(pass) buildTaskExecute spawn > #given the caller session #when spawning #then callerSessionId is injected as parent_session_id [0.11ms]
+(pass) buildTaskExecute spawn > #given a resolved background start #when executed #then resolved metadata and background mode reach result details without prompt persistence [0.11ms]
+(pass) buildTaskExecute spawn > #given config default execution mode #when spawning without an agent overlay #then config mode reaches the start spec [0.12ms]
+(pass) buildTaskExecute spawn > #given run_in_background falsy #when executed #then it composes start + waitFor and returns the final response inline [0.25ms]
+(pass) buildTaskExecute spawn > #given a resolved foreground record #when execution completes #then resolved metadata, raw model fallback, and foreground mode reach details [0.23ms]
+
+packages/senpi-task/src/tools/task/model-visibility.test.ts:
+(pass) batch task model visibility > #given a category task resolves to a model #when batch spawn renders #then the item names both [0.31ms]
+
+packages/senpi-task/src/tools/task/renderers.test.ts:
+(pass) statusThemeColor > #given terminal statuses #when mapped #then success/error/warning colors are chosen [2.35ms]
+(pass) taskCallLines > #given current spawn arguments #when rendered #then the plain row includes task, target, actual prompt, and mode [2.81ms]
+(pass) taskCallLines > #given a category spawn call #when rendered #then its current target prompt and mode stay stable through extraction [0.10ms]
+(pass) taskCallLines > #given a spawn call #when rendered #then target and mode are summarized [0.07ms]
+(pass) taskCallLines > #given a spawn call without a target #when rendered #then it falls back to a generic task label [0.33ms]
+(pass) taskCallLines > #given a long multiline Korean and English prompt #when rendered #then the actual prompt is normalized and width-safe [1.59ms]
+(pass) taskCallLines > #given a task_summary #when rendered #then the summary replaces the truncated prompt excerpt [0.10ms]
+(pass) taskCallLines > #given a task_summary #when rendered width-bounded #then the summary replaces the prompt excerpt [0.18ms]
+(pass) taskCallLines > #given a long Korean prompt #when excerpted #then truncation backs up to a word boundary [1.82ms]
+(pass) taskResultLines >  w2batch #given aggregate item details #when rendered #then each item receives its own ordered result line [0.96ms]
+(pass) taskResultLines > #given a result detail #when rendered #then task_id and status appear [0.08ms]
+(pass) taskResultLines > #given resolved category metadata #when rendered #then target, provider, display, nonduplicate reasoning, mode, status, id, and queue context appear [0.13ms]
+(pass) taskResultLines > #given resolved category metadata with variant only #when rendered #then the variant is shown [0.07ms]
+(pass) taskResultLines > #given resolved category metadata with reasoning effort only #when rendered #then the reasoning effort is shown [0.06ms]
+(pass) taskResultLines > #given resolved category metadata without effort or variant #when rendered #then the model is shown without a suffix [0.06ms]
+(pass) taskResultLines > #given a legacy explicit model result #when rendered #then raw model fallback is useful without empty labels [0.07ms]
+(pass) taskResultLines > #given a persisted display already prefixed by the provider #when full and compact rows render #then the provider is not duplicated [0.14ms]
+(pass) taskResultLines > #given resolved category context #when the real result component renders at width 80 #then provider, model, and reasoning stay visible within bounds [0.13ms]
+(pass) taskResultLines > #given two recorded fallback attempts #when full and compact rows render #then canonical model and fallback count remain visible [0.24ms]
+(pass) renderer grammar > #given injected ANSI in task call and result fields #when themed #then injected controls are removed while trusted theme ANSI remains [0.30ms]
+
+packages/senpi-task/src/tools/task/execute-invocation-guard.test.ts:
+(pass) buildTaskExecute plan-gated agents > #given no skill-invocation resolver wired #when spawning momus #then it fails closed without starting the manager [0.30ms]
+(pass) buildTaskExecute plan-gated agents > #given a session with no skill invocations #when spawning momus #then it denies and names the ulw-plan requirement [0.12ms]
+(pass) buildTaskExecute plan-gated agents > #given a session with no skill invocations #when spawning metis #then it denies and names the ulw-plan requirement [0.09ms]
+(pass) buildTaskExecute plan-gated agents > #given a session with only a SKILL.md-read invocation #when spawning momus #then it stays denied [0.08ms]
+(pass) buildTaskExecute plan-gated agents > #given a user-requested ulw-plan session with a plan artifact #when spawning momus #then the gate opens and the manager starts [0.15ms]
+(pass) buildTaskExecute plan-gated agents > #given a user-requested plan session that then invoked ulw-execute #when spawning momus #then it denies and names ulw-execute [1.79ms]
+(pass) buildTaskExecute plan-gated agents > #given a session that invoked only ulw-execute #when spawning momus #then the forbidden denial takes precedence [0.13ms]
+(pass) buildTaskExecute plan-gated agents > #given a session with no skill invocations #when spawning explore #then the gate does not apply and the manager starts [0.12ms]
+(pass) buildTaskExecute plan-gated agents > #given a session with no skill invocations #when spawning a category #then the gate does not apply and the manager starts [0.10ms]
+(pass) buildTaskExecute plan-gated agents > #given a batch with a gated item and no skill invocations #when executed #then the gated item fails with the gate message and never reaches the manager [0.19ms]
+
+packages/senpi-task/src/tools/task/categories.test.ts:
+(pass) listTaskCategories > #given empty omo config #when listed #then builtin categories carry their descriptions [0.21ms]
+(pass) listTaskCategories > #given a custom omo.json category #when listed #then it appears with its description [0.09ms]
+(pass) listTaskCategories > #given a disabled category #when listed #then it is omitted [0.09ms]
+(pass) listTaskCategories > #given caller-directed builtin guidance #when worker appends are inspected #then only worker context remains [0.12ms]
+(pass) listTaskAgents > #given loaded agent definitions #when listed #then names and descriptions surface, disabled excluded [0.09ms]
+
+packages/senpi-task/src/tools/task/execute-batch-background.test.ts:
+(pass) buildTaskExecute background batch fanout > #given background capacity one #when three items start #then all ids and queue positions return as running [0.47ms]
+(pass) buildTaskExecute background batch fanout > #given inherited and item load_skills #when background items start #then each result reports its own resolution [0.24ms]
+(pass) buildTaskExecute background batch fanout > #given every background start fails #when results are aggregated #then status is error instead of running [0.19ms]
+
+packages/senpi-task/src/tools/task/execute-skills.test.ts:
+(pass) buildTaskExecute skill delivery > #given load_skills #when spawning #then resolved SKILL.md content is prepended to the child prompt [0.34ms]
+(pass) buildTaskExecute skill delivery > #given a missing requested skill #when background spawn succeeds #then the task result reports it without failing [0.17ms]
+
+packages/senpi-task/src/tools/task/start-presentation.test.ts:
+(pass) backgroundStartText > #given a task_summary #when the start text is built #then the summary labels the task over description and name [0.14ms]
+(pass) backgroundStartText > #given only a description #when the start text is built #then the description labels the task [0.07ms]
+(pass) backgroundStartText > #given no labels #when the start text is built #then the name is used and the id form stays stable [0.07ms]
+
+packages/senpi-task/src/tools/task/execute-budget-wait.test.ts:
+(pass) prompt-cache-safe foreground wait budget > #given a context getter and env bridge #when resolving the budget #then the feature-detected getter wins [0.19ms]
+(pass) prompt-cache-safe foreground wait budget > #given a running foreground child #when its prompt-cache-safe budget expires #then it is promoted without cancellation and returns background guidance [0.42ms]
+(pass) prompt-cache-safe foreground wait budget > #given no getter and no env budget #when a foreground child waits #then no deadline is scheduled and waitFor remains unbounded [0.14ms]
+(pass) prompt-cache-safe foreground wait budget > #given a budgeted foreground child #when the parent aborts before the deadline #then existing cancellation semantics win and the deadline is cleared [4.84ms]
+(pass) prompt-cache-safe foreground wait budget > #given a foreground batch with changing budgets #when waits start per item #then settled items stay inline and each remaining item converts on its own deadline [0.68ms]
+
+packages/senpi-task/src/tools/task/renderers-invalid-arguments.test.ts:
+(pass) invalid task arguments > #given invalid_arguments #when mapped #then the status uses the error theme [0.13ms]
+(pass) invalid task arguments > #given the observed malformed task result #when rendered #then it is visibly classified as an error with its reason [0.14ms]
+
+packages/senpi-task/src/tools/task/renderer-text.test.ts:
+(pass) renderer text > #given long multiline Korean and English text #when excerpted at width 72 #then whitespace is normalized and terminal width is bounded [3.53ms]
+(pass) renderer text > #given adversarial terminal sequences and Korean whitespace #when normalized #then controls are removed without damaging ordinary text [0.15ms]
+(pass) linesComponent > #given lines #when a component is built #then render returns those lines and invalidate is callable [0.08ms]
+(pass) linesComponent > #given long Korean and English lines #when rendered at width 72 #then every row is truncated by visible width [0.13ms]
+
+packages/senpi-task/src/tools/task/execute-progress.test.ts:
+(pass) task description wiring > #given a spawn with a description #when the manager starts the child #then the spec carries the human label [1.84ms]
+(pass) task description wiring > #given a background spawn with a description #when the start is acknowledged #then the text leads with the human label [0.73ms]
+(pass) foreground task progress > #given a live child #when it emits task events #then partial updates reflect child state and unsubscribe at completion [7.93ms]
+(pass) foreground task progress > #given a queued child #when it is promoted #then it emits queued progress then attaches at promotion [11.14ms]
+
+packages/senpi-task/src/tools/task/params.test.ts:
+(pass) TaskToolParams > #given the schema #when inspected #then it is a TypeBox object with the task tool fields [0.17ms]
+(pass) TaskToolParams > #given the schema #when properties are inspected #then removed task params are absent [0.06ms]
+(pass) TaskToolParams > #given the schema #when required fields are read #then neither prompt nor tasks is schema-required (the prompt-XOR-tasks rule is enforced by validateBatchShape) [0.05ms]
+(pass) TaskToolParams > #given batch task parameters #when schema is inspected #then a finite maximum is enforced [0.07ms]
+(pass) TaskToolParams > #given the schema #when task_summary is inspected #then it sits right after prompt with the schema length limit [0.06ms]
+(pass) TaskToolParams > #given a batch item schema #when task_summary is inspected #then it sits right after the item prompt with the schema length limit [0.06ms]
+
+packages/senpi-task/src/tools/task/execute-continuation.test.ts:
+(pass) buildTaskExecute spawn-only > #given the task tool #when executed #then it always starts a new child task [10.94ms]
+
+packages/senpi-task/src/tools/task/result-details.test.ts:
+(pass) #given a record with fallback attempts #when result details are built #then the renderer receives the recorded history [0.21ms]
+(pass) #given a record with a task_summary #when result details are built #then the summary reaches the renderer details [0.08ms]
+
+packages/senpi-task/src/tools/task/execute-collision.test.ts:
+(pass) buildTaskExecute collision handling > #given a first-save collision #when one background task executes #then it reports a normal started result without the raw collision [2.19ms]
+(pass) buildTaskExecute collision handling > #given a first-save collision #when a two-item background batch executes #then both tasks start without the raw collision [2.68ms]
+
+packages/senpi-task/src/tools/task/integration.test.ts:
+(pass) task tool over the real TaskManager > #given a background spawn #when driven end to end #then the engine start API persists a running record and returns its st_ id [2.31ms]
+(pass) task tool over the real TaskManager > #given both targets #when driven #then the engine start API is never reached [0.57ms]
+(pass) task tool over the real TaskManager > #given an unknown category #when the planner rejects it #then the tool reports the available categories [0.56ms]
+
+packages/senpi-task/src/tools/task/execute-continuation-scope.test.ts:
+(pass) task tool spawn-only manager seam > #given a real manager #when the task tool executes in two sessions #then both calls spawn children [8.03ms]
+
+packages/senpi-task/src/tools/task/execute-plan-error.test.ts:
+(pass) buildTaskExecute plan errors > #given an unknown target with active agents and categories #when executed #then both roster suffixes are rendered [0.30ms]
+(pass) buildTaskExecute plan errors > #given a model_unavailable plan error #when executed #then the suffix says valid category names with the omo.json config hint [0.13ms]
+
+packages/senpi-task/src/tools/task/gated-categories.test.ts:
+(pass) gated category listing > #given a builtin-only gated category > #when the categories are listed #then architect carries its required model annotation [11.96ms]
+(pass) gated category listing > #given a builtin-only gated category > #when the categories are listed #then ultrabrain carries its required model annotation [0.17ms]
+(pass) gated category listing > #given a builtin-only gated category > #when the categories are listed #then deep carries its required model annotation [0.07ms]
+(pass) gated category listing > #given a gated category configured in omo.json > #when the categories are listed #then the annotation is dropped because the gate is bypassed [0.08ms]
+(pass) gated category listing > #given a gated category configured in omo.json > #when omo.json only overrides the description #then the user text is listed verbatim [0.06ms]
+(pass) gated category listing > #given an ungated builtin category > #when the categories are listed #then no annotation is added [0.06ms]
+
+packages/senpi-task/src/tools/task/validation.test.ts:
+(pass) validateTaskTarget > #given only category #when validated #then resolves to a category selection [1.78ms]
+(pass) validateTaskTarget > #given only subagent_type #when validated #then resolves to a subagent selection [0.08ms]
+(pass) validateTaskTarget > #given both category and subagent_type #when validated #then returns a typed both_targets error [0.13ms]
+(pass) validateTaskTarget > #given neither category nor subagent_type #when validated #then returns a typed no_target error [0.07ms]
+(pass) validateTaskTarget > #given empty-string category #when validated #then treated as absent (no_target) [0.06ms]
+(pass) validateBatchShape > #given prompt without tasks w2val #when shape-validated #then resolves to single [0.06ms]
+(pass) validateBatchShape > #given tasks without prompt w2val #when shape-validated #then resolves to batch [0.06ms]
+(pass) validateBatchShape > #given both prompt and tasks w2val #when shape-validated #then names both fields in a typed error [0.06ms]
+(pass) validateBatchShape > #given neither prompt nor tasks w2val #when shape-validated #then returns a no_prompt_or_tasks error [0.06ms]
+(pass) validateBatchShape > #given an empty tasks array w2val #when shape-validated #then returns an empty_tasks error [0.06ms]
+(pass) resolveSpawnItems > #given legacy single-prompt params w2val #when resolved #then yields exactly one ResolvedSpawnItem (regression) [0.09ms]
+(pass) resolveSpawnItems > #given a 3-item batch w2val #when resolved #then inherits top-level model/subagent and item overrides win [0.11ms]
+(pass) resolveSpawnItems > #given an item subagent_type w2val #when resolved #then it suppresses the inherited top-level category [0.08ms]
+(pass) resolveSpawnItems > #given both prompt and tasks w2val #when resolved #then returns a typed error naming both fields [0.06ms]
+(pass) resolveSpawnItems > #given neither prompt nor tasks w2val #when resolved #then returns a typed error [0.06ms]
+(pass) resolveSpawnItems > #given an empty tasks array w2val #when resolved #then returns a typed error [0.05ms]
+(pass) resolveSpawnItems > #given an item with both category and subagent_type w2val #when resolved #then returns an item_target error naming the index [0.07ms]
+(pass) resolveSpawnItems task_summary > #given a single spawn with a task_summary #when resolved #then the item carries the summary [0.06ms]
+(pass) resolveSpawnItems task_summary > #given batch items with and without task_summary #when resolved #then summaries stay per-item and never inherit [0.06ms]
+(pass) batch spawn types > #given the new batch types w2val #when imported #then ResolvedSpawnItem and TaskToolItemDetail are exported with the documented shape [0.06ms]
+(pass) batch spawn types > #given TaskToolDetails w2val #when constructed with items #then the additive items field is accepted [0.06ms]
+(pass) validateTaskTarget category+model exclusivity > #given category with model #when validated #then returns a typed category_with_model error [0.06ms]
+(pass) validateTaskTarget category+model exclusivity > #given subagent_type with model #when validated #then resolves to a subagent selection [0.05ms]
+(pass) resolveSpawnItems category+model exclusivity > #given single-form category with a model override #then returns an item_target error [0.06ms]
+(pass) resolveSpawnItems category+model exclusivity > #given a top-level model inherited by a category item #then returns an item_target error [0.06ms]
+(pass) resolveSpawnItems category+model exclusivity > #given a top-level category and an item model #then returns an item_target error [0.05ms]
+(pass) resolveSpawnItems category+model exclusivity > #given subagent items inheriting a top-level model #then resolves ok with the model attached [0.05ms]
+
+packages/senpi-task/src/tools/task/execute-abort.test.ts:
+(pass) buildTaskExecute abort handling >  w2sig #given a pre-aborted signal #when spawn executes #then it returns cancelled without starting a child [3.75ms]
+(pass) buildTaskExecute abort handling >  w2sig #given a sync child waiting #when the parent aborts #then it cancels once and reports the task id [0.76ms]
+(pass) buildTaskExecute abort handling >  w2sig #given a child becomes terminal during parent abort #when cancellation is a noop #then execute still returns cancelled cleanly [0.44ms]
+(pass) buildTaskExecute abort handling >  w2sig #given a background child has started #when the parent aborts #then the child survives without cancellation [0.22ms]
+(pass) buildTaskExecute abort handling >  w2sig #given a sync spawn without a signal #when the child completes #then foreground behavior is unchanged [0.18ms]
+
+packages/senpi-task/src/tools/control/send-schema.test.ts:
+(pass) TaskSendParams > #given the task_send schema #when inspected #then it exposes to and hides old recipient keys [0.18ms]
+
+packages/senpi-task/src/tools/control/renderers.test.ts:
+(pass) control tool renderers > #given a plain task_send message #when rendering the call #then it shows a concise target and width-safe excerpt [0.33ms]
+(pass) control tool renderers > #given long multiline Korean and English text #when rendering with ANSI at width 72 #then text is normalized truncated and column-safe [0.17ms]
+(pass) control tool renderers > #given a long Korean continuation #when rendering task_send #then the excerpt ends at a word boundary [0.14ms]
+(pass) control tool renderers > #given structured shutdown task_send messages #when rendering calls #then summaries name request approve reject and reason without object stringification [0.14ms]
+(pass) control tool renderers > #given a structured shutdown request with a meaningful reason #when rendering at normal width #then the real reason remains visible [0.10ms]
+(pass) control tool renderers > #given a structured shutdown request with no room for a meaningful reason #when rendering at the Senpi edge width #then the optional reason field is omitted [0.10ms]
+(pass) control tool renderers > #given task_send without a message #when rendering the call #then it is meaningful without an empty message label [0.07ms]
+(pass) control tool renderers > #given whitespace-only control text #when rendering calls #then empty message and reason labels are omitted [0.09ms]
+(pass) control tool renderers > #given task_cancel arguments and result variants #when rendering #then identifier reason and status rows are concise [0.15ms]
+
+packages/senpi-task/src/tools/control/clamp.test.ts:
+(pass) clampWaitTimeout > #given below-min timeout #when clamped #then rises to min [0.14ms]
+(pass) clampWaitTimeout > #given exactly min timeout #when clamped #then unchanged [0.06ms]
+(pass) clampWaitTimeout > #given above-max timeout #when clamped #then falls to max [0.05ms]
+(pass) clampWaitTimeout > #given exactly max timeout #when clamped #then unchanged [0.05ms]
+(pass) clampWaitTimeout > #given an in-range timeout #when clamped #then passes through [0.05ms]
+(pass) clampWaitTimeout > #given no timeout #when clamped #then uses the configured default [0.05ms]
+
+packages/senpi-task/src/tools/control/send.test.ts:
+(pass) runTaskSend > #given task_send tool factories #when tools are created #then both expose custom call and result renderers [3.22ms]
+(pass) runTaskSend > #given a running child #when a message is sent #then it is delivered as steer [8.91ms]
+(pass) runTaskSend > #given a caller session id #when sending #then callerSessionId is injected into the steering call [0.13ms]
+(pass) runTaskSend > #given all_scope true #when sending #then allScope is forwarded to the engine [0.09ms]
+(pass) runTaskSend > #given plain-text send without a message #when sent #then it is rejected before routing [0.09ms]
+(pass) runTaskSend > #given a child owned by another session #when sent without all_scope #then scope is denied naming the owner [1.98ms]
+(pass) runTaskSend > #given an unknown name #when sending #then not_found lists this session's task names [2.11ms]
+(pass) runTaskSend > #given a string recipient that is not a child and no team routing #when sent #then the child not_found result is preserved [0.11ms]
+(pass) runTaskSend > #given a cancelled child #when task_send targets it #then it is not continuable [1.92ms]
+(pass) runTaskSend one-shot agent refusal > #given a running momus child #when task_send targets it #then the send is refused with the registry reminder and nothing is delivered [2.12ms]
+(pass) runTaskSend one-shot agent refusal > #given a completed resident momus child #when task_send targets it #then the send is refused with the registry reminder and no revive occurs [15.97ms]
+(pass) runTaskSend one-shot agent refusal > #given a completed resident non-momus child #when task_send targets it #then it still revives (regression guard) [16.88ms]
+
+packages/senpi-task/src/tools/control/send-shutdown.test.ts:
+(pass) runTaskSend shutdown routing > #given a lead shutdown_request #when routed through task_send #then requestShutdown is called [0.45ms]
+(pass) runTaskSend shutdown routing > #given a lead shutdown_response approve #when routed through task_send #then approveShutdown is called [18.58ms]
+(pass) runTaskSend shutdown routing > #given a shutdown_response reject without a reason #when routed through task_send #then it fails before rejectShutdown [10.41ms]
+(pass) runTaskSend shutdown routing > #given a lead shutdown_response reject with a reason #when routed through task_send #then rejectShutdown is called [16.84ms]
+(pass) runTaskSend shutdown routing > #given shutdown_request hits missing team state #when routed through task_send #then it returns a sanitized structured failure [0.36ms]
+(pass) runTaskSend shutdown routing > #given shutdown_response approve hits missing team state #when routed through task_send #then it returns a sanitized structured failure [0.11ms]
+(pass) runTaskSend shutdown routing > #given shutdown_response reject hits missing team state #when routed through task_send #then it returns a sanitized structured failure [0.09ms]
+(pass) runTaskSend shutdown routing > #given a shutdown domain failure #when routed through task_send #then it returns stable safe failure details [0.10ms]
+(pass) runTaskSend shutdown routing > #given an unexpected shutdown service error #when routed through task_send #then the original exception propagates [0.11ms]
+(pass) runTaskSend shutdown routing > #given structured message with no team routing #when sent #then it reports not in a team [0.08ms]
+(pass) runTaskSend shutdown routing > #given member-scoped task_send #when it sends a structured shutdown message #then shutdown is lead-only [0.08ms]
+
+packages/senpi-task/src/tools/control/renderers-result.test.ts:
+(pass) task_send result renderers > #given the steered task_send result mapping #when rendering #then the exact themed row is stable [0.22ms]
+(pass) task_send result renderers > #given the revived task_send result mapping #when rendering #then the exact themed row is stable [0.06ms]
+(pass) task_send result renderers > #given the queued task_send result mapping #when rendering #then the exact themed row is stable [0.05ms]
+(pass) task_send result renderers > #given the not_continuable task_send result mapping #when rendering #then the exact themed row is stable [0.05ms]
+(pass) task_send result renderers > #given the scope_denied task_send result mapping #when rendering #then the exact themed row is stable [0.05ms]
+(pass) task_send result renderers > #given the one_shot_agent task_send result mapping #when rendering #then the exact themed row is stable [0.05ms]
+(pass) task_send result renderers > #given the not_found task_send result mapping #when rendering #then the exact themed row is stable [0.06ms]
+(pass) task_send result renderers > #given the invalid_arguments task_send result mapping #when rendering #then the exact themed row is stable [0.04ms]
+(pass) task_send result renderers > #given the team_message task_send result mapping #when rendering #then the exact themed row is stable [0.06ms]
+(pass) task_send result renderers > #given the shutdown_requested task_send result mapping #when rendering #then the exact themed row is stable [0.04ms]
+(pass) task_send result renderers > #given the shutdown_responded task_send result mapping #when rendering #then the exact themed row is stable [0.05ms]
+(pass) task_send result renderers > #given the shutdown_failed task_send result mapping #when rendering #then the exact themed row is stable [0.05ms]
+(pass) task_send result renderers > #given a structured shutdown failure #when rendering the result #then it shows concise safe context with the error theme [0.07ms]
+(pass) task_send result renderers > #given injected controls in task_send and task_cancel results #when rendered #then dynamic controls are removed before trusted theme styling [0.16ms]
+
+packages/senpi-task/src/tools/control/member-scoped-renderer.test.ts:
+(pass) member-scoped task_send renderer > #given a member-scoped team message #when its tool call renders #then delivery mode is not displayed [0.20ms]
+
+packages/senpi-task/src/tools/control/send-unify-integration.test.ts:
+(pass) task_send unified resident revive integration > #given a completed resident child #when task_send sends another message #then the revived turn completes [3.97ms]
+
+packages/senpi-task/src/tools/control/send-team.test.ts:
+(pass) runTaskSend team routing > #given a string recipient that is not a child but is a team member #when team routing is present #then it sends a team message [0.29ms]
+(pass) runTaskSend team routing > #given a team route without a run id #when child lookup misses #then it fails before service calls [0.12ms]
+(pass) runTaskSend team routing > #given no team_run_id and a default resolver with one owned team #when child lookup misses #then the send uses the resolved team [0.12ms]
+(pass) runTaskSend team routing > #given no team_run_id and an ambiguous default resolver #when child lookup misses #then it reports the owned runs without service calls [0.10ms]
+(pass) runTaskSend team routing > #given no team_run_id and a default resolver reporting no owned team #when child lookup misses #then it falls back to the known-tasks not-found [0.09ms]
+(pass) runTaskSend team routing > #given a shutdown_request without team_run_id and a resolver with one owned team #when routed #then requestShutdown uses the resolved team [0.12ms]
+(pass) runTaskSend team routing > #given the member-scoped factory #when created #then it exposes the shared task_send surface [0.09ms]
+(pass) runTaskSend team routing > #given member routing with a bound run id #when params include another run id #then the bound run id wins [0.10ms]
+(pass) runTaskSend team routing > #given a member-scoped peer send #when the recipient is running #then the steering engine delivers as steer [36.81ms]
+(pass) runTaskSend team routing > #given a lead send with team_run_id #when the recipient is running #then the steering engine delivers as steer [1.51ms]
+(pass) runTaskSend team routing > #given a team shutdown message #when lead routing sends it #then no delivery option is needed [0.17ms]
+
+packages/senpi-task/src/tools/control/send-always-steer.test.ts:
+(pass) task_send always-steer surface > #given the lead task_send tool #when its public contract is inspected #then delivery mode is absent [34.83ms]
+(pass) task_send always-steer surface > #given a plain child message #when task_send routes it #then it requests steer unconditionally [0.24ms]
+(pass) task_send always-steer surface > #given a plain task_send call #when rendered #then no delivery option is shown [0.11ms]
+
+packages/senpi-task/src/tools/control/cancel.test.ts:
+(pass) runTaskCancel > #given the task_cancel tool #when created #then it exposes custom call and result renderers [0.72ms]
+(pass) runTaskCancel > #given a running child #when cancelled with a reason #then the exact post-state is reported [3.28ms]
+(pass) runTaskCancel > #given a cancelled child #when task_send follows up #then the child is not continuable [1.70ms]
+(pass) runTaskCancel > #given an already-cancelled child #when cancelled again #then it is a no-op with the cancelled status [1.66ms]
+(pass) runTaskCancel > #given an unknown id #when cancelled #then not_found is returned [0.91ms]
+(pass) runTaskCancel > #given no identifier #when cancelled #then invalid_arguments is returned [0.56ms]
+(pass) runTaskCancel > #given the task_cancel tool #when reading its description #then it names the terminal contract without stale revive wording [0.49ms]
+
+packages/senpi-task/src/tools/control/factory.test.ts:
+(pass) control tool factories > #given the control factories #when built #then names, labels, and TypeBox params are wired [0.20ms]
+(pass) control tool factories > #given the default resolver #when a session carrier is passed #then the current session id is read [0.08ms]
+
+packages/senpi-task/src/agents/builtin/builtin-agents.test.ts:
+(pass) builtin curated agents > #given the builtin defaults #when listing names sorted #then exactly the 4 curated agents are present [0.18ms]
+(pass) builtin curated agents > #given the builtin record #when listing keys sorted #then exactly the 4 curated agents are present and map to their definitions [0.10ms]
+(pass) builtin curated agents > #given the curated name set #when checking membership #then it contains exactly the 4 curated names [0.07ms]
+(pass) builtin curated agents > #given every builtin definition #when inspecting shape #then mode is subagent and executionMode is pinned in-process [0.06ms]
+(pass) builtin curated agents > #given every builtin definition #when inspecting tool rules #then exactly the 9 literal allow-true rules are present [0.10ms]
+(pass) builtin curated agents > #given every builtin definition #when inspecting descriptions #then each is non-empty with the brand tag stripped [0.16ms]
+
+packages/senpi-task/src/agents/builtin/fallback-chains.test.ts:
+(pass) AGENT_FALLBACK_CHAINS > #given the builtin chains #when listing keys #then exactly the 4 curated agent names are present [21.70ms]
+(pass) AGENT_FALLBACK_CHAINS > #given the builtin chains #when inspecting entries #then every entry has a non-empty providers list and model [0.11ms]
+(pass) AGENT_FALLBACK_CHAINS > #given the builtin chains #when counting entries #then chain lengths match the source transcription [0.10ms]
+(pass) AGENT_FALLBACK_CHAINS > #given the mirrored fallback table #when compared with the independent transcription #then every provider model variant and order is pinned [0.10ms]
+(pass) AGENT_FALLBACK_CHAINS > #given the builtin chains #when scanning providers #then no rung lists vercel or quotio-openai [0.10ms]
+(pass) AGENT_FALLBACK_CHAINS > #given the builtin chains #when a rung lists openai #then openai-codex rides alongside [0.08ms]
+
+packages/senpi-task/src/team/member-extension/residency.test.ts:
+(pass) member injection residency > #given a member whose initial turn ended without a wait #when lead mail is injected #then its resident RPC session revives into a working turn [156.06ms]
+
+packages/senpi-task/src/team/member-extension/qa-inject-hold.test.ts:
+(pass) member QA after-inject hold > #given a hold path outside QA #when resolved #then the test hook stays disabled [0.25ms]
+(pass) member QA after-inject hold > #given a QA release file #when an injected message enters the hook #then a marker is written before release [2.27ms]
+
+packages/senpi-task/src/team/member-extension/index.test.ts:
+(pass) member extension lifecycle > #given unread mail during extension loading #when session_start fires #then inbound team mail steers at the lifecycle edge [11.82ms]
+
+packages/senpi-task/src/team/member-extension/identity.test.ts:
+(pass) isTeamMemberProcess > #given an env carrying the member identity #when checked #then it reports a member process [0.16ms]
+(pass) isTeamMemberProcess > #given an env without the member identity #when checked #then it reports a non-member process [0.06ms]
+(pass) isTeamMemberProcess > #given an empty member identity #when checked #then it reports a non-member process [0.06ms]
+
+packages/senpi-task/src/team/member-extension/self-poller.test.ts:
+(pass) member self-poller > #given an after-inject hold w2mem #when delivery reaches the crash window #then reservation stays uncommitted until released [11.12ms]
+(pass) member self-poller > #given an unread message w2mem #when its envelope reaches the session JSONL #then commit happens only after persistence [37.51ms]
+(pass) member self-poller > #given an inject with no acknowledgement yet w2mem #when ack checks repeat #then the reservation is held and never double-injected [19.04ms]
+(pass) member self-poller > #given a crash after envelope persistence w2mem #when a new poller recovers #then it commits without reinjecting [11.63ms]
+(pass) member self-poller > #given a consumed-ledger stray w2mem #when the poller sees the duplicate unread file #then it acks without injecting [27.15ms]
+
+packages/senpi-task/src/team/member-extension/session-scan.test.ts:
+(pass) sessionJsonlContainsMessage > #given a hidden custom message with a peer envelope #when scanned #then it finds the messageId [0.79ms]
+
+packages/senpi-task/src/team/member-extension/tools.test.ts:
+(pass) member extension tools > #given member and lead recipients #when task_send runs #then each durable inbox receives its unchanged message [12.15ms]
+(pass) member extension tools > #given an unknown recipient #when task_send runs #then it rejects without writing mail [4.57ms]
+(pass) member extension tools > #given an unknown recipient #when task_send runs #then the error lists the valid recipients [0.46ms]
+(pass) member extension tools > #given malformed member identity env #when parsed #then typed configuration errors reject malformed values [0.20ms]
+
+packages/senpi-task/src/team/messaging/reclaim.test.ts:
+(pass) reclaimStaleTeamReservations > #given a stale reservation older than the ttl #when reclaimed #then it is restored to unread [30.45ms]
+(pass) reclaimStaleTeamReservations > #given a fresh reservation within the ttl #when reclaimed #then nothing is restored [2.56ms]
+(pass) reclaimStaleTeamReservations > #given multiple members #when reclaimed #then each member's stale reservations are reported per name [4.03ms]
+
+packages/senpi-task/src/team/messaging/delivery-journal.test.ts:
+(pass) lead delivery journal > #given recorded messages #when drained #then it returns the oldest unreported first and reports atomically [0.32ms]
+(pass) lead delivery journal > #given mixed senders #when drained with a from filter #then only matching messages are taken and the rest stay unreported [0.09ms]
+(pass) lead delivery journal > #given two teams #when drained #then deliveries stay isolated per team [0.07ms]
+(pass) lead delivery journal > #given a reported message that is re-recorded #when drained #then it is unreported again [0.09ms]
+(pass) lead delivery journal > #given a dropped team #when drained #then nothing remains [0.08ms]
+(pass) lead delivery journal > #given more deliveries than the cap #when drained #then the oldest are evicted and order is preserved [0.10ms]
+
+packages/senpi-task/src/team/messaging/message.test.ts:
+(pass) buildTeamMessage > #given from/to/body #when built #then a well-formed message-kind Message is produced [0.34ms]
+(pass) buildTeamMessage > #given a summary #when built #then the summary is carried and a broadcast target is preserved [0.19ms]
+(pass) buildPeerMessageEnvelope > #given a message with markup-bearing fields #when the envelope is built #then attributes are escaped in team-core's order [0.18ms]
+(pass) buildPeerMessageEnvelope > #given a summary #when the envelope is built #then the summary attribute is appended [0.17ms]
+
+packages/senpi-task/src/team/messaging/session-start-reconcile.test.ts:
+(pass) reconcileTeamMailboxOnSessionStart > #given an active team with a stale reservation #when reconciled #then the reservation is restored to unread [54.96ms]
+(pass) reconcileTeamMailboxOnSessionStart > #given a fresh reservation within the ttl #when reconciled #then it is left reserved [12.97ms]
+(pass) reconcileTeamMailboxOnSessionStart > #given an owned team with a stale lead reservation #when reconciled #then the lead inbox is restored [8.44ms]
+(pass) reconcileTeamMailboxOnSessionStart > #given a foreign team with a stale lead reservation #when reconciled #then its lead inbox is untouched [8.04ms]
+(pass) reconcileTeamMailboxOnSessionStart > #given no active teams #when reconciled #then it is a no-op that does not throw [0.58ms]
+
+packages/senpi-task/src/team/messaging/send.test.ts:
+(pass) sendTeamMessage recipient guidance > #given an unknown recipient #when the lead sends #then the error names the team members and valid forms [3.76ms]
+(pass) sendTeamMessage recipient guidance > #given an unknown recipient #when the lead sends #then the stable InvalidRecipientError name survives for the tool-layer mapping [3.89ms]
+(pass) sendTeamMessage pull-only delivery > #given a member recipient w2send #when a member sends #then one unread file is written and the send returns enqueued [4.52ms]
+(pass) sendTeamMessage pull-only delivery > #given the lead sentinel w2send #when a member sends #then the lead inbox receives an unread file [2.35ms]
+(pass) sendTeamMessage pull-only delivery > #given three active members w2send #when the lead broadcasts #then every recipient inbox stays unread [3.54ms]
+(pass) sendTeamMessage pull-only delivery > #given a member task mapping w2send #when the member sends #then team_message_sent is anchored to the sender record [4.22ms]
+(pass) sendTeamMessage pull-only delivery > #given no appendEvent dependency w2send #when the lead sends #then enqueue still succeeds [2.62ms]
+(pass) sendTeamMessage pull-only delivery > #given a full recipient inbox w2send #when a member sends #then RecipientBackpressureError still surfaces [2.69ms]
+
+packages/senpi-task/src/team/messaging/lead-poller.test.ts:
+(pass) lead poller injection delivery > #given member mail #when the lead polls #then it injects the peer envelope without a blocking tool [6.29ms]
+(pass) lead poller injection delivery > #given a crash before the lead injection flushes #when a fresh poller resumes #then the durable mailbox redelivers [4.02ms]
+(pass) lead poller injection delivery > #given a crash after lead transcript persistence #when a fresh poller resumes #then it commits without reinjecting [3.82ms]
+(pass) lead poller injection delivery > #given no captured lead transcript #when mail flushes #then the reservation holds until persistence becomes observable [5.97ms]
+
+packages/senpi-task/src/team/messaging/session-marker-index.test.ts:
+(pass) createSessionMarkerIndex > #given a session file with an envelope #when contains is queried #then it finds the messageId [87.64ms]
+(pass) createSessionMarkerIndex > #given repeated queries on an unchanged file #when contains runs again #then no bytes are re-read [1.69ms]
+(pass) createSessionMarkerIndex > #given an appended envelope #when contains runs #then only the appended bytes are read [0.91ms]
+(pass) createSessionMarkerIndex > #given a hidden custom message with an envelope #when contains is queried #then it finds the messageId [0.67ms]
+(pass) createSessionMarkerIndex > #given a missing session file #when contains runs #then it returns false [0.29ms]
+(pass) createSessionMarkerIndex > #given a truncated/rotated file #when contains runs #then the index resets and rescans [0.55ms]
+
+packages/senpi-task/src/runners/in-process/child-handle-restored.test.ts:
+(pass) createRestoredChildHandle > #given a restored session with prior assistant output #when the handle is created #then no prompt is replayed and waitForIdle drains the transcript outcome [20.11ms]
+(pass) createRestoredChildHandle > #given a restored session without assistant output #when waitForIdle is awaited #then a typed empty-turn outcome settles instead of hanging [0.14ms]
+(pass) createRestoredChildHandle > #given an idle restored handle #when a follow-up arrives #then a fresh tracked turn starts from the follow-up text [0.14ms]
+(pass) createRestoredChildHandle > #given a restored handle with a turn in flight #when a follow-up arrives #then it queues on the session exactly like a live resident [0.10ms]
+
+packages/senpi-task/src/runners/in-process/curated-readonly-bash.test.ts:
+(pass) createCuratedReadonlyBashTool > #given output beyond the line limit #when the tool returns #then it keeps the head and reports truncation [2.37ms]
+(pass) createCuratedReadonlyBashTool > #given output beyond the byte limit #when the tool returns #then it is bounded and reports truncation [0.28ms]
+(pass) createCuratedReadonlyBashTool > #given failed output beyond the byte limit #when the tool rejects #then the diagnostic head is retained within budget [0.32ms]
+(pass) createCuratedReadonlyBashTool > #given output within both limits #when the tool returns #then it stays byte-identical [0.08ms]
+(pass) planCuratedReadonlyCommand > #given read-only curl and GitHub requests #when planned #then direct executables are returned without a shell [0.10ms]
+(pass) planCuratedReadonlyCommand > #given mutation-capable flags or commands #when planned #then every request is rejected [0.10ms]
+
+packages/senpi-task/src/runners/in-process/runtime-fallback-settings.test.ts:
+(pass) createRuntimeFallbackSettings > #given no child fallback chain #when settings are created #then global model fallback is disabled [5.10ms]
+(pass) createRuntimeFallbackSettings > #given an explicit child fallback chain #when settings are created #then only that chain is enabled [0.13ms]
+
+packages/senpi-task/src/runners/in-process/shared-tool-filter.test.ts:
+(pass) shared parent tool family filter > #given task, team, and dag orchestration names #when classified #then only orchestration names match [0.12ms]
+(pass) shared parent tool family filter > #given shared tools with family and ui-only entries #when filtered #then family and ui-only removed [0.10ms]
+(pass) shared parent tool family filter > #given family tool in shared and in member-scoped #when merged #then only member-scoped family crosses the exclusion [0.09ms]
+(pass) shared parent tool family filter > #given no member-scoped tools #when merged #then result is only the filtered shared set [0.06ms]
+
+packages/senpi-task/src/runners/in-process/marker-suppression.test.ts:
+(pass) in-process child extension suppression > #given an agent dir with a marker extension #when a child boots through the runner #then the factory never runs and parent tools survive [61.62ms]
+
+packages/senpi-task/src/runners/in-process/child-handle-outcome.test.ts:
+(pass) createChildHandle turn outcomes > #given a turn ending with a stopReason error message #when the prompt resolves #then the outcome is an error carrying the provider message [0.35ms]
+(pass) createChildHandle turn outcomes > #given a turn that produces no assistant output at all #when the prompt resolves #then the outcome is an error, never completed with empty text [0.10ms]
+(pass) createChildHandle turn outcomes > #given a revived child whose new turn produces nothing #when the revive turn resolves #then the stale previous response is NOT reused as a fresh completion [0.15ms]
+(pass) createChildHandle turn outcomes > #given a healthy turn with assistant text #when the prompt resolves #then the outcome completes with this turn's text [0.08ms]
+
+packages/senpi-task/src/runners/in-process/child-handle-revive.test.ts:
+(pass) createChildHandle revive > #given a running child #when followed up mid-turn #then it queues via followUp without starting a new turn [18.04ms]
+(pass) createChildHandle revive > #given a completed resident child #when revived with a follow-up #then a fresh turn is tracked and waitForIdle reflects the new outcome [0.40ms]
+
+packages/senpi-task/src/runners/rpc/protocol-client.test.ts:
+(pass) RpcProtocolClient >  w2reattach #given session RPC commands #when switching and reading entries #then typed command data is preserved [90.21ms]
+(pass) RpcProtocolClient >  w2reattach #given a resume session path #when an RPC process starts #then it switches without replaying the prompt [49.52ms]
+(pass) RpcProtocolClient >  w2reattach #given inherited RPC extensions #when the process runner starts #then its effective spawn facts expose them for persistence [38.70ms]
+(pass) RpcProtocolClient > #given two in-flight requests answered out of order #when correlating #then each promise resolves by id [163.51ms]
+(pass) RpcProtocolClient > #given a completing turn #when subscribing #then agent lifecycle events fan out to every subscriber [72.81ms]
+(pass) RpcProtocolClient > #given an extension_ui_request #when auto-answering #then the child receives a deny and never blocks [64.35ms]
+(pass) RpcProtocolClient > #given a malformed line #when parsing #then it is reported and the connection survives [35.47ms]
+(pass) RpcProtocolClient > #given a heartbeat write races a closed child pipe #when stdin emits EPIPE #then shutdown is contained [0.50ms]
+(pass) RpcProtocolClient > #given a disposed client #when sending #then it rejects because the process is gone [1.49ms]
+(pass) RpcProtocolClient > #given a verbose child stderr #when chunks accumulate #then the internal buffer is capped and tail reflects recent bytes [53.83ms]
+
+packages/senpi-task/src/runners/rpc/ui-auto-answer.test.ts:
+(pass) buildAutoUiResponse > #given a confirm request #when auto-answering #then it denies (confirmed:false) [0.16ms]
+(pass) buildAutoUiResponse > #given select/input/editor requests #when auto-answering #then each cancels [0.10ms]
+(pass) buildAutoUiResponse > #given a display-only request #when auto-answering #then no response is emitted [0.07ms]
+
+packages/senpi-task/src/runners/rpc/model-admission.test.ts:
+(pass) RpcProcessRunner model admission > #given a catalog probe #when spawned #then it is hidden and owns its POSIX process tree [0.71ms]
+(pass) RpcProcessRunner model admission > #given a timed out catalog probe #when tree cleanup is pending #then the timeout result waits for cleanup [2.07ms]
+(pass) RpcProcessRunner model admission > #given a Senpi model table #when parsed #then provider and model columns form exact identities [0.19ms]
+(pass) RpcProcessRunner model admission > #given a compact provider/model identity line #when parsed #then the exact identity is visible [0.07ms]
+(pass) RpcProcessRunner model admission > #given a model absent from the child profile #when started #then admission rejects before spawn [0.38ms]
+(pass) RpcProcessRunner model admission > #given a model visible to the child profile #when started #then admission completes before spawn [98.54ms]
+
+packages/senpi-task/src/runners/rpc/turn-outcome-malformed.test.ts:
+(pass) agentEndOutcome hostile wire payloads > #given an agent_end whose messages field is absent > #when the outcome is derived #then it degrades to a terminal error instead of throwing [0.15ms]
+(pass) agentEndOutcome hostile wire payloads > #given an agent_end whose messages field is not an array > #when the outcome is derived #then it degrades to a terminal error instead of throwing [0.07ms]
+(pass) agentEndOutcome hostile wire payloads > #given an agent_end with no messages but fresh observed assistant text > #when the outcome is derived #then the observed text still completes the turn [0.07ms]
+(pass) agentEndOutcome hostile wire payloads > #given a malformed agent_end that also reports aborted > #when the outcome is derived #then the abort classification is preserved [0.06ms]
+
+packages/senpi-task/src/runners/rpc/exit-mapping.test.ts:
+(pass) classifyChildExit > #given a spawn error #when classifying #then it is a spawn_error outcome [0.17ms]
+(pass) classifyChildExit > #given an exit by signal #when classifying #then it is killed with the signal recorded [0.07ms]
+(pass) classifyChildExit > #given a zero exit code #when classifying #then it is clean [0.07ms]
+(pass) classifyChildExit > #given a Windows external termination (code 1, no signal, no stderr) #when classifying #then it is killed [0.06ms]
+(pass) classifyChildExit > #given a Windows child that crashed on its own #when classifying #then it stays crashed, not killed [0.06ms]
+(pass) classifyChildExit > #given a POSIX child exiting with code 1 and no stderr #when classifying #then it stays crashed [0.06ms]
+(pass) classifyChildExit > #given a nonzero exit code #when classifying #then it is crashed and stderr tail is capped at 4KB [0.06ms]
+(pass) tailStderr > #given text longer than the cap #when tailing #then it keeps the last cap characters [0.05ms]
+(pass) mapExitOutcomeToError > #given a killed child that has NOT reached terminal #when mapping #then status error with killed:true and exit facts [0.07ms]
+(pass) mapExitOutcomeToError > #given a Windows externally terminated child #when mapping #then status error with killed:true [0.07ms]
+(pass) mapExitOutcomeToError > #given a Windows child that died on its own #when mapping #then killed stays false [0.06ms]
+(pass) mapExitOutcomeToError > #given a nonzero exit before terminal #when mapping #then status error carries the stderr tail, not killed [0.06ms]
+(pass) mapExitOutcomeToError > #given an exit AFTER a terminal state #when mapping #then it is resident teardown with no status change [0.05ms]
+
+packages/senpi-task/src/runners/rpc/terminate.test.ts:
+(pass) terminateRpcChild > #given a cooperating child #when terminating #then SIGTERM ends it without escalation [12.19ms]
+(pass) terminateRpcChild > #given a TERM-ignoring child #when terminating #then it escalates to SIGKILL within the budget [192.23ms]
+(pass) terminateRpcChild > #given a non-group-leader child #when terminating #then direct escalation remains available [240.26ms]
+(pass) terminateRpcChild > #given an already-exited child #when terminating #then it resolves without throwing [3.80ms]
+(pass) terminateRpcChild > #given a child with a TERM-ignoring descendant #when terminating #then the whole process tree exits [239.70ms]
+
+packages/senpi-task/src/runners/rpc/handle.test.ts:
+(pass) createRpcChildHandle terminal turn observation > #given an assistant provider error followed by terminal agent_end #when idle settles #then text and failure fields are retained [0.39ms]
+(pass) createRpcChildHandle terminal turn observation > #given an explicit abort command #when the handle records it #then manager classification can distinguish user cancellation [0.11ms]
+(pass) createRpcChildHandle terminal turn observation > #given a completed resident turn #when a follow-up revives it #then terminal facts reset for the new turn while last text remains available [0.17ms]
+
+packages/senpi-task/src/runners/rpc/handle-user-abort.test.ts:
+(pass) rpc turn outcome user abort classification > #given a running turn the user explicitly aborts > #when the terminating agent_end arrives #then the tracked outcome is cancelled [1.96ms]
+(pass) rpc turn outcome user abort classification > #given a turn that ends in a provider error without a user abort > #when the terminating agent_end arrives #then the tracked outcome stays a turn failure [0.14ms]
+(pass) rpc turn outcome user abort classification > #given an aborted turn followed by a fresh prompt > #when the new turn ends normally #then the stale abort no longer cancels it [0.12ms]
+
+packages/senpi-task/src/runners/rpc/model-admission-confirm.test.ts:
+(pass) process model admission confirming probe > #given an exit-0 catalog that omits the requested model > #when a fresh confirming probe lists the model #then admission resolves [0.42ms]
+(pass) process model admission confirming probe > #given a cached catalog that did not contain the requested model > #when a later admission runs inside the cache TTL #then the profile is re-probed instead of served the stale catalog [0.17ms]
+(pass) process model admission confirming probe > #given a model absent from every exit-0 catalog > #when the confirming probe also omits it #then admission still rejects as model_unavailable [0.20ms]
+
+packages/senpi-task/src/runners/rpc/handle-steer-delivery.test.ts:
+(pass) rpc child delivery carries queueing semantics > #given a mid-run initial prompt #when it is delivered #then the request declares steer semantics so a busy child cannot reject it [1.37ms]
+(pass) rpc child delivery carries queueing semantics > #given a host that rejects the steer command as busy #when task_send steers #then delivery falls back to followUp instead of failing hard [0.43ms]
+(pass) rpc child delivery carries queueing semantics > #given a host that rejects a queued prompt as busy #when the initial prompt is delivered #then the followUp fallback keeps the child alive [0.25ms]
+
+packages/senpi-task/src/runners/rpc/parent-extensions.test.ts:
+(pass) parseExtensionEntries > #given an argv with -e and --extension pairs #when parsing #then every entry value is collected in order [0.19ms]
+(pass) parseExtensionEntries > #given an argv with no extension flags #when parsing #then the result is empty [0.07ms]
+(pass) parseExtensionEntries > #given a dangling -e with no value #when parsing #then it is ignored rather than pushing undefined [0.06ms]
+
+packages/senpi-task/src/runners/rpc/model-admission-cache.test.ts:
+(pass) process model admission catalog cache > #given a cached successful catalog whose TTL has expired > #when a later admission runs #then the catalog is re-probed instead of served stale [0.30ms]
+(pass) process model admission catalog cache > #given a cached successful catalog inside its TTL > #when a later admission runs #then the cached catalog is reused [0.14ms]
+
+packages/senpi-task/src/runners/rpc/spawn-node-runtime.test.ts:
+(pass) #given Senpi hides rpc-entry from Node exports #when building a fallback spawn #then it uses the physical dist entry [58.73ms]
+
+packages/senpi-task/src/runners/rpc/spawn.test.ts:
+(pass) detectBunBinary > #given a bun virtual-fs url #when detecting #then it reports a bun binary [0.14ms]
+(pass) detectBunBinary > #given a plain file url #when detecting #then it is not a bun binary [0.06ms]
+(pass) resolveChildSessionDir > #given a state dir and task id #when resolving #then the session dir nests under sessions/<id>/ [0.08ms]
+(pass) resolveSenpiExecutable > #given SENPI_BIN pointing at an existing absolute path #when resolving #then it is used verbatim [0.12ms]
+(pass) resolveSenpiExecutable > #given SENPI_BIN pointing at a missing absolute path #when resolving #then it is null (no silent PATH fallthrough) [0.09ms]
+(pass) resolveSenpiExecutable > #given a relative SENPI_BIN #when resolving #then the validated executable is returned as a canonical absolute path [0.35ms]
+(pass) resolveSenpiExecutable > #given a relative PATH entry #when resolving #then the validated executable is returned as a canonical absolute path [0.57ms]
+(pass) resolveSenpiExecutable > #given no SENPI_BIN and an empty PATH #when resolving a node runtime #then no executable is found [0.06ms]
+(pass) resolveSenpiExecutable > #given a bun runtime whose sibling Senpi binary is absent #when resolving #then it falls through instead of returning a missing path [0.07ms]
+(pass) resolveSenpiExecutable > #given a bun runtime with an existing sibling Senpi binary #when resolving #then that sibling is chosen [0.24ms]
+(pass) buildChildArgs > #given a spec with model and extensions #when building child args #then no-extensions leads, each -e follows, then --model [0.07ms]
+(pass) buildChildArgs > #given a spec with neither model nor extensions #when building child args #then only no-extensions is present [0.05ms]
+(pass) buildChildArgs > #given a spec with a valid variant #when building child args #then --thinking follows --model [0.06ms]
+(pass) buildChildArgs > #given a spec with high reasoning effort #when building child args #then it maps to senpi high [0.14ms]
+(pass) buildChildArgs > #given the omo.json reasoningEffort none as variant #when building child args #then it maps to senpi off [0.05ms]
+(pass) buildChildArgs > #given an unknown variant #when building child args #then no --thinking flag is emitted [0.05ms]
+(pass) buildRpcSpawn spawn strategy > #given a Windows npm senpi installation #when building an RPC child #then Node launches the npm package CLI without shell forwarding [1.09ms]
+(pass) buildRpcSpawn spawn strategy > #given a project-local node_modules/.bin Senpi shim #when building an RPC child #then Node launches its package CLI without rpc-entry fallback [0.94ms]
+(pass) buildRpcSpawn spawn strategy > #given a resolvable senpi executable #when building #then it spawns the EXECUTABLE in rpc mode (not the loader-hijacked rpc-entry) [0.12ms]
+(pass) buildRpcSpawn spawn strategy > #given a bun runtime with a resolvable sibling executable #when building #then the sibling binary runs rpc mode with threaded args [0.07ms]
+(pass) buildRpcSpawn spawn strategy > #given NO resolvable executable #when building #then it falls back to execPath + rpc-entry, still threading child args [0.07ms]
+(pass) buildRpcSpawn spawn strategy > #given a parent env #when building #then the child gets an isolated session dir and inherits parent vars untouched [0.09ms]
+(pass) buildRpcSpawn spawn strategy > #given a generic child spawned by a member #when building #then member identity and extension do not leak [0.07ms]
+(pass) buildRpcSpawn spawn strategy > #given member extension env w2mem #when building #then identity config and task id reach the child without overriding isolation [0.08ms]
+
+packages/senpi-task/src/tools/output/transcript/read-bounded.test.ts:
+(pass) readBoundedFileText > #given a transcript larger than the source budget #when read #then memory is capped while head and tail survive [2.28ms]
+
+packages/senpi-task/src/tools/output/transcript/session-jsonl.test.ts:
+(pass) parseSessionTranscript > #given a v1 linear session #when parsed #then only assistant text entries are extracted in order [0.35ms]
+(pass) parseSessionTranscript > #given a v2 tree session with a model_change and toolResult #when parsed #then user/tool/non-message entries are skipped [0.22ms]
+(pass) parseSessionTranscript > #given a v3 session with custom, custom_message, and an unknown future entry #when parsed #then unknown types are tolerated and only assistant text survives [0.31ms]
+(pass) parseSessionTranscript > #given malformed lines mixed with valid ones #when parsed #then broken lines are skipped without throwing [0.18ms]
+(pass) parseSessionTranscript > #given an assistant message with multiple text blocks #when parsed #then the blocks are concatenated [0.08ms]
+
+packages/senpi-task/src/tools/output/transcript/session-dir.test.ts:
+(pass) readSessionDirTranscriptResult > #given more than two child session files #when read #then only bounded edge files are parsed [1.55ms]
+
+packages/senpi-task/src/tools/output/transcript/event-log.test.ts:
+(pass) readEventLogTranscript > #given a log with assistant, tool, and child_error events #when read #then all three are lifted in order [8.48ms]
+(pass) readEventLogTranscript > #given a large event log #when read #then head and tail events survive with source truncation [2.55ms]
+
+1 tests skipped:
+(skip) #given a console-less parent #when the default RPC child starts #then windowsHide suppresses its console
+
+ 1766 pass
+ 1 skip
+ 0 fail
+ 5737 expect() calls
+Ran 1767 tests across 252 files. [58.88s]

--- a/.omo/evidence/20260827-dag-fallback-waiter-guard/green.txt
+++ b/.omo/evidence/20260827-dag-fallback-waiter-guard/green.txt
@@ -1,0 +1,10 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/senpi-task/src/manager/manager-outcome.test.ts:
+(pass) TaskManager outcome guards > #given a nonterminal record #when an outcome tries to settle waiters and the record then becomes terminal #then the waiter remains armed until terminal settlement [23.70ms]
+
+ 1 pass
+ 9 filtered out
+ 0 fail
+ 2 expect() calls
+Ran 1 test across 1 file. [1429.00ms]

--- a/.omo/evidence/20260827-dag-fallback-waiter-guard/mutation-red.txt
+++ b/.omo/evidence/20260827-dag-fallback-waiter-guard/mutation-red.txt
@@ -1,0 +1,10 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/senpi-task/src/manager/manager-outcome.test.ts:
+(pass) TaskManager outcome guards > #given a nonterminal record #when an outcome tries to settle waiters and the record then becomes terminal #then the waiter remains armed until terminal settlement [7.28ms]
+
+ 1 pass
+ 9 filtered out
+ 0 fail
+ 2 expect() calls
+Ran 1 test across 1 file. [1215.00ms]

--- a/.omo/evidence/20260827-dag-fallback-waiter-guard/mutation-red.txt
+++ b/.omo/evidence/20260827-dag-fallback-waiter-guard/mutation-red.txt
@@ -1,10 +1,33 @@
+# Mutation proof (corrected capture, 2026-08-27)
+# MUTATION: reverted #settleWaiters guard to pre-#7413 form:
+#   if (record === null || record === undefined || !isTerminalRecord(record)) return  ->  if (record === null || record === undefined) return
+# Command: bun test packages/senpi-task/src/manager/manager-outcome.test.ts -t "waiter remains armed until terminal settlement"
+# Result: test FAILS under the mutation (below), PASSES with the guard restored (green.txt).
+# Note: the F2b abort-transition block removal alone does NOT fail this test; F2b remains covered
+# only in combination (waiter would hang without it once F2a holds) - recorded as a known gap.
+
+<<ERR Command failed: cd /Volumes/mengmotaStorage/local-workspaces/omo-wt/fix-dag-owner-completion-loss && bun test packages/senpi-task/src/manager/manager-outcome.test.ts -t "waiter remains armed until terminal settlement" 2>&1>>
 bun test v1.4.0-canary.1 (b58cd4685)
 
 packages/senpi-task/src/manager/manager-outcome.test.ts:
-(pass) TaskManager outcome guards > #given a nonterminal record #when an outcome tries to settle waiters and the record then becomes terminal #then the waiter remains armed until terminal settlement [7.28ms]
+25 |     store.replace({ ...current, status: "pending" })
+26 | 
+27 |     // when - the outcome reaches #settleWaiters while the record is still nonterminal
+28 |     inProcess.handles.get(started.task_id)?.settle({ status: "completed", finalResponse: "late" })
+29 |     await Promise.resolve()
+30 |     expect(manager.waiterKeyCount()).toBe(1)
+                                          ^
+error: expect(received).toBe(expected)
 
- 1 pass
+Expected: 1
+Received: 0
+
+      at <anonymous> (/Volumes/mengmotaStorage/local-workspaces/omo-wt/fix-dag-owner-completion-loss/packages/senpi-task/src/manager/manager-outcome.test.ts:30:38)
+(fail) TaskManager outcome guards > #given a nonterminal record #when an outcome tries to settle waiters and the record then becomes terminal #then the waiter remains armed until terminal settlement [6.05ms]
+
+ 0 pass
  9 filtered out
- 0 fail
- 2 expect() calls
-Ran 1 test across 1 file. [1215.00ms]
+ 1 fail
+ 1 expect() calls
+Ran 1 test across 1 file. [2.00s]
+

--- a/packages/senpi-task/src/manager/manager-outcome.test.ts
+++ b/packages/senpi-task/src/manager/manager-outcome.test.ts
@@ -14,6 +14,26 @@ afterEach(cleanupProjects)
 const iso = (): string => new Date().toISOString()
 
 describe("TaskManager outcome guards", () => {
+  test("#given a nonterminal record #when an outcome tries to settle waiters and the record then becomes terminal #then the waiter remains armed until terminal settlement", async () => {
+    // given
+    const { manager, store, inProcess } = makeManager({})
+    const started = await manager.start(baseSpec())
+    if (started.kind !== "started") throw new Error("expected started")
+    const waiter = manager.waitFor(started.task_id)
+    const current = store.load(started.task_id)
+    if (current === null || current === undefined) throw new Error("expected record")
+    store.replace({ ...current, status: "pending" })
+
+    // when - the outcome reaches #settleWaiters while the record is still nonterminal
+    inProcess.handles.get(started.task_id)?.settle({ status: "completed", finalResponse: "late" })
+    await Promise.resolve()
+    expect(manager.waiterKeyCount()).toBe(1)
+    await manager.cancelTask(started.task_id)
+
+    // then
+    expect(await waiter).toMatchObject({ status: "cancelled" })
+  })
+
   test("#given a running resident child #when suspension forgets its handle and the abort settles cancelled #then the record stays running+persisted_only and no waiter settles with a terminal", async () => {
     // given
     const { manager, store, inProcess } = makeManager({})


### PR DESCRIPTION
Add manager regression coverage for the F2 waiter terminal guard and fallback-abort terminalization from PR #7413. Evidence is under .omo/evidence/20260827-dag-fallback-waiter-guard/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests covering the F2 waiter terminal guard and fallback-abort terminalization from PR #7413.

- Ensures a waiter stays armed until the record actually becomes terminal, even if an outcome tries to settle it early.
- Verifies a runtime fallback records failure before settling its waiter when capacity releases.
- Mutation evidence lives in `.omo/evidence/20260827-dag-fallback-waiter-guard/`; the `senpi-task` suite stays the authoritative gate.
- Known gap: reverting the F2b abort-transition alone doesn't fail this test, so it's only caught when the F2a guard is reverted too.

<sup>Written for commit bffc94320e5c86f31ce34f9d2b2ccaec268595f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

