### PR TITLE
fix(lsp-daemon): preserve spaced Windows runtime paths

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -16,6 +16,15 @@ Focused regression coverage includes the real DAP fixture session, Windows
 drive-letter classification, atomic-write replacement with injected `EPERM`
 from `fsync`, mailbox persistence, and durable receipt lifecycle behavior.
 
+## 2026-08-27 — Keep Windows LSP daemon stamping safe with spaced runtimes
+
+The LSP daemon build helper now disables shell execution when invoking an
+absolute runtime path such as `C:\Program Files\nodejs\node.exe`, while keeping
+shell lookup for bare `tsc` and `bun` commands on Windows. The release builder
+therefore reaches the version-stamping step instead of letting the shell split
+the runtime path at `C:\Program`. The command-policy regression tests cover
+absolute Windows paths, bare package commands, and POSIX execution.
+
 ## 2026-08-27 — Record post-beta.23 merged follow-ups
 
 The root product changelog now records the pull requests merged after the

--- a/packages/lsp-daemon/scripts/build-command.d.mts
+++ b/packages/lsp-daemon/scripts/build-command.d.mts
@@ -1,0 +1,1 @@
+export declare function shouldUseShellForCommand(command: string, platform?: string): boolean

--- a/packages/lsp-daemon/scripts/build-command.mjs
+++ b/packages/lsp-daemon/scripts/build-command.mjs
@@ -1,0 +1,5 @@
+const ABSOLUTE_COMMAND_PATH = /^(?:[A-Za-z]:[\\/]|\\\\|\/)/
+
+export function shouldUseShellForCommand(command, platform = process.platform) {
+  return platform === "win32" && !ABSOLUTE_COMMAND_PATH.test(command)
+}

--- a/packages/lsp-daemon/scripts/build.mjs
+++ b/packages/lsp-daemon/scripts/build.mjs
@@ -5,6 +5,8 @@ import { mkdir, mkdtemp, rename, rm } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
+import { shouldUseShellForCommand } from "./build-command.mjs"
+
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..")
 const distDir = process.env.OMO_LSP_DAEMON_DIST ?? join(packageRoot, "dist")
 const tempParent = await mkdtemp(join(dirname(distDir), ".tmp-lsp-daemon-build-"))
@@ -12,7 +14,11 @@ const tempDist = join(tempParent, "dist")
 const backupDist = `${distDir}.backup-${process.pid}`
 
 function run(command, args) {
-  const result = spawnSync(command, args, { cwd: packageRoot, stdio: "inherit", shell: process.platform === "win32" })
+  const result = spawnSync(command, args, {
+    cwd: packageRoot,
+    stdio: "inherit",
+    shell: shouldUseShellForCommand(command),
+  })
   if (result.error) throw result.error
   if (result.status !== 0) process.exit(result.status ?? 1)
 }

--- a/packages/lsp-daemon/test/build-script.test.ts
+++ b/packages/lsp-daemon/test/build-script.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import { shouldUseShellForCommand } from "../scripts/build-command.mjs"
+
+describe("LSP daemon build command invocation", () => {
+  it("does not shell an absolute Windows runtime path containing spaces", () => {
+    expect(shouldUseShellForCommand("C:\\Program Files\\nodejs\\node.exe", "win32")).toBe(false)
+  })
+
+  it("keeps shell resolution for bare Windows package commands", () => {
+    expect(shouldUseShellForCommand("bun", "win32")).toBe(true)
+    expect(shouldUseShellForCommand("tsc", "win32")).toBe(true)
+  })
+
+  it("does not use a shell for POSIX commands", () => {
+    expect(shouldUseShellForCommand("bun", "darwin")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

The beta.23 publication workflow reached every platform build, but Windows and Linux musl targets failed in the shared LSP daemon build helper after bundling completed. The helper invoked an absolute Node runtime path such as `C:\Program Files\nodejs\node.exe` with `shell: true`, so Windows truncated it to `C:\Program` before the version-stamping script ran.

This PR centralizes shell selection: bare `tsc` and `bun` commands keep Windows shell lookup, while absolute runtime paths run without a shell. No release metadata or package versions change.

## Evidence

- Publication failures: run 33071667377, jobs 98515571722, 98515571723, 98515571757, 98515571762, and 98515571864.
- Focused regression: `npm test -- test/build-script.test.ts` -> 3 passed.
- LSP daemon full suite: `npm test` -> 158 passed.
- Real build: `npm run build` -> passed.
- The local `npm run check` formatter violations are pre-existing and outside this diff.

The beta.23 publication workflow must be rerun only after this fix is merged.
