### PR TITLE
fix(omo-native): avoid locked Windows self-provisioning target

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -25,6 +25,12 @@ the binary's required `libstdc++` runtime package inside Alpine before running
 the version check. These changes keep the smoke gate strict while matching the
 actual Windows home-directory and musl runtime contracts.
 
+The compiled OmO launcher now materializes its first-run Windows executable by
+copying it to a temporary non-executable path and renaming it into place. This
+avoids opening the final running `.exe` destination directly, which Windows can
+reject with `EBUSY`, while retaining hash-checked provisioning and cleaning the
+temporary path after the move.
+
 ## 2026-08-27 — Keep Windows LSP daemon stamping safe with spaced runtimes
 
 The LSP daemon build helper now disables shell execution when invoking an

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { chmodSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs"
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { spawn } from "node:child_process"
@@ -70,6 +70,18 @@ export function isProvisionedExecutable(execPath: string, expectedPath: string):
     return realpathSync(execPath) === realpathSync(expectedPath)
   } catch {
     return resolve(execPath) === resolve(expectedPath)
+  }
+}
+
+export function materializeProvisionedExecutable(sourcePath: string, destinationPath: string): void {
+  const temporaryPath = `${destinationPath}.tmp-${process.pid}`
+  try {
+    rmSync(temporaryPath, { force: true })
+    copyFileSync(sourcePath, temporaryPath)
+    chmodSync(temporaryPath, 0o755)
+    renameSync(temporaryPath, destinationPath)
+  } finally {
+    rmSync(temporaryPath, { force: true })
   }
 }
 
@@ -214,8 +226,7 @@ async function main(): Promise<void> {
   const expected = join(homedir(), ".omo", "binary-runtime", manifest.omoAiVersion, process.platform === "win32" ? "omo.exe" : "omo")
   if (!isProvisionedExecutable(process.execPath, expected)) {
     await provisionEmbeddedRuntime(manifest, embedded, dirname(expected))
-    writeFileSync(expected, readFileSync(process.execPath))
-    chmodSync(expected, 0o755)
+    materializeProvisionedExecutable(process.execPath, expected)
     const child = spawn(expected, process.argv.slice(2), { env: process.env, stdio: "inherit" })
     await new Promise<void>((resolvePromise) => child.on("close", (code) => { process.exitCode = code ?? 1; resolvePromise() }))
     return

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs"
 import { createHash } from "node:crypto"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import {
   buildSenpiArgs,
   isProvisionedExecutable,
+  materializeProvisionedExecutable,
   provisionEmbeddedRuntime,
   remapSenpiEnvironment,
   runCompiledLauncher,
@@ -58,6 +59,19 @@ describe("compiled omo entry launcher parity", () => {
 })
 
 describe("embedded runtime provisioning", () => {
+  test("materializes the executable through a temporary non-executable path", () => {
+    const root = temp()
+    const source = join(root, "source.exe")
+    const destination = join(root, "runtime", "omo.exe")
+    mkdirSync(join(root, "runtime"), { recursive: true })
+    writeFileSync(source, "compiled binary")
+
+    materializeProvisionedExecutable(source, destination)
+
+    expect(readFileSync(destination, "utf8")).toBe("compiled binary")
+    expect(existsSync(`${destination}.tmp-${process.pid}`)).toBe(false)
+  })
+
   test("selects the omo manifest when senpi also embeds an unrelated manifest", async () => {
     const senpiManifest = { name: "runtime/lsp-daemon/dist/.omo-runtime-manifest.json", text: async () => JSON.stringify({ files: [] }) }
     const omoManifest = { name: "omo-runtime/runtime-manifest.json", text: async () => JSON.stringify({ omoAiVersion: "9.2.1", enginePin: "2026.8.27" }) }


### PR DESCRIPTION
## Summary

The third beta.23 publication workflow passed every Linux and macOS platform
smoke, but Windows x64 and x64-baseline failed while first-run provisioning
the compiled executable. The launcher wrote directly to its final `.exe`
destination with `writeFileSync`, and Windows returned `EBUSY` for that path.

This PR materializes the provisioned executable through a temporary path:
copy the running binary, apply executable mode, then rename it into place.
The temporary path is removed in a `finally` block. The behavior remains
hash-checked and the smoke gate remains strict.

## Evidence

- Failed publication workflow: run 33080217821.
- Failed jobs: 98545571249 and 98545571268.
- Exact error: `EBUSY: resource busy or locked, open ...\\.omo\\binary-runtime\\5.0.0-0.beta.23\\omo.exe` at the direct `writeFileSync` call.
- Linux musl and all non-Windows platform smoke lanes passed in that run.
- `bun test packages/omo-native/test/compile-entry.test.ts`: passed.
- `bun test script/publish-release-platform-workflow.test.ts`: passed.
- `bun run typecheck`: passed.
- `git diff --check`: passed.

Beta.23 publication must be retried only after this PR is merged and CI is
green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows self-provisioning so the compiled launcher no longer fails with `EBUSY` when writing directly to the final `.exe` destination.

- Provisions the executable by copying to a temporary path, setting executable mode, then renaming into place. Hash-checked provisioning and strict smoke gates remain unchanged.

<sup>Written for commit cf15df923ed6a74cad012831a572beaac3473921. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

