### PR TITLE
fix: preserve local TUI by default for shared-host parity

### DIFF
--- a/docs/reference/omo-ai-publishing.md
+++ b/docs/reference/omo-ai-publishing.md
@@ -78,6 +78,7 @@ identity instead of impersonating the product.
 | `displayVersion` | the omo-ai version | `omo --version` and the TUI header; the engine version stays internal for update comparisons |
 | `configDir` + `flatLayout` | `.omo`, nested | agent state lives at `~/.omo/agent` - the one directory every omo entry point resolves through `bin/lib/agent-dir.js`; the launcher pins it for the engine with `OMO_CODING_AGENT_DIR` plus the legacy `SENPI_CODING_AGENT_DIR` |
 | `envPrefix` | `OMO` | `OMO_*` variables are read first, then the legacy `SENPI_*` and `PI_*` names |
+| shared interactive host | `OMO_DISABLE_SHARED_HOST=1` by default | keeps the local interactive runtime, whose TUI exposes usage, cache-hit, cost, Goal, and resumed-state data; set `OMO_DISABLE_SHARED_HOST=0` to opt into the shared host |
 | `userAgent` / `originator` | `omo` | outgoing request identity |
 | `update` | `omo-ai`, `beta`, `npm i -g omo-ai@beta` | the update banner checks the beta dist-tag of omo-ai and prints the product's own command |
 
@@ -86,6 +87,11 @@ session filenames, debug-log filenames, and opt-in provider attribution headers
 use `OmO`. Machine contracts remain explicitly pinned by the other fields:
 `.omo`, `OMO_*`, the `omo` User-Agent/originator, and the lowercase `omo`
 command/package names do not derive from the display spelling.
+
+The shared interactive host remains opt-in while its proxy catches up with the local TUI's usage and
+extension-status surfaces. The launcher uses the brand-prefixed `OMO_DISABLE_SHARED_HOST` variable;
+the bare `DISABLE_SHARED_HOST` spelling is not read by the branded engine. An explicit value such as
+`0` is preserved for users who want to test the shared host.
 
 The update channel matters: omo-ai's `latest` tag is pinned to the deprecated bootstrap
 placeholder forever, so a `latest` lookup would never see a release. The engine therefore reads

