### PR TITLE
feat(lsp): format documents through the daemon and cap resident clients

### DIFF
--- a/.omo/evidence/20260827-format-capability/README.md
+++ b/.omo/evidence/20260827-format-capability/README.md
@@ -1,0 +1,93 @@
+# QA evidence - LSP format capability, daemon format request, resident client cap
+
+Branch: `feature/lsp-format-capability` | Date: 2026-08-27 | Base: `origin/dev` @ `339833ad5`
+
+Implements DESIGN.md section 5.2 step 1 (daemon-first formatting through
+`textDocument/formatting`) and section 5.6 rule 3 (`maxResidentClients` LRU cap).
+
+## What was tested
+
+### 1. Live daemon `format` request against a real language server (primary gate)
+
+Driver: `packages/lsp-daemon/scripts/qa/format-request-e2e.mjs`
+(`--self-test` supported; artifact `format-request-e2e.json`).
+
+The driver spawns the REAL built daemon (`dist/cli.js daemon`) on its REAL unix socket and
+sends authenticated `tools/call` frames with `name: "format"`. Language servers are real
+repo-local devDependency installs (`bun add -d @biomejs/biome`, `bun add -d oxlint`) inside
+throwaway fixture repos; no stubs are involved on either side of the socket.
+
+Surfaces driven and the behavior each proves:
+
+| Surface | Proves |
+|---|---|
+| `format` on a drifted `.css` file, biome resident | edits are requested, applied, and committed to disk |
+| second `format` on the same file | an already-formatted file reports `unchanged` and is not rewritten |
+| `format` on `.txt` (no configured server) | the pre-existing missing-dependency result is reused, not a new shape |
+| `format` on `.ts` with oxlint pinned as the only server | the capability gate returns the typed unavailable result |
+| `ps` process count after all requests | no new resident process is introduced |
+
+### 2. Automated gates
+
+- `bun test packages/lsp-core` - 145 pass (`green-02-format.log`)
+- `npx vitest --run` in `packages/lsp-daemon` - 158 pass across 21 files (`green-03-daemon.log`)
+- `bunx tsgo --noEmit -p packages/lsp-core/tsconfig.json` - clean
+- `tsc --noEmit` + `biome check` on the four files this branch touches in lsp-daemon - clean
+
+### 3. Failing-first captures
+
+- `red-01-manager-cap.log` - 3 of 4 resident-cap tests fail before `maxResidentClients` exists
+- `red-02-format.log` - format tests fail on missing `format-document.js` / `format.js`
+- `red-03-daemon-client-surface.log` - client-surface tests fail before `callFormatViaDaemon` exists
+
+## What was observed
+
+Live run verdict: **PASS**, all 10 checks true (`format-request-e2e.json`).
+
+```
+firstFormat  : "Formatted /tmp/fq-*/fixture/drifted.css (+6/-3 lines)"
+               {status:"formatted", linesAdded:6, linesRemoved:3}
+   before     : 'a{color:red;background:blue}\n'
+   after      : 'a {\n  color: red;\n  background: blue;\n}\n'
+secondFormat : "Already formatted: .../drifted.css"
+               {status:"unchanged", linesAdded:0, linesRemoved:0}   bytesChanged:false
+unsupported  : "No LSP server configured for extension: .txt ..."
+               {status:"unavailable", errorKind:"missing_dependency"}  bytesChanged:false
+capability   : "Formatting unavailable for .../linted.ts: the language server does not
+                advertise documentFormattingProvider."
+               {status:"unavailable", reason:"capability_not_advertised"}  bytesChanged:false
+residency    : {residentDaemons: 1}
+```
+
+The capability-gate case is the one that matters most for section 5.6: oxlint really does run,
+really does complete `initialize`, and really does omit `documentFormattingProvider`. The request
+returns a typed result instead of throwing, and the file is byte-identical afterwards.
+
+A first attempt at the live run FAILED with `path must be shorter than SUN_LEN`, because biome's
+`lsp-proxy` opens its own unix socket beneath the fixture and the macOS tmpdir path was too long.
+That is a driver defect, not a product defect; the driver now allocates its work root under a short
+temp path. The failure is recorded here because it is the reason the driver looks the way it does.
+
+## Why it is enough
+
+- Every success criterion is proven on the real surface a consumer will use: an authenticated
+  daemon request over the real socket, not an in-process function call.
+- Both formatting outcomes (`formatted`, `unchanged`) and both non-formatting outcomes
+  (`capability_not_advertised`, missing dependency) are covered, each with a byte comparison, so
+  "did not format" can never silently mean "corrupted the file".
+- The resident-cap change is proven by unit tests that assert the evicted client was actually
+  stopped, that a client with a live request is never evicted, and that the cap is exceeded rather
+  than breaking an in-flight request.
+- Memory safety per section 5.6: the run adds zero resident processes. Formatting reuses the
+  language server the daemon already keeps warm, and the daemon count stays at 1.
+
+## What was omitted
+
+- No secrets, tokens, auth headers, env dumps, or credentials are recorded. The daemon auth token
+  is generated per run inside a throwaway directory and is never written to any artifact.
+- Absolute fixture paths appear inside `/tmp/fq-*` work roots that are deleted at the end of each
+  run; they identify nothing about the host.
+- `residentBiome` is reported but not asserted, because biome spawns short-lived helper processes
+  that are not resident state; the meaningful invariant, asserted, is `residentDaemons == 1`.
+- Windows was not exercised. The socket-length workaround is macOS/Linux specific; the daemon's own
+  named-pipe path is covered by the existing package test suite.

--- a/.omo/evidence/20260827-format-capability/format-request-e2e.json
+++ b/.omo/evidence/20260827-format-capability/format-request-e2e.json
@@ -1,0 +1,122 @@
+{
+  "workRoot": "/tmp/fq-YQ1oxH",
+  "localBiome": "/tmp/fq-YQ1oxH/fixture/node_modules/.bin/biome",
+  "daemonVersionDir": "/tmp/fq-YQ1oxH/daemon/vqa-format",
+  "capabilityGate": {
+    "text": "Formatting unavailable for /tmp/fq-YQ1oxH/linter/linted.ts: the language server does not advertise documentFormattingProvider.",
+    "details": {
+      "filePath": "/tmp/fq-YQ1oxH/linter/linted.ts",
+      "status": "unavailable",
+      "reason": "capability_not_advertised",
+      "linesAdded": 0,
+      "linesRemoved": 0
+    },
+    "bytesChanged": false
+  },
+  "firstFormat": {
+    "text": "Formatted /tmp/fq-YQ1oxH/fixture/drifted.css (+6/-3 lines)",
+    "details": {
+      "filePath": "/tmp/fq-YQ1oxH/fixture/drifted.css",
+      "status": "formatted",
+      "linesAdded": 6,
+      "linesRemoved": 3
+    },
+    "before": "a{color:red;background:blue}\n",
+    "after": "a {\n  color: red;\n  background: blue;\n}\n",
+    "bytesChanged": true
+  },
+  "secondFormat": {
+    "text": "Already formatted: /tmp/fq-YQ1oxH/fixture/drifted.css",
+    "details": {
+      "filePath": "/tmp/fq-YQ1oxH/fixture/drifted.css",
+      "status": "unchanged",
+      "linesAdded": 0,
+      "linesRemoved": 0
+    },
+    "bytesChanged": false
+  },
+  "unsupportedFormat": {
+    "text": "No LSP server configured for extension: .txt\n\nAvailable servers: typescript, deno, vue, eslint, oxlint, biome, gopls, ruby-lsp, basedpyright, pyright...\n\nConfigure a custom server in '/private/tmp/fq-YQ1oxH/fixture/.codex/lsp-client.json' or '/tmp/fq-YQ1oxH/fixture/home/lsp-client.json':\n  {\n    \"lsp\": {\n      \"my-server\": {\n        \"command\": [\"my-lsp\", \"--stdio\"],\n        \"extensions\": [\".txt\"]\n      }\n    }\n  }",
+    "details": {
+      "filePath": "/tmp/fq-YQ1oxH/fixture/notes.txt",
+      "status": "unavailable",
+      "reason": "server_unavailable",
+      "linesAdded": 0,
+      "linesRemoved": 0,
+      "error": "No LSP server configured for extension: .txt\n\nAvailable servers: typescript, deno, vue, eslint, oxlint, biome, gopls, ruby-lsp, basedpyright, pyright...\n\nConfigure a custom server in '/private/tmp/fq-YQ1oxH/fixture/.codex/lsp-client.json' or '/tmp/fq-YQ1oxH/fixture/home/lsp-client.json':\n  {\n    \"lsp\": {\n      \"my-server\": {\n        \"command\": [\"my-lsp\", \"--stdio\"],\n        \"extensions\": [\".txt\"]\n      }\n    }\n  }",
+      "errorKind": "missing_dependency",
+      "availability": {
+        "kind": "not_configured",
+        "extension": ".txt",
+        "availableServers": [
+          "typescript",
+          "deno",
+          "vue",
+          "eslint",
+          "oxlint",
+          "biome",
+          "gopls",
+          "ruby-lsp",
+          "basedpyright",
+          "pyright",
+          "ty",
+          "ruff",
+          "elixir-ls",
+          "zls",
+          "csharp",
+          "fsharp",
+          "sourcekit-lsp",
+          "rust",
+          "clangd",
+          "svelte",
+          "astro",
+          "bash",
+          "bash-ls",
+          "jdtls",
+          "yaml-ls",
+          "lua-ls",
+          "php",
+          "dart",
+          "terraform",
+          "terraform-ls",
+          "prisma",
+          "ocaml-lsp",
+          "texlab",
+          "dockerfile",
+          "gleam",
+          "clojure-lsp",
+          "nixd",
+          "tinymist",
+          "haskell-language-server",
+          "kotlin-ls",
+          "julials",
+          "razor"
+        ],
+        "projectConfigPaths": [
+          "/private/tmp/fq-YQ1oxH/fixture/.codex/lsp-client.json"
+        ],
+        "userConfigPath": "/tmp/fq-YQ1oxH/fixture/home/lsp-client.json",
+        "installDecisionTool": true
+      }
+    },
+    "bytesChanged": false
+  },
+  "residency": {
+    "residentBiome": 4,
+    "residentDaemons": 1
+  },
+  "daemonLogTail": "",
+  "checks": {
+    "firstFormatRewroteFile": true,
+    "firstFormatStatusFormatted": true,
+    "firstFormatReportsLineDeltas": true,
+    "secondFormatUnchanged": true,
+    "secondFormatLeftBytes": true,
+    "unsupportedLeftBytes": true,
+    "unsupportedNotFormatted": true,
+    "oneResidentDaemon": true,
+    "capabilityGateUnavailable": true,
+    "capabilityGateLeftBytes": true
+  },
+  "verdict": "PASS"
+}

