### PR TITLE
fix(omo-native): copy Windows runtime without rename

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -26,10 +26,10 @@ the version check. These changes keep the smoke gate strict while matching the
 actual Windows home-directory and musl runtime contracts.
 
 The compiled OmO launcher now materializes its first-run Windows executable by
-copying it to a temporary non-executable path and renaming it into place. This
-avoids opening the final running `.exe` destination directly, which Windows can
-reject with `EBUSY`, while retaining hash-checked provisioning and cleaning the
-temporary path after the move.
+copying it directly with the platform file-copy API, because Windows rejects
+renaming a newly copied `.exe` into place with `EPERM` even when the
+destination did not previously exist. POSIX keeps the temporary-copy and
+atomic-rename path. Both branches retain hash-checked provisioning and cleanup.
 
 Windows CI now gives the Codex installer integration test and the seven-node
 DAG failure E2E their observed platform-specific execution budgets. The

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -73,7 +73,16 @@ export function isProvisionedExecutable(execPath: string, expectedPath: string):
   }
 }
 
-export function materializeProvisionedExecutable(sourcePath: string, destinationPath: string): void {
+export function materializeProvisionedExecutable(
+  sourcePath: string,
+  destinationPath: string,
+  platform = process.platform,
+): void {
+  if (platform === "win32") {
+    copyFileSync(sourcePath, destinationPath)
+    chmodSync(destinationPath, 0o755)
+    return
+  }
   const temporaryPath = `${destinationPath}.tmp-${process.pid}`
   try {
     rmSync(temporaryPath, { force: true })

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -59,14 +59,26 @@ describe("compiled omo entry launcher parity", () => {
 })
 
 describe("embedded runtime provisioning", () => {
-  test("materializes the executable through a temporary non-executable path", () => {
+  test("materializes the executable directly on Windows", () => {
     const root = temp()
     const source = join(root, "source.exe")
     const destination = join(root, "runtime", "omo.exe")
     mkdirSync(join(root, "runtime"), { recursive: true })
     writeFileSync(source, "compiled binary")
 
-    materializeProvisionedExecutable(source, destination)
+    materializeProvisionedExecutable(source, destination, "win32")
+
+    expect(readFileSync(destination, "utf8")).toBe("compiled binary")
+  })
+
+  test("materializes the executable through a temporary non-executable path on POSIX", () => {
+    const root = temp()
+    const source = join(root, "source.exe")
+    const destination = join(root, "runtime", "omo.exe")
+    mkdirSync(join(root, "runtime"), { recursive: true })
+    writeFileSync(source, "compiled binary")
+
+    materializeProvisionedExecutable(source, destination, "darwin")
 
     expect(readFileSync(destination, "utf8")).toBe("compiled binary")
     expect(existsSync(`${destination}.tmp-${process.pid}`)).toBe(false)


### PR DESCRIPTION
## Summary

The fourth beta.23 publication workflow passed every non-Windows platform
smoke, but Windows x64 and x64-baseline failed while first-run provisioning
the compiled executable. The launcher first failed with a direct write to the
destination (`EBUSY`), then failed with temporary-copy plus rename
(`EPERM: operation not permitted, rename ...omo.exe.tmp -> ...omo.exe`).

This PR uses direct `copyFileSync(source, destination)` only on Windows for
first materialization into the absent versioned destination, followed by the
Windows no-op-safe mode operation. POSIX keeps temporary copy plus atomic
rename. The Windows path never attempts to replace an existing executable.

## Evidence

- Failed publication workflow: run 33086520737.
- Failed jobs: 98567973743 and 98567973819.
- Exact finalized error: `EPERM` from `renameSync` when moving the temporary
  executable into the versioned destination.
- Linux musl and all non-Windows platform smoke lanes passed in that run.
- `bun test packages/omo-native/test/compile-entry.test.ts`: passed, including
  Windows direct-copy and POSIX atomic-rename branches.
- `bun test script/publish-release-platform-workflow.test.ts`: passed.
- `bun run typecheck`: passed.
- `git diff --check`: passed.

Beta.23 publication must be retried only after this PR is merged and its CI is
green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows first-run provisioning of the compiled OmO launcher so Windows x64 and x64-baseline smoke tests no longer fail with `EPERM` during the beta.23 publication workflow.

- Windows now copies the executable directly into the versioned destination instead of copying to a temporary path and renaming, because Windows rejects the rename with `EPERM` even when the destination did not previously exist.
- POSIX keeps the temporary-copy and atomic-rename path.
- Adds a `platform` parameter to `materializeProvisionedExecutable` and updates tests to cover both Windows direct-copy and POSIX rename branches.

<sup>Written for commit 24c3c1611bc15678d79a15f136ac91f5b5f976ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

