### PR TITLE
fix(senpi): resolve TUI model display regressions

### DIFF
--- a/patches/@code-yeongyu%2Fsenpi@2026.8.27.patch
+++ b/patches/@code-yeongyu%2Fsenpi@2026.8.27.patch
@@ -22,3 +22,36 @@ diff --git a/dist/core/extensions/builtin/claude-sdk-oauth/session-registry-pump
          }
          return false;
      }
+diff --git a/dist/modes/interactive/components/favorite-models-selector.js b/dist/modes/interactive/components/favorite-models-selector.js
+--- a/dist/modes/interactive/components/favorite-models-selector.js
++++ b/dist/modes/interactive/components/favorite-models-selector.js
+@@ -1,5 +1,5 @@
+ import { modelsAreEqual } from "@earendil-works/pi-ai";
+-import { Container, getKeybindings, Input, Key, matchesKey, Spacer, Text, } from "@earendil-works/pi-tui";
++import { Container, getKeybindings, Input, Key, matchesKey, Spacer, Text, TruncatedText, } from "@earendil-works/pi-tui";
+ import { rankModelSearchItems } from "../model-search-rank.js";
+ import { theme } from "../theme/theme.js";
+ import { DynamicBorder } from "./dynamic-border.js";
+@@ -146,7 +146,7 @@
+             const modelText = isSelected ? theme.fg("accent", item.model.id) : item.model.id;
+             const providerBadge = theme.fg("muted", ` [${item.model.provider}]`);
+             const currentMarker = this.currentModel && modelsAreEqual(this.currentModel, item.model) ? theme.fg("success", " ✓") : "";
+-            this.listContainer.addChild(new Text(`${prefix}${favoriteMarker} ${modelText}${providerBadge}${currentMarker}`, 0, 0));
++            this.listContainer.addChild(new TruncatedText(`${prefix}${favoriteMarker} ${modelText}${providerBadge}${currentMarker}`, 0, 0));
+         }
+         if (this.filteredItems.length > this.maxVisible) {
+             const scrollInfo = `  (${startIndex + 1}-${endIndex} of ${this.filteredItems.length})`;
+diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
+--- a/dist/modes/interactive/interactive-mode.js
++++ b/dist/modes/interactive/interactive-mode.js
+@@ -4738,8 +4738,8 @@
+         }
+         this.ui.requestRender();
+     }
+-    cycleThinkingLevel() {
+-        const newLevel = this.session.cycleThinkingLevel();
++    async cycleThinkingLevel() {
++        const newLevel = await this.session.cycleThinkingLevel();
+         if (newLevel === undefined) {
+             this.showStatus("Current model does not support thinking");
+         }

--- a/patches/senpi-tui-regressions.test.ts
+++ b/patches/senpi-tui-regressions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+
+import { FavoriteModelsSelectorComponent } from "../node_modules/@code-yeongyu/senpi/dist/modes/interactive/components/favorite-models-selector.js"
+import { InteractiveMode } from "../node_modules/@code-yeongyu/senpi/dist/modes/interactive/interactive-mode.js"
+import { initTheme } from "../node_modules/@code-yeongyu/senpi/dist/modes/interactive/theme/theme.js"
+import { stripAnsi } from "../node_modules/@code-yeongyu/senpi/dist/utils/ansi.js"
+
+describe("patched Senpi TUI regressions", () => {
+  test("favorite model rows stay on one line in a narrow terminal", () => {
+    initTheme("dark")
+    const selector = new FavoriteModelsSelectorComponent(
+      {
+        allModels: [
+          {
+            provider: "openai-codex",
+            id: "gpt-5.6-extraordinarily-long-favorite-model",
+            name: "Long",
+            reasoning: true,
+          },
+        ],
+        favoriteModelIds: ["openai-codex/gpt-5.6-extraordinarily-long-favorite-model"],
+      },
+      {
+        onChange() {},
+        onPersist() {},
+        onCancel() {},
+        onSelect() {},
+      },
+    )
+
+    const selectedRow = selector
+      .render(36)
+      .map(stripAnsi)
+      .find((line) => line.includes("→ *"))
+
+    expect(selectedRow).toContain("gpt-5.6")
+  })
+
+  test("thinking-level status waits for the asynchronous session result", async () => {
+    const statuses: string[] = []
+    const mode = {
+      session: { cycleThinkingLevel: async () => "high" },
+      showStatus: (value: string) => statuses.push(value),
+      footer: { invalidate() {} },
+      updateEditorBorderColor() {},
+    }
+
+    await InteractiveMode.prototype.cycleThinkingLevel.call(mode)
+
+    expect(statuses).toEqual(["Thinking level: high"])
+  })
+})


### PR DESCRIPTION
## Summary

- Resolve the Shift+Tab status regression that rendered `Thinking level: [object Promise]`.
- Keep each favorite model on one terminal row, truncating long entries instead of wrapping over later favorites.

## Changes

- Await Senpi's asynchronous thinking-level transition before invalidating the footer and showing status.
- Use the existing width-aware `TruncatedText` component for favorite model rows.
- Add executable regression coverage for both behaviors against the patched package.

## QA & Evidence

- **What was tested:** `bun test patches/senpi-tui-regressions.test.ts`
  **Observed result:** 2 passed, 0 failed.
  **Artifact:** Sanitized local test log.
  **Why sufficient:** Executes the patched package at both regression seams.

- **What was tested:** Isolated local Senpi TUI at 120x40 and 36x30.
  **Observed result:** Shift+Tab showed `Thinking level: high`; `/favorite-models` kept all model entries on one row and ellipsized long entries.
  **Artifact:** Sanitized local terminal capture.
  **Why sufficient:** Exercises both fixes through the real interactive surface.

- **What was tested:** `bun run typecheck`, `bun run build`, and `bun run test:senpi`.
  **Observed result:** All passed; the Senpi gate reported 2,427 passed, 1 Windows-only skip, 0 failed across its two test runs.
  **Artifact:** Local command logs.
  **Why sufficient:** Covers repository typing, production output, and the Senpi adapter integration gate.

## Risks & Residuals

- The full `bun test` run reached 16,771 passing tests but retained 29 failures in unrelated existing config-path, embedded-manifest, and tmux suites. The focused Senpi suite, typecheck, build, and manual TUI checks are clean.

## Automated Checks

```bash
bun test patches/senpi-tui-regressions.test.ts
bun run typecheck
bun run build
bun run test:senpi
bun test # 16,771 pass; 29 unrelated failures noted above
```

## Related Issues

Closes #7449

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Senpi TUI regressions where Shift+Tab showed `Thinking level: [object Promise]` and favorite model rows wrapped in narrow terminals.

**Bug Fixes**
- Waits for the async thinking-level result before showing status.
- Uses `TruncatedText` so long favorite model names ellipsize on one row.
- Adds regression tests for both behaviors.

Closes #7449.

<sup>Written for commit c0529ba2a1829e33a2b6c61c836bb8f1543a851b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

