### PR TITLE
feat(lsp-core): resolve repo-local LSP server binaries

### DIFF
--- a/packages/lsp-core/AGENTS.md
+++ b/packages/lsp-core/AGENTS.md
@@ -17,8 +17,8 @@ Harness-neutral LSP engine (`@oh-my-opencode/lsp-core`). Manages language server
 | `src/lsp/json-rpc-connection.ts` | Raw JSON-RPC 2.0 framing over stdio |
 | `src/lsp/config-loader.ts` | Load `.codex/lsp-client.json` (project + user), merge with builtins |
 | `src/lsp/server-definitions.ts` | `BUILTIN_SERVERS` (51 languages), `LSP_INSTALL_HINTS`, `AUTO_INSTALLABLE_SERVERS` |
-| `src/lsp/server-resolution.ts` | `findServerForExtension()`: map extension to installed server |
-| `src/lsp/server-installation.ts` | `isServerInstalled()`: PATH lookup with Windows extension handling |
+| `src/lsp/server-resolution.ts` | `findServerForExtension()`: map extension to installed server; substitutes the resolved absolute binary path into `command[0]` |
+| `src/lsp/server-installation.ts` | `resolveServerBinary()`: marker-gated repo-local lookup then PATH, with Windows extension handling; `isServerInstalled()` retained for existing consumers |
 | `src/lsp/directory-diagnostics.ts` | `aggregateDiagnosticsForDirectory()`: walk directory, cap files + diagnostics; `AbortSignal` cancels acquisition and per-file scans |
 | `src/lsp/formatters.ts` | Format locations, symbols, diagnostics, rename results, workspace edits |
 | `src/lsp/workspace-edit.ts` + `workspace-edit-*.ts` | `applyWorkspaceEdit()` / `applyWorkspaceEditDetailed()`: parse → fingerprint/snapshot → simulate → commit pipeline |
@@ -37,6 +37,7 @@ Harness-neutral LSP engine (`@oh-my-opencode/lsp-core`). Manages language server
 - **Subpath exports:** `.`, `./tools`, `./request-context`, `./missing-dependency-result`, `./mcp`, `./post-edit`, and wildcard `./lsp/*` — all point at source `.ts`, no dist build.
 - **RequestContext seam:** `request-context.ts` uses `AsyncLocalStorage` so the MCP proxy can thread `cwd` and `env` through shared daemon sessions.
 - **Config priority:** project `.codex/lsp-client.json` beats user `~/.codex/lsp-client.json` beats `BUILTIN_SERVERS`.
+- **Binary resolution:** `resolveServerBinary()` probes a path-shaped command, then marker-gated repo-local bin directories walking up from the request cwd, then `PATH`. A local bin directory is only trusted when a sibling project marker (`package.json`, `pyproject.toml`, `Gemfile`, `go.mod`, ...) proves it belongs to that ecosystem, so an unmarked `node_modules/.bin` is never trusted; the walk stops at a `.git` boundary. Results are cached per process, keyed by working directory and command. Live QA driver: `scripts/qa/local-binary-resolution-e2e.mjs`.
 - **Reaper:** `LspManager` reaps clients idle longer than `IDLE_TIMEOUT_MS` (default 5 min) or stuck initializing past `INIT_TIMEOUT_MS` (default 30 s).
 - **Workspace-edit safety:** paths are canonicalized, prevalidated, simulated, and lease-guarded before commit; client wrappers reject paths outside the request context (`outside-context-workspace.ts`).
 - **Directory diagnostics cancellation:** `aggregateDiagnosticsForDirectory()` accepts an `AbortSignal`; it throws if aborted before acquisition, threads the signal into `manager.getClient()` so a cold acquisition is cancellable, and checks it between files. An aborted cold start rejects with `AbortError` and leaves `clientCount()` at 0.

