### PR TITLE
feat(mcp): add optional Parallel search provider

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -9775,7 +9775,8 @@
           "type": "string",
           "enum": [
             "exa",
-            "tavily"
+            "tavily",
+            "parallel"
           ]
         }
       },

--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -5,6 +5,47 @@
   "description": "Configuration schema for the omo.json / omo.jsonc harness-neutral config surface",
   "type": "object",
   "properties": {
+    "formatOnMutation": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "default": "best-effort",
+          "type": "string",
+          "enum": [
+            "off",
+            "best-effort",
+            "required"
+          ]
+        },
+        "languages": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        },
+        "maxFileBytes": {
+          "default": 1048576,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "timeoutMs": {
+          "default": 3000,
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        }
+      },
+      "required": [
+        "mode",
+        "maxFileBytes",
+        "timeoutMs"
+      ],
+      "additionalProperties": false
+    },
     "$schema": {
       "type": "string"
     },
@@ -11615,7 +11656,8 @@
               "type": "string",
               "enum": [
                 "exa",
-                "tavily"
+                "tavily",
+                "parallel"
               ]
             }
           },
@@ -11789,6 +11831,39 @@
     "[senpi]": {
       "type": "object",
       "properties": {
+        "formatOnMutation": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "off",
+                "best-effort",
+                "required"
+              ]
+            },
+            "languages": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "boolean"
+              }
+            },
+            "maxFileBytes": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "timeoutMs": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "additionalProperties": false
+        },
         "categories": {
           "type": "object",
           "propertyNames": {
@@ -13390,6 +13465,39 @@
     "[codex]": {
       "type": "object",
       "properties": {
+        "formatOnMutation": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "off",
+                "best-effort",
+                "required"
+              ]
+            },
+            "languages": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "boolean"
+              }
+            },
+            "maxFileBytes": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            },
+            "timeoutMs": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "additionalProperties": false
+        },
         "categories": {
           "type": "object",
           "propertyNames": {
@@ -14997,6 +15105,39 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
+          "formatOnMutation": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "off",
+                  "best-effort",
+                  "required"
+                ]
+              },
+              "languages": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "boolean"
+                }
+              },
+              "maxFileBytes": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "timeoutMs": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "additionalProperties": false
+          },
           "categories": {
             "type": "object",
             "propertyNames": {
@@ -26369,7 +26510,8 @@
                     "type": "string",
                     "enum": [
                       "exa",
-                      "tavily"
+                      "tavily",
+                      "parallel"
                     ]
                   }
                 },