--- a/.omo/evidence/20260827-format-capability/green-01-manager-cap.log
+++ b/.omo/evidence/20260827-format-capability/green-01-manager-cap.log
@@ -1,0 +1,197 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/lsp-core/src/tool-surface.test.ts:
+(pass) LSP core tool surface > #given tool descriptors #when listed #then the public eight-tool schemas are pinned [0.56ms]
+(pass) LSP core tool surface > #given legacy tool aliases #when executed #then aliases are callable but not listed [1.24ms]
+(pass) LSP core tool surface > #given non-object tool arguments #when coerced #then they produce an empty argument record [0.10ms]
+
+packages/lsp-core/src/request-context.test.ts:
+(pass) LspRequestContext > #given exact typed context #when parsed #then canonicalizes cwd and preserves typed paths [0.57ms]
+(pass) LspRequestContext > #given no active context #when requested #then throws an actionable typed error [0.12ms]
+(pass) LspRequestContext > #given unknown field #when parsed #then rejects before lookup [0.24ms]
+(pass) LspRequestContext > #given project path outside cwd #when parsed #then rejects before config loading [0.33ms]
+(pass) LspRequestContext > #given equivalent macOS var spelling #when parsed #then canonicalizes to one identity [0.35ms]
+(pass) LspRequestContext > #given missing standard project config inside cwd #when parsed #then accepts and preserves the intended suffix [0.30ms]
+(pass) LspRequestContext > #given symlink project config escaping cwd #when parsed #then rejects the escape [0.52ms]
+(pass) LspRequestContext > #given standalone MCP env #when translated #then resolves exact defaults and relative paths [0.53ms]
+
+packages/lsp-core/src/missing-dependency-result.test.ts:
+(pass) missingDependencyResult > #given not configured lookup #when converted #then includes structured availability and typed config paths [0.40ms]
+(pass) missingDependencyResult > #given not installed lookup #when converted #then includes install decision availability [0.29ms]
+
+packages/lsp-core/src/mcp-protocol-pin.test.ts:
+(pass) lsp MCP protocol pins > #given initialize request #when handled #then exact server info and capabilities stay stable [0.28ms]
+(pass) lsp MCP protocol pins > #given malformed stdio line #when read #then parse error envelope includes parser data [1.94ms]
+
+packages/lsp-core/src/lsp/workspace-apply-edit.integration.test.ts:
+(pass) LspClient workspace/applyEdit > #given a server-applied edit returned again by rename #when rename completes #then one write is reused truthfully [42.69ms]
+(pass) LspClient workspace/applyEdit > #given a server-applied edit and a null rename result #when rename completes #then the recorded result is reused [45.84ms]
+(pass) LspClient workspace/applyEdit > #given two versioned server edits #when applied sequentially #then the synchronized version accepts the second edit [61.03ms]
+(pass) LspClient workspace/applyEdit > #given a mismatched document version #when the server requests applyEdit #then mutation is rejected truthfully [41.62ms]
+(pass) LspClient workspace/applyEdit > #given a server-applied edit and a different rename result #when rename completes #then conflict is reported without a second mutation [48.69ms]
+(pass) LspClient workspace/applyEdit > #given a real commit I/O failure #when the server requests applyEdit #then both protocol and rename result report failure [41.14ms]
+
+packages/lsp-core/src/lsp/manager-max-clients.test.ts:
+(pass) LspManager resident client cap > #given a cap of two idle clients #when a third client is admitted #then the least recently used one is stopped and evicted [0.67ms]
+(pass) LspManager resident client cap > #given the least recently used client is mid-request #when a new client is admitted #then the busy client survives and an idle one is evicted [0.15ms]
+(pass) LspManager resident client cap > #given every resident client is busy #when a new client is admitted #then nothing is evicted and the cap is exceeded rather than breaking a live request [0.12ms]
+(pass) LspManager resident client cap > #given warmup requests beyond the cap #when a warm client is admitted #then the idle least recently used client is evicted too [0.16ms]
+
+packages/lsp-core/src/lsp/directory-diagnostics.test.ts:
+(pass) directory diagnostics > #given multiple files and one per-file failure #when directory diagnostics run #then work stays bounded and file failures stay structured [0.89ms]
+(pass) directory diagnostics > #given directory diagnostics are aborted after one file #when the worker loops #then no later file is scheduled [1.48ms]
+(pass) directory diagnostics > #given cold client acquisition is pending #when directory diagnostics are aborted #then acquisition settles and cleans up before startup releases [0.59ms]
+
+packages/lsp-core/src/lsp/workspace-document-state.test.ts:
+(pass) WorkspaceDocumentState watched-file bounds > #given more closed-file mutations than one batch #when synchronized #then every notification stays bounded [0.41ms]
+(pass) WorkspaceDocumentState watched-file bounds > #given changed closed files #when synchronized #then sends bounded changed watched-file notifications [0.27ms]
+
+packages/lsp-core/src/lsp/utils.test.ts:
+(pass) formatKnownLspStartupFailure > #given rust-src component conflict #when formatting startup failure #then returns repair guidance [0.16ms]
+(pass) formatKnownLspStartupFailure > #given rust-analyzer sysroot error #when handling missing dependency #then returns repair guidance [0.07ms]
+(pass) formatKnownLspStartupFailure > #given unrelated process exits #when formatting startup failure #then returns null [0.07ms]
+(pass) handleMissingDependencyError > #given existing dependency messages #when handling error #then preserves current messages [0.18ms]
+
+packages/lsp-core/src/lsp/client-wrapper-outside-cwd.test.ts:
+(pass) LSP read-only access outside request cwd > #given an absolute file outside cwd #when resolving a read path #then returns the canonical path [0.89ms]
+(pass) LSP read-only access outside request cwd > #given an outside file inside its own marked project #when inferring workspace #then uses that project root [0.97ms]
+(pass) LSP read-only access outside request cwd > #given an outside file without any marker #when inferring workspace #then falls back to its own directory [0.81ms]
+(pass) LSP read-only access outside request cwd > #given an outside file #when resolving a mutating path #then still rejects to keep writes confined [1.51ms]
+
+packages/lsp-core/src/lsp/workspace-edit-adversarial.test.ts:
+(pass) workspace edit adversarial inputs > #given malformed and decorated URIs #when planned #then every variant is rejected before mutation [1.16ms]
+(pass) workspace edit adversarial inputs > #given invalid ranges and resource options #when planned #then each failure retains its operation index [0.82ms]
+(pass) workspace edit adversarial inputs > #given an outside target and a dirty unrelated file #when prevalidation fails #then neither is touched [0.70ms]
+(pass) workspace edit adversarial inputs > #given an in-workspace symlink to an outside file #when applying an edit #then rejects without modifying target [0.65ms]
+(pass) workspace edit adversarial inputs > #given annotations or mixed edit representations #when planned #then unsupported claims are rejected [0.33ms]
+
+packages/lsp-core/src/lsp/server-installation.test.ts:
+(pass) resolveServerBinary node marker resolution > #given a package.json marker and a local node bin #when resolving with an empty PATH #then it returns the local absolute path [1.52ms]
+(pass) resolveServerBinary node marker resolution > #given a nested working directory #when resolving #then it walks up to the marker root [1.49ms]
+(pass) resolveServerBinary node marker resolution > #given a local bin without any project marker #when resolving #then the unmarked directory is not trusted [1.03ms]
+(pass) resolveServerBinary node marker resolution > #given a bun.lock marker #when resolving #then the node bin directory is probed [0.64ms]
+(pass) resolveServerBinary non-node ecosystems > #given a pyproject marker and a venv binary #when resolving #then it returns the venv path [0.83ms]
+(pass) resolveServerBinary non-node ecosystems > #given a Gemfile marker and a bundled binary #when resolving #then it returns the vendored bundle path [0.78ms]
+(pass) resolveServerBinary non-node ecosystems > #given a go.mod marker and a project bin #when resolving #then it returns the project bin path [0.62ms]
+(pass) resolveServerBinary non-node ecosystems > #given a python marker without a matching venv binary #when resolving #then node bin dirs are not borrowed [1.21ms]
+(pass) resolveServerBinary probe ordering > #given a local binary and a PATH binary #when resolving #then the local binary wins [0.87ms]
+(pass) resolveServerBinary probe ordering > #given only a PATH binary #when resolving #then the PATH entry is returned [0.71ms]
+(pass) resolveServerBinary probe ordering > #given a path-shaped command #when resolving #then the command path itself is validated [0.37ms]
+(pass) resolveServerBinary probe ordering > #given no working directory #when resolving #then it falls back to PATH only [0.27ms]
+(pass) resolveServerBinary probe ordering > #given nothing anywhere #when resolving #then it returns null [0.75ms]
+(pass) resolveServerBinary containment > #given a marker only above the working directory root #when resolving with a stop boundary #then it does not escape the boundary [2.33ms]
+(pass) resolveServerBinary containment > #given a git repository boundary #when resolving #then the walk stops at the repository root [0.88ms]
+(pass) resolveServerBinary windows suffix probing > #given a windows platform and a .cmd shim #when resolving locally #then the suffixed binary is found [0.59ms]
+(pass) resolveServerBinary windows suffix probing > #given a windows platform and a PATH .exe #when resolving #then the suffixed PATH entry is found [0.29ms]
+(pass) resolveServerBinary caching > #given a repeated lookup #when resolving twice #then the filesystem is probed only once [0.53ms]
+(pass) resolveServerBinary caching > #given a cached negative lookup #when resolving twice #then the miss is also cached [0.49ms]
+(pass) resolveServerBinary caching > #given distinct working directories #when resolving the same command #then the cache keys stay separate [0.83ms]
+(pass) isServerInstalled compatibility > #given a repo-local binary #when checking installation #then it reports installed [0.48ms]
+(pass) isServerInstalled compatibility > #given a PATH binary and no working directory #when checking installation #then it reports installed [0.24ms]
+(pass) isServerInstalled compatibility > #given no binary at all #when checking installation #then it reports not installed [0.50ms]
+(pass) isServerInstalled compatibility > #given the node command #when checking installation #then the existing node allowance is preserved [0.53ms]
+(pass) resolveServerBinary node fallback > #given a node command missing from PATH #when resolving #then the name is kept so the server stays selectable [0.39ms]
+(pass) resolveServerBinary node fallback > #given a node command present on PATH #when resolving #then the PATH entry still wins [0.28ms]
+
+packages/lsp-core/src/lsp/workspace-edit-commit.test.ts:
+(pass) workspace edit commit barrier > #given cancellation before commit #when a valid plan is applied #then no mutation begins [1.30ms]
+(pass) workspace edit commit barrier > #given repeated pre-gate interruptions #when retried #then every attempt leaves the snapshot untouched [0.59ms]
+(pass) workspace edit commit barrier > #given cancellation after the first write #when commit has crossed the barrier #then all operations finish once [1.08ms]
+(pass) workspace edit commit barrier > #given an injected write failure #when commit begins #then the result reports real I/O failure [0.48ms]
+(pass) workspace edit commit barrier > #given a stale file snapshot #when a prepared plan commits #then the newer bytes are preserved [0.43ms]
+
+packages/lsp-core/src/lsp/client-wrapper.test.ts:
+(pass) LSP client path confinement > #given a relative file inside context cwd #when resolving workspace #then marker search stays inside cwd [1.72ms]
+(pass) LSP client path confinement > #given an absolute file outside context cwd #when resolving #then infers the file's own project root [1.32ms]
+(pass) LSP client path confinement > #given a symlink inside cwd that points outside #when resolving read path #then keeps lexical path and cwd root [1.29ms]
+(pass) LSP client path confinement > #given an absolute macOS alias path through an outside symlink #when resolving read path #then preserves the lexical suffix [0.96ms]
+(pass) LSP client path confinement > #given missing parent directories without markers #when resolving workspace #then uses an existing directory [0.49ms]
+(pass) LSP client path confinement > #given a symlink inside cwd that points outside #when starting rename #then rejects before client acquisition [0.93ms]
+
+packages/lsp-core/src/lsp/workspace-apply-edit-lease.integration.test.ts:
+(pass) LspClient workspace mutation lease > #given no mutating request #when the server calls applyEdit #then the request is rejected as unscoped [53.91ms]
+(pass) LspClient workspace mutation lease > #given one valid server apply #when the server applies twice #then the repeated request is rejected [41.80ms]
+(pass) LspClient workspace mutation lease > #given two concurrent server applies #when one enters commit #then the other is rejected without a second write [39.87ms]
+(pass) LspClient workspace mutation lease > #given a rename lease is held #when another rename starts #then it is rejected without a second request [189.21ms]
+(pass) LspClient workspace mutation lease > #given no server apply #when rename directly returns an edit #then it is applied exactly once [42.80ms]
+(pass) LspClient workspace mutation lease > #given cancellation before a delayed server apply #when the rename request is aborted #then no file is mutated [60.59ms]
+(pass) LspClient workspace mutation lease > #given cancellation after the commit gate #when applyEdit finishes #then rename reports one completed late-abort mutation [49.28ms]
+(pass) LspClient workspace mutation lease > #given lease-backed and bare clients #when initialized #then applyEdit and annotations are advertised honestly [104.98ms]
+
+packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts:
+(pass) LspClient diagnostics freshness > #given a versionless publish that arrives after the current change #when no newer eligible publish arrives before quiescence #then diagnostics wait for that quiescence window and return the versionless payload [63.87ms]
+(pass) LspClient diagnostics freshness > #given only a pre-generation versionless publish #when a newer local version asks for diagnostics #then the stale versionless publish is ignored and the request does not resolve clean [355.68ms]
+(pass) LspClient diagnostics freshness > #given stale and future publish versions #when diagnostics target the current version #then neither stale nor future diagnostics satisfy the request [325.16ms]
+(pass) LspClient diagnostics freshness > #given a pull response overtaken by a later local change #when the stale full report returns first #then diagnostics restart within the same request and resolve from the current version [243.47ms]
+(pass) LspClient diagnostics freshness > #given a full pull report followed by an unchanged report for the same version and resultId #when diagnostics repeat without a local change #then the cached full items are reused [43.23ms]
+[lsp] ignored connection error notification failure during cleanup: Cannot call write after a stream was destroyed
+[lsp] ignored shutdown request failure during cleanup: LSP server workspace-edit-fixture at /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/lsp-apply-edit-MP2ctD exited with code 0
+(pass) LspClient diagnostics freshness > #given a server that claims pull support but closes instead of answering #when diagnostics run #then the transport failure is not labeled clean [536.84ms]
+(pass) LspClient diagnostics freshness > #given an advertised pull method that is explicitly unsupported and a matching push publish #when diagnostics run #then the client falls back to push diagnostics [558.44ms]
+(pass) LspClient diagnostics freshness > #given a diagnostic pull request times out #when the fake server keeps it pending #then the client sends cancel for the LSP request id [125.77ms]
+(pass) LspClient diagnostics freshness > #given a server without pull support that never publishes diagnostics #when diagnostics run on a clean file #then the request resolves clean after the freshness window instead of reporting a timeout [108.67ms]
+(pass) LspClient diagnostics freshness > #given a pull-supported server that cached diagnostics for an older document version #when the file changes and a later pull is rejected as unsupported without any publish #then the fallback resolves empty instead of returning the stale cached diagnostics [561.13ms]
+(pass) LspClient diagnostics freshness > #given a pull-supported server with a current cached pull report #when a later pull is rejected as unsupported without any publish and the document is unchanged #then the fallback resolves with the current cached diagnostics [575.87ms]
+
+packages/lsp-core/src/lsp/workspace-edit-options.test.ts:
+(pass) applyWorkspaceEdit resource options > #given create ignoreIfExists #when the target exists #then existing bytes are preserved [1.23ms]
+(pass) applyWorkspaceEdit resource options > #given rename ignoreIfExists #when the destination exists #then both files are preserved [0.90ms]
+(pass) applyWorkspaceEdit resource options > #given rename overwrite #when the destination exists #then source replaces destination [0.87ms]
+(pass) applyWorkspaceEdit resource options > #given delete ignoreIfNotExists #when the target is missing #then it is a successful no-op [0.52ms]
+(pass) applyWorkspaceEdit resource options > #given recursive delete #when the target is a non-empty directory #then the subtree is removed [0.85ms]
+
+packages/lsp-core/src/lsp/workspace-apply-edit-sync.integration.test.ts:
+(pass) LspClient workspace edit synchronization > #given an open edited document #when applyEdit commits #then didChange precedes didSave with the next version [48.97ms]
+(pass) LspClient workspace edit synchronization > #given an open file resource rename #when applyEdit commits #then didClose and didOpen move document state [46.29ms]
+(pass) LspClient workspace edit synchronization > #given an open file deletion #when applyEdit commits #then didClose removes document state [38.95ms]
+(pass) LspClient workspace edit synchronization > #given a closed edited file #when applyEdit commits #then one changed watched-file event is emitted [52.82ms]
+(pass) LspClient workspace edit synchronization > #given a new closed file #when applyEdit creates it #then one created watched-file event is emitted [61.03ms]
+(pass) LspClient workspace edit synchronization > #given an open file overwritten by create #when applyEdit commits #then didClose and didOpen reset its state [40.99ms]
+
+packages/lsp-core/src/lsp/server-resolution-local-binary.test.ts:
+(pass) findServerForExtension local binary substitution > #given a repo-local biome #when looking up a typescript file #then the command spawns the absolute local path [2.12ms]
+(pass) findServerForExtension local binary substitution > #given a PATH-only server #when looking up #then the resolved PATH entry is substituted [1.87ms]
+(pass) findServerForExtension local binary substitution > #given no server anywhere #when looking up #then the not_installed result is preserved [1.22ms]
+(pass) findServerForExtension local binary substitution > #given an unknown extension #when looking up #then the not_configured result is preserved [0.32ms]
+(pass) not-installed message repo-local guidance > #given a missing biome #when formatting the message #then the repo-local install is suggested before the global hint [0.71ms]
+(pass) not-installed message repo-local guidance > #given a server with no repo-local route #when formatting the message #then only the global hint is shown [0.65ms]
+(pass) not-installed message repo-local guidance > #given a pre-authorized install #when formatting the message #then both install routes stay visible [0.94ms]
+
+packages/lsp-core/src/lsp/json-rpc-connection-cancellation.test.ts:
+(pass) JsonRpcConnection cancellation > #given an active request #when its signal aborts #then cancel uses the same id and late responses are ignored [0.82ms]
+
+packages/lsp-core/src/lsp/client-diagnostics-concurrency.integration.test.ts:
+(pass) LspClient diagnostics concurrency > #given concurrent diagnostics on a cold file and an exact didOpen publish #when pull is not advertised #then one didOpen opens the file and both requests receive the current diagnostics [43.86ms]
+
+packages/lsp-core/src/lsp/cleanup-errors.test.ts:
+(pass) reportBestEffortCleanupError > #given an injected cleanup logger #when cleanup fails #then the normal diagnostic is emitted without an environment gate [4.67ms]
+
+packages/lsp-core/src/lsp/workspace-edit-prevalidation.test.ts:
+(pass) applyWorkspaceEdit prevalidation > #given a valid edit before an overlapping edit #when validated #then neither file is mutated [0.96ms]
+(pass) applyWorkspaceEdit prevalidation > #given byte-identical non-empty edits #when applied #then one edit is committed [0.47ms]
+(pass) applyWorkspaceEdit prevalidation > #given equal-position insertions #when applied #then all insertions retain declared order [0.43ms]
+(pass) applyWorkspaceEdit prevalidation > #given a range beyond the snapshot #when validated #then the edit fails without mutation [0.47ms]
+(pass) applyWorkspaceEdit prevalidation > #given a create followed by an invalid edit #when the sequence is validated #then no file is created [0.29ms]
+(pass) applyWorkspaceEdit prevalidation > #given rename then text edit of the destination #when applied #then declared order uses virtual state [0.69ms]
+
+packages/lsp-core/src/lsp/workspace-edit.characterization.test.ts:
+(pass) applyWorkspaceEdit preserved behavior > #given a valid text edit #when applied #then the file and ApplyResult remain compatible [0.94ms]
+(pass) applyWorkspaceEdit preserved behavior > #given a resource rename #when applied #then content moves and the destination is reported [0.67ms]
+(pass) applyWorkspaceEdit preserved behavior > #given an empty workspace edit #when applied #then it remains a successful no-op [0.29ms]
+(pass) applyWorkspaceEdit preserved behavior > #given no workspace edit #when applied #then the existing failure remains explicit [0.20ms]
+
+packages/lsp-core/src/lsp/workspace-edit-contract-evidence.test.ts:
+(pass) workspace edit contract evidence > #given both legitimate concurrent applyEdit lease outcomes #when failure evidence is hashed #then one canonical shape and hash is produced [0.40ms]
+(pass) workspace edit contract evidence > #given workspace-scoped evidence and a non-concurrent failure #when normalized #then paths are sanitized and the reason is preserved [0.12ms]
+
+packages/lsp-core/src/post-edit/orchestration.test.ts:
+(pass) collectPostEditDiagnostics > #given rendered not_configured text #when the same extension is checked again #then the text is not cached [0.54ms]
+(pass) collectPostEditDiagnostics > #given duplicate edited paths #when diagnostics run #then first seen paths are processed once and blocks stay ordered [0.15ms]
+(pass) collectPostEditDiagnostics > #given many edited paths #when diagnostics run #then concurrency is bounded to four and failures isolate [0.27ms]
+(pass) collectPostEditDiagnostics > #given structured not_configured diagnostics #when cache is reused and reset #then only not_configured is cached [0.21ms]
+(pass) collectPostEditDiagnostics > #given non-not_configured failures #when cache is reused #then every failure retries [0.16ms]
+
+ 137 pass
+ 0 fail
+ 360 expect() calls
+Ran 137 tests across 26 files. [5.63s]

