### PR TITLE
test(omo-senpi): widen mailbox durability timeout

### DIFF
--- a/packages/omo-senpi/changes.md
+++ b/packages/omo-senpi/changes.md
@@ -5,6 +5,15 @@
 development dependency. Keep the peer, dev dependency, root patched-dependency
 key, and generated lockfile aligned with the native runtime pin.
 
+## 2026-08-27 — Allow the mailbox durability stress test to finish on Windows
+
+The mailbox cap-and-restart test now has a 15-second per-test budget. It performs
+128 durable atomic queue writes plus a second byte-cap queue on Windows, where
+filesystem write and rename latency can exceed Bun's default five-second test
+budget even though the queue contract completes correctly. This changes only the
+test deadline; mailbox bounds, ordering, persistence, and production retry
+behavior remain unchanged.
+
 ## 2026-08-27 — Keep thread persistence and DAP portable on Windows
 
 The thread mailbox and durable receipt stores now use the shared atomic-write

--- a/packages/omo-senpi/changes.md
+++ b/packages/omo-senpi/changes.md
@@ -14,6 +14,14 @@ budget even though the queue contract completes correctly. This changes only the
 test deadline; mailbox bounds, ordering, persistence, and production retry
 behavior remain unchanged.
 
+## 2026-08-27 — Preserve the full Windows model-admission test budget
+
+The task RPC model-admission parity tests now pass their calculated timeout
+through Bun's supported timeout option object. This preserves the intended
+`PROBE_TIMEOUT_MS * 3 + 20_000` budget on Windows instead of allowing the
+legacy numeric argument form to be capped by the runner's default test
+deadline. Production probe behavior is unchanged.
+
 ## 2026-08-27 — Keep thread persistence and DAP portable on Windows
 
 The thread mailbox and durable receipt stores now use the shared atomic-write

--- a/packages/omo-senpi/src/components/task/task-rpc-launch-parity.test.ts
+++ b/packages/omo-senpi/src/components/task/task-rpc-launch-parity.test.ts
@@ -102,7 +102,7 @@ describe("task RPC launch profile parity", () => {
 
     // then
     expect(await admission).toBeUndefined()
-  }, ADMISSION_TEST_TIMEOUT_MS)
+  }, { timeout: ADMISSION_TEST_TIMEOUT_MS })
 
   test("#given a model known only through parent resources #when its provider extension is not forwarded #then admission rejects before launch", async () => {
     // given
@@ -118,5 +118,5 @@ describe("task RPC launch profile parity", () => {
         message: expect.stringMatching(/omo-mock\/mock-1.*probed catalog has/),
       },
     })
-  }, ADMISSION_TEST_TIMEOUT_MS)
+  }, { timeout: ADMISSION_TEST_TIMEOUT_MS })
 })

--- a/packages/omo-senpi/src/components/thread/mailbox.test.ts
+++ b/packages/omo-senpi/src/components/thread/mailbox.test.ts
@@ -213,5 +213,5 @@ describe("ordered delivery mailbox", () => {
     byteMailbox.close()
     rmSync(directory, { recursive: true, force: true })
     rmSync(byteDirectory, { recursive: true, force: true })
-  })
+  }, { timeout: 15_000 })
 })


### PR DESCRIPTION
## Summary

The beta.23 release-state CI passed every gate except the Windows Senpi compatibility job. That job's only failure was the mailbox durability cap stress test exceeding Bun's default 5-second per-test budget after the intentional atomic-write portability fix.

This follow-up changes only that test deadline to 15 seconds. The exact focused test passes locally, the thread suite passes 113/113, and the adapter typecheck passes. No production mailbox or fsync behavior changes.

## Evidence

- \bun test packages/omo-senpi/src/components/thread/mailbox.test.ts -t 'persists pending messages and enforces count and byte caps'\: pass
- \bun test packages/omo-senpi/src/components/thread\: 113 pass / 0 fail
- \tsgo --noEmit -p packages/omo-senpi/tsconfig.json\: pass
- Failure source: Windows CI job 98491853687, one timeout only

No release publication should begin until this follow-up is green and merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widens Windows CI test budgets so the Senpi compatibility job no longer times out, covering two test-only fixes.

- Raises the mailbox durability stress test deadline from 5 to 15 seconds to accommodate Windows fsync and rename latency.
- Passes the RPC model-admission timeout through Bun's object option form so the intended `PROBE_TIMEOUT_MS * 3 + 20_000` budget is preserved instead of being capped by the default deadline.

No production mailbox bounds, ordering, persistence, retry, or probe behavior changes.

<sup>Written for commit 4e0ced272e610ef8f4b09feabc823fab87a37da5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