@@ -26543,6 +26685,39 @@
           "[senpi]": {
             "type": "object",
             "properties": {
+              "formatOnMutation": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "off",
+                      "best-effort",
+                      "required"
+                    ]
+                  },
+                  "languages": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  },
+                  "maxFileBytes": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "additionalProperties": false
+              },
               "categories": {
                 "type": "object",
                 "propertyNames": {
@@ -28144,6 +28319,39 @@
           "[codex]": {
             "type": "object",
             "properties": {
+              "formatOnMutation": {
+                "type": "object",
+                "properties": {
+                  "mode": {
+                    "type": "string",
+                    "enum": [
+                      "off",
+                      "best-effort",
+                      "required"
+                    ]
+                  },
+                  "languages": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  },
+                  "maxFileBytes": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "timeoutMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "additionalProperties": false
+              },
               "categories": {
                 "type": "object",
                 "propertyNames": {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -821,6 +821,41 @@ Built-in MCPs (enabled by default): `websearch` (Exa AI), `context7` (library do
 { "disabled_mcps": ["websearch", "context7", "grep_app", "lsp", "codegraph"] }
 ```
 
+#### Web search provider
+
+Exa remains the default. To select a different provider, set `websearch.provider`
+inside `[opencode]` in `~/.omo/omo.jsonc` or your project's `.omo/omo.jsonc`:
+
+```jsonc
+{
+  "[opencode]": {
+    "websearch": { "provider": "parallel" }
+  }
+}
+```
+
+| Provider | Credentials | Tools |
+|----------|-------------|-------|
+| `exa` (default) | Optional `EXA_API_KEY` | Web search |
+| `tavily` | Required `TAVILY_API_KEY`; omitted from MCPs if missing | Web search |
+| `parallel` | No Parallel account or API key required | `web_search` and `web_fetch` |
+
+Parallel connects to `https://search.parallel.ai/mcp` through OpenCode's remote
+MCP client, without authentication headers or OAuth. This selection uses the
+anonymous service even if provider API keys are set in the environment. Free
+access is rate limited; see the [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp).
+
+Once selected and enabled, agents can invoke these tools during their work.
+Search queries, requested URLs, and any supplied objectives, context, or metadata
+are sent to Parallel. OpenCode exposes the tools as `websearch_web_search` and
+`websearch_web_fetch`, using the input schemas returned by the server.
+
+Existing MCP overrides and permissions still apply. A custom `websearch` entry
+in OpenCode's `mcp` configuration overrides the built-in provider. To disable
+web search, add `"websearch"` to `disabled_mcps` inside `[opencode]`. Remove the
+provider setting or select `"exa"` to return to the default. There is no automatic
+fallback between providers.
+
 ### LSP
 
 LSP tools are served by the built-in `lsp` MCP server (see [MCPs](#mcps)). The

--- a/packages/omo-opencode/src/agents/librarian.ts
+++ b/packages/omo-opencode/src/agents/librarian.ts
@@ -242,10 +242,10 @@ https://github.com/tanstack/query/blob/abc123def/packages/react-query/src/useQue
 ### Primary Tools by Purpose
 
 - **Official Docs**: Use context7 - \`context7_resolve-library-id\` → \`context7_query-docs\`
-- **Find Docs URL**: Use websearch_exa - \`websearch_web_search_exa("library official documentation")\`
+- **Find Docs URL**: Use the configured websearch MCP's search tool with its advertised input schema to find the library's official documentation.
 - **Sitemap Discovery**: Use webfetch - \`webfetch(docs_url + "/sitemap.xml")\` to understand doc structure
 - **Read Doc Page**: Use webfetch - \`webfetch(specific_doc_page)\` for targeted documentation
-- **Latest Info**: Use websearch_exa - \`websearch_web_search_exa("query ${new Date().getFullYear()}")\`
+- **Latest Info**: Use the configured websearch MCP's search tool with its advertised input schema, including ${new Date().getFullYear()} when looking for current information.
 - **Fast Code Search**: Use grep_app - \`grep_app_searchGitHub(query, language, useRegexp)\`
 - **Deep Code Search**: Use gh CLI - \`gh search code "query" --repo owner/repo\`
 - **Clone Repo**: Use gh CLI - \`gh repo clone owner/repo \${TMPDIR:-/tmp}/name -- --depth 1\`

--- a/packages/omo-opencode/src/config/AGENTS.md
+++ b/packages/omo-opencode/src/config/AGENTS.md
@@ -24,7 +24,7 @@ config/schema/
 ├── goal.ts                     # GoalConfigSchema (enabled, auto_start, default_max_iterations) - replaces ralph_loop
 ├── ralph-loop.ts               # RalphLoopConfigSchema (DEPRECATED: parsed loose at root, migrated to goal in validate.ts)
 ├── tmux.ts                     # TmuxConfigSchema + TmuxLayoutSchema
-├── websearch.ts                # provider: "exa" | "tavily"
+├── websearch.ts                # provider: "exa" | "tavily" | "parallel"
 ├── claude-code.ts              # CC compatibility settings (plugins, plugins_override)
 ├── comment-checker.ts          # AI comment detection config
 ├── notification.ts             # OS notification settings

--- a/packages/omo-opencode/src/config/schema/websearch.ts
+++ b/packages/omo-opencode/src/config/schema/websearch.ts
@@ -1,12 +1,13 @@
 import { z } from "zod"
 
-export const WebsearchProviderSchema = z.enum(["exa", "tavily"])
+export const WebsearchProviderSchema = z.enum(["exa", "tavily", "parallel"])
 
 export const WebsearchConfigSchema = z.object({
   /**
    * Websearch provider to use.
    * - "exa": Uses Exa websearch (default, works without API key)
    * - "tavily": Uses Tavily websearch (requires TAVILY_API_KEY)
+   * - "parallel": Uses Parallel Search MCP (no account or API key required)
    */
   provider: WebsearchProviderSchema.optional(),
 })

--- a/packages/omo-opencode/src/hooks/agent-usage-reminder/constants.ts
+++ b/packages/omo-opencode/src/hooks/agent-usage-reminder/constants.ts
@@ -15,6 +15,8 @@ export const TARGET_TOOLS = new Set([
   "context7_resolve-library-id",
   "context7_query-docs",
   "websearch_web_search_exa",
+  "websearch_web_search",
+  "websearch_web_fetch",
   "context7_get-library-docs",
   "grep_app_searchgithub",
 ]);

--- a/packages/omo-opencode/src/hooks/agent-usage-reminder/index.test.ts
+++ b/packages/omo-opencode/src/hooks/agent-usage-reminder/index.test.ts
@@ -108,4 +108,23 @@ describe("agent-usage-reminder hook", () => {
 
     clearSessionAgent(sessionID);
   });
+
+  test("recognizes each built-in websearch provider tool", async () => {
+    const hook = createHook();
+
+    for (const [index, tool] of [
+      "websearch_web_search_exa",
+      "websearch_web_search",
+      "websearch_web_fetch",
+    ].entries()) {
+      const sessionID = `agent-usage-websearch-${index}`;
+      updateSessionAgent(sessionID, "Sisyphus");
+      const output = { title: "", output: "result", metadata: {} };
+
+      await hook["tool.execute.after"]({ tool, sessionID, callID: tool }, output);
+
+      expect(output.output).toContain("[Agent Usage Reminder]");
+      clearSessionAgent(sessionID);
+    }
+  });
 });

--- a/packages/omo-opencode/src/hooks/json-error-recovery/hook.ts
+++ b/packages/omo-opencode/src/hooks/json-error-recovery/hook.ts
@@ -9,6 +9,8 @@ export const JSON_ERROR_TOOL_EXCLUDE_LIST = [
   "look_at",
   "grep_app_searchgithub",
   "websearch_web_search_exa",
+  "websearch_web_search",
+  "websearch_web_fetch",
   "todowrite",
   "todoread",
   "task",

--- a/packages/omo-opencode/src/hooks/json-error-recovery/index.test.ts
+++ b/packages/omo-opencode/src/hooks/json-error-recovery/index.test.ts
@@ -119,6 +119,19 @@ describe("createJsonErrorRecoveryHook", () => {
       expect(output.output).toBe("JSON parse error: unexpected end of JSON input")
     })
 
+    it("does not append reminder for either Parallel websearch tool", async () => {
+      const parallelTools = ["websearch_web_search", "websearch_web_fetch"]
+      const proseMentioningJson = "The page contains invalid JSON here"
+
+      for (const tool of parallelTools) {
+        const output = createOutput(proseMentioningJson)
+
+        await hook["tool.execute.after"](createInput(tool), output)
+
+        expect(output.output).toBe(proseMentioningJson)
+      }
+    })
+
     it("does not append reminder for subagent and session-content tools", async () => {
       // given
       const subagentTools = [
@@ -208,6 +221,8 @@ describe("createJsonErrorRecoveryHook", () => {
         "read",
         "bash",
         "webfetch",
+        "websearch_web_search",
+        "websearch_web_fetch",
         "task",
         "call_omo_agent",
         "background_output",

--- a/packages/omo-opencode/src/mcp/AGENTS.md
+++ b/packages/omo-opencode/src/mcp/AGENTS.md
@@ -10,7 +10,7 @@ Tier 1 of the three-tier MCP system. Built-ins are created by `createBuiltinMcps
 
 | Name | Type | Endpoint / Command | Env Vars | Tools |
 |------|------|--------------------|----------|-------|
-| **websearch** | remote | `mcp.exa.ai` (default) or `mcp.tavily.com` | `EXA_API_KEY` (optional), `TAVILY_API_KEY` (if tavily) | Web search |
+| **websearch** | remote | `mcp.exa.ai` (default), `mcp.tavily.com`, or `search.parallel.ai/mcp` | `EXA_API_KEY` (optional), `TAVILY_API_KEY` (if tavily); none for parallel | Web search; Parallel also exposes `web_fetch` |
 | **context7** | remote | `mcp.context7.com/mcp` | `CONTEXT7_API_KEY` (optional) | Library documentation |
 | **grep_app** | remote | `mcp.grep.app` | None | GitHub code search |
 | **lsp** | local (stdio, node/bun) | `node packages/lsp-tools-mcp/dist/cli.js mcp` or `bun packages/lsp-tools-mcp/src/cli.ts mcp` | `LSP_TOOLS_MCP_PROJECT_CONFIG`, `LSP_TOOLS_MCP_USER_CONFIG`, `LSP_TOOLS_MCP_INSTALL_DECISIONS` | `status`, diagnostics, goto definition, references, symbols, prepare_rename, rename |
@@ -41,7 +41,7 @@ Tier 1 of the three-tier MCP system. Built-ins are created by `createBuiltinMcps
 |------|---------|
 | `index.ts` | `createBuiltinMcps()` registry for built-in MCPs |
 | `types.ts` | `McpNameSchema`: `"websearch" \| "context7" \| "grep_app" \| "lsp" \| "codegraph"` |
-| `websearch.ts` | Exa/Tavily provider with config |
+| `websearch.ts` | Exa/Tavily/Parallel provider with config |
 | `context7.ts` | Context7 with optional auth header |
 | `grep-app.ts` | Grep.app (no auth) |
 | `lsp.ts` | Local stdio MCP config for packaged `lsp-tools-mcp` |

--- a/packages/omo-opencode/src/mcp/websearch.test.ts
+++ b/packages/omo-opencode/src/mcp/websearch.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, test, expect, spyOn, beforeEach, afterEach } from "bun:test"
 import * as logger from "../shared/logger"
+import { WebsearchConfigSchema } from "../config/schema/websearch"
 
 let logSpy: ReturnType<typeof spyOn>
 let createWebsearchConfig: (typeof import("./websearch"))["createWebsearchConfig"]
@@ -56,6 +57,11 @@ describe("createWebsearchConfig Tavily handling", () => {
 })
 
 describe("createWebsearchConfig Exa handling", () => {
+  test("keeps Exa as the default when no provider is selected", () => {
+    expect(createWebsearchConfig()).toEqual(createWebsearchConfig({ provider: "exa" }))
+    expect(createWebsearchConfig({})).toEqual(createWebsearchConfig({ provider: "exa" }))
+  })
+
   test("keeps EXA_API_KEY out of URL query params and sends bearer auth header", () => {
     process.env.EXA_API_KEY = "exa-secret"
 
@@ -85,5 +91,41 @@ describe("createWebsearchConfig Exa handling", () => {
       enabled: true,
       oauth: false,
     })
+  })
+})
+
+describe("createWebsearchConfig Parallel handling", () => {
+  test("accepts explicit Parallel selection through the config schema", () => {
+    expect(WebsearchConfigSchema.parse({ provider: "parallel" })).toEqual({ provider: "parallel" })
+  })
+
+  test("connects anonymously without an OAuth flow", () => {
+    // given
+    const selection = WebsearchConfigSchema.parse({ provider: "parallel" })
+
+    // when
+    const config = createWebsearchConfig(selection)
+
+    // then
+    expect(config).toEqual({
+      type: "remote",
+      url: "https://search.parallel.ai/mcp",
+      enabled: true,
+      oauth: false,
+    })
+  })
+
+  test("does not forward existing provider credentials to Parallel", () => {
+    // given
+    process.env.EXA_API_KEY = "exa-secret"
+    process.env.TAVILY_API_KEY = "tavily-secret"
+    const selection = WebsearchConfigSchema.parse({ provider: "parallel" })
+
+    // when
+    const config = createWebsearchConfig(selection)
+
+    // then
+    expect(config?.headers).toBeUndefined()
+    expect(config?.url).toBe("https://search.parallel.ai/mcp")
   })
 })

--- a/packages/omo-opencode/src/mcp/websearch.ts
+++ b/packages/omo-opencode/src/mcp/websearch.ts
@@ -12,6 +12,15 @@ type RemoteMcpConfig = {
 export function createWebsearchConfig(config?: WebsearchConfig): RemoteMcpConfig | undefined {
   const provider = config?.provider || "exa"
 
+  if (provider === "parallel") {
+    return {
+      type: "remote",
+      url: "https://search.parallel.ai/mcp",
+      enabled: true,
+      oauth: false,
+    }
+  }
+
   if (provider === "tavily") {
     const tavilyKey = process.env.TAVILY_API_KEY
     if (!tavilyKey) {

--- a/packages/omo-opencode/src/mcp/zauc-mocks-mcp-index/index.test.ts
+++ b/packages/omo-opencode/src/mcp/zauc-mocks-mcp-index/index.test.ts
@@ -14,6 +14,27 @@ function mockLocalMcps(): void {
 }
 
 describe("createBuiltinMcps", () => {
+  test("registers Parallel under the existing websearch name only when enabled", () => {
+    // given
+    mockLocalMcps()
+    const { createBuiltinMcps } = require("../index") as typeof import("../index")
+    const config = { websearch: { provider: "parallel" as const } }
+
+    // when
+    const enabled = createBuiltinMcps([], config)
+    const disabled = createBuiltinMcps(["websearch"], config)
+
+    // then
+    expect(enabled.websearch).toEqual({
+      type: "remote",
+      url: "https://search.parallel.ai/mcp",
+      enabled: true,
+      oauth: false,
+    })
+    expect(disabled.websearch).toBeUndefined()
+    expect(enabled).not.toHaveProperty("parallel")
+  })
+
   test("should return all MCPs when disabled_mcps is empty", () => {
     // given
     mockLocalMcps()

--- a/packages/omo-opencode/src/tools/skill-mcp/builtin-mcp-hint.test.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/builtin-mcp-hint.test.ts
@@ -51,6 +51,18 @@ describe("skill_mcp builtin MCP hint", () => {
     ).rejects.toThrow(/context7_resolve-library-id/)
   })
 
+  it("lists all built-in websearch provider tools", async () => {
+    const tool = createSkillMcpTool({
+      manager: new SkillMcpManager(),
+      getLoadedSkills: () => [],
+      getSessionID: () => "session",
+    })
+
+    await expect(
+      tool.execute({ mcp_name: "websearch", tool_name: "web_search" }, mockContext),
+    ).rejects.toThrow(/websearch_web_search_exa[\s\S]*websearch_web_search[\s\S]*websearch_web_fetch/)
+  })
+
   it("keeps skill-loading hint for unknown MCP names", async () => {
     const tool = createSkillMcpTool({
       manager: new SkillMcpManager(),

--- a/packages/omo-opencode/src/tools/skill-mcp/constants.ts
+++ b/packages/omo-opencode/src/tools/skill-mcp/constants.ts
@@ -14,6 +14,6 @@ export const BUILTIN_MCP_TOOL_HINTS: Record<string, string[]> = {
     "codegraph_files",
   ],
   context7: ["context7_resolve-library-id", "context7_query-docs"],
-  websearch: ["websearch_web_search_exa"],
+  websearch: ["websearch_web_search_exa", "websearch_web_search", "websearch_web_fetch"],
   grep_app: ["grep_app_searchGitHub"],
 }


### PR DESCRIPTION
## Summary

Adds Parallel to the existing `websearch.provider` setting for web search and page extraction without a Parallel account or API key. Exa stays the default, Tavily keeps its current key handling, and existing MCP overrides and permissions still apply.

I work at Parallel, which operates this service.

## Changes

- Adds an explicit `"parallel"` selection using OpenCode's existing remote MCP client and `https://search.parallel.ai/mcp`. No new dependency, transport, fallback, or credential handling.
- Documents setup in `omo.jsonc`, disabling, rate limits, and data sent to Parallel. Once enabled, agents may send queries, URLs, and supplied context through the tools.
- Makes the Librarian's two search references use the configured provider's advertised tool schema, and recognizes Parallel tool names in agent reminders, JSON error recovery exclusions, and built-in tool guidance.
- Regenerates both configuration schemas. The unified schema also picks up existing `formatOnMutation` fields that were absent from the checked-in artifact. Regenerating the unmodified base reproduces those same 206 lines; the only additional schema changes are the Parallel enum entries.

## QA & Evidence

- **Real OpenCode 1.18.25 in Docker:** loaded the built plugin and documented configuration, connected anonymously, and exposed `websearch_web_search` and `websearch_web_fetch`. Search returned 10 results; fetch returned one page with no per-URL errors. A local response fixture drove tool selection; the MCP calls and results were live. The initial container had no host mounts; the follow-up containers mounted only task-owned code and evidence. All used isolated configuration and state with no real API credentials.
- **Configuration and runtime counterexamples:** 12 independent config cases pass, including project/profile precedence and credential isolation. Four native OpenCode cases verify `disabled_mcps`, `enabled:false`, custom URL precedence without fallback, and permission denial.
- **Regression checks:** 98 focused tests pass, covering provider behavior, credential isolation, configuration merging, schema freshness, and the helper paths that consume websearch tool names. New behavior was reproduced as failing before the corresponding fixes. The updated OpenCode suite passed with 8,434 tests and one skip; typecheck passed.
- Sanitized evidence is recorded locally under `.omo/evidence/20260828-parallel-search/`, including `live-qa.log`, `loader-qa.log`, `scoped-final.log`, `typecheck-final.log`, `build.log`, `root-tests-bun14.log`, and the baseline schema comparison.

## Risks & Residuals

- This is an explicitly selected anonymous service with rate limits. Paid authentication, quota exhaustion, and model-driven search quality were not tested.
- Before the tool-name follow-up, the full root suite on Bun 1.4.0 passed with 16,812 tests, 32 skips, and no failures across 2,163 files. Full build also passed. After the follow-up, the plugin was rebuilt and real search/fetch plus the reminder hook were reverified in OpenCode. The initial run on installed Bun 1.3.14 was interrupted after an unsupported binary-asset test; the completed run uses the required version.
- No Codex or Senpi runtime source was changed; unrelated generated distribution bundles are excluded.

## Automated Checks

```bash
bun test packages/omo-opencode/src/mcp packages/omo-opencode/src/plugin-handlers/mcp-config-handler.test.ts tests/omo-schema-freshness.test.ts
bun run build:schema
bun run typecheck
bun run build
bun test
git diff --check
```