--- a/.omo/evidence/20260827-format-capability/green-02-format.log
+++ b/.omo/evidence/20260827-format-capability/green-02-format.log
@@ -1,0 +1,209 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/lsp-core/src/tool-surface.test.ts:
+(pass) LSP core tool surface > #given tool descriptors #when listed #then the public nine-tool schemas are pinned [0.57ms]
+(pass) LSP core tool surface > #given legacy tool aliases #when executed #then aliases are callable but not listed [1.29ms]
+(pass) LSP core tool surface > #given non-object tool arguments #when coerced #then they produce an empty argument record [0.08ms]
+
+packages/lsp-core/src/request-context.test.ts:
+(pass) LspRequestContext > #given exact typed context #when parsed #then canonicalizes cwd and preserves typed paths [3.25ms]
+(pass) LspRequestContext > #given no active context #when requested #then throws an actionable typed error [0.13ms]
+(pass) LspRequestContext > #given unknown field #when parsed #then rejects before lookup [0.25ms]
+(pass) LspRequestContext > #given project path outside cwd #when parsed #then rejects before config loading [0.35ms]
+(pass) LspRequestContext > #given equivalent macOS var spelling #when parsed #then canonicalizes to one identity [0.38ms]
+(pass) LspRequestContext > #given missing standard project config inside cwd #when parsed #then accepts and preserves the intended suffix [0.31ms]
+(pass) LspRequestContext > #given symlink project config escaping cwd #when parsed #then rejects the escape [18.70ms]
+(pass) LspRequestContext > #given standalone MCP env #when translated #then resolves exact defaults and relative paths [0.47ms]
+
+packages/lsp-core/src/missing-dependency-result.test.ts:
+(pass) missingDependencyResult > #given not configured lookup #when converted #then includes structured availability and typed config paths [0.48ms]
+(pass) missingDependencyResult > #given not installed lookup #when converted #then includes install decision availability [0.25ms]
+
+packages/lsp-core/src/mcp-protocol-pin.test.ts:
+(pass) lsp MCP protocol pins > #given initialize request #when handled #then exact server info and capabilities stay stable [0.28ms]
+(pass) lsp MCP protocol pins > #given malformed stdio line #when read #then parse error envelope includes parser data [2.08ms]
+
+packages/lsp-core/src/tools/format.test.ts:
+(pass) executeLspFormat > #given an extension with no configured server #when format runs #then the missing dependency result is returned and the file is untouched [0.92ms]
+(pass) executeLspFormat > #given a missing filePath argument #when format runs #then the parameter contract is enforced [0.14ms]
+
+packages/lsp-core/src/lsp/workspace-apply-edit.integration.test.ts:
+(pass) LspClient workspace/applyEdit > #given a server-applied edit returned again by rename #when rename completes #then one write is reused truthfully [49.00ms]
+(pass) LspClient workspace/applyEdit > #given a server-applied edit and a null rename result #when rename completes #then the recorded result is reused [40.12ms]
+(pass) LspClient workspace/applyEdit > #given two versioned server edits #when applied sequentially #then the synchronized version accepts the second edit [56.96ms]
+(pass) LspClient workspace/applyEdit > #given a mismatched document version #when the server requests applyEdit #then mutation is rejected truthfully [54.36ms]
+(pass) LspClient workspace/applyEdit > #given a server-applied edit and a different rename result #when rename completes #then conflict is reported without a second mutation [49.90ms]
+(pass) LspClient workspace/applyEdit > #given a real commit I/O failure #when the server requests applyEdit #then both protocol and rename result report failure [40.60ms]
+
+packages/lsp-core/src/lsp/manager-max-clients.test.ts:
+(pass) LspManager resident client cap > #given a cap of two idle clients #when a third client is admitted #then the least recently used one is stopped and evicted [0.69ms]
+(pass) LspManager resident client cap > #given the least recently used client is mid-request #when a new client is admitted #then the busy client survives and an idle one is evicted [0.15ms]
+(pass) LspManager resident client cap > #given every resident client is busy #when a new client is admitted #then nothing is evicted and the cap is exceeded rather than breaking a live request [0.11ms]
+(pass) LspManager resident client cap > #given warmup requests beyond the cap #when a warm client is admitted #then the idle least recently used client is evicted too [0.15ms]
+
+packages/lsp-core/src/lsp/directory-diagnostics.test.ts:
+(pass) directory diagnostics > #given multiple files and one per-file failure #when directory diagnostics run #then work stays bounded and file failures stay structured [1.00ms]
+(pass) directory diagnostics > #given directory diagnostics are aborted after one file #when the worker loops #then no later file is scheduled [0.34ms]
+(pass) directory diagnostics > #given cold client acquisition is pending #when directory diagnostics are aborted #then acquisition settles and cleans up before startup releases [0.60ms]
+
+packages/lsp-core/src/lsp/workspace-document-state.test.ts:
+(pass) WorkspaceDocumentState watched-file bounds > #given more closed-file mutations than one batch #when synchronized #then every notification stays bounded [0.41ms]
+(pass) WorkspaceDocumentState watched-file bounds > #given changed closed files #when synchronized #then sends bounded changed watched-file notifications [0.29ms]
+
+packages/lsp-core/src/lsp/utils.test.ts:
+(pass) formatKnownLspStartupFailure > #given rust-src component conflict #when formatting startup failure #then returns repair guidance [1.50ms]
+(pass) formatKnownLspStartupFailure > #given rust-analyzer sysroot error #when handling missing dependency #then returns repair guidance [0.10ms]
+(pass) formatKnownLspStartupFailure > #given unrelated process exits #when formatting startup failure #then returns null [0.08ms]
+(pass) handleMissingDependencyError > #given existing dependency messages #when handling error #then preserves current messages [0.07ms]
+
+packages/lsp-core/src/lsp/client-wrapper-outside-cwd.test.ts:
+(pass) LSP read-only access outside request cwd > #given an absolute file outside cwd #when resolving a read path #then returns the canonical path [0.98ms]
+(pass) LSP read-only access outside request cwd > #given an outside file inside its own marked project #when inferring workspace #then uses that project root [0.95ms]
+(pass) LSP read-only access outside request cwd > #given an outside file without any marker #when inferring workspace #then falls back to its own directory [0.73ms]
+(pass) LSP read-only access outside request cwd > #given an outside file #when resolving a mutating path #then still rejects to keep writes confined [0.66ms]
+
+packages/lsp-core/src/lsp/workspace-edit-adversarial.test.ts:
+(pass) workspace edit adversarial inputs > #given malformed and decorated URIs #when planned #then every variant is rejected before mutation [0.72ms]
+(pass) workspace edit adversarial inputs > #given invalid ranges and resource options #when planned #then each failure retains its operation index [0.66ms]
+(pass) workspace edit adversarial inputs > #given an outside target and a dirty unrelated file #when prevalidation fails #then neither is touched [0.61ms]
+(pass) workspace edit adversarial inputs > #given an in-workspace symlink to an outside file #when applying an edit #then rejects without modifying target [0.50ms]
+(pass) workspace edit adversarial inputs > #given annotations or mixed edit representations #when planned #then unsupported claims are rejected [0.23ms]
+
+packages/lsp-core/src/lsp/server-installation.test.ts:
+(pass) resolveServerBinary node marker resolution > #given a package.json marker and a local node bin #when resolving with an empty PATH #then it returns the local absolute path [0.91ms]
+(pass) resolveServerBinary node marker resolution > #given a nested working directory #when resolving #then it walks up to the marker root [0.96ms]
+(pass) resolveServerBinary node marker resolution > #given a local bin without any project marker #when resolving #then the unmarked directory is not trusted [0.88ms]
+(pass) resolveServerBinary node marker resolution > #given a bun.lock marker #when resolving #then the node bin directory is probed [0.58ms]
+(pass) resolveServerBinary non-node ecosystems > #given a pyproject marker and a venv binary #when resolving #then it returns the venv path [0.47ms]
+(pass) resolveServerBinary non-node ecosystems > #given a Gemfile marker and a bundled binary #when resolving #then it returns the vendored bundle path [0.65ms]
+(pass) resolveServerBinary non-node ecosystems > #given a go.mod marker and a project bin #when resolving #then it returns the project bin path [0.42ms]
+(pass) resolveServerBinary non-node ecosystems > #given a python marker without a matching venv binary #when resolving #then node bin dirs are not borrowed [0.78ms]
+(pass) resolveServerBinary probe ordering > #given a local binary and a PATH binary #when resolving #then the local binary wins [0.77ms]
+(pass) resolveServerBinary probe ordering > #given only a PATH binary #when resolving #then the PATH entry is returned [1.01ms]
+(pass) resolveServerBinary probe ordering > #given a path-shaped command #when resolving #then the command path itself is validated [0.47ms]
+(pass) resolveServerBinary probe ordering > #given no working directory #when resolving #then it falls back to PATH only [0.34ms]
+(pass) resolveServerBinary probe ordering > #given nothing anywhere #when resolving #then it returns null [0.51ms]
+(pass) resolveServerBinary containment > #given a marker only above the working directory root #when resolving with a stop boundary #then it does not escape the boundary [0.85ms]
+(pass) resolveServerBinary containment > #given a git repository boundary #when resolving #then the walk stops at the repository root [0.77ms]
+(pass) resolveServerBinary windows suffix probing > #given a windows platform and a .cmd shim #when resolving locally #then the suffixed binary is found [0.55ms]
+(pass) resolveServerBinary windows suffix probing > #given a windows platform and a PATH .exe #when resolving #then the suffixed PATH entry is found [0.28ms]
+(pass) resolveServerBinary caching > #given a repeated lookup #when resolving twice #then the filesystem is probed only once [0.48ms]
+(pass) resolveServerBinary caching > #given a cached negative lookup #when resolving twice #then the miss is also cached [0.55ms]
+(pass) resolveServerBinary caching > #given distinct working directories #when resolving the same command #then the cache keys stay separate [0.92ms]
+(pass) isServerInstalled compatibility > #given a repo-local binary #when checking installation #then it reports installed [0.51ms]
+(pass) isServerInstalled compatibility > #given a PATH binary and no working directory #when checking installation #then it reports installed [0.27ms]
+(pass) isServerInstalled compatibility > #given no binary at all #when checking installation #then it reports not installed [0.40ms]
+(pass) isServerInstalled compatibility > #given the node command #when checking installation #then the existing node allowance is preserved [0.37ms]
+(pass) resolveServerBinary node fallback > #given a node command missing from PATH #when resolving #then the name is kept so the server stays selectable [0.35ms]
+(pass) resolveServerBinary node fallback > #given a node command present on PATH #when resolving #then the PATH entry still wins [0.26ms]
+
+packages/lsp-core/src/lsp/workspace-edit-commit.test.ts:
+(pass) workspace edit commit barrier > #given cancellation before commit #when a valid plan is applied #then no mutation begins [0.70ms]
+(pass) workspace edit commit barrier > #given repeated pre-gate interruptions #when retried #then every attempt leaves the snapshot untouched [0.56ms]
+(pass) workspace edit commit barrier > #given cancellation after the first write #when commit has crossed the barrier #then all operations finish once [0.90ms]
+(pass) workspace edit commit barrier > #given an injected write failure #when commit begins #then the result reports real I/O failure [0.47ms]
+(pass) workspace edit commit barrier > #given a stale file snapshot #when a prepared plan commits #then the newer bytes are preserved [0.41ms]
+
+packages/lsp-core/src/lsp/client-wrapper.test.ts:
+(pass) LSP client path confinement > #given a relative file inside context cwd #when resolving workspace #then marker search stays inside cwd [0.97ms]
+(pass) LSP client path confinement > #given an absolute file outside context cwd #when resolving #then infers the file's own project root [1.08ms]
+(pass) LSP client path confinement > #given a symlink inside cwd that points outside #when resolving read path #then keeps lexical path and cwd root [0.85ms]
+(pass) LSP client path confinement > #given an absolute macOS alias path through an outside symlink #when resolving read path #then preserves the lexical suffix [0.66ms]
+(pass) LSP client path confinement > #given missing parent directories without markers #when resolving workspace #then uses an existing directory [0.31ms]
+(pass) LSP client path confinement > #given a symlink inside cwd that points outside #when starting rename #then rejects before client acquisition [0.59ms]
+
+packages/lsp-core/src/lsp/workspace-apply-edit-lease.integration.test.ts:
+(pass) LspClient workspace mutation lease > #given no mutating request #when the server calls applyEdit #then the request is rejected as unscoped [55.94ms]
+(pass) LspClient workspace mutation lease > #given one valid server apply #when the server applies twice #then the repeated request is rejected [40.42ms]
+(pass) LspClient workspace mutation lease > #given two concurrent server applies #when one enters commit #then the other is rejected without a second write [42.64ms]
+(pass) LspClient workspace mutation lease > #given a rename lease is held #when another rename starts #then it is rejected without a second request [191.32ms]
+(pass) LspClient workspace mutation lease > #given no server apply #when rename directly returns an edit #then it is applied exactly once [48.47ms]
+(pass) LspClient workspace mutation lease > #given cancellation before a delayed server apply #when the rename request is aborted #then no file is mutated [79.16ms]
+(pass) LspClient workspace mutation lease > #given cancellation after the commit gate #when applyEdit finishes #then rename reports one completed late-abort mutation [40.80ms]
+(pass) LspClient workspace mutation lease > #given lease-backed and bare clients #when initialized #then applyEdit and annotations are advertised honestly [82.45ms]
+
+packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts:
+(pass) LspClient diagnostics freshness > #given a versionless publish that arrives after the current change #when no newer eligible publish arrives before quiescence #then diagnostics wait for that quiescence window and return the versionless payload [61.46ms]
+(pass) LspClient diagnostics freshness > #given only a pre-generation versionless publish #when a newer local version asks for diagnostics #then the stale versionless publish is ignored and the request does not resolve clean [363.72ms]
+(pass) LspClient diagnostics freshness > #given stale and future publish versions #when diagnostics target the current version #then neither stale nor future diagnostics satisfy the request [307.55ms]
+(pass) LspClient diagnostics freshness > #given a pull response overtaken by a later local change #when the stale full report returns first #then diagnostics restart within the same request and resolve from the current version [237.67ms]
+(pass) LspClient diagnostics freshness > #given a full pull report followed by an unchanged report for the same version and resultId #when diagnostics repeat without a local change #then the cached full items are reused [48.51ms]
+[lsp] ignored connection error notification failure during cleanup: Cannot call write after a stream was destroyed
+[lsp] ignored shutdown request failure during cleanup: LSP server workspace-edit-fixture at /var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/lsp-apply-edit-As5sVK exited with code 0
+(pass) LspClient diagnostics freshness > #given a server that claims pull support but closes instead of answering #when diagnostics run #then the transport failure is not labeled clean [552.70ms]
+(pass) LspClient diagnostics freshness > #given an advertised pull method that is explicitly unsupported and a matching push publish #when diagnostics run #then the client falls back to push diagnostics [545.13ms]
+(pass) LspClient diagnostics freshness > #given a diagnostic pull request times out #when the fake server keeps it pending #then the client sends cancel for the LSP request id [103.04ms]
+(pass) LspClient diagnostics freshness > #given a server without pull support that never publishes diagnostics #when diagnostics run on a clean file #then the request resolves clean after the freshness window instead of reporting a timeout [108.89ms]
+(pass) LspClient diagnostics freshness > #given a pull-supported server that cached diagnostics for an older document version #when the file changes and a later pull is rejected as unsupported without any publish #then the fallback resolves empty instead of returning the stale cached diagnostics [545.19ms]
+(pass) LspClient diagnostics freshness > #given a pull-supported server with a current cached pull report #when a later pull is rejected as unsupported without any publish and the document is unchanged #then the fallback resolves with the current cached diagnostics [544.51ms]
+
+packages/lsp-core/src/lsp/workspace-edit-options.test.ts:
+(pass) applyWorkspaceEdit resource options > #given create ignoreIfExists #when the target exists #then existing bytes are preserved [0.79ms]
+(pass) applyWorkspaceEdit resource options > #given rename ignoreIfExists #when the destination exists #then both files are preserved [0.76ms]
+(pass) applyWorkspaceEdit resource options > #given rename overwrite #when the destination exists #then source replaces destination [0.72ms]
+(pass) applyWorkspaceEdit resource options > #given delete ignoreIfNotExists #when the target is missing #then it is a successful no-op [0.30ms]
+(pass) applyWorkspaceEdit resource options > #given recursive delete #when the target is a non-empty directory #then the subtree is removed [0.64ms]
+
+packages/lsp-core/src/lsp/workspace-apply-edit-sync.integration.test.ts:
+(pass) LspClient workspace edit synchronization > #given an open edited document #when applyEdit commits #then didChange precedes didSave with the next version [42.19ms]
+(pass) LspClient workspace edit synchronization > #given an open file resource rename #when applyEdit commits #then didClose and didOpen move document state [43.98ms]
+(pass) LspClient workspace edit synchronization > #given an open file deletion #when applyEdit commits #then didClose removes document state [45.72ms]
+(pass) LspClient workspace edit synchronization > #given a closed edited file #when applyEdit commits #then one changed watched-file event is emitted [40.11ms]
+(pass) LspClient workspace edit synchronization > #given a new closed file #when applyEdit creates it #then one created watched-file event is emitted [43.06ms]
+(pass) LspClient workspace edit synchronization > #given an open file overwritten by create #when applyEdit commits #then didClose and didOpen reset its state [37.44ms]
+
+packages/lsp-core/src/lsp/server-resolution-local-binary.test.ts:
+(pass) findServerForExtension local binary substitution > #given a repo-local biome #when looking up a typescript file #then the command spawns the absolute local path [2.11ms]
+(pass) findServerForExtension local binary substitution > #given a PATH-only server #when looking up #then the resolved PATH entry is substituted [1.52ms]
+(pass) findServerForExtension local binary substitution > #given no server anywhere #when looking up #then the not_installed result is preserved [1.18ms]
+(pass) findServerForExtension local binary substitution > #given an unknown extension #when looking up #then the not_configured result is preserved [0.25ms]
+(pass) not-installed message repo-local guidance > #given a missing biome #when formatting the message #then the repo-local install is suggested before the global hint [0.63ms]
+(pass) not-installed message repo-local guidance > #given a server with no repo-local route #when formatting the message #then only the global hint is shown [0.46ms]
+(pass) not-installed message repo-local guidance > #given a pre-authorized install #when formatting the message #then both install routes stay visible [0.96ms]
+
+packages/lsp-core/src/lsp/json-rpc-connection-cancellation.test.ts:
+(pass) JsonRpcConnection cancellation > #given an active request #when its signal aborts #then cancel uses the same id and late responses are ignored [0.88ms]
+
+packages/lsp-core/src/lsp/format-document.test.ts:
+(pass) formatDocumentWithClient > #given a server returning text edits #when the document is formatted #then the file is rewritten and line deltas are reported [0.78ms]
+(pass) formatDocumentWithClient > #given a server returning an edit that adds lines #when the document is formatted #then the added and removed line counts differ [0.43ms]
+(pass) formatDocumentWithClient > #given a server that does not advertise document formatting #when the document is formatted #then the result is unavailable and the file bytes are untouched [0.29ms]
+(pass) formatDocumentWithClient > #given a server returning no edits #when the document is formatted #then the result is unchanged and the file bytes are untouched [0.29ms]
+(pass) formatDocumentWithClient > #given edits that reproduce the current bytes #when the document is formatted #then the result is unchanged [0.32ms]
+(pass) formatDocumentWithClient > #given a formatted document #when the write completes #then no temporary file is left behind [0.49ms]
+
+packages/lsp-core/src/lsp/client-diagnostics-concurrency.integration.test.ts:
+(pass) LspClient diagnostics concurrency > #given concurrent diagnostics on a cold file and an exact didOpen publish #when pull is not advertised #then one didOpen opens the file and both requests receive the current diagnostics [41.04ms]
+
+packages/lsp-core/src/lsp/cleanup-errors.test.ts:
+(pass) reportBestEffortCleanupError > #given an injected cleanup logger #when cleanup fails #then the normal diagnostic is emitted without an environment gate [0.17ms]
+
+packages/lsp-core/src/lsp/workspace-edit-prevalidation.test.ts:
+(pass) applyWorkspaceEdit prevalidation > #given a valid edit before an overlapping edit #when validated #then neither file is mutated [0.89ms]
+(pass) applyWorkspaceEdit prevalidation > #given byte-identical non-empty edits #when applied #then one edit is committed [0.52ms]
+(pass) applyWorkspaceEdit prevalidation > #given equal-position insertions #when applied #then all insertions retain declared order [0.45ms]
+(pass) applyWorkspaceEdit prevalidation > #given a range beyond the snapshot #when validated #then the edit fails without mutation [0.38ms]
+(pass) applyWorkspaceEdit prevalidation > #given a create followed by an invalid edit #when the sequence is validated #then no file is created [0.32ms]
+(pass) applyWorkspaceEdit prevalidation > #given rename then text edit of the destination #when applied #then declared order uses virtual state [0.58ms]
+
+packages/lsp-core/src/lsp/workspace-edit.characterization.test.ts:
+(pass) applyWorkspaceEdit preserved behavior > #given a valid text edit #when applied #then the file and ApplyResult remain compatible [0.78ms]
+(pass) applyWorkspaceEdit preserved behavior > #given a resource rename #when applied #then content moves and the destination is reported [0.56ms]
+(pass) applyWorkspaceEdit preserved behavior > #given an empty workspace edit #when applied #then it remains a successful no-op [0.20ms]
+(pass) applyWorkspaceEdit preserved behavior > #given no workspace edit #when applied #then the existing failure remains explicit [0.17ms]
+
+packages/lsp-core/src/lsp/workspace-edit-contract-evidence.test.ts:
+(pass) workspace edit contract evidence > #given both legitimate concurrent applyEdit lease outcomes #when failure evidence is hashed #then one canonical shape and hash is produced [0.19ms]
+(pass) workspace edit contract evidence > #given workspace-scoped evidence and a non-concurrent failure #when normalized #then paths are sanitized and the reason is preserved [0.09ms]
+
+packages/lsp-core/src/post-edit/orchestration.test.ts:
+(pass) collectPostEditDiagnostics > #given rendered not_configured text #when the same extension is checked again #then the text is not cached [0.39ms]
+(pass) collectPostEditDiagnostics > #given duplicate edited paths #when diagnostics run #then first seen paths are processed once and blocks stay ordered [0.12ms]
+(pass) collectPostEditDiagnostics > #given many edited paths #when diagnostics run #then concurrency is bounded to four and failures isolate [0.17ms]
+(pass) collectPostEditDiagnostics > #given structured not_configured diagnostics #when cache is reused and reset #then only not_configured is cached [0.14ms]
+(pass) collectPostEditDiagnostics > #given non-not_configured failures #when cache is reused #then every failure retries [0.12ms]
+
+ 145 pass
+ 0 fail
+ 379 expect() calls
+Ran 145 tests across 28 files. [5.49s]

