### PR TITLE
fix(release): install musl runtime for arm64 smoke

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -666,7 +666,7 @@ jobs:
           if [ "$MUSL_EXISTS" != "true" ]; then
             # alpine container for the musl binary.
             docker run --rm -v "${PWD}:/work" -w /work -e HOME=/tmp/omo-smoke-home \
-              alpine:3.21 sh -c "chmod +x .omo/release-binaries/omo-linux-arm64-musl && .omo/release-binaries/omo-linux-arm64-musl --version" \
+              alpine:3.21 sh -c "apk add --no-cache libstdc++ >/dev/null && chmod +x .omo/release-binaries/omo-linux-arm64-musl && .omo/release-binaries/omo-linux-arm64-musl --version" \
               | grep -F "$EXPECTED_VERSION_LINE"
           fi
 

--- a/changes.md
+++ b/changes.md
@@ -35,6 +35,8 @@ The compiled Windows child now identifies its launched executable from
 self-provisioning and the resulting `AssignProcessToJobObject` loop. Windows
 first-run provisioning now continues in-process after materialization, while
 POSIX keeps the child reexec handoff.
+The dedicated Linux arm64 Alpine smoke lane now installs `libstdc++` before
+executing the musl binary, matching the x64 musl smoke contract.
 
 Windows CI now gives the Codex installer integration test and the seven-node
 DAG failure E2E their observed platform-specific execution budgets. The

--- a/script/publish-release-platform-workflow.test.ts
+++ b/script/publish-release-platform-workflow.test.ts
@@ -430,6 +430,7 @@ describe("release binary asset lane in the platform publish workflow", () => {
     // glibc leg execs natively, musl leg runs in an alpine container
     expect(job).toContain("omo-linux-arm64")
     expect(job).toContain("alpine:")
+    expect(job).toContain("apk add --no-cache libstdc++")
     // same exact version-line contract as the build-job smoke
     expect(job).toContain("(engine: senpi ${ENGINE_PIN})")
     expect(job).toContain("binary-runtime/${OMO_AI_VERSION}")


### PR DESCRIPTION
## Summary

The seventh beta.23 publication workflow passed all Windows x64, Windows
baseline, Windows arm64, Linux, and Darwin build/smoke lanes. The only
failure was the dedicated `publish-platform / smoke-linux-arm64` job.

Its Alpine command executed `omo-linux-arm64-musl --version` without installing
the same `libstdc++` runtime package already required by the x64 musl smoke
helper. Alpine reported `libstdc++.so.6` missing and the expected C++ ABI
symbols could not relocate.

This PR adds `apk add --no-cache libstdc++` to the dedicated arm64 musl smoke
command and locks the requirement into the workflow contract test. No binary
build flags or smoke assertions are weakened.

## Evidence

- Failed workflow: run 33100287029.
- Failed job: 98618833808, step `Smoke linux-arm64 binaries`.
- Exact error: Alpine could not load `libstdc++.so.6` for
  `omo-linux-arm64-musl`.
- All Windows platform smoke lanes passed in that same workflow.
- `bun test script/publish-release-platform-workflow.test.ts`: passed.
- `bun run typecheck`: passed.
- `git diff --check`: passed.

Beta.23 publication must be retried only after this PR is merged and CI is
green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs the `libstdc++` runtime in the Linux arm64 musl smoke lane so the Alpine container can run the musl binary, matching the x64 musl setup. Adds a workflow contract test to keep the requirement from regressing.

<sup>Written for commit 8307b47c96281ab811af9f151ac473a9ce88e691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

