### PR TITLE
fix: handle tuple-style plugin entries in installer

### DIFF
--- a/packages/omo-opencode/src/cli/config-manager/add-plugin-to-opencode-config.ts
+++ b/packages/omo-opencode/src/cli/config-manager/add-plugin-to-opencode-config.ts
@@ -7,7 +7,11 @@ import { getConfigDir } from "./config-context"
 import { ensureConfigDirectoryExists } from "./ensure-config-directory-exists"
 import { formatErrorWithSuggestion } from "./format-error-with-suggestion"
 import { detectConfigFormat, type ConfigFormat } from "./opencode-config-format"
-import { parseOpenCodeConfigFileWithError, type OpenCodeConfig } from "./parse-opencode-config-file"
+import {
+  parseOpenCodeConfigFileWithError,
+  type OpenCodeConfig,
+  type OpenCodePluginEntry,
+} from "./parse-opencode-config-file"
 import { getPluginNameWithVersion } from "./plugin-name-with-version"
 import { checkVersionCompatibility, extractVersionFromPluginEntry } from "./version-compatibility"
 
@@ -68,24 +72,32 @@ function getConfigTargets(): ConfigTarget[] {
   })
 }
 
-function isSourceOmoPluginEntry(plugin: string): boolean {
-  const normalized = plugin.toLowerCase().replaceAll("\\", "/")
+function entryName(plugin: unknown): string {
+  if (Array.isArray(plugin)) {
+    return typeof plugin[0] === "string" ? plugin[0] : ""
+  }
+  return typeof plugin === "string" ? plugin : ""
+}
+
+function isSourceOmoPluginEntry(plugin: OpenCodePluginEntry): boolean {
+  const normalized = entryName(plugin).toLowerCase().replaceAll("\\", "/")
   if (!normalized.startsWith("file://")) return false
 
   return /\/(omo(?:-[^/]*)?|oh-my-opencode|oh-my-openagent)\/(src|dist)\/index\.(ts|js)$/.test(normalized)
 }
 
-function isPackageOmoPluginEntry(plugin: string): boolean {
-  return plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`) ||
-    plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+function isPackageOmoPluginEntry(plugin: OpenCodePluginEntry): boolean {
+  const name = entryName(plugin)
+  return name === PLUGIN_NAME || name.startsWith(`${PLUGIN_NAME}@`) ||
+    name === LEGACY_PLUGIN_NAME || name.startsWith(`${LEGACY_PLUGIN_NAME}@`)
 }
 
-function isOurPlugin(plugin: string): boolean {
+function isOurPlugin(plugin: OpenCodePluginEntry): boolean {
   return isPackageOmoPluginEntry(plugin) || isSourceOmoPluginEntry(plugin)
 }
 
-function findOurPluginEntry(plugins: readonly string[]): string | undefined {
-  return plugins.find(isOurPlugin)
+function findOurPluginEntry(plugins: readonly OpenCodePluginEntry[]): string | undefined {
+  return entryName(plugins.find(isOurPlugin)) || undefined
 }
 
 function findSourcePluginEntryInTarget(target: ConfigTarget): string | null {
@@ -93,7 +105,7 @@ function findSourcePluginEntryInTarget(target: ConfigTarget): string | null {
 
   const parseResult = parseOpenCodeConfigFileWithError(target.path)
   const plugins = parseResult.config?.plugin ?? []
-  return plugins.find(isSourceOmoPluginEntry) ?? null
+  return entryName(plugins.find(isSourceOmoPluginEntry)) || null
 }
 
 function choosePluginEntry(params: {
@@ -181,7 +193,7 @@ function writePluginEntryToTarget(params: {
       const match = content.match(pluginArrayRegex)
 
       if (match) {
-        const formattedPlugins = normalizedPlugins.map((p) => `"${p}"`).join(",\n    ")
+        const formattedPlugins = normalizedPlugins.map((p) => JSON.stringify(p)).join(",\n    ")
         const newContent = content.replace(pluginArrayRegex, `$1[\n    ${formattedPlugins}\n  ]`)
         writeFileSync(target.path, newContent)
       } else {

--- a/packages/omo-opencode/src/cli/config-manager/detect-current-config.ts
+++ b/packages/omo-opencode/src/cli/config-manager/detect-current-config.ts
@@ -3,7 +3,10 @@ import { parseJsonc, LEGACY_PLUGIN_NAME, PLUGIN_NAME } from "../../shared"
 import type { DetectedConfig } from "../types"
 import { getOmoConfigPath } from "./config-context"
 import { detectConfigFormat } from "./opencode-config-format"
-import { parseOpenCodeConfigFileWithError } from "./parse-opencode-config-file"
+import {
+  parseOpenCodeConfigFileWithError,
+  type OpenCodePluginEntry,
+} from "./parse-opencode-config-file"
 import { extractVersionFromPluginEntry } from "./version-compatibility"
 
 function detectProvidersFromOmoConfig(): {
@@ -99,13 +102,21 @@ function detectProvidersFromOmoConfig(): {
   }
 }
 
-function isOurPlugin(plugin: string): boolean {
-  return plugin === PLUGIN_NAME || plugin.startsWith(`${PLUGIN_NAME}@`) ||
-         plugin === LEGACY_PLUGIN_NAME || plugin.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+function entryName(plugin: unknown): string {
+  if (Array.isArray(plugin)) {
+    return typeof plugin[0] === "string" ? plugin[0] : ""
+  }
+  return typeof plugin === "string" ? plugin : ""
 }
 
-function findOurPluginEntry(plugins: string[]): string | null {
-  return plugins.find(isOurPlugin) ?? null
+function isOurPlugin(plugin: OpenCodePluginEntry): boolean {
+  const name = entryName(plugin)
+  return name === PLUGIN_NAME || name.startsWith(`${PLUGIN_NAME}@`) ||
+         name === LEGACY_PLUGIN_NAME || name.startsWith(`${LEGACY_PLUGIN_NAME}@`)
+}
+
+function findOurPluginEntry(plugins: readonly OpenCodePluginEntry[]): string | null {
+  return entryName(plugins.find(isOurPlugin)) || null
 }
 
 export function detectCurrentConfig(): DetectedConfig {

--- a/packages/omo-opencode/src/cli/config-manager/parse-opencode-config-file.ts
+++ b/packages/omo-opencode/src/cli/config-manager/parse-opencode-config-file.ts
@@ -8,9 +8,11 @@ interface ParseConfigResult {
 }
 
 export interface OpenCodeConfig {
-  plugin?: string[]
+  plugin?: OpenCodePluginEntry[]
   [key: string]: unknown
 }
+
+export type OpenCodePluginEntry = string | readonly [string, unknown]
 
 function isEmptyOrWhitespace(content: string): boolean {
   return content.trim().length === 0

--- a/packages/omo-opencode/src/cli/config-manager/plugin-detection.test.ts
+++ b/packages/omo-opencode/src/cli/config-manager/plugin-detection.test.ts
@@ -61,6 +61,37 @@ describe("detectCurrentConfig - single package detection", () => {
     expect(result.isInstalled).toBe(false)
   })
 
+  it("ignores tuple plugin entries that do not belong to OMO", () => {
+    // given
+    writeFileSync(
+      testConfigPath,
+      JSON.stringify({ plugin: [["./badge.tsx", { label: "custom" }]] }, null, 2) + "\n",
+      "utf-8",
+    )
+
+    // when
+    const result = detectCurrentConfig()
+
+    // then
+    expect(result.isInstalled).toBe(false)
+  })
+
+  it("detects OMO when its tuple plugin entry includes options", () => {
+    // given
+    writeFileSync(
+      testConfigPath,
+      JSON.stringify({ plugin: [["oh-my-openagent@3.11.0", { enabled: true }]] }, null, 2) + "\n",
+      "utf-8",
+    )
+
+    // when
+    const result = detectCurrentConfig()
+
+    // then
+    expect(result.isInstalled).toBe(true)
+    expect(result.installedVersion).toBe("3.11.0")
+  })
+
   it("detects OpenCode Go from the existing omo config", () => {
     // given
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-opencode"] }, null, 2) + "\n", "utf-8")
@@ -172,6 +203,37 @@ describe("addPluginToOpenCodeConfig - single package writes", () => {
   it("removes stale legacy entry when canonical and legacy entries both exist", async () => {
     // given
     writeFileSync(testConfigPath, JSON.stringify({ plugin: ["oh-my-openagent", "oh-my-opencode"] }, null, 2) + "\n", "utf-8")
+
+    // when
+    const result = await addPluginToOpenCodeConfig("3.11.0")
+
+    // then
+    expect(result.success).toBe(true)
+    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
+    expect(savedConfig.plugin).toEqual(["oh-my-openagent"])
+  })
+
+  it("preserves non-OMO tuple entries while adding the canonical plugin", async () => {
+    // given
+    const tupleEntry = ["./badge.tsx", { label: "custom" }]
+    writeFileSync(testConfigPath, JSON.stringify({ plugin: [tupleEntry] }, null, 2) + "\n", "utf-8")
+
+    // when
+    const result = await addPluginToOpenCodeConfig("3.11.0")
+
+    // then
+    expect(result.success).toBe(true)
+    const savedConfig = JSON.parse(readFileSync(testConfigPath, "utf-8"))
+    expect(savedConfig.plugin).toEqual([tupleEntry, "oh-my-openagent"])
+  })
+
+  it("replaces an OMO tuple entry without throwing", async () => {
+    // given
+    writeFileSync(
+      testConfigPath,
+      JSON.stringify({ plugin: [["oh-my-openagent@3.10.0", { enabled: true }]] }, null, 2) + "\n",
+      "utf-8",
+    )
 
     // when
     const result = await addPluginToOpenCodeConfig("3.11.0")


### PR DESCRIPTION
## Summary
- unwrap string names from OpenCode tuple-style plugin entries before installer matching
- preserve unrelated tuple entries during JSONC plugin rewrites
- add regression coverage for detection and replacement paths

Fixes #7458

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the plugin installer crashing on tuple-style plugin entries in OpenCode configs, so install and detection work whether the entry is a plain string or a `[name, options]` tuple.

**Bug Fixes**
- Unwraps tuple entries to their plugin name before matching and version extraction.
- Preserves unrelated tuple entries when rewriting the config to add or update our plugin.

<sup>Written for commit 416add92f75f967427b7c7c5e2721cd0c43bcc79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