--- a/.omo/evidence/20260827-format-capability/green-03-daemon.log
+++ b/.omo/evidence/20260827-format-capability/green-03-daemon.log
@@ -1,0 +1,17 @@
+
+ RUN  v4.1.8 /Volumes/mengmotaStorage/local-workspaces/omo-wt/feature/lsp-format-capability/packages/lsp-daemon
+
+error: write EPIPE
+   errno: -32,
+ syscall: "write",
+    code: "EPIPE"
+
+      at failWrite (node:net:53:30)
+      at processTicksAndRejections (native:7:39)
+[lsp-daemon] startup diagnostic failed: synthetic diagnostic failure
+
+ Test Files  21 passed (21)
+      Tests  158 passed (158)
+   Start at  17:48:16
+   Duration  1.52s (transform 8.30s, setup 0ms, import 11.10s, tests 1.30s, environment 3ms)
+

--- a/.omo/evidence/20260827-format-capability/red-01-manager-cap.log
+++ b/.omo/evidence/20260827-format-capability/red-01-manager-cap.log
@@ -1,0 +1,51 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/lsp-core/src/lsp/manager-max-clients.test.ts:
+71 | 			// when
+72 | 			await manager.getClient("/root-c", SERVER);
+73 | 			manager.releaseClient("/root-c", SERVER.id);
+74 | 
+75 | 			// then
+76 | 			expect(manager.clientCount()).toBe(2);
+                                      ^
+error: expect(received).toBe(expected)
+
+Expected: 2
+Received: 3
+
+      at <anonymous> (/Volumes/mengmotaStorage/local-workspaces/omo-wt/feature/lsp-format-capability/packages/lsp-core/src/lsp/manager-max-clients.test.ts:76:34)
+(fail) LspManager resident client cap > #given a cap of two idle clients #when a third client is admitted #then the least recently used one is stopped and evicted [2.82ms]
+ 97 | 			await manager.getClient("/root-new", SERVER);
+ 98 | 			manager.releaseClient("/root-new", SERVER.id);
+ 99 | 
+100 | 			// then
+101 | 			expect(manager.hasClient("/root-busy", SERVER.id)).toBe(true);
+102 | 			expect(manager.hasClient("/root-idle", SERVER.id)).toBe(false);
+                                                            ^
+error: expect(received).toBe(expected)
+
+Expected: false
+Received: true
+
+      at <anonymous> (/Volumes/mengmotaStorage/local-workspaces/omo-wt/feature/lsp-format-capability/packages/lsp-core/src/lsp/manager-max-clients.test.ts:102:55)
+(fail) LspManager resident client cap > #given the least recently used client is mid-request #when a new client is admitted #then the busy client survives and an idle one is evicted [0.28ms]
+(pass) LspManager resident client cap > #given every resident client is busy #when a new client is admitted #then nothing is evicted and the cap is exceeded rather than breaking a live request [0.13ms]
+139 | 			manager.warmupClient("/root-warm", SERVER);
+140 | 			await Promise.resolve();
+141 | 			await Promise.resolve();
+142 | 
+143 | 			// then
+144 | 			expect(manager.hasClient("/root-first", SERVER.id)).toBe(false);
+                                                             ^
+error: expect(received).toBe(expected)
+
+Expected: false
+Received: true
+
+      at <anonymous> (/Volumes/mengmotaStorage/local-workspaces/omo-wt/feature/lsp-format-capability/packages/lsp-core/src/lsp/manager-max-clients.test.ts:144:56)
+(fail) LspManager resident client cap > #given warmup requests beyond the cap #when a warm client is admitted #then the idle least recently used client is evicted too [0.26ms]
+
+ 1 pass
+ 3 fail
+ 6 expect() calls
+Ran 4 tests across 1 file. [1076.00ms]

--- a/.omo/evidence/20260827-format-capability/red-02-format.log
+++ b/.omo/evidence/20260827-format-capability/red-02-format.log
@@ -1,0 +1,22 @@
+bun test v1.4.0-canary.1 (b58cd4685)
+
+packages/lsp-core/src/tools/format.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+error: Cannot find module './format.js' from '/Volumes/mengmotaStorage/local-workspaces/omo-wt/feature/lsp-format-capability/packages/lsp-core/src/tools/format.test.ts'
+-------------------------------
+
+
+packages/lsp-core/src/lsp/format-document.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+error: Cannot find module './format-document.js' from '/Volumes/mengmotaStorage/local-workspaces/omo-wt/feature/lsp-format-capability/packages/lsp-core/src/lsp/format-document.test.ts'
+-------------------------------
+
+
+ 0 pass
+ 2 fail
+ 2 errors
+Ran 2 tests across 2 files. [966.00ms]

