### PR TITLE
fix(omo-native): stop Windows self-provisioning loop

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -30,6 +30,9 @@ copying it directly with the platform file-copy API, because Windows rejects
 renaming a newly copied `.exe` into place with `EPERM` even when the
 destination did not previously exist. POSIX keeps the temporary-copy and
 atomic-rename path. Both branches retain hash-checked provisioning and cleanup.
+The compiled Windows child now identifies its launched executable from
+`process.argv[0]` rather than Bun's original compile path, preventing repeated
+self-provisioning and the resulting `AssignProcessToJobObject` loop.
 
 Windows CI now gives the Codex installer integration test and the seven-node
 DAG failure E2E their observed platform-specific execution budgets. The

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -94,6 +94,14 @@ export function materializeProvisionedExecutable(
   }
 }
 
+export function runningExecutablePath(
+  argv0 = process.argv[0],
+  execPath = process.execPath,
+  platform = process.platform,
+): string {
+  return platform === "win32" && argv0.toLowerCase().endsWith(".exe") ? argv0 : execPath
+}
+
 export function remapSenpiEnvironment(source: NodeJS.ProcessEnv = process.env, execDir: string): NodeJS.ProcessEnv {
   const env = { ...source }
   delete env.OMO_BIN
@@ -232,10 +240,11 @@ async function main(): Promise<void> {
   const manifestFile = await selectRuntimeManifest(embedded)
   if (!manifestFile) throw new Error("embedded runtime-manifest.json is missing")
   const manifest = JSON.parse(await embeddedText(manifestFile)) as EmbeddedManifest
+  const runningExecutable = runningExecutablePath()
   const expected = join(homedir(), ".omo", "binary-runtime", manifest.omoAiVersion, process.platform === "win32" ? "omo.exe" : "omo")
-  if (!isProvisionedExecutable(process.execPath, expected)) {
+  if (!isProvisionedExecutable(runningExecutable, expected)) {
     await provisionEmbeddedRuntime(manifest, embedded, dirname(expected))
-    materializeProvisionedExecutable(process.execPath, expected)
+    materializeProvisionedExecutable(runningExecutable, expected)
     const child = spawn(expected, process.argv.slice(2), { env: process.env, stdio: "inherit" })
     await new Promise<void>((resolvePromise) => child.on("close", (code) => { process.exitCode = code ?? 1; resolvePromise() }))
     return

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -9,6 +9,7 @@ import {
   materializeProvisionedExecutable,
   provisionEmbeddedRuntime,
   remapSenpiEnvironment,
+  runningExecutablePath,
   runCompiledLauncher,
   selectRuntimeManifest,
   versionLine,
@@ -23,6 +24,14 @@ const sha = (value: string) => createHash("sha256").update(value).digest("hex")
 afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }) })
 
 describe("compiled omo entry launcher parity", () => {
+  test("uses the launched Windows executable path for self-provisioning identity", () => {
+    expect(runningExecutablePath("C:\\runtime\\omo.exe", "B:\\~BUN\\root\\omo.exe", "win32")).toBe(
+      "C:\\runtime\\omo.exe",
+    )
+    expect(runningExecutablePath("bun", "/usr/local/bin/bun", "win32")).toBe("/usr/local/bin/bun")
+    expect(runningExecutablePath("/runtime/omo", "/usr/local/bin/bun", "darwin")).toBe("/usr/local/bin/bun")
+  })
+
   test("early commands pass through without an extension", () => {
     expect(buildSenpiArgs(["install", "x"], "/provisioned")).toEqual(["install", "x"])
   })


### PR DESCRIPTION
## Summary

The fifth beta.23 publication attempt reached the corrected Windows direct-copy
path, but both Windows x64 smoke jobs hung until the 20-minute workflow
timeout. Their logs showed repeated `AssignProcessToJobObject: (50) The
request is not supported.` messages.

The compiled child was still comparing Bun's original `process.execPath`
(`B:/~BUN/root/omo-windows-x64.exe`) with the provisioned runtime path. It
therefore re-entered first-run provisioning after every self-reexec. This PR
uses the launched Windows executable path from `process.argv[0]` when it is an
`.exe`, stopping the provisioning loop. Non-Windows behavior and uncompiled
fallbacks remain unchanged.

## Evidence

- Failed/cancelled publication workflow: run 33090010585.
- Windows x64 and x64-baseline smoke jobs exceeded the 20-minute budget with
  repeated `AssignProcessToJobObject` messages.
- Prior direct destination write failed `EBUSY`; temp-copy plus rename failed
  `EPERM`; direct copy now succeeds before this identity fix.
- `bun test packages/omo-native/test/compile-entry.test.ts`: passed.
- `bun run build:omo-native`: passed with the full native payload.
- `bun run typecheck`: passed.
- `git diff --check`: passed.

Beta.23 publication must be retried only after this PR is merged and its CI is
green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the Windows self-provisioning loop in compiled `omo` children by using `process.argv[0]` for the executable identity when it is an `.exe`, instead of Bun's original compile path. Adds a helper `runningExecutablePath` and a unit test covering Windows `.exe`, Windows non-`.exe`, and non-Windows cases.

<sup>Written for commit 650aee784999a3c52e972adceae4eb71a80355a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