--- a/packages/omo-native/bin/lib/launcher.js
+++ b/packages/omo-native/bin/lib/launcher.js
@@ -74,6 +74,7 @@ function senpiEnvironment(senpiRoot) {
   // under bun. Handing that answer down stops the engine from making its own, conflicting choice.
   env.SENPI_RUNTIME = process.versions.bun ? "bun" : "node"
   env.SENPI_BRAND = JSON.stringify(brandProfile())
+  env.OMO_DISABLE_SHARED_HOST ??= "1"
 
   const binDir = nearestNodeBin(senpiRoot)
   if (binDir) {

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -117,6 +117,7 @@ export function remapSenpiEnvironment(source: NodeJS.ProcessEnv = process.env, e
   env.SENPI_CODING_AGENT_DIR = agentDir
   env.OMO_NATIVE = "1"
   env.SENPI_RUNTIME = process.versions.bun ? "bun" : "node"
+  env.OMO_DISABLE_SHARED_HOST ??= "1"
   let displayVersion = "unknown"
   try { displayVersion = readJson(join(execDir, "package.json")).version } catch { /* test fixtures may omit the sibling manifest */ }
   env.SENPI_BRAND = JSON.stringify({

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -67,6 +67,13 @@ describe("compiled omo entry launcher parity", () => {
     expect(env.OMO_AGENT_TOOLKIT_BIN).toBe(join("/provisioned", "plugin", "runtime", "agent-toolkit", process.platform === "win32" ? "omo-agent-toolkit.cmd" : "omo-agent-toolkit"))
     expect(env.OMO_BIN).toBe(join("/provisioned", process.platform === "win32" ? "omo.exe" : "omo"))
     expect(env.OMO_CODING_AGENT_DIR).toBeDefined()
+    expect(env.OMO_DISABLE_SHARED_HOST).toBe("1")
+  })
+
+  test("preserves an explicit shared-host opt-in", () => {
+    const env = remapSenpiEnvironment({ OMO_DISABLE_SHARED_HOST: "0", PATH: "/bin" }, "/provisioned")
+
+    expect(env.OMO_DISABLE_SHARED_HOST).toBe("0")
   })
 })
 

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -186,6 +186,7 @@ describe("omo launcher", () => {
         expect(environment.OMO_AGENT_TOOLKIT_BIN).toBe(join(fixture.packageRoot, "bin", "omo-agent-toolkit.js"))
         expect(environment.OMO_CODING_AGENT_DIR).toBe(join(home, ".omo", "agent"))
         expect(environment.SENPI_CODING_AGENT_DIR).toBe(join(home, ".omo", "agent"))
+        expect(environment.OMO_DISABLE_SHARED_HOST).toBe("1")
         // An inherited value must never survive; it is replaced by this launcher's own entry so
         // anything resolving the product by name re-enters here instead of the bare engine.
         // Windows reports this path in its long form while the fixture root may be the 8.3 short
@@ -193,6 +194,13 @@ describe("omo launcher", () => {
         expect(existsSync(environment.OMO_BIN ?? "")).toBe(true)
         expect((environment.OMO_BIN ?? "").replace(/\\/g, "/")).toMatch(/\/bin\/omo\.js$/)
         expect(environment.OMO_BIN).not.toBe(environment.SENPI_BIN)
+      })
+
+      test("#then an explicit shared-host opt-in survives environment remapping", () => {
+        const fixture = createFixture()
+        const result = run(fixture, ["say", "hi"], { OMO_DISABLE_SHARED_HOST: "0" })
+        expect(result.status).toBe(0)
+        expect(capture(fixture).env.OMO_DISABLE_SHARED_HOST).toBe("0")
       })
 
       test("#then SENPI_BIN stays absent when no shim exists", () => {

--- a/packages/omo-senpi/src/install/local-launcher.test.ts
+++ b/packages/omo-senpi/src/install/local-launcher.test.ts
@@ -39,6 +39,7 @@ describe("local omo launcher", () => {
         expect(source).toContain("OMO_PLUGIN_ROOT")
         expect(source).toContain("OMO_CODING_AGENT_DIR")
         expect(source).toContain("SENPI_CODING_AGENT_DIR")
+        expect(source).toContain('OMO_DISABLE_SHARED_HOST: process.env.OMO_DISABLE_SHARED_HOST ?? "1"')
         expect(source).toContain('join(homedir(), ".omo", "agent")')
       })
     })

--- a/packages/omo-senpi/src/install/local-launcher.ts
+++ b/packages/omo-senpi/src/install/local-launcher.ts
@@ -70,6 +70,7 @@ const env = {
   OMO_NATIVE: "1",
   OMO_CODING_AGENT_DIR: agentDir,
   SENPI_CODING_AGENT_DIR: agentDir,
+  OMO_DISABLE_SHARED_HOST: process.env.OMO_DISABLE_SHARED_HOST ?? "1",
 }
 // Anything resolving the product by name must re-enter through this launcher, never the engine.
 env.OMO_BIN = process.argv[1]


### PR DESCRIPTION
## Summary
- default published and local Senpi launchers to the local runtime so TUI usage, cache-hit, cost, Goal, and resumed-state surfaces remain available
- preserve explicit `OMO_DISABLE_SHARED_HOST=0` opt-in
- document the compatibility guardrail and add regression coverage

## Validation
- Focused tests: 61 passed, 0 failed, 184 assertions
- `bun run typecheck`
- `bun run build:omo-native`
- `bun run build`
- LSP diagnostics clean on changed TypeScript files
- Senpi self-test passed
- Live Senpi QA skipped: senpi binary unavailable; evidence recorded under `.omo/evidence/omo-senpi-adapter/20260828-7459-shared-host/`

Fixes #7459

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults published and local Senpi launchers to the local interactive runtime, so the TUI's usage, cache-hit, cost, Goal, and resumed-state surfaces stay available. The shared host is now opt-in via `OMO_DISABLE_SHARED_HOST=0`; the bare `DISABLE_SHARED_HOST` spelling is not read.

- Applies `OMO_DISABLE_SHARED_HOST=1` by default across the launcher, compile entry, and local launcher while preserving an explicit `0` opt-in.
- Documents the guardrail and adds regression coverage for both the default and the explicit opt-in.

Fixes #7459.

<sup>Written for commit 9eea7de43d177a359a2accac0a5788b23640bf9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