--- a/.omo/evidence/20260827-format-capability/red-03-daemon-client-surface.log
+++ b/.omo/evidence/20260827-format-capability/red-03-daemon-client-surface.log
@@ -1,0 +1,250 @@
+
+ RUN  v4.1.8 /Volumes/mengmotaStorage/local-workspaces/omo-wt/feature/lsp-format-capability/packages/lsp-daemon
+
+ ❯ test/client-surface.test.ts (10 tests | 2 failed) 12ms
+     × #given the client source #when reviewing public exports #then server proxy ownership and lock internals stay private 7ms
+     × #given the public format entry point #when a caller omits context #then rejection happens before daemon dispatch 1ms
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  test/client-surface.test.ts > public client package surface > #given the client source #when reviewing public exports #then server proxy ownership and lock internals stay private
+AssertionError: expected 'import {\n\tcallDiagnosticsViaDaemon …' to contain 'callFormatViaDaemon'
+
+- Expected
++ Received
+
+- callFormatViaDaemon
++ import {
++ 	callDiagnosticsViaDaemon as callDiagnosticsViaDaemonInternal,
++ 	callToolViaDaemon as callToolViaDaemonInternal,
++ 	currentRequestContext as currentRequestContextInternal,
++ } from "./daemon-client.js";
++ import { statSync } from "node:fs";
++ import { isAbsolute } from "node:path";
++
++ export const OMO_LSP_DAEMON_DIR = "OMO_LSP_DAEMON_DIR";
++ export const OMO_LSP_DAEMON_CLI = "OMO_LSP_DAEMON_CLI";
++ export const OMO_LSP_DAEMON_VERSION = "OMO_LSP_DAEMON_VERSION";
++
++ const DAEMON_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/;
++
++ export type DaemonRuntime = {
++ 	readonly cliPath: string;
++ 	readonly version: string;
++ };
++
++ export type DaemonRuntimeDefaults = DaemonRuntime;
++
++ export type InvalidRuntimeOverrideReason =
++ 	| "paired_values_required"
++ 	| "cli_must_be_absolute"
++ 	| "cli_not_found"
++ 	| "cli_not_file"
++ 	| "packaged_cli_must_be_absolute";
++
++ export class InvalidRuntimeOverrideError extends Error {
++ 	readonly code = "invalid_runtime_override";
++ 	readonly reason: InvalidRuntimeOverrideReason;
++
++ 	constructor(reason: InvalidRuntimeOverrideReason, message: string) {
++ 		super(message);
++ 		this.name = "InvalidRuntimeOverrideError";
++ 		this.reason = reason;
++ 	}
++ }
++
++ export function validateDaemonVersion(version: string): string {
++ 	if (!DAEMON_VERSION_PATTERN.test(version)) {
++ 		throw new Error("LSP daemon version must match [A-Za-z0-9][A-Za-z0-9._+-]{0,127}");
++ 	}
++ 	return version;
++ }
++
++ export function resolveDaemonRuntime(
++ 	env: Record<string, string | undefined>,
++ 	defaults: DaemonRuntimeDefaults,
++ ): DaemonRuntime {
++ 	const cliOverride = env[OMO_LSP_DAEMON_CLI];
++ 	const versionOverride = env[OMO_LSP_DAEMON_VERSION];
++ 	const hasCliOverride = cliOverride !== undefined;
++ 	const hasVersionOverride = versionOverride !== undefined;
++
++ 	if (hasCliOverride !== hasVersionOverride) {
++ 		throw new InvalidRuntimeOverrideError(
++ 			"paired_values_required",
++ 			`${OMO_LSP_DAEMON_CLI} and ${OMO_LSP_DAEMON_VERSION} must be set together`,
++ 		);
++ 	}
++
++ 	if (!hasCliOverride || !hasVersionOverride) {
++ 		if (!isAbsolute(defaults.cliPath)) {
++ 			throw new InvalidRuntimeOverrideError(
++ 				"packaged_cli_must_be_absolute",
++ 				"Packaged LSP daemon CLI path must be absolute",
++ 			);
++ 		}
++ 		return { cliPath: defaults.cliPath, version: validateDaemonVersion(defaults.version) };
++ 	}
++
++ 	if (!isAbsolute(cliOverride)) {
++ 		throw new InvalidRuntimeOverrideError(
++ 			"cli_must_be_absolute",
++ 			`${OMO_LSP_DAEMON_CLI} must be an absolute path to an existing regular file`,
++ 		);
++ 	}
++
++ 	const stat = statSync(cliOverride, { throwIfNoEntry: false });
++ 	if (!stat) {
++ 		throw new InvalidRuntimeOverrideError("cli_not_found", `${OMO_LSP_DAEMON_CLI} points to a missing file`);
++ 	}
++ 	if (!stat.isFile()) {
++ 		throw new InvalidRuntimeOverrideError("cli_not_file", `${OMO_LSP_DAEMON_CLI} must point to a regular file`);
++ 	}
++
++ 	return { cliPath: cliOverride, version: validateDaemonVersion(versionOverride) };
++ }
++
++ export type LspRequestCapabilities = {
++ 	readonly installDecisionTool: boolean;
++ };
++
++ export type LspRequestContext = {
++ 	readonly cwd: string;
++ 	readonly projectConfigPaths: readonly string[];
++ 	readonly userConfigPath: string;
++ 	readonly installDecisionsPath: string;
++ 	readonly capabilities: LspRequestCapabilities;
++ };
++
++ export type DaemonToolContext = LspRequestContext;
++
++ export type CallToolOptions = {
++ 	readonly context: DaemonToolContext;
++ 	readonly requestTimeoutMs?: number;
++ 	readonly signal?: AbortSignal;
++ };
++
++ export type TextContent = {
++ 	readonly type: "text";
++ 	readonly text: string;
++ };
++
++ export type ToolExecutionResult = {
++ 	readonly content: readonly TextContent[];
++ 	readonly isError?: boolean;
++ 	readonly details?: unknown;
++ };
++
++ export type SeverityFilter = "error" | "warning" | "information" | "hint" | "all";
++
++ export type LspDiagnosticsDetails = {
++ 	readonly filePath: string;
++ 	readonly severity: SeverityFilter;
++ 	readonly mode: "file" | "directory";
++ 	readonly diagnostics: readonly unknown[];
++ 	readonly totalDiagnostics: number;
++ 	readonly truncated: boolean;
++ 	readonly error?: string;
++ 	readonly errorKind?: "freshness_timeout" | "missing_dependency" | "no_files" | "invalid_path";
++ 	readonly fileFailures?: readonly { readonly file: string; readonly error: string }[];
++ };
++
++ export type LspGotoDefinitionDetails = {
++ 	readonly filePath: string;
++ 	readonly line: number;
++ 	readonly character: number;
++ 	readonly locations: readonly unknown[];
++ 	readonly error?: string;
++ 	readonly errorKind?: "missing_dependency";
++ };
++
++ export type LspFindReferencesDetails = {
++ 	readonly filePath: string;
++ 	readonly line: number;
++ 	readonly character: number;
++ 	readonly references: readonly unknown[];
++ 	readonly totalReferences: number;
++ 	readonly truncated: boolean;
++ 	readonly error?: string;
++ 	readonly errorKind?: "missing_dependency";
++ };
++
++ export type LspSymbolsDetails = {
++ 	readonly filePath: string;
++ 	readonly scope: "document" | "workspace";
++ 	readonly query?: string;
++ 	readonly symbols: readonly unknown[];
++ 	readonly totalSymbols: number;
++ 	readonly truncated: boolean;
++ 	readonly error?: string;
++ 	readonly errorKind?: "missing_dependency" | "missing_query";
++ };
++
++ export type LspPrepareRenameDetails = {
++ 	readonly filePath: string;
++ 	readonly line: number;
++ 	readonly character: number;
++ 	readonly result: unknown;
++ 	readonly error?: string;
++ 	readonly errorKind?: "missing_dependency";
++ };
++
++ export type LspRenameDetails = {
++ 	readonly filePath: string;
++ 	readonly line: number;
++ 	readonly character: number;
++ 	readonly newName: string;
++ 	readonly apply: unknown;
++ 	readonly edit: unknown;
++ 	readonly error?: string;
++ 	readonly errorKind?: "missing_dependency";
++ };
++
++ export function callToolViaDaemon(
++ 	name: string,
++ 	args: Record<string, unknown>,
++ 	options: CallToolOptions,
++ ): Promise<ToolExecutionResult> {
++ 	return callToolViaDaemonInternal(name, args, options);
++ }
++
++ export function callDiagnosticsViaDaemon(
++ 	filePath: string,
++ 	options: CallToolOptions,
++ ): Promise<ToolExecutionResult> {
++ 	return callDiagnosticsViaDaemonInternal(filePath, options);
++ }
++
++ export function currentRequestContext(env: Record<string, string | undefined> = process.env): DaemonToolContext {
++ 	return currentRequestContextInternal(env);
++ }
++
+
+ ❯ test/client-surface.test.ts:27:24
+     25|   expect(clientSource).toContain("callToolViaDaemon");
+     26|   expect(clientSource).toContain("callDiagnosticsViaDaemon");
+     27|   expect(clientSource).toContain("callFormatViaDaemon");
+       |                        ^
+     28|   expect(clientSource).toContain("OMO_LSP_DAEMON_CLI");
+     29|   expect(clientSource).not.toContain("runMcpStdioProxy");
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
+
+ FAIL  test/client-surface.test.ts > public client package surface > #given the public format entry point #when a caller omits context #then rejection happens before daemon dispatch
+TypeError: Function.prototype.apply was called on undefined, which is undefined and not a function
+ ❯ test/client-surface.test.ts:40:24
+     38|   const paths = daemonTestPaths(fileURLToPath(new URL("client-surface-…
+     39|
+     40|   await expect(Reflect.apply(callFormatViaDaemon, undefined, ["/a.ts",…
+       |                        ^
+     41|    /context/i,
+     42|   );
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
+
+
+ Test Files  1 failed | 1 passed (2)
+      Tests  2 failed | 23 passed (25)
+   Start at  17:46:52
+   Duration  958ms (transform 815ms, setup 0ms, import 942ms, tests 21ms, environment 0ms)
+

--- a/.omo/plans/20260827-lsp-format-capability.md
+++ b/.omo/plans/20260827-lsp-format-capability.md
@@ -1,0 +1,58 @@
+# Plan: LSP formatting execution path + daemon format request + LspManager LRU cap
+
+Design contract: `documents/omo-format-hook-design-20260827/DESIGN.md` section 5.2 step 1 (daemon-first
+formatting via `textDocument/formatting`) and section 5.6 rule 3 (`maxResidentClients` LRU cap).
+Memory-safety binding: no new resident processes. Formatting reuses the resident client the diagnostics
+path already warms; the cap only reduces residency.
+
+Scope: `packages/lsp-core/**` and `packages/lsp-daemon/**` plus their tests. Out of scope: omo-senpi,
+comment-checker, config schemas, CLI formatter fallbacks, server-installation internals.
+
+## Atomic steps
+
+1. **RED: manager LRU cap test** (`packages/lsp-core/src/lsp/manager-max-clients.test.ts`)
+   - cap 2, three distinct roots -> the least-recently-used idle client is stopped and dropped,
+     the newest is resident, `clientCount() === 2`.
+   - a client with `refCount > 0` (mid-request) is never evicted.
+   - Verification: `bun test packages/lsp-core/src/lsp/manager-max-clients.test.ts` fails first.
+
+2. **GREEN: `maxResidentClients` in `LspManager`** (default 6)
+   - Evict before admitting a new client in `getClient` and `warmupClient`.
+   - Eviction candidate: `refCount === 0 && pendingWaiters === 0 && !isInitializing`, lowest `lastUsedAt`.
+   - Idle reaper untouched.
+
+3. **RED: `formatDocument` tests** (`packages/lsp-core/src/lsp/format-document.test.ts`)
+   - stubbed client returning TextEdits -> file rewritten, `{status:"formatted", linesAdded, linesRemoved}`.
+   - server without `documentFormattingProvider` -> `{status:"unavailable", reason:"capability_not_advertised"}`
+     and the file bytes are unchanged (byte compare).
+   - server returning no edits / identical text -> `{status:"unchanged"}`.
+
+4. **GREEN: `formatDocument`** (`packages/lsp-core/src/lsp/format-document.ts`)
+   - `LspClient.formatDocument(filePath, options, signal)`: open/sync doc, capability gate,
+     `textDocument/formatting`, return raw TextEdits or `null` when unsupported.
+   - `LspClientTransport` records `documentFormattingProvider` from the initialize result.
+   - Apply edits with the existing `normalizeTextEdits` helper; write via temp file + rename (atomic).
+   - Line deltas computed from the normalized edits (before/after text of the edited spans).
+
+5. **GREEN: `format` tool** (`packages/lsp-core/src/tools/format.ts` + definitions + types + index)
+   - Missing server reuses `missingDependencyResult` (existing `not_installed` shape).
+   - Update the pinned tool-surface test with the new descriptor.
+
+6. **RED then GREEN: daemon routing + client surface**
+   - `packages/lsp-daemon/test/request-routing.test.ts`: a `format` tools/call reaches the core handler.
+   - `packages/lsp-daemon/src/client.ts`: `callFormatViaDaemon` + `LspFormatDetails` mirror of the
+     core detail type; `client-surface.test.ts` pins it.
+   - Protocol bookkeeping: format is an MCP tool like every other request, so
+     `OMO_DAEMON_PROTOCOL_VERSION` stays 1 (no envelope change). The proxy protocol pin test covers it.
+
+7. **QA + evidence**: `.omo/evidence/20260827-format-capability/`
+   - lsp-core unit gate, lsp-daemon vitest gate, repo typecheck.
+   - Live daemon QA: real `omo-lsp-daemon` over its unix socket, real `biome` LSP resolved repo-locally,
+     `format` request against a drifted fixture file; capture the request/response and file before/after,
+     plus a resident-process count proving no extra resident process.
+
+## Verification per step
+
+- Steps 1-5: `bun test packages/lsp-core`
+- Step 6: `npm --prefix packages/lsp-daemon test`
+- Step 7: `bun run typecheck`, live daemon driver output under the evidence dir.

--- a/packages/lsp-core/src/index.ts
+++ b/packages/lsp-core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./lsp/constants.js";
 export * from "./lsp/directory-diagnostics.js";
 export * from "./lsp/effective-extension.js";
 export * from "./lsp/errors.js";
+export * from "./lsp/format-document.js";
 export * from "./lsp/formatters.js";
 export * from "./lsp/infer-extension.js";
 export * from "./lsp/json-rpc-connection.js";

--- a/packages/lsp-core/src/lsp/client.ts
+++ b/packages/lsp-core/src/lsp/client.ts
@@ -6,6 +6,7 @@ import type { LspClientTimeoutOptions } from "./transport.js";
 import type {
 	Diagnostic,
 	DocumentSymbol,
+	FormattingOptions,
 	Location,
 	LocationLink,
 	PrepareRenameDefaultBehavior,
@@ -13,6 +14,7 @@ import type {
 	Range,
 	ResolvedServer,
 	SymbolInfo,
+	TextEdit,
 	WorkspaceEdit,
 } from "./types.js";
 import { LspRequestTimeoutError } from "./errors.js";
@@ -131,6 +133,30 @@ export class LspClient extends LspClientConnection {
 		return this.sendRequest<Array<DocumentSymbol | SymbolInfo>>("textDocument/documentSymbol", {
 			textDocument: { uri: pathToFileURL(absPath).href },
 		}, options);
+	}
+
+	/**
+	 * Requests whole-document formatting edits, returning null when the server never advertised the
+	 * capability so callers can report unavailability instead of surfacing a method-not-found error.
+	 */
+	async formatDocument(
+		filePath: string,
+		options: FormattingOptions,
+		signal?: AbortSignal,
+	): Promise<TextEdit[] | null> {
+		if (!this.isDocumentFormattingSupported()) return null;
+		const absPath = this.resolveWorkspacePath(filePath);
+		await this.openFile(absPath);
+		const requestOptions = signal === undefined ? {} : { signal };
+		const edits = await this.sendRequest<TextEdit[] | null>(
+			"textDocument/formatting",
+			{
+				textDocument: { uri: pathToFileURL(absPath).href },
+				options,
+			},
+			requestOptions,
+		);
+		return edits ?? [];
 	}
 
 	async workspaceSymbols(query: string, signal?: AbortSignal): Promise<SymbolInfo[]> {

--- a/packages/lsp-core/src/lsp/connection.ts
+++ b/packages/lsp-core/src/lsp/connection.ts
@@ -4,11 +4,25 @@ import { LspClientTransport } from "./transport.js";
 
 interface InitializeCapabilities {
 	readonly diagnosticProvider?: unknown;
+	readonly documentFormattingProvider?: unknown;
 }
 
 function supportsDiagnosticPull(capabilities: InitializeCapabilities | undefined): boolean {
 	if (capabilities === undefined) return false;
 	return Object.hasOwn(capabilities, "diagnosticProvider");
+}
+
+/**
+ * Reads the whole-document formatting capability the server advertised at initialize time.
+ *
+ * The provider is either a boolean or an options object, and an explicit `false` means the
+ * server refuses the request, so both shapes are checked instead of mere key presence.
+ */
+function supportsDocumentFormatting(capabilities: InitializeCapabilities | undefined): boolean {
+	if (capabilities === undefined) return false;
+	const provider = capabilities.documentFormattingProvider;
+	if (provider === undefined || provider === null || provider === false) return false;
+	return provider === true || typeof provider === "object";
 }
 
 export class LspClientConnection extends LspClientTransport {
@@ -28,6 +42,7 @@ export class LspClientConnection extends LspClientTransport {
 						references: {},
 						documentSymbol: { hierarchicalDocumentSymbolSupport: true },
 						publishDiagnostics: {},
+						formatting: { dynamicRegistration: false },
 						rename: {
 							prepareSupport: true,
 							prepareSupportDefaultBehavior: 1,
@@ -71,6 +86,7 @@ export class LspClientConnection extends LspClientTransport {
 			{ timeoutMs: this.initializeTimeoutMs },
 		);
 		this.setDiagnosticPullSupported(supportsDiagnosticPull(result?.capabilities));
+		this.setDocumentFormattingSupported(supportsDocumentFormatting(result?.capabilities));
 		await this.sendNotification("initialized", {});
 		await this.sendNotification("workspace/didChangeConfiguration", {
 			settings: { json: { validate: { enable: true } } },

--- a/packages/lsp-core/src/lsp/constants.ts
+++ b/packages/lsp-core/src/lsp/constants.ts
@@ -6,6 +6,7 @@ export const DEFAULT_MAX_DIRECTORY_FILES = 50;
 export const REQUEST_TIMEOUT_MS = 15_000;
 export const INIT_TIMEOUT_MS = 60_000;
 export const IDLE_TIMEOUT_MS = 5 * 60_000;
+export const MAX_RESIDENT_CLIENTS = 6;
 export const REAPER_INTERVAL_MS = 60_000;
 export const STOP_HARD_KILL_TIMEOUT_MS = 5_000;
 export const STOP_SIGKILL_GRACE_MS = 1_000;

--- a/packages/lsp-core/src/lsp/format-document.test.ts
+++ b/packages/lsp-core/src/lsp/format-document.test.ts
@@ -107,6 +107,25 @@ describe("formatDocumentWithClient", () => {
 		expect(readFileSync(filePath, "utf-8")).toBe(original);
 	});
 
+	it("#given the file shrinks after the server computed its edits #when the edits are applied #then the stale edit is rejected instead of corrupting the file", async () => {
+		// given
+		const { filePath } = workspaceWith("sample.ts", "const a=1\nconst b=2\n");
+		const staleEdits: TextEdit[] = [
+			{ range: { start: { line: 1, character: 0 }, end: { line: 1, character: 9 } }, newText: "const b = 2;" },
+		];
+		const racingClient = {
+			async formatDocument() {
+				writeFileSync(filePath, "short\n", "utf-8");
+				return staleEdits;
+			},
+			async openFile() {},
+		} as Pick<LspClient, "formatDocument" | "openFile"> as LspClient;
+
+		// when / then
+		await expect(formatDocumentWithClient(racingClient, filePath)).rejects.toThrow(/outside line/);
+		expect(readFileSync(filePath, "utf-8")).toBe("short\n");
+	});
+
 	it("#given a formatted document #when the write completes #then no temporary file is left behind", async () => {
 		// given
 		const { root, filePath } = workspaceWith("sample.ts", "const a=1\n");

--- a/packages/lsp-core/src/lsp/format-document.test.ts
+++ b/packages/lsp-core/src/lsp/format-document.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+import type { LspClient } from "./client.js";
+import { formatDocumentWithClient } from "./format-document.js";
+import type { TextEdit } from "./types.js";
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) rmSync(workspace, { recursive: true, force: true });
+});
+
+function workspaceWith(fileName: string, content: string): { readonly root: string; readonly filePath: string } {
+	const root = mkdtempSync(join(tmpdir(), "lsp-format-"));
+	workspaces.push(root);
+	const filePath = join(root, fileName);
+	writeFileSync(filePath, content, "utf-8");
+	return { root, filePath };
+}
+
+function stubClient(edits: TextEdit[] | null): LspClient {
+	return {
+		async formatDocument() {
+			return edits;
+		},
+		async openFile() {},
+	} as Pick<LspClient, "formatDocument" | "openFile"> as LspClient;
+}
+
+describe("formatDocumentWithClient", () => {
+	it("#given a server returning text edits #when the document is formatted #then the file is rewritten and line deltas are reported", async () => {
+		// given
+		const { filePath } = workspaceWith("sample.ts", "const a=1\nconst b   =2\nconst c=3\n");
+		const edits: TextEdit[] = [
+			{ range: { start: { line: 0, character: 0 }, end: { line: 1, character: 12 } }, newText: "const a = 1;\nconst b = 2;" },
+		];
+
+		// when
+		const result = await formatDocumentWithClient(stubClient(edits), filePath);
+
+		// then
+		expect(result.status).toBe("formatted");
+		expect(readFileSync(filePath, "utf-8")).toBe("const a = 1;\nconst b = 2;\nconst c=3\n");
+		expect(result).toMatchObject({ status: "formatted", linesAdded: 2, linesRemoved: 2 });
+	});
+
+	it("#given a server returning an edit that adds lines #when the document is formatted #then the added and removed line counts differ", async () => {
+		// given
+		const { filePath } = workspaceWith("sample.ts", "const a=1;const b=2\n");
+		const edits: TextEdit[] = [
+			{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 19 } }, newText: "const a = 1;\nconst b = 2;" },
+		];
+
+		// when
+		const result = await formatDocumentWithClient(stubClient(edits), filePath);
+
+		// then
+		expect(result).toMatchObject({ status: "formatted", linesAdded: 2, linesRemoved: 1 });
+		expect(readFileSync(filePath, "utf-8")).toBe("const a = 1;\nconst b = 2;\n");
+	});
+
+	it("#given a server that does not advertise document formatting #when the document is formatted #then the result is unavailable and the file bytes are untouched", async () => {
+		// given
+		const original = "const a=1\n";
+		const { filePath } = workspaceWith("sample.ts", original);
+		const before = statSync(filePath);
+
+		// when
+		const result = await formatDocumentWithClient(stubClient(null), filePath);
+
+		// then
+		expect(result).toEqual({ status: "unavailable", reason: "capability_not_advertised" });
+		expect(readFileSync(filePath)).toEqual(Buffer.from(original));
+		expect(statSync(filePath).mtimeMs).toBe(before.mtimeMs);
+	});
+
+	it("#given a server returning no edits #when the document is formatted #then the result is unchanged and the file bytes are untouched", async () => {
+		// given
+		const original = "const a = 1;\n";
+		const { filePath } = workspaceWith("sample.ts", original);
+
+		// when
+		const result = await formatDocumentWithClient(stubClient([]), filePath);
+
+		// then
+		expect(result).toEqual({ status: "unchanged", linesAdded: 0, linesRemoved: 0 });
+		expect(readFileSync(filePath)).toEqual(Buffer.from(original));
+	});
+
+	it("#given edits that reproduce the current bytes #when the document is formatted #then the result is unchanged", async () => {
+		// given
+		const original = "const a = 1;\n";
+		const { filePath } = workspaceWith("sample.ts", original);
+		const edits: TextEdit[] = [
+			{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 12 } }, newText: "const a = 1;" },
+		];
+
+		// when
+		const result = await formatDocumentWithClient(stubClient(edits), filePath);
+
+		// then
+		expect(result.status).toBe("unchanged");
+		expect(readFileSync(filePath, "utf-8")).toBe(original);
+	});
+
+	it("#given a formatted document #when the write completes #then no temporary file is left behind", async () => {
+		// given
+		const { root, filePath } = workspaceWith("sample.ts", "const a=1\n");
+		const edits: TextEdit[] = [
+			{ range: { start: { line: 0, character: 0 }, end: { line: 0, character: 9 } }, newText: "const a = 1;" },
+		];
+
+		// when
+		await formatDocumentWithClient(stubClient(edits), filePath);
+
+		// then
+		expect(readFileSync(filePath, "utf-8")).toBe("const a = 1;\n");
+		expect(() => statSync(join(root, "sample.ts.tmp"))).toThrow();
+	});
+});

--- a/packages/lsp-core/src/lsp/format-document.ts
+++ b/packages/lsp-core/src/lsp/format-document.ts
@@ -1,0 +1,90 @@
+import { readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+
+import type { LspClient } from "./client.js";
+import type { FormattingOptions, TextEdit } from "./types.js";
+import { normalizeTextEdits } from "./workspace-edit-text.js";
+
+export const DEFAULT_FORMATTING_OPTIONS: FormattingOptions = {
+	tabSize: 4,
+	insertSpaces: false,
+	trimTrailingWhitespace: true,
+	insertFinalNewline: true,
+	trimFinalNewlines: true,
+};
+
+export type FormatDocumentResult =
+	| { readonly status: "formatted"; readonly linesAdded: number; readonly linesRemoved: number }
+	| { readonly status: "unchanged"; readonly linesAdded: 0; readonly linesRemoved: 0 }
+	| { readonly status: "unavailable"; readonly reason: "capability_not_advertised" };
+
+export interface FormatDocumentOptions {
+	readonly formattingOptions?: FormattingOptions;
+	readonly signal?: AbortSignal;
+}
+
+const UNCHANGED: FormatDocumentResult = { status: "unchanged", linesAdded: 0, linesRemoved: 0 };
+
+/**
+ * Formats one document through the resident language server and commits the result to disk.
+ *
+ * The server is asked for whole-document edits rather than formatted text, so the edits are
+ * validated and applied with the same normalization the workspace-edit path uses. Nothing is
+ * written when the server declines the capability or when the edits reproduce the current bytes,
+ * which keeps a no-op format from touching file mtimes that downstream tooling watches.
+ */
+export async function formatDocumentWithClient(
+	client: LspClient,
+	filePath: string,
+	options: FormatDocumentOptions = {},
+): Promise<FormatDocumentResult> {
+	const edits = await client.formatDocument(
+		filePath,
+		options.formattingOptions ?? DEFAULT_FORMATTING_OPTIONS,
+		options.signal,
+	);
+	if (edits === null) return { status: "unavailable", reason: "capability_not_advertised" };
+	if (edits.length === 0) return UNCHANGED;
+
+	const before = readFileSync(filePath, "utf-8");
+	const normalized = normalizeTextEdits(before, edits, 0);
+	if (normalized.text === before) return UNCHANGED;
+
+	writeAtomically(filePath, normalized.text);
+	await client.openFile(filePath);
+
+	return {
+		status: "formatted",
+		...lineDelta(normalized.edits),
+	};
+}
+
+/**
+ * Counts the lines each edit removes from the document and adds back in its place.
+ *
+ * Counting from the edits instead of diffing the whole file keeps the report proportional to what
+ * the server actually rewrote, so an unrelated line never shows up as churn.
+ */
+function lineDelta(edits: readonly TextEdit[]): { readonly linesAdded: number; readonly linesRemoved: number } {
+	let linesAdded = 0;
+	let linesRemoved = 0;
+	for (const edit of edits) {
+		linesRemoved += edit.range.end.line - edit.range.start.line + 1;
+		linesAdded += edit.newText.split("\n").length;
+	}
+	return { linesAdded, linesRemoved };
+}
+
+function writeAtomically(filePath: string, content: string): void {
+	const tempPath = `${filePath}.omo-format.tmp`;
+	writeFileSync(tempPath, content, "utf-8");
+	try {
+		renameSync(tempPath, filePath);
+	} catch (error) {
+		try {
+			unlinkSync(tempPath);
+		} catch {
+			// The rename failure is the actionable error; a leftover temp file must not mask it.
+		}
+		throw error;
+	}
+}

--- a/packages/lsp-core/src/lsp/manager-max-clients.test.ts
+++ b/packages/lsp-core/src/lsp/manager-max-clients.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+
+import type { LspClient } from "./client.js";
+import { LspManager } from "./manager.js";
+import type { ResolvedServer } from "./types.js";
+
+const SERVER: ResolvedServer = {
+	id: "typescript",
+	command: ["typescript-language-server", "--stdio"],
+	extensions: [".ts"],
+	priority: 1,
+};
+
+class FakeLspClient {
+	alive = true;
+	stopCallCount = 0;
+
+	constructor(readonly root: string) {}
+
+	async start(): Promise<void> {}
+
+	async initialize(): Promise<void> {}
+
+	isAlive(): boolean {
+		return this.alive;
+	}
+
+	command(): string[] {
+		return [...SERVER.command];
+	}
+
+	async stop(): Promise<void> {
+		this.stopCallCount += 1;
+		this.alive = false;
+	}
+}
+
+function managerWithFakes(maxResidentClients: number): {
+	readonly manager: LspManager;
+	readonly clients: Map<string, FakeLspClient>;
+	readonly clock: { value: number };
+} {
+	const clients = new Map<string, FakeLspClient>();
+	const clock = { value: 1_000 };
+	const manager = new LspManager({
+		maxResidentClients,
+		reaperIntervalMs: 60_000,
+		idleTimeoutMs: 60_000_000,
+		now: () => clock.value,
+		clientFactory: (root) => {
+			const client = new FakeLspClient(root);
+			clients.set(root, client);
+			return client as unknown as LspClient;
+		},
+	});
+	return { manager, clients, clock };
+}
+
+describe("LspManager resident client cap", () => {
+	it("#given a cap of two idle clients #when a third client is admitted #then the least recently used one is stopped and evicted", async () => {
+		// given
+		const { manager, clients, clock } = managerWithFakes(2);
+		try {
+			await manager.getClient("/root-a", SERVER);
+			manager.releaseClient("/root-a", SERVER.id);
+			clock.value += 10;
+			await manager.getClient("/root-b", SERVER);
+			manager.releaseClient("/root-b", SERVER.id);
+			clock.value += 10;
+
+			// when
+			await manager.getClient("/root-c", SERVER);
+			manager.releaseClient("/root-c", SERVER.id);
+
+			// then
+			expect(manager.clientCount()).toBe(2);
+			expect(manager.hasClient("/root-a", SERVER.id)).toBe(false);
+			expect(manager.hasClient("/root-b", SERVER.id)).toBe(true);
+			expect(manager.hasClient("/root-c", SERVER.id)).toBe(true);
+			expect(clients.get("/root-a")?.stopCallCount).toBe(1);
+		} finally {
+			await manager.stopAll();
+		}
+	});
+
+	it("#given the least recently used client is mid-request #when a new client is admitted #then the busy client survives and an idle one is evicted", async () => {
+		// given
+		const { manager, clients, clock } = managerWithFakes(2);
+		try {
+			await manager.getClient("/root-busy", SERVER);
+			clock.value += 10;
+			await manager.getClient("/root-idle", SERVER);
+			manager.releaseClient("/root-idle", SERVER.id);
+			clock.value += 10;
+
+			// when
+			await manager.getClient("/root-new", SERVER);
+			manager.releaseClient("/root-new", SERVER.id);
+
+			// then
+			expect(manager.hasClient("/root-busy", SERVER.id)).toBe(true);
+			expect(manager.hasClient("/root-idle", SERVER.id)).toBe(false);
+			expect(clients.get("/root-busy")?.stopCallCount).toBe(0);
+			expect(clients.get("/root-idle")?.stopCallCount).toBe(1);
+		} finally {
+			manager.releaseClient("/root-busy", SERVER.id);
+			await manager.stopAll();
+		}
+	});
+
+	it("#given every resident client is busy #when a new client is admitted #then nothing is evicted and the cap is exceeded rather than breaking a live request", async () => {
+		// given
+		const { manager, clients } = managerWithFakes(1);
+		try {
+			await manager.getClient("/root-busy", SERVER);
+
+			// when
+			await manager.getClient("/root-second", SERVER);
+
+			// then
+			expect(manager.clientCount()).toBe(2);
+			expect(clients.get("/root-busy")?.stopCallCount).toBe(0);
+		} finally {
+			manager.releaseClient("/root-busy", SERVER.id);
+			manager.releaseClient("/root-second", SERVER.id);
+			await manager.stopAll();
+		}
+	});
+
+	it("#given warmup requests beyond the cap #when a warm client is admitted #then the idle least recently used client is evicted too", async () => {
+		// given
+		const { manager, clients, clock } = managerWithFakes(1);
+		try {
+			await manager.getClient("/root-first", SERVER);
+			manager.releaseClient("/root-first", SERVER.id);
+			clock.value += 10;
+
+			// when
+			manager.warmupClient("/root-warm", SERVER);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// then
+			expect(manager.hasClient("/root-first", SERVER.id)).toBe(false);
+			expect(clients.get("/root-first")?.stopCallCount).toBe(1);
+			expect(manager.hasClient("/root-warm", SERVER.id)).toBe(true);
+		} finally {
+			await manager.stopAll();
+		}
+	});
+});

--- a/packages/lsp-core/src/lsp/manager.ts
+++ b/packages/lsp-core/src/lsp/manager.ts
@@ -1,6 +1,6 @@
 import { reportBestEffortCleanupError } from "./cleanup-errors.js";
 import { LspClient } from "./client.js";
-import { IDLE_TIMEOUT_MS, INIT_TIMEOUT_MS, REAPER_INTERVAL_MS } from "./constants.js";
+import { IDLE_TIMEOUT_MS, INIT_TIMEOUT_MS, MAX_RESIDENT_CLIENTS, REAPER_INTERVAL_MS } from "./constants.js";
 import { installProcessSignalCleanup } from "./process-signal-cleanup.js";
 import type { ResolvedServer } from "./types.js";
 
@@ -28,6 +28,7 @@ export interface ClientSnapshot {
 export interface LspManagerOptions {
 	idleTimeoutMs?: number;
 	initTimeoutMs?: number;
+	maxResidentClients?: number;
 	reaperIntervalMs?: number;
 	clientFactory?: (root: string, server: ResolvedServer) => LspClient;
 	now?: () => number;
@@ -80,6 +81,7 @@ export class LspManager {
 
 	private readonly idleTimeoutMs: number;
 	private readonly initTimeoutMs: number;
+	private readonly maxResidentClients: number;
 	private readonly reaperIntervalMs: number;
 	private readonly clientFactory: (root: string, server: ResolvedServer) => LspClient;
 	private readonly now: () => number;
@@ -87,6 +89,7 @@ export class LspManager {
 	constructor(options: LspManagerOptions = {}) {
 		this.idleTimeoutMs = options.idleTimeoutMs ?? IDLE_TIMEOUT_MS;
 		this.initTimeoutMs = options.initTimeoutMs ?? INIT_TIMEOUT_MS;
+		this.maxResidentClients = options.maxResidentClients ?? MAX_RESIDENT_CLIENTS;
 		this.reaperIntervalMs = options.reaperIntervalMs ?? REAPER_INTERVAL_MS;
 		this.clientFactory = options.clientFactory ?? ((root, server) => new LspClient(root, server));
 		this.now = options.now ?? (() => Date.now());
@@ -132,6 +135,32 @@ export class LspManager {
 				this.clients.delete(key);
 			}
 		}
+	}
+
+	/**
+	 * Frees capacity for one new client by stopping the least recently used idle client.
+	 *
+	 * Only clients with no in-flight work are eligible, so a resident server is never torn down
+	 * underneath a live request; when every resident client is busy the cap is exceeded instead.
+	 */
+	private evictForAdmission(): void {
+		while (this.clients.size >= this.maxResidentClients) {
+			const victim = this.leastRecentlyUsedIdleClient();
+			if (!victim) return;
+			this.clients.delete(victim.key);
+			void stopClientBestEffort(victim.managed.client);
+		}
+	}
+
+	private leastRecentlyUsedIdleClient(): { readonly key: string; readonly managed: ManagedClient } | null {
+		let candidate: { readonly key: string; readonly managed: ManagedClient } | null = null;
+		for (const [key, managed] of this.clients) {
+			if (managed.refCount > 0 || managed.pendingWaiters > 0 || managed.isInitializing) continue;
+			if (candidate === null || managed.lastUsedAt < candidate.managed.lastUsedAt) {
+				candidate = { key, managed };
+			}
+		}
+		return candidate;
 	}
 
 	private async tryDeleteIfOrphaned(key: string, managed: ManagedClient): Promise<void> {
@@ -196,6 +225,8 @@ export class LspManager {
 			managed.lastUsedAt = this.now();
 			return managed.client;
 		}
+
+		this.evictForAdmission();
 
 		const client = this.clientFactory(root, server);
 		const initStartedAt = this.now();
@@ -263,6 +294,8 @@ export class LspManager {
 		if (this.disposed) return;
 		const key = this.getKey(root, server.id);
 		if (this.clients.has(key)) return;
+
+		this.evictForAdmission();
 
 		const client = this.clientFactory(root, server);
 		const initStartedAt = this.now();

--- a/packages/lsp-core/src/lsp/transport.ts
+++ b/packages/lsp-core/src/lsp/transport.ts
@@ -37,6 +37,7 @@ export class LspClientTransport {
 	protected readonly initializeTimeoutMs: number;
 	private workspaceApplyEditHandler: WorkspaceApplyEditHandler | null = null;
 	private diagnosticPullSupported = false;
+	private documentFormattingSupported = false;
 
 	constructor(
 		protected readonly root: string,
@@ -69,6 +70,14 @@ export class LspClientTransport {
 
 	protected isDiagnosticPullSupported(): boolean {
 		return this.diagnosticPullSupported;
+	}
+
+	protected setDocumentFormattingSupported(supported: boolean): void {
+		this.documentFormattingSupported = supported;
+	}
+
+	isDocumentFormattingSupported(): boolean {
+		return this.documentFormattingSupported;
 	}
 
 	protected handlePublishDiagnostics(params: {

--- a/packages/lsp-core/src/lsp/types.ts
+++ b/packages/lsp-core/src/lsp/types.ts
@@ -72,6 +72,14 @@ export interface Diagnostic {
 	message: string;
 }
 
+export interface FormattingOptions {
+	tabSize: number;
+	insertSpaces: boolean;
+	trimTrailingWhitespace?: boolean;
+	insertFinalNewline?: boolean;
+	trimFinalNewlines?: boolean;
+}
+
 export interface TextDocumentIdentifier {
 	uri: string;
 }

--- a/packages/lsp-core/src/tool-surface.test.ts
+++ b/packages/lsp-core/src/tool-surface.test.ts
@@ -105,6 +105,18 @@ const expectedToolSurface = [
 		},
 	},
 	{
+		name: "format",
+		title: "LSP Format",
+		description: "Format a source file with its language server and write the returned edits to disk.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				filePath: { type: "string", description: "Source file path to format." },
+			},
+			required: ["filePath"],
+		},
+	},
+	{
 		name: "install_decision",
 		title: "LSP Install Decision",
 		description:
@@ -128,7 +140,7 @@ const expectedToolSurface = [
 ];
 
 describe("LSP core tool surface", () => {
-	test("#given tool descriptors #when listed #then the public eight-tool schemas are pinned", () => {
+	test("#given tool descriptors #when listed #then the public nine-tool schemas are pinned", () => {
 		// given / when
 		const surface = LSP_MCP_TOOLS.map((tool) => ({
 			name: tool.name,

--- a/packages/lsp-core/src/tools/definitions.ts
+++ b/packages/lsp-core/src/tools/definitions.ts
@@ -1,4 +1,5 @@
 import { executeLspDiagnostics } from "./diagnostics.js";
+import { executeLspFormat } from "./format.js";
 import { executeLspInstallDecision } from "./install-decision.js";
 import { executeLspFindReferences, executeLspGotoDefinition } from "./navigation.js";
 import { executeLspPrepareRename, executeLspRename } from "./rename.js";
@@ -115,6 +116,19 @@ export const LSP_MCP_TOOLS: LspMcpTool[] = [
 			["filePath", "line", "character", "newName"],
 		),
 		execute: executeLspRename,
+	},
+	{
+		name: "format",
+		aliases: ["lsp_format"],
+		title: "LSP Format",
+		description: "Format a source file with its language server and write the returned edits to disk.",
+		inputSchema: objectSchema(
+			{
+				filePath: { type: "string", description: "Source file path to format." },
+			},
+			["filePath"],
+		),
+		execute: executeLspFormat,
 	},
 	{
 		name: "install_decision",

--- a/packages/lsp-core/src/tools/format.test.ts
+++ b/packages/lsp-core/src/tools/format.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { parseLspRequestContext, runWithRequestContext } from "../request-context.js";
+import { executeLspFormat } from "./format.js";
+import type { LspFormatDetails } from "./types.js";
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) rmSync(workspace, { recursive: true, force: true });
+});
+
+function workspaceWith(fileName: string, content: string): { readonly root: string; readonly filePath: string } {
+	const root = mkdtempSync(join(tmpdir(), "lsp-format-tool-"));
+	workspaces.push(root);
+	const filePath = join(root, fileName);
+	writeFileSync(filePath, content, "utf-8");
+	return { root, filePath };
+}
+
+function contextFor(root: string) {
+	return parseLspRequestContext({
+		cwd: root,
+		projectConfigPaths: [join(root, "lsp.json")],
+		userConfigPath: join(root, "user-lsp.json"),
+		installDecisionsPath: join(root, "install-decisions.json"),
+		capabilities: { installDecisionTool: false },
+	});
+}
+
+describe("executeLspFormat", () => {
+	it("#given an extension with no configured server #when format runs #then the missing dependency result is returned and the file is untouched", async () => {
+		// given
+		const original = "value\n";
+		const { root, filePath } = workspaceWith("module.wat", original);
+
+		// when
+		const result = await runWithRequestContext(contextFor(root), () => executeLspFormat({ filePath }));
+
+		// then
+		const details = result.details as LspFormatDetails;
+		expect(details.errorKind).toBe("missing_dependency");
+		expect(details.status).toBe("unavailable");
+		expect(result.content[0]?.text).toContain("No LSP server configured for extension: .wat");
+		expect(readFileSync(filePath)).toEqual(Buffer.from(original));
+	});
+
+	it("#given a missing filePath argument #when format runs #then the parameter contract is enforced", async () => {
+		// given / when / then
+		await expect(executeLspFormat({})).rejects.toThrow(/filePath/);
+	});
+});

--- a/packages/lsp-core/src/tools/format.ts
+++ b/packages/lsp-core/src/tools/format.ts
@@ -1,0 +1,56 @@
+import { withLspClient } from "../lsp/client-wrapper.js";
+import { type FormatDocumentResult, formatDocumentWithClient } from "../lsp/format-document.js";
+import { missingDependencyResult } from "../missing-dependency-result.js";
+import { clientOptions, requireString } from "./parameters.js";
+import { text } from "./result.js";
+import type { LspFormatDetails, ToolExecutionResult } from "./types.js";
+
+export async function executeLspFormat(
+	params: Record<string, unknown>,
+	signal?: AbortSignal,
+): Promise<ToolExecutionResult> {
+	const filePath = requireString(params, "filePath");
+
+	try {
+		const result = await withLspClient(
+			filePath,
+			async (client, _workspaceRoot, resolvedFilePath) =>
+				formatDocumentWithClient(client, resolvedFilePath, signal === undefined ? {} : { signal }),
+			"format",
+			clientOptions(signal),
+		);
+		return text(describeResult(filePath, result), formatDetails(filePath, result));
+	} catch (error) {
+		const missingDependency = missingDependencyResult(error, {
+			filePath,
+			status: "unavailable",
+			reason: "server_unavailable",
+			linesAdded: 0,
+			linesRemoved: 0,
+		} satisfies Omit<LspFormatDetails, "error" | "errorKind">);
+		if (missingDependency) return missingDependency;
+		throw error;
+	}
+}
+
+function formatDetails(filePath: string, result: FormatDocumentResult): LspFormatDetails {
+	if (result.status === "unavailable") {
+		return { filePath, status: "unavailable", reason: result.reason, linesAdded: 0, linesRemoved: 0 };
+	}
+	return {
+		filePath,
+		status: result.status,
+		linesAdded: result.linesAdded,
+		linesRemoved: result.linesRemoved,
+	};
+}
+
+function describeResult(filePath: string, result: FormatDocumentResult): string {
+	if (result.status === "unavailable") {
+		return `Formatting unavailable for ${filePath}: the language server does not advertise documentFormattingProvider.`;
+	}
+	if (result.status === "unchanged") {
+		return `Already formatted: ${filePath}`;
+	}
+	return `Formatted ${filePath} (+${result.linesAdded}/-${result.linesRemoved} lines)`;
+}

--- a/packages/lsp-core/src/tools/index.ts
+++ b/packages/lsp-core/src/tools/index.ts
@@ -1,5 +1,6 @@
 export { executeLspDiagnostics } from "./diagnostics.js";
 export { LSP_MCP_TOOLS } from "./definitions.js";
+export { executeLspFormat } from "./format.js";
 export { executeLspInstallDecision } from "./install-decision.js";
 export { executeLspFindReferences, executeLspGotoDefinition } from "./navigation.js";
 export { isRecord } from "./parameters.js";

--- a/packages/lsp-core/src/tools/types.ts
+++ b/packages/lsp-core/src/tools/types.ts
@@ -93,6 +93,16 @@ export interface LspPrepareRenameDetails {
 	errorKind?: "missing_dependency";
 }
 
+export interface LspFormatDetails {
+	filePath: string;
+	status: "formatted" | "unchanged" | "unavailable";
+	reason?: "capability_not_advertised" | "server_unavailable";
+	linesAdded: number;
+	linesRemoved: number;
+	error?: string;
+	errorKind?: "missing_dependency";
+}
+
 export interface LspRenameDetails {
 	filePath: string;
 	line: number;

--- a/packages/lsp-daemon/scripts/qa/format-request-e2e.mjs
+++ b/packages/lsp-daemon/scripts/qa/format-request-e2e.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+// allow: SIZE_OK - one live QA driver keeps fixture setup, daemon lifecycle and evidence in one executable.
+//
+// Live QA for the daemon "format" request.
+//
+// Drives the REAL built daemon over its REAL unix socket with a REAL biome language
+// server installed as a repo-local devDependency, and proves four things end to end:
+//   1. a drifted file is rewritten by textDocument/formatting and reports line deltas,
+//   2. a second format of the same file reports "unchanged" and leaves bytes untouched,
+//   3. an extension whose server advertises no documentFormattingProvider yields the
+//      typed unavailable result with the file byte-identical,
+//   4. the run adds no resident process beyond the single daemon: language servers stay
+//      inside the daemon and the daemon itself is stopped at the end.
+import { spawn, spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { connect } from "node:net"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, "..", "..")
+const daemonCli = join(packageRoot, "dist", "cli.js")
+
+function parseArgs(argv) {
+  const args = { evidenceDir: undefined, selfTest: false }
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--self-test") args.selfTest = true
+    else if (arg === "--evidence-dir") args.evidenceDir = argv[++index]
+    else throw new Error(`unknown argument: ${arg}`)
+  }
+  return args
+}
+
+/**
+ * Creates a fixture repository whose only biome is a genuine repo-local devDependency,
+ * so the format request can only succeed through repo-local binary resolution.
+ */
+function createFixtureRepo(root) {
+  mkdirSync(root, { recursive: true })
+  writeFileSync(
+    join(root, "package.json"),
+    `${JSON.stringify({ name: "lsp-format-fixture", private: true, version: "0.0.0" }, null, 2)}\n`,
+  )
+  writeFileSync(
+    join(root, "biome.json"),
+    `${JSON.stringify(
+      {
+        $schema: "https://biomejs.dev/schemas/2.0.0/schema.json",
+        formatter: { enabled: true, indentStyle: "space", indentWidth: 2 },
+      },
+      null,
+      2,
+    )}\n`,
+  )
+  const install = spawnSync("bun", ["add", "-d", "@biomejs/biome"], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 300_000,
+    maxBuffer: 32 * 1024 * 1024,
+  })
+  const localBiome = join(root, "node_modules", ".bin", "biome")
+  if (install.status !== 0 || !existsSync(localBiome)) {
+    throw new Error(`fixture devDependency install failed: ${install.stderr || install.stdout}`)
+  }
+  const drifted = join(root, "drifted.css")
+  writeFileSync(drifted, "a{color:red;background:blue}\n")
+  const unsupported = join(root, "notes.txt")
+  writeFileSync(unsupported, "plain text\n")
+  return { localBiome, drifted, unsupported }
+}
+
+/**
+ * Creates a second fixture whose .ts server is oxlint, a real language server that runs but
+ * advertises no documentFormattingProvider. This is the only way to exercise the capability
+ * gate against a live server rather than a stub.
+ */
+function createLinterOnlyFixture(root) {
+  mkdirSync(join(root, "home"), { recursive: true })
+  writeFileSync(
+    join(root, "package.json"),
+    `${JSON.stringify({ name: "lsp-format-linter-fixture", private: true, version: "0.0.0" }, null, 2)}\n`,
+  )
+  const install = spawnSync("bun", ["add", "-d", "oxlint"], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 300_000,
+    maxBuffer: 32 * 1024 * 1024,
+  })
+  const localOxlint = join(root, "node_modules", ".bin", "oxlint")
+  if (install.status !== 0 || !existsSync(localOxlint)) {
+    return { available: false, reason: (install.stderr || install.stdout).trim().slice(-400) }
+  }
+  // Pinning oxlint in the user config keeps biome from winning the .ts extension by priority.
+  writeFileSync(
+    join(root, "home", "lsp-client.json"),
+    `${JSON.stringify({ lsp: { oxlint: { priority: 100 }, biome: { disabled: true }, typescript: { disabled: true } } }, null, 2)}\n`,
+  )
+  const source = join(root, "linted.ts")
+  writeFileSync(source, "const a=1\n")
+  return { available: true, localOxlint, source }
+}
+
+/** Picks the shortest writable temp root available, so nested socket paths stay under SUN_LEN. */
+function shortTempRoot() {
+  for (const candidate of ["/tmp", tmpdir()]) {
+    try {
+      mkdirSync(candidate, { recursive: true })
+      const probe = join(candidate, `.fq-probe-${process.pid}`)
+      writeFileSync(probe, "")
+      rmSync(probe, { force: true })
+      return candidate
+    } catch {
+      // An unwritable candidate is not a failure; the next one is tried instead.
+    }
+  }
+  throw new Error("no writable temp root found")
+}
+
+function daemonEnv(fixtureRoot, daemonDir) {
+  return {
+    ...process.env,
+    OMO_LSP_DAEMON_DIR: daemonDir,
+    OMO_LSP_DAEMON_CLI: daemonCli,
+    OMO_LSP_DAEMON_VERSION: "qa-format",
+    HOME: join(fixtureRoot, "home"),
+  }
+}
+
+function requestContext(fixtureRoot) {
+  return {
+    cwd: fixtureRoot,
+    projectConfigPaths: [join(fixtureRoot, ".codex", "lsp-client.json")],
+    userConfigPath: join(fixtureRoot, "home", "lsp-client.json"),
+    installDecisionsPath: join(fixtureRoot, "home", "lsp-install-decisions.json"),
+    capabilities: { installDecisionTool: true },
+  }
+}
+
+/**
+ * Sends one authenticated tools/call over the daemon's real unix socket and resolves
+ * with the parsed JSON-RPC response.
+ */
+function sendRequest(socketPath, token, id, name, args) {
+  return new Promise((resolvePromise, reject) => {
+    const socket = connect(socketPath)
+    let buffer = ""
+    const timer = setTimeout(() => {
+      socket.destroy()
+      reject(new Error(`daemon request ${name} timed out`))
+    }, 120_000)
+    const finish = (run) => {
+      clearTimeout(timer)
+      socket.destroy()
+      run()
+    }
+    socket.once("connect", () => {
+      socket.write(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          method: "tools/call",
+          params: { _omo: { protocolVersion: 1, token }, name, arguments: args },
+        })}\n`,
+      )
+    })
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8")
+      const newline = buffer.indexOf("\n")
+      if (newline === -1) return
+      const line = buffer.slice(0, newline)
+      finish(() => {
+        try {
+          resolvePromise(JSON.parse(line))
+        } catch (error) {
+          reject(error)
+        }
+      })
+    })
+    socket.once("error", (error) => finish(() => reject(error)))
+  })
+}
+
+function waitForFile(path, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  return new Promise((resolvePromise, reject) => {
+    const poll = () => {
+      if (existsSync(path)) {
+        resolvePromise()
+        return
+      }
+      if (Date.now() > deadline) {
+        reject(new Error(`daemon never created ${path}`))
+        return
+      }
+      setTimeout(poll, 50)
+    }
+    poll()
+  })
+}
+
+/** Counts live processes whose command line matches a pattern, for the residency check. */
+function countProcesses(pattern) {
+  const result = spawnSync("bash", ["-lc", `ps -Ao pid,command | grep -F ${JSON.stringify(pattern)} | grep -v grep | wc -l`], {
+    encoding: "utf8",
+  })
+  return Number.parseInt(result.stdout.trim(), 10)
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  if (args.selfTest) {
+    if (!existsSync(daemonCli)) throw new Error(`daemon CLI missing at ${daemonCli}; run npm run build first`)
+    console.log(JSON.stringify({ selfTest: "PASS", daemonCli }))
+    return
+  }
+  if (!existsSync(daemonCli)) throw new Error(`daemon CLI missing at ${daemonCli}; run npm run build first`)
+
+  // biome's lsp-proxy opens its own unix socket under the fixture, and macOS caps a socket
+  // path at SUN_LEN, so the work root must stay short rather than nest under a long tmpdir.
+  const workRoot = mkdtempSync(join(shortTempRoot(), "fq-"))
+  const fixtureRoot = join(workRoot, "fixture")
+  const daemonDir = join(workRoot, "daemon")
+  mkdirSync(join(fixtureRoot, "home"), { recursive: true })
+  mkdirSync(daemonDir, { recursive: true })
+  let daemon
+  const evidence = { workRoot }
+
+  try {
+    const fixture = createFixtureRepo(fixtureRoot)
+    evidence.localBiome = fixture.localBiome
+
+    const env = daemonEnv(fixtureRoot, daemonDir)
+    daemon = spawn(process.execPath, [daemonCli, "daemon"], { cwd: fixtureRoot, env, stdio: ["ignore", "pipe", "pipe"] })
+    const daemonLog = []
+    daemon.stdout.on("data", (chunk) => daemonLog.push(chunk.toString("utf8")))
+    daemon.stderr.on("data", (chunk) => daemonLog.push(chunk.toString("utf8")))
+
+    // Layout mirrors daemonPaths(): <OMO_LSP_DAEMON_DIR>/v<version>/daemon.{auth,sock}.
+    const versionDir = join(daemonDir, "vqa-format")
+    const authPath = join(versionDir, "daemon.auth")
+    const socketPath = join(versionDir, "daemon.sock")
+    evidence.daemonVersionDir = versionDir
+    await waitForFile(authPath, 60_000)
+    await waitForFile(socketPath, 60_000)
+    const token = readFileSync(authPath, "utf8").trim()
+    const context = requestContext(fixtureRoot)
+
+    const beforeBytes = readFileSync(fixture.drifted)
+    const firstFormat = await sendRequest(socketPath, token, 1, "format", {
+      filePath: fixture.drifted,
+      _context: context,
+    })
+    const afterBytes = readFileSync(fixture.drifted)
+
+    const secondFormat = await sendRequest(socketPath, token, 2, "format", {
+      filePath: fixture.drifted,
+      _context: context,
+    })
+    const afterSecondBytes = readFileSync(fixture.drifted)
+
+    const unsupportedBefore = readFileSync(fixture.unsupported)
+    const unsupportedFormat = await sendRequest(socketPath, token, 3, "format", {
+      filePath: fixture.unsupported,
+      _context: context,
+    })
+    const unsupportedAfter = readFileSync(fixture.unsupported)
+
+    const linterRoot = join(workRoot, "linter")
+    const linterFixture = createLinterOnlyFixture(linterRoot)
+    if (linterFixture.available) {
+      const linterBefore = readFileSync(linterFixture.source)
+      const linterFormat = await sendRequest(socketPath, token, 4, "format", {
+        filePath: linterFixture.source,
+        _context: requestContext(linterRoot),
+      })
+      const linterAfter = readFileSync(linterFixture.source)
+      evidence.capabilityGate = {
+        text: linterFormat.result?.content?.[0]?.text,
+        details: linterFormat.result?.details,
+        bytesChanged: !linterBefore.equals(linterAfter),
+      }
+    } else {
+      evidence.capabilityGate = { skipped: true, reason: linterFixture.reason }
+    }
+
+    const residentBiome = countProcesses("biome")
+    const residentDaemons = countProcesses(daemonCli)
+
+    evidence.firstFormat = {
+      text: firstFormat.result?.content?.[0]?.text,
+      details: firstFormat.result?.details,
+      before: beforeBytes.toString("utf8"),
+      after: afterBytes.toString("utf8"),
+      bytesChanged: !beforeBytes.equals(afterBytes),
+    }
+    evidence.secondFormat = {
+      text: secondFormat.result?.content?.[0]?.text,
+      details: secondFormat.result?.details,
+      bytesChanged: !afterBytes.equals(afterSecondBytes),
+    }
+    evidence.unsupportedFormat = {
+      text: unsupportedFormat.result?.content?.[0]?.text,
+      details: unsupportedFormat.result?.details,
+      bytesChanged: !unsupportedBefore.equals(unsupportedAfter),
+    }
+    evidence.residency = { residentBiome, residentDaemons }
+    evidence.daemonLogTail = daemonLog.join("").split(/\r?\n/).slice(-20).join("\n")
+
+    const checks = {
+      firstFormatRewroteFile: evidence.firstFormat.bytesChanged === true,
+      firstFormatStatusFormatted: evidence.firstFormat.details?.status === "formatted",
+      firstFormatReportsLineDeltas:
+        typeof evidence.firstFormat.details?.linesAdded === "number" &&
+        typeof evidence.firstFormat.details?.linesRemoved === "number",
+      secondFormatUnchanged: evidence.secondFormat.details?.status === "unchanged",
+      secondFormatLeftBytes: evidence.secondFormat.bytesChanged === false,
+      unsupportedLeftBytes: evidence.unsupportedFormat.bytesChanged === false,
+      unsupportedNotFormatted: evidence.unsupportedFormat.details?.status !== "formatted",
+      oneResidentDaemon: residentDaemons === 1,
+      capabilityGateUnavailable:
+        evidence.capabilityGate.skipped === true ||
+        (evidence.capabilityGate.details?.status === "unavailable" &&
+          evidence.capabilityGate.details?.reason === "capability_not_advertised"),
+      capabilityGateLeftBytes:
+        evidence.capabilityGate.skipped === true || evidence.capabilityGate.bytesChanged === false,
+    }
+    evidence.checks = checks
+    evidence.verdict = Object.values(checks).every(Boolean) ? "PASS" : "FAIL"
+
+    if (args.evidenceDir !== undefined) {
+      mkdirSync(args.evidenceDir, { recursive: true })
+      writeFileSync(join(args.evidenceDir, "format-request-e2e.json"), `${JSON.stringify(evidence, null, 2)}\n`)
+    }
+    console.log(JSON.stringify(evidence, null, 2))
+    if (evidence.verdict !== "PASS") process.exitCode = 1
+  } finally {
+    if (daemon) {
+      daemon.kill("SIGTERM")
+      await new Promise((resolvePromise) => {
+        const timer = setTimeout(() => {
+          daemon.kill("SIGKILL")
+          resolvePromise()
+        }, 5_000)
+        daemon.once("exit", () => {
+          clearTimeout(timer)
+          resolvePromise()
+        })
+      })
+    }
+    rmSync(workRoot, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error))
+  process.exitCode = 1
+})

--- a/packages/lsp-daemon/src/client.ts
+++ b/packages/lsp-daemon/src/client.ts
@@ -1,10 +1,11 @@
+import { statSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import {
 	callDiagnosticsViaDaemon as callDiagnosticsViaDaemonInternal,
+	callFormatViaDaemon as callFormatViaDaemonInternal,
 	callToolViaDaemon as callToolViaDaemonInternal,
 	currentRequestContext as currentRequestContextInternal,
 } from "./daemon-client.js";
-import { statSync } from "node:fs";
-import { isAbsolute } from "node:path";
 
 export const OMO_LSP_DAEMON_DIR = "OMO_LSP_DAEMON_DIR";
 export const OMO_LSP_DAEMON_CLI = "OMO_LSP_DAEMON_CLI";
@@ -173,6 +174,16 @@ export type LspPrepareRenameDetails = {
 	readonly errorKind?: "missing_dependency";
 };
 
+export type LspFormatDetails = {
+	readonly filePath: string;
+	readonly status: "formatted" | "unchanged" | "unavailable";
+	readonly reason?: "capability_not_advertised" | "server_unavailable";
+	readonly linesAdded: number;
+	readonly linesRemoved: number;
+	readonly error?: string;
+	readonly errorKind?: "missing_dependency";
+};
+
 export type LspRenameDetails = {
 	readonly filePath: string;
 	readonly line: number;
@@ -192,11 +203,12 @@ export function callToolViaDaemon(
 	return callToolViaDaemonInternal(name, args, options);
 }
 
-export function callDiagnosticsViaDaemon(
-	filePath: string,
-	options: CallToolOptions,
-): Promise<ToolExecutionResult> {
+export function callDiagnosticsViaDaemon(filePath: string, options: CallToolOptions): Promise<ToolExecutionResult> {
 	return callDiagnosticsViaDaemonInternal(filePath, options);
+}
+
+export function callFormatViaDaemon(filePath: string, options: CallToolOptions): Promise<ToolExecutionResult> {
+	return callFormatViaDaemonInternal(filePath, options);
 }
 
 export function currentRequestContext(env: Record<string, string | undefined> = process.env): DaemonToolContext {

--- a/packages/lsp-daemon/src/daemon-client.ts
+++ b/packages/lsp-daemon/src/daemon-client.ts
@@ -74,6 +74,10 @@ export function callDiagnosticsViaDaemon(filePath: string, options: CallToolOpti
 	return callToolViaDaemon("diagnostics", { filePath, severity: "error" }, options);
 }
 
+export function callFormatViaDaemon(filePath: string, options: CallToolOptions): Promise<ToolExecutionResult> {
+	return callToolViaDaemon("format", { filePath }, options);
+}
+
 export function currentRequestContext(env: NodeJS.ProcessEnv = process.env): DaemonToolContext {
 	const cwd = process.cwd();
 	const home = env["HOME"] ?? homedir();

--- a/packages/lsp-daemon/test/client-surface.test.ts
+++ b/packages/lsp-daemon/test/client-surface.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
-import { callToolViaDaemon } from "../src/client.js";
+import { callFormatViaDaemon, callToolViaDaemon } from "../src/client.js";
 import { daemonTestPaths } from "./daemon-path-fixture.js";
 
 const packageJson = JSON.parse(readFileSync(fileURLToPath(new URL("../package.json", import.meta.url)), "utf8")) as {
@@ -24,12 +24,23 @@ describe("public client package surface", () => {
 	it("#given the client source #when reviewing public exports #then server proxy ownership and lock internals stay private", () => {
 		expect(clientSource).toContain("callToolViaDaemon");
 		expect(clientSource).toContain("callDiagnosticsViaDaemon");
+		expect(clientSource).toContain("callFormatViaDaemon");
 		expect(clientSource).toContain("OMO_LSP_DAEMON_CLI");
 		expect(clientSource).not.toContain("runMcpStdioProxy");
 		expect(clientSource).not.toContain("startDaemonServer");
 		expect(clientSource).not.toContain("ensureDaemonRunning");
 		expect(clientSource).not.toContain("daemonPaths");
 		expect(clientSource).not.toContain("disposeDefaultLspManager");
+	});
+
+	it("#given the public format entry point #when a caller omits context #then rejection happens before daemon dispatch", async () => {
+		const ensure = vi.fn(async () => {});
+		const paths = daemonTestPaths(fileURLToPath(new URL("client-surface-format-daemon", import.meta.url)));
+
+		await expect(Reflect.apply(callFormatViaDaemon, undefined, ["/a.ts", { paths, ensure }])).rejects.toThrow(
+			/context/i,
+		);
+		expect(ensure).not.toHaveBeenCalled();
 	});
 
 	it("#given the public client type surface #when reviewing call options #then daemon context is mandatory", () => {
@@ -53,16 +64,16 @@ describe("public client package surface", () => {
 		{ name: "array", context: [] },
 		{ name: "scalar", context: "not-a-context" },
 		{ name: "unknown field", context: { cwd: process.cwd(), env: {} } },
-	])(
-		"#given malformed public client context $name #when calling the public client #then rejection happens before daemon dispatch",
-		async ({ name, context }) => {
-			const ensure = vi.fn(async () => {});
-			const paths = daemonTestPaths(fileURLToPath(new URL(`client-surface-malformed-${name}`, import.meta.url)));
+	])("#given malformed public client context $name #when calling the public client #then rejection happens before daemon dispatch", async ({
+		name,
+		context,
+	}) => {
+		const ensure = vi.fn(async () => {});
+		const paths = daemonTestPaths(fileURLToPath(new URL(`client-surface-malformed-${name}`, import.meta.url)));
 
-			await expect(
-				Reflect.apply(callToolViaDaemon, undefined, ["status", {}, { paths, ensure, context }]),
-			).rejects.toThrow(/context|field|capabilities/i);
-			expect(ensure).not.toHaveBeenCalled();
-		},
-	);
+		await expect(
+			Reflect.apply(callToolViaDaemon, undefined, ["status", {}, { paths, ensure, context }]),
+		).rejects.toThrow(/context|field|capabilities/i);
+		expect(ensure).not.toHaveBeenCalled();
+	});
 });

--- a/packages/lsp-daemon/test/request-routing.test.ts
+++ b/packages/lsp-daemon/test/request-routing.test.ts
@@ -1,9 +1,8 @@
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { handleLspMcpRequest, type JsonRpcResponse } from "@oh-my-opencode/lsp-core/mcp";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { authEnvelope } from "../src/ipc-protocol.js";
 import { extractRequestContext, handleDaemonMessage } from "../src/request-routing.js";
@@ -43,12 +42,12 @@ function validContext(root: string) {
 	};
 }
 
-function authenticatedToolCall(id: number, token: string, args: Record<string, unknown>) {
+function authenticatedToolCall(id: number, token: string, args: Record<string, unknown>, name = "status") {
 	return {
 		jsonrpc: "2.0",
 		id,
 		method: "tools/call",
-		params: { _omo: authEnvelope(token), name: "status", arguments: args },
+		params: { _omo: authEnvelope(token), name, arguments: args },
 	};
 }
 
@@ -62,7 +61,10 @@ function responseCode(response: unknown): string | undefined {
 	return typeof code === "string" ? code : undefined;
 }
 
-function deferredResponse(): { readonly promise: Promise<JsonRpcResponse | undefined>; readonly resolve: (value: JsonRpcResponse) => void } {
+function deferredResponse(): {
+	readonly promise: Promise<JsonRpcResponse | undefined>;
+	readonly resolve: (value: JsonRpcResponse) => void;
+} {
 	let resolvePromise: (value: JsonRpcResponse) => void = () => {};
 	const promise = new Promise<JsonRpcResponse | undefined>((resolve) => {
 		resolvePromise = resolve;
@@ -130,25 +132,34 @@ describe("extractRequestContext", () => {
 		{ name: "scalar", context: "not-an-object" },
 		{ name: "array", context: [] },
 		{ name: "null", context: null },
-	])(
-		"#given authenticated tools/call with $name _context #when routed #then invalid request returns before Core dispatch",
-		async ({ context }) => {
-			const token = "secret-token";
-			const response = await handleDaemonMessage(authenticatedToolCall(20, token, { _context: context }), {
-				token,
-				owner: { pid: process.pid, nonce: "test-owner", startedAt: "now", endpoint: { kind: "missing", path: "memory" } },
-			});
+	])("#given authenticated tools/call with $name _context #when routed #then invalid request returns before Core dispatch", async ({
+		context,
+	}) => {
+		const token = "secret-token";
+		const response = await handleDaemonMessage(authenticatedToolCall(20, token, { _context: context }), {
+			token,
+			owner: {
+				pid: process.pid,
+				nonce: "test-owner",
+				startedAt: "now",
+				endpoint: { kind: "missing", path: "memory" },
+			},
+		});
 
-			expect(responseCode(response)).toBe("invalid_daemon_request");
-			expect(dispatchMock).not.toHaveBeenCalled();
-		},
-	);
+		expect(responseCode(response)).toBe("invalid_daemon_request");
+		expect(dispatchMock).not.toHaveBeenCalled();
+	});
 
 	it("#given authenticated tools/call with omitted _context #when routed #then invalid request returns before Core dispatch", async () => {
 		const token = "secret-token";
 		const response = await handleDaemonMessage(authenticatedToolCall(21, token, {}), {
 			token,
-			owner: { pid: process.pid, nonce: "test-owner", startedAt: "now", endpoint: { kind: "missing", path: "memory" } },
+			owner: {
+				pid: process.pid,
+				nonce: "test-owner",
+				startedAt: "now",
+				endpoint: { kind: "missing", path: "memory" },
+			},
 		});
 
 		expect(responseCode(response)).toBe("invalid_daemon_request");
@@ -168,7 +179,12 @@ describe("extractRequestContext", () => {
 		const root = tempProject();
 		const running = handleDaemonMessage(authenticatedToolCall(30, token, { _context: validContext(root) }), {
 			token,
-			owner: { pid: process.pid, nonce: "test-owner", startedAt: "now", endpoint: { kind: "missing", path: "memory" } },
+			owner: {
+				pid: process.pid,
+				nonce: "test-owner",
+				startedAt: "now",
+				endpoint: { kind: "missing", path: "memory" },
+			},
 			activeRequests,
 		});
 		expect(activeRequests.size).toBe(1);
@@ -180,7 +196,12 @@ describe("extractRequestContext", () => {
 			},
 			{
 				token,
-				owner: { pid: process.pid, nonce: "test-owner", startedAt: "now", endpoint: { kind: "missing", path: "memory" } },
+				owner: {
+					pid: process.pid,
+					nonce: "test-owner",
+					startedAt: "now",
+					endpoint: { kind: "missing", path: "memory" },
+				},
 				activeRequests,
 			},
 		);
@@ -205,13 +226,61 @@ describe("extractRequestContext", () => {
 			},
 			{
 				token,
-				owner: { pid: process.pid, nonce: "test-owner", startedAt: "now", endpoint: { kind: "missing", path: "memory" } },
+				owner: {
+					pid: process.pid,
+					nonce: "test-owner",
+					startedAt: "now",
+					endpoint: { kind: "missing", path: "memory" },
+				},
 				activeRequests,
 			},
 		);
 
 		expect(controller.signal.aborted).toBe(false);
 		expect(activeRequests.size).toBe(1);
+	});
+
+	it("#given an authenticated format tools/call #when routed #then the request reaches Core with its context and filePath", async () => {
+		const token = "secret-token";
+		const root = tempProject();
+		const filePath = join(root, "drifted.ts");
+		writeFileSync(filePath, "const a=1\n");
+
+		await handleDaemonMessage(
+			authenticatedToolCall(40, token, { filePath, _context: validContext(root) }, "format"),
+			{
+				token,
+				owner: {
+					pid: process.pid,
+					nonce: "test-owner",
+					startedAt: "now",
+					endpoint: { kind: "missing", path: "memory" },
+				},
+			},
+		);
+
+		expect(dispatchMock).toHaveBeenCalledTimes(1);
+		const dispatched = dispatchMock.mock.calls[0]?.[0] as {
+			params: { name: string; arguments: Record<string, unknown> };
+		};
+		expect(dispatched.params.name).toBe("format");
+		expect(dispatched.params.arguments).toEqual({ filePath });
+	});
+
+	it("#given a format tools/call without _context #when routed #then it is rejected before Core dispatch", async () => {
+		const token = "secret-token";
+		const response = await handleDaemonMessage(authenticatedToolCall(41, token, { filePath: "/a.ts" }, "format"), {
+			token,
+			owner: {
+				pid: process.pid,
+				nonce: "test-owner",
+				startedAt: "now",
+				endpoint: { kind: "missing", path: "memory" },
+			},
+		});
+
+		expect(responseCode(response)).toBe("invalid_daemon_request");
+		expect(dispatchMock).not.toHaveBeenCalled();
 	});
 
 	it("#given actual symlink project config escaping cwd #when extract #then rejects before Core dispatch", () => {
@@ -224,7 +293,9 @@ describe("extractRequestContext", () => {
 
 		expect(() =>
 			extractRequestContext(
-				authenticatedToolCall(22, "secret-token", { _context: { ...validContext(root), projectConfigPaths: [linkedConfig] } }),
+				authenticatedToolCall(22, "secret-token", {
+					_context: { ...validContext(root), projectConfigPaths: [linkedConfig] },
+				}),
 			),
 		).toThrow(/Project LSP config path must be inside cwd/);
 	});

--- a/packages/lsp-tools-mcp/test/mcp.test.ts
+++ b/packages/lsp-tools-mcp/test/mcp.test.ts
@@ -71,6 +71,7 @@ describe("lsp MCP server", () => {
 			"symbols",
 			"prepare_rename",
 			"rename",
+			"format",
 			"install_decision",
 		]);
 	});

--- a/packages/lsp-tools-mcp/test/tool-surface.test.ts
+++ b/packages/lsp-tools-mcp/test/tool-surface.test.ts
@@ -109,6 +109,18 @@ const expectedToolSurface = [
 		},
 	},
 	{
+		name: "format",
+		title: "LSP Format",
+		description: "Format a source file with its language server and write the returned edits to disk.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				filePath: { type: "string", description: "Source file path to format." },
+			},
+			required: ["filePath"],
+		},
+	},
+	{
 		name: "install_decision",
 		title: "LSP Install Decision",
 		description:
@@ -132,7 +144,7 @@ const expectedToolSurface = [
 ] as const;
 
 describe("LSP MCP tool surface", () => {
-	it("#given a JSON-RPC tools/list request #when descriptors are returned #then the eight public tool schemas are pinned", async () => {
+	it("#given a JSON-RPC tools/list request #when descriptors are returned #then the nine public tool schemas are pinned", async () => {
 		// given
 		const request = { jsonrpc: "2.0", id: 21, method: "tools/list" };
 


### PR DESCRIPTION
## Summary

The LSP layer could report problems but never fix formatting: there was no execution path for `textDocument/formatting`, so format drift could only be cleaned up after the fact by a separate tool. This PR adds that path to `lsp-core`, exposes it as a daemon `format` request, and adds a count-based cap on how many language servers may stay resident at once.

After this PR a caller can send one `format` request to the shared daemon and get back a typed result saying whether the file was rewritten, was already clean, or could not be formatted because the server does not offer the capability. Formatting reuses the language server the diagnostics path already keeps warm, so no new resident process is introduced.

This implements section 5.2 step 1 and section 5.6 rule 3 of the format-hook design. A later change consumes this API; nothing outside `lsp-core` and `lsp-daemon` is touched here.

## Changes

**Formatting engine (`packages/lsp-core/src/lsp/`)**
- `format-document.ts` is the new entry point. It asks the resident client for whole-document edits, applies them with the same `normalizeTextEdits` validator the workspace-edit path already uses, and commits the result atomically via temp file plus rename.
- `client.ts` gains `formatDocument`, which opens and syncs the document, then returns `null` when the server never advertised the capability so callers can report unavailability instead of surfacing a method-not-found error.
- `connection.ts` and `transport.ts` record `documentFormattingProvider` from the initialize response. The provider may be a boolean or an options object, and an explicit `false` means refusal, so both shapes are handled rather than checking key presence.
- Nothing is written when the server declines, when it returns no edits, or when the edits reproduce the current bytes. A no-op format therefore does not disturb the file mtime that downstream tooling watches.

**Tool surface (`packages/lsp-core/src/tools/`)**
- `format.ts` wires the engine into the MCP tool list as `format` (alias `lsp_format`), so daemon callers reach it exactly the way they reach diagnostics. A file whose extension has no configured or installed server reuses the existing missing-dependency result rather than inventing a second not-installed shape.
- `tool-surface.test.ts` pins the new nine-tool descriptor set.

**Daemon (`packages/lsp-daemon/src/`)**
- `callFormatViaDaemon` on the public client surface, with `LspFormatDetails` mirroring the Core detail type consumers destructure.
- Routing needed no new branch: the daemon dispatches `tools/call` by name, so `format` flows through the existing path. `OMO_DAEMON_PROTOCOL_VERSION` stays at 1 because the wire envelope is unchanged. New routing tests pin that a `format` request reaches Core with its arguments intact, and that a `format` call without `_context` is still rejected before dispatch.

**Resident client cap (`packages/lsp-core/src/lsp/manager.ts`)**
- `maxResidentClients` (default 6) evicts the least recently used idle client before admitting a new one. A multi-language monorepo can otherwise keep several heavyweight servers alive simultaneously, and the idle reaper bounds them only by time, never by count.
- A client with in-flight work is never eligible for eviction: when every resident client is busy the cap is exceeded rather than tearing a server down underneath a live request. The idle reaper is untouched.

## QA & Evidence

Evidence directory: `.omo/evidence/20260827-format-capability/` (see `README.md` there for the full write-up).

**Live daemon format request against real language servers** (the primary gate)
- **What was tested:** `packages/lsp-daemon/scripts/qa/format-request-e2e.mjs` spawns the real built daemon (`dist/cli.js daemon`) on its real unix socket and sends authenticated `tools/call` frames named `format`. The language servers are genuine repo-local devDependency installs (`bun add -d @biomejs/biome`, `bun add -d oxlint`) in throwaway fixture repos. No stubs on either side of the socket.
- **Observed result:** verdict PASS, all 10 checks true.
  - drifted `.css`: `Formatted .../drifted.css (+6/-3 lines)`, `{status:"formatted", linesAdded:6, linesRemoved:3}`; bytes went from `a{color:red;background:blue}` to a properly indented rule block.
  - second format of the same file: `{status:"unchanged", linesAdded:0, linesRemoved:0}`, bytes unchanged.
  - `.txt` with no configured server: the pre-existing missing-dependency message, `errorKind:"missing_dependency"`, bytes unchanged.
  - `.ts` with oxlint pinned as the only server: `{status:"unavailable", reason:"capability_not_advertised"}`, bytes unchanged. oxlint really runs and really completes initialize; it simply does not offer formatting.
  - process count after all requests: exactly 1 resident daemon.
- **Artifact:** `.omo/evidence/20260827-format-capability/format-request-e2e.json`
- **Why sufficient:** every outcome the result type can express is proven on the real surface a consumer uses, and each one carries a byte comparison, so "did not format" can never silently mean "corrupted the file".

**Failing-first captures**
- **What was tested:** each behavior was pinned by a failing test before the production code existed.
- **Observed result:** `red-01-manager-cap.log` (3 of 4 cap tests fail without `maxResidentClients`), `red-02-format.log` (format tests fail on missing modules), `red-03-daemon-client-surface.log` (client-surface tests fail without `callFormatViaDaemon`).
- **Artifact:** the three `red-*.log` files in the evidence directory.
- **Why sufficient:** confirms the tests actually exercise the new code rather than passing vacuously.

**Automated gates**
- **What was tested:** `bun test packages/lsp-core`, `npx vitest --run` in `packages/lsp-daemon`, `bun run typecheck`, and `biome check` plus `tsc --noEmit` on the daemon files this branch touches.
- **Observed result:** 145 lsp-core tests pass, 158 daemon tests pass across 21 files, typecheck clean across all workspace packages, biome clean on the four daemon files changed here.
- **Artifact:** `green-01-manager-cap.log`, `green-02-format.log`, `green-03-daemon.log`.
- **Why sufficient:** covers the unit-level invariants the live driver cannot isolate, in particular that an evicted client is actually stopped and that a busy client is never evicted.

## Risks & Residuals

- **Formatting could corrupt a file.** Mitigated: edits go through the existing workspace-edit validator, which rejects out-of-range and overlapping ranges, and the commit is temp-file plus rename so a partial write cannot be observed. Every live case asserts the resulting bytes.
- **A server without the capability could throw instead of reporting.** Mitigated: proven live against oxlint, which returns the typed unavailable result with the file byte-identical.
- **The cap could evict a server mid-request.** Mitigated: eviction candidates require zero refCount, zero pending waiters, and no in-flight initialization; a dedicated test asserts the cap is exceeded rather than evicting a busy client.
- **Memory growth from a new feature.** Mitigated: no new resident process. Formatting reuses the already-warm server, and the live run asserts a single resident daemon. The cap strictly reduces worst-case residency.
- **Retry could double-apply a format.** Accepted as already-safe: the daemon client breaks out of its retry loop whenever the request was written, so a format that reached the daemon is never resent.
- **Pre-existing unrelated failures.** `packages/omo-native` setup/doctor tests fail on this machine because they read the developer's real `~/.senpi` credentials. Verified identical on a pristine `origin/dev` checkout (11 failures there, and this branch touches none of those files). Not addressed here.
- **Windows not exercised live.** The driver keeps its work root short because the biome lsp-proxy opens its own unix socket and macOS caps the path at `SUN_LEN`; the named-pipe path is covered by the existing daemon test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a whole-document format path to `lsp-core`, exposed to daemon callers as a `format` request, and caps resident language servers at six by evicting the least recently used idle client before admitting a new one.

- Formatting reuses the already-warm server the diagnostics path keeps resident, so no new process starts.
- Callers get a typed result: `formatted` with line deltas, `unchanged`, or `unavailable` when the server never advertised `documentFormattingProvider`.
- A no-op format leaves file bytes and mtime untouched; a server edit computed against stale text is rejected by the range validator, so a concurrent write cannot be corrupted.
- Busy clients are never evicted; a busy set exceeds the cap rather than tearing a server down mid-request.
- The wire envelope is unchanged, so `OMO_DAEMON_PROTOCOL_VERSION` stays at 1.
- `lsp-tools-mcp` re-exports the Core tool list, so its `tools/list` pins now assert the nine-tool surface.

<sup>Written for commit 8c4981fef1e88c02112f6ab163c90ad5a6207a14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

