### PR TITLE
fix(release): align platform smoke runtime contracts

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -271,6 +271,11 @@ jobs:
             export XDG_STATE_HOME="${SMOKE_ROOT}/xdg/state"
             export XDG_CACHE_HOME="${SMOKE_ROOT}/xdg/cache"
             export OMO_CODING_AGENT_DIR="${SMOKE_ROOT}/agent"
+            # Node's Windows os.homedir() follows USERPROFILE; HOME alone is
+            # only the Git Bash shell view and does not control provisioning.
+            if [[ "$TARGET" == windows-* ]]; then
+              export USERPROFILE="${HOME}"
+            fi
           }
 
           assert_version_line() {
@@ -308,7 +313,7 @@ jobs:
           musl_smoke() {
             # musl binaries cannot run on the glibc runner: alpine container.
             docker run --rm -v "${PWD}:/work" -w /work -e HOME=/tmp/omo-smoke-home \
-              alpine:3.21 sh -c "${BIN} --version" | grep -F "$EXPECTED_VERSION_LINE"
+              alpine:3.21 sh -c "apk add --no-cache libstdc++ >/dev/null && ${BIN} --version" | grep -F "$EXPECTED_VERSION_LINE"
           }
 
           verify_checksum_and_size_only() {

--- a/changes.md
+++ b/changes.md
@@ -16,6 +16,15 @@ Focused regression coverage includes the real DAP fixture session, Windows
 drive-letter classification, atomic-write replacement with injected `EPERM`
 from `fsync`, mailbox persistence, and durable receipt lifecycle behavior.
 
+## 2026-08-27 — Keep platform smoke tests aligned with runtime requirements
+
+The release-binary smoke harness now exports `USERPROFILE` alongside the
+isolated Git Bash `HOME` on Windows so Node's `os.homedir()` resolves the same
+directory used by the provisioning assertion. Linux x64 musl smoke now installs
+the binary's required `libstdc++` runtime package inside Alpine before running
+the version check. These changes keep the smoke gate strict while matching the
+actual Windows home-directory and musl runtime contracts.
+
 ## 2026-08-27 — Keep Windows LSP daemon stamping safe with spaced runtimes
 
 The LSP daemon build helper now disables shell execution when invoking an
@@ -24,7 +33,6 @@ shell lookup for bare `tsc` and `bun` commands on Windows. The release builder
 therefore reaches the version-stamping step instead of letting the shell split
 the runtime path at `C:\Program`. The command-policy regression tests cover
 absolute Windows paths, bare package commands, and POSIX execution.
-
 ## 2026-08-27 — Record post-beta.23 merged follow-ups
 
 The root product changelog now records the pull requests merged after the

--- a/script/publish-release-platform-workflow.test.ts
+++ b/script/publish-release-platform-workflow.test.ts
@@ -365,6 +365,8 @@ describe("release binary asset lane in the platform publish workflow", () => {
     expect(smokeStep).toContain("mktemp -d")
     expect(smokeStep).toContain("XDG_CONFIG_HOME")
     expect(smokeStep).toContain("OMO_CODING_AGENT_DIR")
+    // Node's Windows os.homedir() uses USERPROFILE, not Git Bash's HOME.
+    expect(smokeStep).toContain('export USERPROFILE="${HOME}"')
     // first-run self-provisioning must materialize before any PASS
     expect(smokeStep).toContain("binary-runtime/${OMO_AI_VERSION}")
     // pty round-trip on the pty-capable legs
@@ -387,6 +389,7 @@ describe("release binary asset lane in the platform publish workflow", () => {
     )
     expect(muslSmokeFn).toContain("docker run")
     expect(muslSmokeFn).toContain("alpine:")
+    expect(muslSmokeFn).toContain("apk add --no-cache libstdc++")
     // windows x64 legs exec natively; windows-arm64 is checksum+size only
     expect(branch("windows-x64|windows-x64-baseline)")).toContain("assert_version_line")
     const windowsArm64 = branch("windows-arm64)")


### PR DESCRIPTION
## Summary

The beta.23 platform build workflow reached the smoke step after successful
compilation, but four targets failed for two runtime-contract reasons:

- Windows x64 and x64-baseline used an isolated Git Bash `HOME`, while Node's
  Windows `os.homedir()` follows `USERPROFILE`; first-run provisioning therefore
  landed outside the smoke assertion path.
- Linux x64 musl and musl-baseline binaries require `libstdc++.so.6` and C++
  ABI symbols, which were absent from the Alpine smoke image.

This PR exports `USERPROFILE` to the isolated smoke home for Windows targets
and installs Alpine's `libstdc++` package before executing musl binaries. It
keeps the smoke gate strict and does not bypass or skip any platform.

## Evidence

- Failed publication workflow: run 33075238064.
- Failed steps: `Smoke test release binary` for Windows x64, Windows x64
  baseline, Linux x64 musl, and Linux x64 musl baseline.
- Exact diagnostics: Windows provisioning path mismatch; Alpine reported
  missing `libstdc++.so.6` and C++ ABI symbols.
- `bun test script/publish-release-platform-workflow.test.ts`: passed.
- `bun test script/build-omo-binary.test.ts`: 21 passed, 1 skipped.
- `git diff --check`: passed.

Beta.23 publication must be retried only after this PR is merged and its CI is
green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Four release targets—Windows x64 and x64-baseline, Linux musl and musl-baseline—failed the smoke gate because the smoke environment did not match each runtime's actual contract. The smoke harness now aligns with those contracts and keeps the gate strict.

- Windows smoke now exports `USERPROFILE` alongside the isolated `HOME` so Node's `os.homedir()` resolves the same provisioning path.
- Musl smoke installs Alpine's `libstdc++` package before running the binary version check.
- Workflow tests now assert both fixes remain in the smoke step.
- Retry the beta.23 publication only after this PR merges and CI is green.

<sup>Written for commit db060f5550b141bd9498846ba9899a312ab0cdaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

