### PR TITLE
fix(omo-native): avoid Windows self-reexec

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -32,7 +32,9 @@ destination did not previously exist. POSIX keeps the temporary-copy and
 atomic-rename path. Both branches retain hash-checked provisioning and cleanup.
 The compiled Windows child now identifies its launched executable from
 `process.argv[0]` rather than Bun's original compile path, preventing repeated
-self-provisioning and the resulting `AssignProcessToJobObject` loop.
+self-provisioning and the resulting `AssignProcessToJobObject` loop. Windows
+first-run provisioning now continues in-process after materialization, while
+POSIX keeps the child reexec handoff.
 
 Windows CI now gives the Codex installer integration test and the seven-node
 DAG failure E2E their observed platform-specific execution budgets. The

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -79,6 +79,7 @@ export function materializeProvisionedExecutable(
   platform = process.platform,
 ): void {
   if (platform === "win32") {
+    if (existsSync(destinationPath)) return
     copyFileSync(sourcePath, destinationPath)
     chmodSync(destinationPath, 0o755)
     return
@@ -100,6 +101,10 @@ export function runningExecutablePath(
   platform = process.platform,
 ): string {
   return platform === "win32" && argv0.toLowerCase().endsWith(".exe") ? argv0 : execPath
+}
+
+export function shouldReexecAfterProvisioning(platform = process.platform): boolean {
+  return platform !== "win32"
 }
 
 export function remapSenpiEnvironment(source: NodeJS.ProcessEnv = process.env, execDir: string): NodeJS.ProcessEnv {
@@ -242,18 +247,22 @@ async function main(): Promise<void> {
   const manifest = JSON.parse(await embeddedText(manifestFile)) as EmbeddedManifest
   const runningExecutable = runningExecutablePath()
   const expected = join(homedir(), ".omo", "binary-runtime", manifest.omoAiVersion, process.platform === "win32" ? "omo.exe" : "omo")
+  let execDir = dirname(runningExecutable)
   if (!isProvisionedExecutable(runningExecutable, expected)) {
     await provisionEmbeddedRuntime(manifest, embedded, dirname(expected))
     materializeProvisionedExecutable(runningExecutable, expected)
-    const child = spawn(expected, process.argv.slice(2), { env: process.env, stdio: "inherit" })
-    await new Promise<void>((resolvePromise) => child.on("close", (code) => { process.exitCode = code ?? 1; resolvePromise() }))
-    return
+    if (shouldReexecAfterProvisioning()) {
+      const child = spawn(expected, process.argv.slice(2), { env: process.env, stdio: "inherit" })
+      await new Promise<void>((resolvePromise) => child.on("close", (code) => { process.exitCode = code ?? 1; resolvePromise() }))
+      return
+    }
+    execDir = dirname(expected)
   }
   // Inspector and custom execArgv isolation is unsupported in compiled binaries; the provisioned
   // executable delegates to the engine in-process as required by the native startup contract.
-  if (await runCompiledLauncher(process.argv.slice(2), dirname(process.execPath), manifest.enginePin, dirname(process.execPath))) return
-  process.argv.splice(2, process.argv.length - 2, ...buildSenpiArgs(process.argv.slice(2), dirname(process.execPath)))
-  Object.assign(process.env, remapSenpiEnvironment(process.env, dirname(process.execPath)))
+  if (await runCompiledLauncher(process.argv.slice(2), execDir, manifest.enginePin, execDir)) return
+  process.argv.splice(2, process.argv.length - 2, ...buildSenpiArgs(process.argv.slice(2), execDir))
+  Object.assign(process.env, remapSenpiEnvironment(process.env, execDir))
   await import("../../node_modules/@code-yeongyu/senpi/dist/cli.js") // literal: see import note above
 }
 

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -12,6 +12,7 @@ import {
   runningExecutablePath,
   runCompiledLauncher,
   selectRuntimeManifest,
+  shouldReexecAfterProvisioning,
   versionLine,
   updateLine,
   type EmbeddedManifest,
@@ -30,6 +31,8 @@ describe("compiled omo entry launcher parity", () => {
     )
     expect(runningExecutablePath("bun", "/usr/local/bin/bun", "win32")).toBe("/usr/local/bin/bun")
     expect(runningExecutablePath("/runtime/omo", "/usr/local/bin/bun", "darwin")).toBe("/usr/local/bin/bun")
+    expect(shouldReexecAfterProvisioning("win32")).toBe(false)
+    expect(shouldReexecAfterProvisioning("darwin")).toBe(true)
   })
 
   test("early commands pass through without an extension", () => {
@@ -78,6 +81,19 @@ describe("embedded runtime provisioning", () => {
     materializeProvisionedExecutable(source, destination, "win32")
 
     expect(readFileSync(destination, "utf8")).toBe("compiled binary")
+  })
+
+  test("does not overwrite an existing Windows provisioned executable", () => {
+    const root = temp()
+    const source = join(root, "source.exe")
+    const destination = join(root, "runtime", "omo.exe")
+    mkdirSync(join(root, "runtime"), { recursive: true })
+    writeFileSync(source, "new binary")
+    writeFileSync(destination, "existing binary")
+
+    materializeProvisionedExecutable(source, destination, "win32")
+
+    expect(readFileSync(destination, "utf8")).toBe("existing binary")
   })
 
   test("materializes the executable through a temporary non-executable path on POSIX", () => {


### PR DESCRIPTION
## Summary

The sixth beta.23 publication attempt reached the Windows smoke step after the
direct-copy and argv identity fixes, but both Windows x64 smoke jobs hung until
they were cancelled. The previous logs showed repeated
`AssignProcessToJobObject: (50) The request is not supported.` messages.

The provisioned child still cannot usefully re-exec itself under Bun on the
Windows runner: the compiled runtime reports Bun's original compile path even
after launch from the versioned destination. This PR avoids that Windows
self-reexec path. After first-run materialization it continues in-process from
the provisioned runtime directory; POSIX retains the existing child reexec
handoff. Windows provisioning is idempotent and does not overwrite an existing
destination.

## Evidence

- Cancelled publication workflow: run 33095914652.
- Windows x64 and x64-baseline were stuck in `Smoke test release binary` and
  repeatedly emitted `AssignProcessToJobObject: (50) The request is not
  supported.` before cancellation.
- Local compile-entry tests pass, including Windows no-reexec and existing
  destination preservation.
- `bun test script/publish-release-platform-workflow.test.ts`: passed.
- `bun run build:omo-native`: passed with 36 required artifacts.
- `bun run typecheck`: passed.
- `git diff --check`: passed.

Beta.23 publication must be retried only after this PR is merged and its CI is
green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows first-run provisioning hanging by avoiding child re-exec on Windows; the runtime now continues in-process after materialization, while POSIX keeps the existing child reexec handoff.

- Windows provisioning no longer overwrites an existing provisioned destination.
- Adds `shouldReexecAfterProvisioning` to gate the Windows in-process path and tests for it.

<sup>Written for commit f9f483753a4193f82aaf111a67f71c22e1bad484. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

