### PR TITLE
test(windows): widen integration time budgets

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -31,6 +31,12 @@ avoids opening the final running `.exe` destination directly, which Windows can
 reject with `EBUSY`, while retaining hash-checked provisioning and cleaning the
 temporary path after the move.
 
+Windows CI now gives the Codex installer integration test and the seven-node
+DAG failure E2E their observed platform-specific execution budgets. The
+assertions and event-driven behavior remain unchanged; only the test harness
+deadlines are widened from the prior 60-second and 15-second ceilings that
+expired on the full Windows matrix.
+
 ## 2026-08-27 — Keep Windows LSP daemon stamping safe with spaced runtimes
 
 The LSP daemon build helper now disables shell execution when invoking an

--- a/packages/omo-codex/src/install/install-codex.test.ts
+++ b/packages/omo-codex/src/install/install-codex.test.ts
@@ -9,7 +9,7 @@ import { findRepoRoot, findRepoRootFromImporter, resolveCodexInstallerBinDir, ru
 import { createRepoWithBuiltComponentBins } from "./install-codex-test-fixtures"
 import { createLegacyCodexHome, liveLegacyEndpointFor, startLegacyDaemonProcess, stopChild, waitForChildReady, writeLegacyVersionState } from "./lsp-daemon-reaper.test-support"
 
-const INSTALL_CODEX_INTEGRATION_TEST_TIMEOUT_MS = process.platform === "win32" ? 60_000 : 20_000
+const INSTALL_CODEX_INTEGRATION_TEST_TIMEOUT_MS = process.platform === "win32" ? 120_000 : 20_000
 
 const skipAstGrepInstall = async () => ({ kind: "skipped" as const, reason: "test" })
 

--- a/packages/senpi-task/src/dag/e2e-failure.test.ts
+++ b/packages/senpi-task/src/dag/e2e-failure.test.ts
@@ -477,6 +477,8 @@ async function readLine(stream: ReadableStream<Uint8Array>): Promise<string> {
 }
 
 describe("DAG failure, crash, and policy end to end", () => {
+  const DAG_FAILURE_E2E_TIMEOUT_MS = process.platform === "win32" ? 90_000 : 15_000
+
   test("#given two failures whose completion order opposes graph order #when the real engine runs #then siblings and independent branches finish, dependents skip, and graph order selects the primary failure", async () => {
     // given
     const runner = new ControlledRunner()
@@ -519,7 +521,7 @@ describe("DAG failure, crash, and policy end to end", () => {
       type: "dag.run.failed",
       error: { nodeId: "graph-first-failure", message: "failure:graph-first-failure" },
     })
-  }, { timeout: 15_000 })
+  }, { timeout: DAG_FAILURE_E2E_TIMEOUT_MS })
 
   test("#given a crash after an owned task spawns but before task attachment #when a fresh manager resumes #then startOwned recovers the existing task and spawn count remains exactly one", async () => {
     // given


### PR DESCRIPTION
## Summary

The first merged-`dev` CI run after the Windows launcher fix exposed three
Windows-only timing failures unrelated to the launcher change:

- the Codex installer integration test hit its 60-second ceiling;
- the seven-node DAG failure E2E hit its hardcoded 15-second ceiling;
- the Windows Senpi RPC E2E failed in the same full compatibility run without
  emitting a structured driver diagnostic.

This PR widens only the two deterministic test budgets to 120 seconds and 90
seconds respectively. It does not skip tests, change assertions, or alter
production behavior. The RPC test is intentionally unchanged until a
repeatable diagnostic is available.

## Evidence

- Failed merged CI: run 33081706100, exact head
  `73a023c024bf77bb3beab05ea81285d7d6f9dc16`.
- Windows shard 2: 5,299 passed, 77 skipped, 2 failed; installer elapsed
  60,004 ms and DAG elapsed about 67,083 ms.
- Windows Senpi compatibility: 2,403 passed, 14 skipped, 1 failed; the RPC
  test failed after about 147,114 ms without a diagnostic payload.
- Local installer test: 11 passed.
- Local DAG E2E: 17 passed.
- Full OmO typecheck: passed.
- `git diff --check`: passed.

The beta.23 publication workflow must be retried only after this PR is merged
and its CI is green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widens two Windows-only test timeouts that expired on the full Windows CI matrix, so the Codex installer integration test and the seven-node DAG failure E2E no longer flake.

- Raises the Codex installer integration test timeout from 60 to 120 seconds on Windows.
- Raises the seven-node DAG failure E2E timeout from 15 to 90 seconds on Windows.
- Leaves the Senpi RPC E2E unchanged until a repeatable diagnostic is available.
- Does not skip tests or change assertions or production behavior.

<sup>Written for commit 8897ead880ca4a5ba0aa6035e5694e0f5e3e57d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