--- a/packages/lsp-core/scripts/qa/local-binary-resolution-e2e.mjs
+++ b/packages/lsp-core/scripts/qa/local-binary-resolution-e2e.mjs
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+// allow: SIZE_OK - one live QA driver keeps fixture setup, PATH scrubbing and evidence in one executable.
+//
+// Live QA for repo-local LSP binary resolution (lsp-core).
+//
+// Proves that a language server installed ONLY as a repository devDependency is
+// resolved and spawned, by driving the real senpi binary with a PATH that
+// deliberately contains no biome. Before this change the same fixture produced the
+// "NOT INSTALLED / npm install -g" message instead of diagnostics.
+import { spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { delimiter, dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..", "..")
+const repoRoot = resolve(packageRoot, "..", "..")
+const realSenpiAgentDir = join(homedir(), ".senpi", "agent")
+const mockProviderEntry = join(repoRoot, "packages", "omo-senpi", "scripts", "qa", "mock-provider", "index.ts")
+
+function parseArgs(argv) {
+  const args = { evidenceDir: undefined, selfTest: false }
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--self-test") args.selfTest = true
+    else if (arg === "--evidence-dir") args.evidenceDir = argv[++index]
+    else throw new Error(`unknown argument: ${arg}`)
+  }
+  return args
+}
+
+function findOnPath(bin) {
+  if (bin.includes("/")) return existsSync(bin) ? resolve(bin) : null
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    const candidate = resolve(dir || ".", bin)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+function listFiles(root) {
+  const out = []
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = join(root, entry.name)
+    if (entry.isDirectory()) out.push(...listFiles(full))
+    else if (entry.isFile()) out.push(full)
+  }
+  return out
+}
+
+function digestDirectory(root) {
+  if (!existsSync(root)) return "absent"
+  const hash = createHash("sha256")
+  for (const file of listFiles(root).sort()) {
+    hash.update(relative(root, file))
+    hash.update("\0")
+    hash.update(createHash("sha256").update(readFileSync(file)).digest("hex"))
+    hash.update("\0")
+  }
+  return hash.digest("hex")
+}
+
+/**
+ * Builds a PATH that keeps the node/bun runtime reachable but guarantees the
+ * language server itself is absent, so a successful resolution can only have come
+ * from the repository-local install.
+ */
+function scrubbedPath(serverBinaryName) {
+  const kept = []
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (dir.length === 0) continue
+    if (existsSync(join(dir, serverBinaryName))) continue
+    kept.push(dir)
+  }
+  return kept.join(delimiter)
+}
+
+/**
+ * Creates a fixture repository whose only biome is a real repo-local devDependency,
+ * installed with `bun add -d` so node_modules/.bin/biome is a genuine install rather
+ * than a hand-written stub.
+ */
+function createFixtureRepo(root) {
+  mkdirSync(root, { recursive: true })
+  writeFileSync(
+    join(root, "package.json"),
+    `${JSON.stringify({ name: "lspcore-local-fixture", private: true, version: "0.0.0" }, null, 2)}\n`,
+  )
+  writeFileSync(
+    join(root, "biome.json"),
+    `${JSON.stringify({ $schema: "https://biomejs.dev/schemas/2.0.0/schema.json", linter: { enabled: true } }, null, 2)}\n`,
+  )
+  const install = spawnSync("bun", ["add", "-d", "@biomejs/biome"], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 300_000,
+    maxBuffer: 32 * 1024 * 1024,
+  })
+  const localBiome = join(root, "node_modules", ".bin", "biome")
+  if (install.status !== 0 || !existsSync(localBiome)) {
+    throw new Error(`fixture devDependency install failed: ${install.stderr || install.stdout}`)
+  }
+  // A nested source directory proves the upward walk, not just a root-level hit.
+  const nested = join(root, "src", "nested")
+  mkdirSync(nested, { recursive: true })
+  const sample = join(nested, "sample.css")
+  writeFileSync(sample, "a { colr: red; }\n")
+  return { localBiome, sample, nested, installStdout: install.stdout.trim() }
+}
+
+/**
+ * Resolves through the real lsp-core code path under the fixture's request context,
+ * with biome removed from PATH.
+ */
+function runResolutionProbe(fixture, pathValue, evidenceDir) {
+  const probe = spawnSync(
+    "bun",
+    [
+      "-e",
+      `
+import { runWithRequestContext } from ${JSON.stringify(join(packageRoot, "src", "request-context.ts"))}
+import { findServerForExtension } from ${JSON.stringify(join(packageRoot, "src", "lsp", "server-resolution.ts"))}
+import { formatServerLookupError } from ${JSON.stringify(join(packageRoot, "src", "lsp", "client-wrapper.ts"))}
+import { resolveServerBinary } from ${JSON.stringify(join(packageRoot, "src", "lsp", "server-installation.ts"))}
+const cwd = ${JSON.stringify(fixture.root)}
+const nested = ${JSON.stringify(fixture.nested)}
+const context = {
+  cwd,
+  projectConfigPaths: [cwd + "/.codex/lsp-client.json"],
+  userConfigPath: cwd + "/home/lsp-client.json",
+  installDecisionsPath: cwd + "/home/lsp-install-decisions.json",
+  capabilities: { installDecisionTool: true },
+}
+const found = runWithRequestContext(context, () => findServerForExtension(".css"))
+const fromNested = resolveServerBinary(["biome", "lsp-proxy", "--stdio"], nested)
+const message = found.status === "found" ? null : runWithRequestContext(context, () => formatServerLookupError(found))
+console.log(JSON.stringify({
+  biomeOnPath: Bun.which("biome"),
+  status: found.status,
+  spawnedCommand: found.status === "found" ? found.server.command : null,
+  resolvedFromNestedDir: fromNested,
+  notInstalledMessage: message,
+}))
+`,
+    ],
+    {
+      cwd: fixture.root,
+      encoding: "utf8",
+      env: { ...process.env, PATH: pathValue },
+      timeout: 120_000,
+      maxBuffer: 32 * 1024 * 1024,
+    },
+  )
+  if (probe.status !== 0) {
+    throw new Error(`resolution probe failed: ${probe.stderr || probe.stdout}`)
+  }
+  if (evidenceDir !== undefined) {
+    writeFileSync(join(evidenceDir, "resolution-probe.log"), `${probe.stdout}\n${probe.stderr}`)
+  }
+  const line = probe.stdout.trim().split(/\r?\n/).findLast((entry) => entry.startsWith("{"))
+  if (line === undefined) throw new Error("resolution probe printed no JSON")
+  return JSON.parse(line)
+}
+
+/**
+ * Captures the pre-change behavior by forcing a PATH-only resolution, which is what
+ * the old implementation did for every lookup.
+ */
+function runBaselineProbe(fixture, pathValue, evidenceDir) {
+  const probe = spawnSync(
+    "bun",
+    [
+      "-e",
+      `
+import { resolveServerBinary } from ${JSON.stringify(join(packageRoot, "src", "lsp", "server-installation.ts"))}
+// Omitting workingDirectory reproduces the previous PATH-only behavior.
+console.log(JSON.stringify({ pathOnly: resolveServerBinary(["biome", "lsp-proxy", "--stdio"]) }))
+`,
+    ],
+    {
+      cwd: fixture.root,
+      encoding: "utf8",
+      env: { ...process.env, PATH: pathValue },
+      timeout: 120_000,
+      maxBuffer: 16 * 1024 * 1024,
+    },
+  )
+  if (probe.status !== 0) throw new Error(`baseline probe failed: ${probe.stderr || probe.stdout}`)
+  if (evidenceDir !== undefined) {
+    writeFileSync(join(evidenceDir, "baseline-path-only-probe.log"), `${probe.stdout}\n${probe.stderr}`)
+  }
+  const line = probe.stdout.trim().split(/\r?\n/).findLast((entry) => entry.startsWith("{"))
+  return JSON.parse(line)
+}
+
+function parseJsonEvents(stdout) {
+  const events = []
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.startsWith("{")) continue
+    try {
+      events.push(JSON.parse(line))
+    } catch {
+      // non-JSON diagnostic chatter is ignored
+    }
+  }
+  return events
+}
+
+function findToolExecution(events, toolName) {
+  return events.findLast(
+    (event) => event?.toolName === toolName && (event?.type === "tool_execution_end" || event?.result !== undefined),
+  )
+}
+
+/**
+ * Drives the real senpi binary end to end so the resolution is proven on a live
+ * harness surface. A scripted mock provider supplies the turn, so the run needs no
+ * API key and makes no network call, while lsp_diagnostics still executes for real
+ * against the repo-local biome.
+ */
+function runSenpiProbe(fixture, pathValue, senpiBin, workRoot, evidenceDir) {
+  const agentDir = join(workRoot, "agent")
+  const sessionDir = join(workRoot, "sessions")
+  const homeDir = join(workRoot, "home")
+  mkdirSync(agentDir, { recursive: true })
+  mkdirSync(sessionDir, { recursive: true })
+  mkdirSync(homeDir, { recursive: true })
+  writeFileSync(
+    join(agentDir, "settings.json"),
+    `${JSON.stringify({ permission: { lsp_diagnostics: "allow" } }, null, 2)}\n`,
+  )
+  writeFileSync(
+    join(fixture.root, "mock-script.json"),
+    `${JSON.stringify(
+      {
+        steps: [
+          { type: "tool_call", name: "lsp_diagnostics", arguments: { filePath: fixture.sample } },
+          { type: "text", text: "local biome diagnostics scenario complete" },
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  )
+
+  const result = spawnSync(
+    senpiBin,
+    [
+      "-e",
+      mockProviderEntry,
+      "-p",
+      "--mode",
+      "json",
+      "--provider",
+      "omo-mock",
+      "--model",
+      "mock-1",
+      "--session-dir",
+      sessionDir,
+      "run lsp diagnostics on the sample file",
+    ],
+    {
+      cwd: fixture.root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: pathValue,
+        HOME: homeDir,
+        XDG_CONFIG_HOME: join(homeDir, ".config"),
+        XDG_DATA_HOME: join(homeDir, ".local", "share"),
+        XDG_STATE_HOME: join(homeDir, ".local", "state"),
+        XDG_CACHE_HOME: join(homeDir, ".cache"),
+        SENPI_CODING_AGENT_DIR: agentDir,
+        SENPI_CODING_AGENT_SESSION_DIR: sessionDir,
+        OMO_SENPI_QA: "1",
+      },
+      timeout: 180_000,
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  )
+  if (evidenceDir !== undefined) {
+    writeFileSync(join(evidenceDir, "senpi.stdout.log"), result.stdout ?? "")
+    writeFileSync(join(evidenceDir, "senpi.stderr.log"), result.stderr ?? "")
+  }
+  const events = parseJsonEvents(result.stdout ?? "")
+  const toolEvent = findToolExecution(events, "lsp_diagnostics")
+  return {
+    exitStatus: result.status,
+    isolatedAgentDir: agentDir,
+    toolEvent,
+    sessionStarted: events.some((event) => event?.type === "session"),
+    // The packaged omo extension and its daemon runtime are built by another lane, so
+    // this binary is not expected to expose lsp_* tools here. It proves the harness runs
+    // against the fixture with a scrubbed PATH; the diagnostics assertion itself comes
+    // from runDiagnosticsProbe(), which drives the lsp-core tool runtime this PR changes.
+    lspToolExposed: toolEvent !== undefined && toolEvent?.isError !== true,
+  }
+}
+
+/**
+ * Executes lsp_diagnostics through the real lsp-core tool runtime, which spawns the
+ * language server that resolution selected. This is the decisive proof: real
+ * diagnostics can only come back if the repo-local biome was actually launched.
+ */
+function runDiagnosticsProbe(fixture, pathValue, evidenceDir) {
+  const probe = spawnSync(
+    "bun",
+    [
+      "-e",
+      `
+import { runWithRequestContext } from ${JSON.stringify(join(packageRoot, "src", "request-context.ts"))}
+import { executeLspTool } from ${JSON.stringify(join(packageRoot, "src", "tools", "runtime.ts"))}
+import { getLspManager } from ${JSON.stringify(join(packageRoot, "src", "lsp", "manager.ts"))}
+const cwd = ${JSON.stringify(fixture.root)}
+const context = {
+  cwd,
+  projectConfigPaths: [cwd + "/.codex/lsp-client.json"],
+  userConfigPath: cwd + "/home/lsp-client.json",
+  installDecisionsPath: cwd + "/home/lsp-install-decisions.json",
+  capabilities: { installDecisionTool: true },
+}
+const result = await runWithRequestContext(context, async () =>
+  executeLspTool("lsp_diagnostics", { filePath: ${JSON.stringify(fixture.sample)} }),
+)
+const text = JSON.stringify(result)
+console.log(JSON.stringify({ biomeOnPath: Bun.which("biome"), text }))
+await runWithRequestContext(context, async () => { await getLspManager().stopAll() })
+`,
+    ],
+    {
+      cwd: fixture.root,
+      encoding: "utf8",
+      env: { ...process.env, PATH: pathValue },
+      timeout: 180_000,
+      maxBuffer: 32 * 1024 * 1024,
+    },
+  )
+  if (evidenceDir !== undefined) {
+    writeFileSync(join(evidenceDir, "diagnostics-probe.log"), `${probe.stdout}\n${probe.stderr}`)
+  }
+  if (probe.status !== 0) throw new Error(`diagnostics probe failed: ${probe.stderr || probe.stdout}`)
+  const line = probe.stdout.trim().split(/\r?\n/).findLast((entry) => entry.startsWith("{"))
+  if (line === undefined) throw new Error("diagnostics probe printed no JSON")
+  const parsed = JSON.parse(line)
+  return {
+    biomeOnPath: parsed.biomeOnPath,
+    resultText: parsed.text,
+    notInstalledMessageAbsent: !parsed.text.includes("NOT INSTALLED"),
+    globalInstallHintAbsent: !parsed.text.includes("npm install -g @biomejs/biome"),
+    // The fixture stylesheet has a misspelled property, so a working biome must flag it.
+    // Only a spawned biome can attribute a diagnostic to itself with its own rule id.
+    reportsRealDiagnostic:
+      parsed.text.includes("error[biome]") &&
+      parsed.text.includes("noUnknownProperty") &&
+      parsed.text.includes('"source":"biome"'),
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv)
+  const evidenceDir = args.evidenceDir
+  if (evidenceDir !== undefined) mkdirSync(evidenceDir, { recursive: true })
+
+  const senpiBin = findOnPath(process.env.SENPI_BIN?.trim() || "senpi")
+  if (senpiBin === null) throw new Error("senpi binary unavailable; QA cannot SKIP")
+
+  const workRoot = mkdtempSync(join(tmpdir(), "lspcore-local-resolve-qa-"))
+  const beforeRealSenpi = digestDirectory(realSenpiAgentDir)
+  try {
+    const fixtureRoot = join(workRoot, "fixture-repo")
+    const fixture = { root: fixtureRoot, ...createFixtureRepo(fixtureRoot) }
+    const pathValue = scrubbedPath("biome")
+
+    const baseline = runBaselineProbe(fixture, pathValue, evidenceDir)
+    const probe = runResolutionProbe(fixture, pathValue, evidenceDir)
+    const diagnostics = runDiagnosticsProbe(fixture, pathValue, evidenceDir)
+    const senpi = runSenpiProbe(fixture, pathValue, senpiBin, workRoot, evidenceDir)
+    const afterRealSenpi = digestDirectory(realSenpiAgentDir)
+
+    const checks = {
+      biomeAbsentFromPath: probe.biomeOnPath === null,
+      baselinePathOnlyUnresolved: baseline.pathOnly === null,
+      resolvedToRepoLocalBinary: probe.spawnedCommand?.[0] === fixture.localBiome,
+      serverFound: probe.status === "found",
+      argsPreserved: JSON.stringify(probe.spawnedCommand?.slice(1)) === JSON.stringify(["lsp-proxy", "--stdio"]),
+      resolvesFromNestedDirectory: probe.resolvedFromNestedDir === fixture.localBiome,
+      noNotInstalledMessage: probe.notInstalledMessage === null,
+      diagnosticsBiomeAbsentFromPath: diagnostics.biomeOnPath === null,
+      diagnosticsReturnedRealFindings: diagnostics.reportsRealDiagnostic === true,
+      diagnosticsNoNotInstalledMessage: diagnostics.notInstalledMessageAbsent === true,
+      diagnosticsNoGlobalInstallHint: diagnostics.globalInstallHintAbsent === true,
+      senpiSessionStarted: senpi.sessionStarted === true,
+      realSenpiUntouched: beforeRealSenpi === afterRealSenpi,
+      noSkip: true,
+    }
+    const payload = {
+      result: Object.values(checks).every(Boolean) ? "PASS" : "FAIL",
+      scenario: "lspcore-local-binary-resolution",
+      checks,
+      whatWasTested:
+        "A fixture repository whose only biome is a repo-local devDependency, driven with biome scrubbed from PATH.",
+      observed: {
+        beforeChange:
+          "PATH-only resolution (the previous behavior) returns null, which is what produced the NOT INSTALLED message.",
+        afterChange: `Resolution returns the repo-local binary ${fixture.localBiome} and substitutes it as command[0].`,
+      },
+      baselineProbe: baseline,
+      resolutionProbe: probe,
+      diagnosticsProbe: diagnostics,
+      senpiProbe: senpi,
+      isolation: {
+        fixtureRoot: fixture.root,
+        isolatedAgentDir: senpi.isolatedAgentDir,
+        realSenpiAgentDir,
+        realSenpiUntouched: beforeRealSenpi === afterRealSenpi,
+      },
+      cleanup: "work root removed in finally",
+    }
+    if (evidenceDir !== undefined) {
+      writeFileSync(join(evidenceDir, "result.json"), `${JSON.stringify(payload, null, 2)}\n`)
+    }
+    console.log(JSON.stringify(payload, null, 2))
+    if (payload.result !== "PASS") process.exitCode = 1
+  } finally {
+    rmSync(workRoot, { recursive: true, force: true })
+  }
+}
+
+main()

--- a/packages/lsp-core/src/lsp/client-wrapper.ts
+++ b/packages/lsp-core/src/lsp/client-wrapper.ts
@@ -17,6 +17,7 @@ import {
 } from "./errors.js";
 import { getLspManager, type LspManager } from "./manager.js";
 import { findWorkspaceRootOutsideContext } from "./outside-context-workspace.js";
+import { LSP_LOCAL_INSTALL_HINTS } from "./server-definitions.js";
 import { loadInstallDecision } from "./server-install-state.js";
 import { findServerForExtension } from "./server-resolution.js";
 import type { ServerLookupResult } from "./types.js";
@@ -138,6 +139,26 @@ export function formatServerLookupError(result: Exclude<ServerLookupResult, { st
 	].join("\n");
 }
 
+/**
+ * Builds the install guidance, offering the repo-local install first.
+ *
+ * A repo-local install is resolvable without touching the global environment, so it is the
+ * recommended route whenever the server ships as a project dependency.
+ */
+function formatInstallOptions(serverId: string, installHint: string): string[] {
+	const localHint = LSP_LOCAL_INSTALL_HINTS[serverId];
+	if (localHint === undefined) {
+		return ["To install, run:", `  ${installHint}`];
+	}
+	return [
+		"To install in THIS repository (preferred — no global install needed):",
+		`  ${localHint}`,
+		"",
+		"Or install it globally:",
+		`  ${installHint}`,
+	];
+}
+
 function formatNotInstalled(result: Extract<ServerLookupResult, { status: "not_installed" }>): string {
 	const { server, installHint } = result;
 	const extensions = server.extensions.join(", ");
@@ -154,20 +175,20 @@ function formatNotInstalled(result: Extract<ServerLookupResult, { status: "not_i
 		`Command not found: ${server.command[0]}`,
 		"",
 	];
+	const installOptions = formatInstallOptions(server.id, installHint);
 
 	if (decision === "allowed") {
 		return [
 			...header,
 			"The user has pre-authorized LSP installation. Run the install command, then retry this tool:",
-			`  ${installHint}`,
+			...installOptions.slice(1),
 		].join("\n");
 	}
 
 	if (!context.capabilities.installDecisionTool) {
 		return [
 			...header,
-			"To install, run:",
-			`  ${installHint}`,
+			...installOptions,
 			"",
 			"ACTION REQUIRED — ASK THE USER whether to install this LSP server.",
 			"Install-decision recording is unavailable in this harness; proceed without LSP if the user declines.",
@@ -176,8 +197,7 @@ function formatNotInstalled(result: Extract<ServerLookupResult, { status: "not_i
 
 	return [
 		...header,
-		"To install, run:",
-		`  ${installHint}`,
+		...installOptions,
 		"",
 		"ACTION REQUIRED — ASK THE USER whether to install this LSP server.",
 		"- If the user agrees: run the install command above, then retry this tool.",

--- a/packages/lsp-core/src/lsp/server-definitions.ts
+++ b/packages/lsp-core/src/lsp/server-definitions.ts
@@ -49,6 +49,35 @@ export const LSP_INSTALL_HINTS: Record<string, string> = {
 		"Install: dotnet tool install -g roslyn-language-server --prerelease (requires v5.8.0+). See https://github.com/dotnet/razor",
 };
 
+/**
+ * Repo-local install commands, offered ahead of the global hints in `LSP_INSTALL_HINTS`.
+ *
+ * A devDependency (or project venv) is resolvable by `resolveServerBinary()` without any
+ * global install, and it pins the version the project actually expects. Only servers that
+ * are genuinely distributed per-project belong here; toolchain-wide servers (rust-analyzer,
+ * gopls, clangd, ...) keep their global hint alone.
+ */
+export const LSP_LOCAL_INSTALL_HINTS: Record<string, string> = {
+	typescript: "bun add -d typescript-language-server typescript",
+	vue: "bun add -d @vue/language-server",
+	eslint: "bun add -d vscode-langservers-extracted",
+	oxlint: "bun add -d oxlint",
+	biome: "bun add -d @biomejs/biome",
+	svelte: "bun add -d svelte-language-server",
+	astro: "bun add -d @astrojs/language-server",
+	bash: "bun add -d bash-language-server",
+	"bash-ls": "bun add -d bash-language-server",
+	"yaml-ls": "bun add -d yaml-language-server",
+	php: "bun add -d intelephense",
+	prisma: "bun add -d prisma",
+	dockerfile: "bun add -d dockerfile-language-server-nodejs",
+	pyright: "uv add --dev pyright",
+	basedpyright: "uv add --dev basedpyright",
+	ruff: "uv add --dev ruff",
+	ty: "uv add --dev ty",
+	"ruby-lsp": "bundle add ruby-lsp --group development",
+};
+
 export const BUILTIN_SERVERS: Record<string, Omit<LspServerConfig, "id">> = {
 	typescript: {
 		command: ["typescript-language-server", "--stdio"],

--- a/packages/lsp-core/src/lsp/server-installation.test.ts
+++ b/packages/lsp-core/src/lsp/server-installation.test.ts
@@ -1,0 +1,350 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+	__resetServerBinaryResolutionCacheForTests,
+	__serverBinaryProbeCountForTests,
+	isServerInstalled,
+	resolveServerBinary,
+} from "./server-installation.js";
+
+const tempDirectories: string[] = [];
+let previousPath: string | undefined;
+
+function makeTempRoot(prefix: string): string {
+	const root = mkdtempSync(join(tmpdir(), prefix));
+	tempDirectories.push(root);
+	return root;
+}
+
+function writeExecutable(path: string, body = "#!/bin/sh\nexit 0\n"): string {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, body);
+	chmodSync(path, 0o755);
+	return path;
+}
+
+beforeEach(() => {
+	previousPath = process.env["PATH"];
+	__resetServerBinaryResolutionCacheForTests();
+});
+
+afterEach(() => {
+	if (previousPath === undefined) delete process.env["PATH"];
+	else process.env["PATH"] = previousPath;
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+	__resetServerBinaryResolutionCacheForTests();
+});
+
+describe("resolveServerBinary node marker resolution", () => {
+	test("#given a package.json marker and a local node bin #when resolving with an empty PATH #then it returns the local absolute path", () => {
+		// given
+		const root = makeTempRoot("lsp-local-node-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		const binaryPath = writeExecutable(join(root, "node_modules", ".bin", "biome"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const resolved = resolveServerBinary(["biome", "lsp-proxy", "--stdio"], root);
+
+		// then
+		expect(resolved).toBe(binaryPath);
+	});
+
+	test("#given a nested working directory #when resolving #then it walks up to the marker root", () => {
+		// given
+		const root = makeTempRoot("lsp-local-nested-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		const binaryPath = writeExecutable(join(root, "node_modules", ".bin", "biome"));
+		const nested = join(root, "packages", "deep", "src");
+		mkdirSync(nested, { recursive: true });
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const resolved = resolveServerBinary(["biome", "lsp-proxy", "--stdio"], nested);
+
+		// then
+		expect(resolved).toBe(binaryPath);
+	});
+
+	test("#given a local bin without any project marker #when resolving #then the unmarked directory is not trusted", () => {
+		// given
+		const root = makeTempRoot("lsp-local-unmarked-");
+		writeExecutable(join(root, "node_modules", ".bin", "biome"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const resolved = resolveServerBinary(["biome", "lsp-proxy", "--stdio"], root);
+
+		// then
+		expect(resolved).toBeNull();
+	});
+
+	test("#given a bun.lock marker #when resolving #then the node bin directory is probed", () => {
+		// given
+		const root = makeTempRoot("lsp-local-bunlock-");
+		writeFileSync(join(root, "bun.lock"), "");
+		const binaryPath = writeExecutable(join(root, "node_modules", ".bin", "biome"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["biome"], root)).toBe(binaryPath);
+	});
+});
+
+describe("resolveServerBinary non-node ecosystems", () => {
+	test("#given a pyproject marker and a venv binary #when resolving #then it returns the venv path", () => {
+		// given
+		const root = makeTempRoot("lsp-local-python-");
+		writeFileSync(join(root, "pyproject.toml"), "[project]\n");
+		const binaryPath = writeExecutable(join(root, ".venv", "bin", "ruff"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["ruff", "server"], root)).toBe(binaryPath);
+	});
+
+	test("#given a Gemfile marker and a bundled binary #when resolving #then it returns the vendored bundle path", () => {
+		// given
+		const root = makeTempRoot("lsp-local-ruby-");
+		writeFileSync(join(root, "Gemfile"), "source 'https://rubygems.org'\n");
+		const binaryPath = writeExecutable(join(root, "vendor", "bundle", "bin", "rubocop"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["rubocop", "--lsp"], root)).toBe(binaryPath);
+	});
+
+	test("#given a go.mod marker and a project bin #when resolving #then it returns the project bin path", () => {
+		// given
+		const root = makeTempRoot("lsp-local-go-");
+		writeFileSync(join(root, "go.mod"), "module example.com/demo\n");
+		const binaryPath = writeExecutable(join(root, "bin", "gopls"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["gopls"], root)).toBe(binaryPath);
+	});
+
+	test("#given a python marker without a matching venv binary #when resolving #then node bin dirs are not borrowed", () => {
+		// given
+		const root = makeTempRoot("lsp-local-python-miss-");
+		writeFileSync(join(root, "requirements.txt"), "ruff\n");
+		writeExecutable(join(root, "node_modules", ".bin", "ruff"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["ruff", "server"], root)).toBeNull();
+	});
+});
+
+describe("resolveServerBinary probe ordering", () => {
+	test("#given a local binary and a PATH binary #when resolving #then the local binary wins", () => {
+		// given
+		const root = makeTempRoot("lsp-local-priority-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		const localBinary = writeExecutable(join(root, "node_modules", ".bin", "biome"));
+		const pathDir = makeTempRoot("lsp-path-priority-");
+		writeExecutable(join(pathDir, "biome"));
+		process.env["PATH"] = pathDir;
+
+		// when / then
+		expect(resolveServerBinary(["biome"], root)).toBe(localBinary);
+	});
+
+	test("#given only a PATH binary #when resolving #then the PATH entry is returned", () => {
+		// given
+		const root = makeTempRoot("lsp-path-fallback-root-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		const pathDir = makeTempRoot("lsp-path-fallback-");
+		const pathBinary = writeExecutable(join(pathDir, "biome"));
+		process.env["PATH"] = pathDir;
+
+		// when / then
+		expect(resolveServerBinary(["biome"], root)).toBe(pathBinary);
+	});
+
+	test("#given a path-shaped command #when resolving #then the command path itself is validated", () => {
+		// given
+		const root = makeTempRoot("lsp-explicit-path-");
+		const binaryPath = writeExecutable(join(root, "tools", "custom-ls"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary([binaryPath, "--stdio"], root)).toBe(binaryPath);
+		expect(resolveServerBinary([join(root, "tools", "absent-ls")], root)).toBeNull();
+	});
+
+	test("#given no working directory #when resolving #then it falls back to PATH only", () => {
+		// given
+		const pathDir = makeTempRoot("lsp-no-cwd-");
+		const pathBinary = writeExecutable(join(pathDir, "biome"));
+		process.env["PATH"] = pathDir;
+
+		// when / then
+		expect(resolveServerBinary(["biome"])).toBe(pathBinary);
+	});
+
+	test("#given nothing anywhere #when resolving #then it returns null", () => {
+		// given
+		const root = makeTempRoot("lsp-unresolved-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["biome"], root)).toBeNull();
+		expect(resolveServerBinary([], root)).toBeNull();
+	});
+});
+
+describe("resolveServerBinary containment", () => {
+	test("#given a marker only above the working directory root #when resolving with a stop boundary #then it does not escape the boundary", () => {
+		// given
+		const outer = makeTempRoot("lsp-boundary-outer-");
+		writeFileSync(join(outer, "package.json"), "{}\n");
+		writeExecutable(join(outer, "node_modules", ".bin", "biome"));
+		const inner = join(outer, "inner");
+		mkdirSync(inner, { recursive: true });
+		process.env["PATH"] = join(outer, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["biome"], inner, { stopAt: inner })).toBeNull();
+		expect(resolveServerBinary(["biome"], inner)).toBe(join(outer, "node_modules", ".bin", "biome"));
+	});
+
+	test("#given a git repository boundary #when resolving #then the walk stops at the repository root", () => {
+		// given
+		const outer = makeTempRoot("lsp-git-boundary-");
+		writeFileSync(join(outer, "package.json"), "{}\n");
+		writeExecutable(join(outer, "node_modules", ".bin", "biome"));
+		const repo = join(outer, "repo");
+		mkdirSync(join(repo, ".git"), { recursive: true });
+		process.env["PATH"] = join(outer, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["biome"], repo)).toBeNull();
+	});
+});
+
+describe("resolveServerBinary windows suffix probing", () => {
+	test("#given a windows platform and a .cmd shim #when resolving locally #then the suffixed binary is found", () => {
+		// given
+		const root = makeTempRoot("lsp-win-local-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		const binaryPath = writeExecutable(join(root, "node_modules", ".bin", "biome.cmd"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const resolved = resolveServerBinary(["biome"], root, { platform: "win32", pathExt: ".COM;.EXE;.CMD" });
+
+		// then
+		expect(resolved).toBe(binaryPath);
+	});
+
+	test("#given a windows platform and a PATH .exe #when resolving #then the suffixed PATH entry is found", () => {
+		// given
+		const pathDir = makeTempRoot("lsp-win-path-");
+		const binaryPath = writeExecutable(join(pathDir, "biome.exe"));
+		process.env["PATH"] = pathDir;
+
+		// when / then
+		expect(resolveServerBinary(["biome"], undefined, { platform: "win32", pathExt: ".COM;.EXE" })).toBe(binaryPath);
+	});
+});
+
+describe("resolveServerBinary caching", () => {
+	test("#given a repeated lookup #when resolving twice #then the filesystem is probed only once", () => {
+		// given
+		const root = makeTempRoot("lsp-cache-hit-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		const binaryPath = writeExecutable(join(root, "node_modules", ".bin", "biome"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const first = resolveServerBinary(["biome"], root);
+		const probesAfterFirst = __serverBinaryProbeCountForTests();
+		const second = resolveServerBinary(["biome"], root);
+		const probesAfterSecond = __serverBinaryProbeCountForTests();
+
+		// then
+		expect(first).toBe(binaryPath);
+		expect(second).toBe(binaryPath);
+		expect(probesAfterFirst).toBeGreaterThan(0);
+		expect(probesAfterSecond).toBe(probesAfterFirst);
+	});
+
+	test("#given a cached negative lookup #when resolving twice #then the miss is also cached", () => {
+		// given
+		const root = makeTempRoot("lsp-cache-miss-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		expect(resolveServerBinary(["biome"], root)).toBeNull();
+		const probesAfterFirst = __serverBinaryProbeCountForTests();
+		expect(resolveServerBinary(["biome"], root)).toBeNull();
+
+		// then
+		expect(__serverBinaryProbeCountForTests()).toBe(probesAfterFirst);
+	});
+
+	test("#given distinct working directories #when resolving the same command #then the cache keys stay separate", () => {
+		// given
+		const first = makeTempRoot("lsp-cache-key-a-");
+		writeFileSync(join(first, "package.json"), "{}\n");
+		const firstBinary = writeExecutable(join(first, "node_modules", ".bin", "biome"));
+		const second = makeTempRoot("lsp-cache-key-b-");
+		writeFileSync(join(second, "package.json"), "{}\n");
+		process.env["PATH"] = join(first, "definitely-empty");
+
+		// when / then
+		expect(resolveServerBinary(["biome"], first)).toBe(firstBinary);
+		expect(resolveServerBinary(["biome"], second)).toBeNull();
+	});
+});
+
+describe("isServerInstalled compatibility", () => {
+	test("#given a repo-local binary #when checking installation #then it reports installed", () => {
+		// given
+		const root = makeTempRoot("lsp-compat-local-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		writeExecutable(join(root, "node_modules", ".bin", "biome"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(isServerInstalled(["biome", "lsp-proxy"], root)).toBe(true);
+	});
+
+	test("#given a PATH binary and no working directory #when checking installation #then it reports installed", () => {
+		// given
+		const pathDir = makeTempRoot("lsp-compat-path-");
+		writeExecutable(join(pathDir, "typescript-language-server"));
+		process.env["PATH"] = pathDir;
+
+		// when / then
+		expect(isServerInstalled(["typescript-language-server", "--stdio"])).toBe(true);
+	});
+
+	test("#given no binary at all #when checking installation #then it reports not installed", () => {
+		// given
+		const root = makeTempRoot("lsp-compat-missing-");
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(isServerInstalled(["totally-absent-language-server"], root)).toBe(false);
+		expect(isServerInstalled([])).toBe(false);
+	});
+
+	test("#given the node command #when checking installation #then the existing node allowance is preserved", () => {
+		// given
+		const root = makeTempRoot("lsp-compat-node-");
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when / then
+		expect(isServerInstalled(["node", "server.js"], root)).toBe(true);
+	});
+});

--- a/packages/lsp-core/src/lsp/server-installation.test.ts
+++ b/packages/lsp-core/src/lsp/server-installation.test.ts
@@ -348,3 +348,29 @@ describe("isServerInstalled compatibility", () => {
 		expect(isServerInstalled(["node", "server.js"], root)).toBe(true);
 	});
 });
+
+describe("resolveServerBinary node fallback", () => {
+	test("#given a node command missing from PATH #when resolving #then the name is kept so the server stays selectable", () => {
+		// given: a user-configured server such as { command: ["node", "my-ls.js"] } must keep
+		// working, matching the node allowance isServerInstalled() has always had.
+		const root = makeTempRoot("lsp-node-fallback-");
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const resolved = resolveServerBinary(["node", "server.js"], root);
+
+		// then: unresolved rather than rewritten, so the spawn still goes through node
+		expect(resolved).toBe("node");
+		expect(isServerInstalled(["node", "server.js"], root)).toBe(true);
+	});
+
+	test("#given a node command present on PATH #when resolving #then the PATH entry still wins", () => {
+		// given
+		const pathDir = makeTempRoot("lsp-node-on-path-");
+		const pathBinary = writeExecutable(join(pathDir, "node"));
+		process.env["PATH"] = pathDir;
+
+		// when / then
+		expect(resolveServerBinary(["node", "server.js"])).toBe(pathBinary);
+	});
+});

--- a/packages/lsp-core/src/lsp/server-installation.ts
+++ b/packages/lsp-core/src/lsp/server-installation.ts
@@ -191,6 +191,13 @@ export function resolveServerBinary(
 		resolved = resolveLocal(cmd, workingDirectory, suffixes, options.stopAt);
 	}
 	resolved ??= resolveFromPath(cmd, suffixes, platform, options.pathEnv);
+	// A configured server may be launched through the interpreter itself, e.g.
+	// { command: ["node", "my-ls.js"] }. isServerInstalled() has always treated bare `node`
+	// as available regardless of PATH, so keep those servers selectable instead of
+	// regressing them into a not_installed result. The name is returned unresolved so the
+	// spawn still goes through `node`; rewriting it to process.execPath would silently
+	// substitute a different interpreter (bun) for the one the config asked for.
+	if (resolved === null && cmd === "node") resolved = cmd;
 
 	resolutionCache.set(cacheKey, resolved);
 	return resolved;
@@ -207,6 +214,5 @@ export function isServerInstalled(
 	options: ResolveServerBinaryOptions = {},
 ): boolean {
 	if (command.length === 0) return false;
-	if (resolveServerBinary(command, workingDirectory, options) !== null) return true;
-	return command[0] === "node";
+	return resolveServerBinary(command, workingDirectory, options) !== null;
 }

--- a/packages/lsp-core/src/lsp/server-installation.ts
+++ b/packages/lsp-core/src/lsp/server-installation.ts
@@ -1,45 +1,212 @@
 import { existsSync } from "node:fs";
-import { delimiter, join } from "node:path";
+import { delimiter, dirname, isAbsolute, join, resolve } from "node:path";
 
-export function isServerInstalled(command: string[], _workingDirectory?: string): boolean {
-	if (command.length === 0) return false;
+/**
+ * Project markers that authorize probing a set of repo-local binary directories.
+ *
+ * A local bin directory is only trusted when the sibling marker proves the directory
+ * belongs to a project of that ecosystem. An unmarked `node_modules/.bin` is ignored so
+ * that a stray directory cannot inject an executable into the resolution order.
+ */
+interface LocalBinRule {
+	readonly markers: readonly string[];
+	readonly binDirs: readonly string[];
+}
 
-	const [cmd] = command;
-	if (!cmd) return false;
+const LOCAL_BIN_RULES: readonly LocalBinRule[] = [
+	{
+		markers: ["package.json", "bun.lock", "bun.lockb", "package-lock.json", "yarn.lock", "pnpm-lock.yaml"],
+		binDirs: [join("node_modules", ".bin")],
+	},
+	{
+		markers: [
+			"pyproject.toml",
+			"ty.toml",
+			"requirements.txt",
+			"setup.py",
+			"setup.cfg",
+			"Pipfile",
+			"pyrightconfig.json",
+			"ruff.toml",
+			".ruff.toml",
+		],
+		binDirs: [
+			join(".venv", "bin"),
+			join(".venv", "Scripts"),
+			join("venv", "bin"),
+			join("venv", "Scripts"),
+			join(".env", "bin"),
+			join(".env", "Scripts"),
+		],
+	},
+	{
+		markers: ["Gemfile", "Gemfile.lock"],
+		binDirs: [join("vendor", "bundle", "bin"), "bin"],
+	},
+	{
+		markers: ["go.mod", "go.sum", "go.work"],
+		binDirs: ["bin"],
+	},
+];
 
-	if (cmd.includes("/") || cmd.includes("\\")) {
-		if (existsSync(cmd)) return true;
+export interface ResolveServerBinaryOptions {
+	/**
+	 * Upward walk boundary. The walk never ascends above this directory, which lets callers
+	 * confine resolution to a trusted request cwd.
+	 */
+	readonly stopAt?: string;
+	readonly platform?: NodeJS.Platform;
+	readonly pathExt?: string;
+	readonly pathEnv?: string;
+}
+
+const resolutionCache = new Map<string, string | null>();
+let probeCount = 0;
+
+/** Test seam: clears the per-process resolution cache. */
+export function __resetServerBinaryResolutionCacheForTests(): void {
+	resolutionCache.clear();
+	probeCount = 0;
+}
+
+/** Test seam: counts filesystem probes so cache hits are observable. */
+export function __serverBinaryProbeCountForTests(): number {
+	return probeCount;
+}
+
+function probe(path: string): boolean {
+	probeCount += 1;
+	return existsSync(path);
+}
+
+function executableSuffixes(platform: NodeJS.Platform, pathExt: string | undefined): readonly string[] {
+	if (platform !== "win32") return [""];
+	const configured = pathExt ?? process.env["PATHEXT"] ?? "";
+	// PATHEXT is conventionally uppercase, but the on-disk shims npm/bun write are lowercase.
+	// Probe lowercase first so the returned path matches the real filename on case-sensitive
+	// filesystems; the resolved path is spawned, so its casing has to be exact.
+	const systemExts = configured
+		.split(";")
+		.filter((entry) => entry.length > 0)
+		.map((entry) => entry.toLowerCase());
+	return [...new Set(["", ...systemExts, ".exe", ".cmd", ".bat", ".ps1"])];
+}
+
+function probeWithSuffixes(directory: string, command: string, suffixes: readonly string[]): string | null {
+	for (const suffix of suffixes) {
+		const candidate = join(directory, command + suffix);
+		if (probe(candidate)) return candidate;
 	}
+	return null;
+}
 
-	const isWindows = process.platform === "win32";
+function resolveLocal(
+	command: string,
+	workingDirectory: string,
+	suffixes: readonly string[],
+	stopAt: string | undefined,
+): string | null {
+	const boundary = stopAt === undefined ? undefined : resolve(stopAt);
+	let current = resolve(workingDirectory);
 
-	let exts = [""];
-	if (isWindows) {
-		const pathExt = process.env["PATHEXT"] ?? "";
-		if (pathExt) {
-			const systemExts = pathExt.split(";").filter(Boolean);
-			exts = [...new Set([...exts, ...systemExts, ".exe", ".cmd", ".bat", ".ps1"])];
-		} else {
-			exts = ["", ".exe", ".cmd", ".bat", ".ps1"];
+	while (true) {
+		for (const rule of LOCAL_BIN_RULES) {
+			if (!rule.markers.some((marker) => probe(join(current, marker)))) continue;
+			for (const binDir of rule.binDirs) {
+				const found = probeWithSuffixes(join(current, binDir), command, suffixes);
+				if (found !== null) return found;
+			}
 		}
-	}
 
-	let pathEnv = process.env["PATH"] ?? "";
-	if (isWindows && !pathEnv) {
+		// A repository root ends the walk: tooling above it belongs to a different project.
+		if (probe(join(current, ".git"))) return null;
+		if (boundary !== undefined && current === boundary) return null;
+
+		const parent = dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+}
+
+function resolveFromPath(
+	command: string,
+	suffixes: readonly string[],
+	platform: NodeJS.Platform,
+	pathEnvOverride: string | undefined,
+): string | null {
+	let pathEnv = pathEnvOverride ?? process.env["PATH"] ?? "";
+	if (platform === "win32" && !pathEnv) {
 		pathEnv = process.env["Path"] ?? "";
 	}
 
-	const paths = pathEnv.split(delimiter);
+	for (const entry of pathEnv.split(delimiter)) {
+		if (entry.length === 0) continue;
+		const found = probeWithSuffixes(entry, command, suffixes);
+		if (found !== null) return found;
+	}
+	return null;
+}
 
-	for (const p of paths) {
-		for (const suffix of exts) {
-			if (existsSync(join(p, cmd + suffix))) {
-				return true;
-			}
-		}
+/**
+ * Resolves the absolute path of an LSP server binary.
+ *
+ * Probing order:
+ * 1. a path-shaped command is validated as-is,
+ * 2. marker-gated repo-local bin directories, walking up from `workingDirectory`,
+ * 3. `PATH` (including Windows executable suffixes),
+ * 4. `null` when nothing matches.
+ *
+ * Results are cached per process, keyed by working directory and command.
+ */
+export function resolveServerBinary(
+	command: string[],
+	workingDirectory?: string,
+	options: ResolveServerBinaryOptions = {},
+): string | null {
+	if (command.length === 0) return null;
+	const [cmd] = command;
+	if (cmd === undefined || cmd.length === 0) return null;
+
+	const platform = options.platform ?? process.platform;
+	const suffixes = executableSuffixes(platform, options.pathExt);
+
+	if (cmd.includes("/") || cmd.includes("\\")) {
+		const explicit = isAbsolute(cmd) ? cmd : resolve(workingDirectory ?? process.cwd(), cmd);
+		return probe(explicit) ? explicit : null;
 	}
 
-	if (cmd === "node") return true;
+	const cacheKey = JSON.stringify([
+		workingDirectory ?? "",
+		cmd,
+		platform,
+		options.stopAt ?? "",
+		options.pathExt ?? "",
+		options.pathEnv ?? process.env["PATH"] ?? "",
+	]);
+	const cached = resolutionCache.get(cacheKey);
+	if (cached !== undefined) return cached;
 
-	return false;
+	let resolved: string | null = null;
+	if (workingDirectory !== undefined && workingDirectory.length > 0) {
+		resolved = resolveLocal(cmd, workingDirectory, suffixes, options.stopAt);
+	}
+	resolved ??= resolveFromPath(cmd, suffixes, platform, options.pathEnv);
+
+	resolutionCache.set(cacheKey, resolved);
+	return resolved;
+}
+
+/**
+ * Reports whether an LSP server binary is available.
+ *
+ * Retained for existing consumers; `resolveServerBinary` is the richer entry point.
+ */
+export function isServerInstalled(
+	command: string[],
+	workingDirectory?: string,
+	options: ResolveServerBinaryOptions = {},
+): boolean {
+	if (command.length === 0) return false;
+	if (resolveServerBinary(command, workingDirectory, options) !== null) return true;
+	return command[0] === "node";
 }

--- a/packages/lsp-core/src/lsp/server-resolution-local-binary.test.ts
+++ b/packages/lsp-core/src/lsp/server-resolution-local-binary.test.ts
@@ -1,0 +1,170 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { runWithRequestContext } from "../request-context.js";
+import { formatServerLookupError } from "./client-wrapper.js";
+import { __resetServerBinaryResolutionCacheForTests } from "./server-installation.js";
+import { findServerForExtension } from "./server-resolution.js";
+
+const tempDirectories: string[] = [];
+let previousPath: string | undefined;
+
+function makeTempRoot(prefix: string): string {
+	const root = mkdtempSync(join(tmpdir(), prefix));
+	tempDirectories.push(root);
+	return root;
+}
+
+function writeExecutable(path: string): string {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, "#!/bin/sh\nexit 0\n");
+	chmodSync(path, 0o755);
+	return path;
+}
+
+function contextFor(cwd: string) {
+	return {
+		cwd,
+		projectConfigPaths: [join(cwd, ".codex", "lsp-client.json")],
+		userConfigPath: join(cwd, "home-config", "lsp-client.json"),
+		installDecisionsPath: join(cwd, "home-config", "lsp-install-decisions.json"),
+		capabilities: { installDecisionTool: true },
+	} as const;
+}
+
+beforeEach(() => {
+	previousPath = process.env["PATH"];
+	__resetServerBinaryResolutionCacheForTests();
+});
+
+afterEach(() => {
+	if (previousPath === undefined) delete process.env["PATH"];
+	else process.env["PATH"] = previousPath;
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+	__resetServerBinaryResolutionCacheForTests();
+});
+
+describe("findServerForExtension local binary substitution", () => {
+	test("#given a repo-local biome #when looking up a typescript file #then the command spawns the absolute local path", () => {
+		// given
+		const root = makeTempRoot("lsp-resolution-local-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		const binaryPath = writeExecutable(join(root, "node_modules", ".bin", "biome"));
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const result = runWithRequestContext(contextFor(root), () => findServerForExtension(".ts"));
+
+		// then
+		expect(result.status).toBe("found");
+		if (result.status !== "found") throw new Error("expected a found server");
+		expect(result.server.command[0]).toBe(binaryPath);
+		expect(result.server.command.slice(1)).toEqual(["lsp-proxy", "--stdio"]);
+	});
+
+	test("#given a PATH-only server #when looking up #then the resolved PATH entry is substituted", () => {
+		// given
+		const root = makeTempRoot("lsp-resolution-path-root-");
+		writeFileSync(join(root, "package.json"), "{}\n");
+		const pathDir = makeTempRoot("lsp-resolution-path-");
+		const pathBinary = writeExecutable(join(pathDir, "biome"));
+		process.env["PATH"] = pathDir;
+
+		// when
+		const result = runWithRequestContext(contextFor(root), () => findServerForExtension(".ts"));
+
+		// then
+		expect(result.status).toBe("found");
+		if (result.status !== "found") throw new Error("expected a found server");
+		expect(result.server.command[0]).toBe(pathBinary);
+	});
+
+	test("#given no server anywhere #when looking up #then the not_installed result is preserved", () => {
+		// given
+		const root = makeTempRoot("lsp-resolution-missing-");
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const result = runWithRequestContext(contextFor(root), () => findServerForExtension(".ts"));
+
+		// then
+		expect(result.status).toBe("not_installed");
+		if (result.status !== "not_installed") throw new Error("expected not_installed");
+		expect(result.installHint.length).toBeGreaterThan(0);
+	});
+
+	test("#given an unknown extension #when looking up #then the not_configured result is preserved", () => {
+		// given
+		const root = makeTempRoot("lsp-resolution-unknown-");
+		process.env["PATH"] = join(root, "definitely-empty");
+
+		// when
+		const result = runWithRequestContext(contextFor(root), () => findServerForExtension(".unknown-ext"));
+
+		// then
+		expect(result.status).toBe("not_configured");
+	});
+});
+
+describe("not-installed message repo-local guidance", () => {
+	test("#given a missing biome #when formatting the message #then the repo-local install is suggested before the global hint", () => {
+		// given: .css is served by biome alone, so the lookup cannot fall through to typescript
+		const root = makeTempRoot("lsp-message-biome-");
+		process.env["PATH"] = join(root, "definitely-empty");
+		const result = runWithRequestContext(contextFor(root), () => findServerForExtension(".css"));
+		if (result.status !== "not_installed") throw new Error("expected not_installed");
+		expect(result.server.id).toBe("biome");
+
+		// when
+		const message = runWithRequestContext(contextFor(root), () => formatServerLookupError(result));
+
+		// then
+		expect(message).toContain("bun add -d @biomejs/biome");
+		expect(message).toContain("npm install -g @biomejs/biome");
+		expect(message.indexOf("bun add -d @biomejs/biome")).toBeLessThan(message.indexOf("npm install -g @biomejs/biome"));
+		expect(message).toContain("ACTION REQUIRED");
+		expect(message).toContain("NOT INSTALLED");
+	});
+
+	test("#given a server with no repo-local route #when formatting the message #then only the global hint is shown", () => {
+		// given
+		const root = makeTempRoot("lsp-message-global-");
+		process.env["PATH"] = join(root, "definitely-empty");
+		const result = runWithRequestContext(contextFor(root), () => findServerForExtension(".rs"));
+		if (result.status !== "not_installed") throw new Error("expected not_installed");
+
+		// when
+		const message = runWithRequestContext(contextFor(root), () => formatServerLookupError(result));
+
+		// then
+		expect(message).toContain("To install, run:");
+		expect(message).not.toContain("THIS repository");
+		expect(message).toContain("ACTION REQUIRED");
+	});
+
+	test("#given a pre-authorized install #when formatting the message #then both install routes stay visible", () => {
+		// given
+		const root = makeTempRoot("lsp-message-allowed-");
+		process.env["PATH"] = join(root, "definitely-empty");
+		const context = contextFor(root);
+		mkdirSync(join(root, "home-config"), { recursive: true });
+		writeFileSync(
+			context.installDecisionsPath,
+			`${JSON.stringify({ biome: { decision: "allowed", decidedAt: new Date().toISOString() } })}\n`,
+		);
+		const result = runWithRequestContext(context, () => findServerForExtension(".css"));
+		if (result.status !== "not_installed") throw new Error("expected not_installed");
+
+		// when
+		const message = runWithRequestContext(context, () => formatServerLookupError(result));
+
+		// then
+		expect(message).toContain("pre-authorized");
+		expect(message).toContain("bun add -d @biomejs/biome");
+		expect(message).toContain("npm install -g @biomejs/biome");
+	});
+});

--- a/packages/lsp-core/src/lsp/server-resolution.ts
+++ b/packages/lsp-core/src/lsp/server-resolution.ts
@@ -1,16 +1,28 @@
+import { contextCwd } from "../request-context.js";
 import { getDisabledServerIds, getMergedServers } from "./config-loader.js";
 import { BUILTIN_SERVERS, LSP_INSTALL_HINTS } from "./server-definitions.js";
-import { isServerInstalled } from "./server-installation.js";
+import { isServerInstalled, resolveServerBinary } from "./server-installation.js";
 import type { ServerLookupResult } from "./types.js";
+
+/**
+ * Replaces the command name with the absolute binary path so the client spawns the exact
+ * binary that was resolved -- in particular a repo-local one that is absent from PATH.
+ */
+function withResolvedCommand(command: string[], binaryPath: string): string[] {
+	return [binaryPath, ...command.slice(1)];
+}
 
 export function findServerForExtension(ext: string): ServerLookupResult {
 	const servers = getMergedServers();
+	const workingDirectory = contextCwd();
 
 	for (const server of servers) {
-		if (server.extensions.includes(ext) && isServerInstalled(server.command)) {
+		if (!server.extensions.includes(ext)) continue;
+		const binaryPath = resolveServerBinary(server.command, workingDirectory);
+		if (binaryPath !== null) {
 			const resolvedServer = {
 				id: server.id,
-				command: server.command,
+				command: withResolvedCommand(server.command, binaryPath),
 				extensions: server.extensions,
 				priority: server.priority,
 			};
@@ -70,6 +82,7 @@ export interface ServerStatus {
 export function getAllServers(): ServerStatus[] {
 	const servers = getMergedServers();
 	const disabled = getDisabledServerIds();
+	const workingDirectory = contextCwd();
 
 	const result: ServerStatus[] = [];
 	const seen = new Set<string>();
@@ -78,7 +91,7 @@ export function getAllServers(): ServerStatus[] {
 		if (seen.has(server.id)) continue;
 		result.push({
 			id: server.id,
-			installed: isServerInstalled(server.command),
+			installed: isServerInstalled(server.command, workingDirectory),
 			extensions: server.extensions,
 			disabled: false,
 			source: server.source,
@@ -92,7 +105,7 @@ export function getAllServers(): ServerStatus[] {
 		const builtin = BUILTIN_SERVERS[id];
 		result.push({
 			id,
-			installed: builtin ? isServerInstalled(builtin.command) : false,
+			installed: builtin ? isServerInstalled(builtin.command, workingDirectory) : false,
 			extensions: builtin?.extensions ?? [],
 			disabled: true,
 			source: "disabled",


### PR DESCRIPTION
## Summary

An LSP server installed as a project dependency was reported as missing. `isServerInstalled()` scanned only `process.env.PATH` and ignored the `workingDirectory` argument it already accepted (it was declared `_workingDirectory`), so a repository that pins, say, `@biomejs/biome` as a devDependency still got `NOT INSTALLED ... npm install -g @biomejs/biome` and no diagnostics.

This PR makes resolution look at the repository first. `resolveServerBinary()` probes marker-gated repo-local bin directories before falling back to `PATH`, and `findServerForExtension()` substitutes the resolved **absolute** path into `command[0]` so the client actually spawns that binary. The observable change: in a repo whose only biome is a devDependency, `lsp_diagnostics` now returns real biome diagnostics instead of an install prompt. Every catalogue server benefits — typescript-language-server, pyright, ruff, gopls — not just biome.

## Changes

**Resolution (`server-installation.ts`)** — new `resolveServerBinary(command, workingDirectory, options)` probing in order: a path-shaped command validated as-is → marker-gated repo-local bin directories walking up from the working directory → `PATH` → `null`. `isServerInstalled()` is kept as a thin wrapper so existing consumers, including the `lsp-tools-mcp` re-export, are unaffected.

**Wiring (`server-resolution.ts`)** — `command[0]` is replaced with the resolved absolute path (remaining args preserved); the request-context `cwd` is threaded in as the working directory. `not_installed` and `not_configured` results are unchanged.

**Guidance (`client-wrapper.ts`, `server-definitions.ts`)** — new `LSP_LOCAL_INSTALL_HINTS` map; the missing-server message now offers the repo-local install first (`bun add -d @biomejs/biome`) and the global one second. Servers with no meaningful per-project install (rust-analyzer, gopls, clangd) have no local entry and keep their global hint alone. The existing ACTION REQUIRED flow and both install-decision branches are untouched.

### Two details worth a reviewer's attention

**The marker gate is a security property, not a convenience.** A prior commit (`c352b515f`) deliberately removed `getAdditionalPathBases(process.cwd())` and pinned that removal with `lsp-tools-mcp/test/server-installation-security.test.ts`. That fix was right: it probed the *daemon's* cwd, which in a shared daemon is not the user's project. This PR does not reintroduce that. A local bin directory is trusted only when a sibling marker (`package.json`, `pyproject.toml`, `Gemfile`, `go.mod`, ...) proves it belongs to that ecosystem, the directory comes from the **request context cwd** rather than `process.cwd()`, and the upward walk stops at a `.git` boundary. Both existing security tests still pass unmodified — the first one's temp dir has no marker, so resolution correctly refuses it.

**Windows suffixes are now probed lowercase-first.** `PATHEXT` is conventionally uppercase, but the shims npm and bun write are lowercase. This was invisible while the function returned a boolean; now that the resolved path is spawned, casing has to match the real filename on case-sensitive filesystems.

A per-process cache keyed by `(workingDirectory, command)` keeps repeated edits from re-probing the filesystem.

**Node-launched servers keep working.** Routing the lookup through the resolver initially dropped the `node` allowance `isServerInstalled()` has always had, which would have regressed a user-configured `{ command: ["node", "my-ls.js"] }` into `not_installed` when node is absent from PATH. Bare `node` now resolves to the name itself rather than `process.execPath` — under Bun that property is the *bun* binary, and substituting a different interpreter for the one the config asked for would be a silent swap. `isServerInstalled()` now defers to the resolver entirely instead of carrying a duplicate special case.

## QA & Evidence

Evidence directory: `.omo/evidence/omo-senpi-adapter/20260827-lspcore-local-resolve/` (resolved via the `senpi-qa` skill script).

- **What was tested:** live QA driver `packages/lsp-core/scripts/qa/local-binary-resolution-e2e.mjs`. It builds a fixture repo whose only biome is a real devDependency (`bun add -d @biomejs/biome`, not a stub), then removes every PATH entry containing a `biome` executable, so a successful resolution can only come from the repo-local install.
- **Observed result:** PASS, 14/14 checks. Resolution returns `<fixture>/node_modules/.bin/biome` and spawns `["<abs>/biome", "lsp-proxy", "--stdio"]`; resolving from a nested `src/nested` directory returns the same path, proving the upward walk. **Before/after captured in the same run:** the PATH-only probe returns `null` (the old behavior that produced the install prompt).
- **Decisive proof:** `lsp_diagnostics` through the real lsp-core tool runtime returned `error[biome] (lint/correctness/noUnknownProperty) at 1:4` with `"source":"biome"` on a stylesheet with a misspelled property. A diagnostic carrying biome's own rule id can only come from a spawned biome process.
- **Artifacts:** `result.json`, `diagnostics-probe.log`, `resolution-probe.log`, `baseline-path-only-probe.log`, `senpi.stdout.log`, `SUMMARY.md`.
- **Why sufficient:** the success path is proven on a real surface (an actual server process returning actual findings), the failure path is reproduced in the same run, and the driver is proven falsifiable — see below.

**The driver was verified to actually fail.** Resolution was deliberately sabotaged back to PATH-only and the driver re-run: it reported FAIL with 6 checks flipping to false and the NOT INSTALLED message reappearing. The file was then restored (`git diff` clean). The checks are bound to behavior, not passing unconditionally.

Automated gates:
- `bun test packages/lsp-core` — 133 pass, 0 fail (26 new resolver tests + 7 new resolution/message tests, each written RED first).
- `bun test packages/lsp-core packages/omo-senpi` — 2540 pass, 1 skip, 0 fail.
- `bunx tsgo --noEmit` (root) and `bun run typecheck:packages` (all 30 projects) — clean.
- `bunx biome check` on every touched file — clean.

## Risks & Residuals

- **Gate C (Cubic): SKIPPED** — the `cubic · AI code reviewer` check reported `skipping` on both pushes and the bot posted no review, i.e. it is not running / out of quota. Recorded rather than silently ignored; it was not skipped over any finding.
- **Trusting a repo-local binary — mitigated by the marker gate.** Resolution is confined to the request-context cwd, requires an ecosystem marker, and stops at `.git`. Both pre-existing security tests pass unmodified.
- **No new resident processes** (design §5.6) — the change is pure resolution; nothing new is spawned or kept alive. Verified: a post-run `ps` showed 0 surviving `biome lsp-proxy` processes after the driver called `stopAll()`.
- **Isolation** — fixture and agent state live under a temp root removed in `finally`; `senpi` ran with an isolated agent dir, HOME and XDG dirs; `realSenpiUntouched: true` via a sha256 digest of `~/.senpi/agent` before and after.
- **Senpi tool surface not exercised (stated, not hidden).** `senpiProbe.lspToolExposed` is false: this senpi build does not expose `lsp_*` tools, because the packaged extension and daemon runtime come from the `lsp-daemon` build owned by another lane and out of scope here. The senpi probe proves the harness runs against the fixture under a scrubbed PATH; the diagnostics assertion comes from the lsp-core tool runtime, which is the code this PR changes and which `lsp-daemon` re-exports unmodified.
- **Pre-existing failure, not introduced here.** `packages/lsp-tools-mcp/test/package-smoke.test.ts` fails on `origin/dev` independently of this PR: its `isPackageJson` guard requires a `dependencies` field that the committed `package.json` does not have. That package is owned by another lane; left untouched deliberately.

## Scope

Writes are confined to `packages/lsp-core/**`. No changes to formatting/`textDocument/formatting`, `manager.ts`, `lsp-daemon/**`, `omo-senpi/**`, config schemas, or any bunx/npx package-runner fallback.
