### PR TITLE
fix: preserve assistant model variants for continuations

### DIFF
--- a/packages/omo-opencode/src/features/hook-message-injector/injector.test.ts
+++ b/packages/omo-opencode/src/features/hook-message-injector/injector.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="bun-types" />
 // allow: SIZE_OK - hook injector tests share one transcript/session harness for duplicate-injection cases; this release adds narrow regressions and future growth should split by trigger route.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test"
@@ -53,6 +54,7 @@ function createMockClient(messages: Array<{
     model?: { providerID?: string; modelID?: string; variant?: string }
     providerID?: string
     modelID?: string
+    variant?: string
     tools?: Record<string, boolean>
     time?: { created?: number }
   }
@@ -96,6 +98,23 @@ describe("findNearestMessageWithFieldsFromSDK", () => {
     expect(result).toEqual({
       agent: "sisyphus",
       model: { providerID: "openai", modelID: "gpt-5" },
+      tools: undefined,
+    })
+  })
+
+  it("preserves the variant from an assistant-shaped message", async () => {
+    // given
+    const mockClient = createMockClient([
+      { info: { agent: "sisyphus", providerID: "openai", modelID: "gpt-5.6", variant: "high" } },
+    ])
+
+    // when
+    const result = await findNearestMessageWithFieldsFromSDK(unsafeTestValue(mockClient), "ses_123")
+
+    // then
+    expect(result).toEqual({
+      agent: "sisyphus",
+      model: { providerID: "openai", modelID: "gpt-5.6", variant: "high" },
       tools: undefined,
     })
   })

--- a/packages/omo-opencode/src/features/hook-message-injector/sdk-message-lookup.ts
+++ b/packages/omo-opencode/src/features/hook-message-injector/sdk-message-lookup.ts
@@ -20,6 +20,7 @@ export interface SDKMessage {
     }
     readonly providerID?: string
     readonly modelID?: string
+    readonly variant?: string
     readonly tools?: Record<string, ToolPermission>
     readonly time?: {
       readonly created?: number
@@ -38,7 +39,7 @@ function convertSDKMessageToStoredMessage(msg: SDKMessage): StoredMessage | null
 
   const providerID = info.model?.providerID ?? info.providerID
   const modelID = info.model?.modelID ?? info.modelID
-  const variant = info.model?.variant
+  const variant = info.model?.variant ?? info.variant
 
   if (!info.agent && !providerID && !modelID) {
     return null

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.test.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.test.ts
@@ -66,4 +66,34 @@ describe("resolveLatestMessageInfo", () => {
       tools: undefined,
     })
   })
+
+  test("given an assistant message with a flat model variant, preserves the variant in resolved model info", async () => {
+    // given
+    const messages = unsafeTestValue<MessageWithInfo[]>([
+      {
+        info: {
+          role: "assistant",
+          agent: "sisyphus",
+          providerID: "openai",
+          modelID: "gpt-5.6",
+          variant: "high",
+        },
+        parts: [{ type: "text", text: "continuing the task" }],
+      },
+    ])
+
+    // when
+    const result = await resolveLatestMessageInfo(
+      unsafeTestValue({}),
+      "ses_flat_variant",
+      messages,
+    )
+
+    // then
+    expect(result.resolvedInfo).toEqual({
+      agent: "sisyphus",
+      model: { providerID: "openai", modelID: "gpt-5.6", variant: "high" },
+      tools: undefined,
+    })
+  })
 })

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.ts
@@ -35,10 +35,13 @@ export async function resolveLatestMessageInfo(
       continue
     }
     if (info?.agent || info?.model || (info?.modelID && info?.providerID)) {
+      const variant = info.model?.variant ?? info.variant
       return {
         resolvedInfo: {
           agent: info.agent,
-          model: info.model ?? (info.providerID && info.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined),
+          model: info.model ?? (info.providerID && info.modelID
+            ? { providerID: info.providerID, modelID: info.modelID, ...(variant ? { variant } : {}) }
+            : undefined),
           tools: info.tools,
         },
         encounteredCompaction,

--- a/packages/omo-opencode/src/hooks/todo-continuation-enforcer/types.ts
+++ b/packages/omo-opencode/src/hooks/todo-continuation-enforcer/types.ts
@@ -54,6 +54,7 @@ export interface MessageInfo {
   model?: { providerID: string; modelID: string; variant?: string }
   providerID?: string
   modelID?: string
+  variant?: string
   tools?: Record<string, ToolPermission>
 }
 


### PR DESCRIPTION
## Summary
- Preserve flat assistant-message variants when todo continuation rebuilds model metadata.
- Preserve the same variant through SDK message lookup.
- Add direct regressions for both message shapes.

## Validation
- `bun test packages/omo-opencode/src/hooks/todo-continuation-enforcer/resolve-message-info.test.ts packages/omo-opencode/src/features/hook-message-injector/injector.test.ts packages/omo-opencode/src/features/hook-message-injector/sdk-message-lookup-error-envelope.test.ts`
- `bun run typecheck`
- `bun run build`
- Isolated Docker OpenCode live-plugin QA recorded under `.omo/evidence/20260828-fix-7462-variant-cache/`

Fixes #7462

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops todo continuation from dropping the model variant on flat assistant messages, so resumed tasks keep the same model variant.

- Preserves flat `variant` when rebuilding model metadata during continuation.
- Keeps the variant through SDK message lookup when the nested variant is absent.
- Adds regression tests for both message shapes.

Fixes #7462.

<sup>Written for commit 9cc761be84b3c9966f69901dfe486f367bbbc340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

