### PR TITLE
fix(omo-senpi): prevent orphaned memory test fixtures

### DIFF
--- a/packages/omo-senpi/src/components/memory/facts-run-prune.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/facts-run-prune.test-support.ts
@@ -11,15 +11,29 @@ import { join } from "node:path"
 import type { FactsQueueEntry } from "@oh-my-opencode/memory-core"
 
 import { reserveFactsRunDir } from "./facts-run-storage"
+import { exitedWithin } from "./worker/process-liveness.test-support"
 import { writeRunJsonAtomic } from "./worker/run-artifacts"
 
 const holdLockFixture = join(import.meta.dir, "worker", "__fixtures__", "hold-lock.ts")
 const temporaryRoots: string[] = []
 const children = new Set<ChildProcessWithoutNullStreams>()
 
+const TEARDOWN_GRACE_MS = 2_000
+
 afterEach(async () => {
-  for (const child of children) child.kill("SIGKILL")
+  // Temp roots die only after every tracked child is confirmed exited: rm under a live holder strands it.
+  const tracked = [...children]
   children.clear()
+  for (const child of tracked) {
+    if (child.exitCode !== null || child.signalCode !== null) continue
+    child.kill("SIGTERM")
+    if (!(await exitedWithin(child, TEARDOWN_GRACE_MS))) {
+      child.kill("SIGKILL")
+      if (!(await exitedWithin(child, TEARDOWN_GRACE_MS))) {
+        throw new Error(`tracked lock holder pid ${String(child.pid)} survived SIGTERM and SIGKILL teardown`)
+      }
+    }
+  }
   await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 

--- a/packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts
+++ b/packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts
@@ -3,6 +3,9 @@
 // owners) cannot reclaim it while the test is running. The test normally kills the child; readiness is
 // signalled on stdout, never timed.
 
+import { writeFileSync } from "node:fs"
+import { connect } from "node:net"
+
 import { acquireLock, createLockRecord } from "@oh-my-opencode/memory-core"
 
 const lockPath = process.argv[2]
@@ -13,8 +16,19 @@ await acquireLock(lockPath, record, { waitTimeoutMs: 10_000, retryDelayMs: 10 })
 process.stdout.write("held\n")
 
 await new Promise<void>((resolve) => {
-  process.stdin.once("end", resolve)
-  process.stdin.once("close", resolve)
-  process.stdin.once("error", resolve)
+  const done = (): void => {
+    const marker = process.env.EXIT_MARKER
+    if (marker !== undefined) writeFileSync(marker, "exited\n")
+    resolve()
+  }
+  process.stdin.once("end", done)
+  process.stdin.once("close", done)
+  process.stdin.once("error", done)
   process.stdin.resume()
+  const port = process.env.CONTROL_PORT
+  if (port !== undefined) {
+    const control = connect({ host: "127.0.0.1", port: Number(port) })
+    control.once("close", done)
+    control.once("error", done)
+  }
 })

--- a/packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts
+++ b/packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts
@@ -12,17 +12,9 @@ const record = await createLockRecord("facts-finalize", { runId: "hold-lock-fixt
 await acquireLock(lockPath, record, { waitTimeoutMs: 10_000, retryDelayMs: 10 })
 process.stdout.write("held\n")
 
-// A killed test runner closes the child's stdin, but keep a PPID watchdog as a fallback for runtimes
-// that do not deliver the pipe close event after reparenting.
-const parentPid = process.ppid
-const watchdog = setInterval(() => {
-  if (process.ppid === 1 || process.ppid !== parentPid) process.exit(0)
-}, 1_000)
-watchdog.unref()
-
 await new Promise<void>((resolve) => {
   process.stdin.once("end", resolve)
   process.stdin.once("close", resolve)
+  process.stdin.once("error", resolve)
   process.stdin.resume()
 })
-clearInterval(watchdog)

--- a/packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts
+++ b/packages/omo-senpi/src/components/memory/worker/__fixtures__/hold-lock.ts
@@ -19,6 +19,9 @@ await new Promise<void>((resolve) => {
   const done = (): void => {
     const marker = process.env.EXIT_MARKER
     if (marker !== undefined) writeFileSync(marker, "exited\n")
+    // A still-open stdin holds the event loop after a control-channel exit; release it so the
+    // process can actually terminate on every ownership-loss path.
+    process.stdin.destroy()
     resolve()
   }
   process.stdin.once("end", done)

--- a/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { spawn } from "node:child_process"
 import type { ChildProcess, ChildProcessWithoutNullStreams } from "node:child_process"
-import { existsSync, watch } from "node:fs"
-import type { FSWatcher } from "node:fs"
+import { existsSync } from "node:fs"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { createServer } from "node:net"
 import type { Server, Socket } from "node:net"
 import { tmpdir } from "node:os"
-import { basename, dirname, join } from "node:path"
+import { join } from "node:path"
 
-import { captureIdentity, pidAlive, pidTerminalWithin, readPidFileWhenWritten } from "./process-liveness.test-support"
+import { captureIdentity, killIfAlive, pidAlive, pidTerminalWithin, readPidFileWhenWritten, waitForFileToExist } from "./process-liveness.test-support"
 
 const holdLockFixture = join(import.meta.dir, "__fixtures__", "hold-lock.ts")
 const READY_TIMEOUT_MS = 10_000
@@ -38,27 +37,6 @@ function waitForReady(child: ChildProcessWithoutNullStreams): Promise<void> {
     }
     child.stdout.on("data", onData)
     child.once("exit", () => reject(new Error("lock holder exited before readiness")))
-  })
-}
-
-function waitForFile(path: string, boundMs: number): Promise<void> {
-  if (existsSync(path)) return Promise.resolve()
-  return new Promise((resolve, reject) => {
-    let watcher: FSWatcher
-    const timer = setTimeout(() => { watcher.close(); reject(new Error(`file never appeared: ${path}`)) }, boundMs)
-    try {
-      watcher = watch(dirname(path), (_event, name) => {
-        if (name !== basename(path)) return
-        clearTimeout(timer)
-        watcher.close()
-        resolve()
-      })
-    } catch (error) {
-      clearTimeout(timer)
-      reject(error as Error)
-      return
-    }
-    watcher.on("error", (error) => { clearTimeout(timer); reject(error) })
   })
 }
 
@@ -109,9 +87,10 @@ describe("hold-lock fixture lifecycle", () => {
       for (const socket of connections) socket.destroy()
       control.close()
 
-      // then
-      await waitForFile(marker, EXIT_TIMEOUT_MS)
+      // then: the child's own exit is the terminal event; the fixture writes the marker before
+      // releasing its parking promise, so the marker is on disk once the exit lands.
       expect((await exit).signal).toBeNull()
+      expect(existsSync(marker)).toBe(true)
     } finally {
       child.kill("SIGKILL")
       control.close()
@@ -158,9 +137,12 @@ child.stdout.on("data", (chunk) => {
       if (wrapper.exitCode !== null || wrapper.signalCode !== null) { onExit(wrapper.exitCode, wrapper.signalCode); return }
       wrapper.once("exit", onExit)
     })
-    let holderPid: number | null = null
+    let holderIdentityForCleanup: import("./process-liveness.test-support").ProcessIdentity | null = null
     try {
-      holderPid = await readPidFileWhenWritten(holderPidPath, READY_TIMEOUT_MS)
+      const holderPid = await readPidFileWhenWritten(holderPidPath, READY_TIMEOUT_MS)
+      // The holder is alive at this point (the wrapper dies only after writing the pid file), so
+      // the identity snapshot doubles as the fail-safe's PID-reuse guard.
+      holderIdentityForCleanup = captureIdentity(holderPid)
 
       // when
       await wrapperExit
@@ -169,18 +151,15 @@ child.stdout.on("data", (chunk) => {
       // precedes the process's actual exit by a beat, so termination is awaited event-first
       // (the /proc watcher on linux, a bounded liveness probe elsewhere) instead of being
       // asserted from a single point-in-time probe.
-      const holderIdentity = captureIdentity(holderPid)
-      await waitForFile(marker, EXIT_TIMEOUT_MS)
-      if (holderIdentity !== null) {
-        expect(await pidTerminalWithin(holderIdentity, EXIT_TIMEOUT_MS)).toBe(true)
+      expect(await waitForFileToExist(marker, EXIT_TIMEOUT_MS)).toBe(true)
+      if (holderIdentityForCleanup !== null) {
+        expect(await pidTerminalWithin(holderIdentityForCleanup, EXIT_TIMEOUT_MS)).toBe(true)
       } else {
         expect(pidAlive(holderPid)).toBe(false)
       }
     } finally {
       wrapper.kill("SIGKILL")
-      if (holderPid !== null && pidAlive(holderPid)) {
-        try { process.kill(holderPid, "SIGKILL") } catch { /* already gone */ }
-      }
+      if (holderIdentityForCleanup !== null) killIfAlive(holderIdentityForCleanup)
       await rm(root, { recursive: true, force: true })
     }
   }, 30_000)

--- a/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
@@ -1,159 +1,97 @@
-// Process-lifecycle regressions for the memory lock-holder fixture: a holder must be unable to
-// outlive its parent's control pipe, so an aborted test run can never strand CPU-burning orphans
-// holding marker locks (incident class: PPID-1 hold-lock processes spinning near 100% CPU).
-
 import { describe, expect, test } from "bun:test"
 import { spawn } from "node:child_process"
 import type { ChildProcess, ChildProcessWithoutNullStreams } from "node:child_process"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { createServer, type Socket } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { killIfAlive, pidTerminalWithin, readPidWhenWritten } from "./process-liveness.test-support"
+import { identityMatches, killIfAlive, type ProcessIdentity } from "./process-liveness.test-support"
 
 const holdLockFixture = join(import.meta.dir, "__fixtures__", "hold-lock.ts")
-
 const READY_TIMEOUT_MS = 10_000
-const EXIT_BOUND_MS = 5_000
-const FAILSAFE_BOUND_MS = 5_000
+const EXIT_TIMEOUT_MS = 5_000
 
 type ExitInfo = { readonly code: number | null; readonly signal: NodeJS.Signals | null }
 
-/** Resolves with exit info once the child exits, or null after `boundMs` (never rejects). */
-function exitInfoWithin(child: ChildProcess, boundMs: number): Promise<ExitInfo | null> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return Promise.resolve({ code: child.exitCode, signal: child.signalCode })
-  }
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => settle(null), boundMs)
-    function settle(info: ExitInfo | null): void {
-      clearTimeout(timer)
-      child.off("exit", onExit)
-      resolve(info)
-    }
-    function onExit(code: number | null, signal: NodeJS.Signals | null): void {
-      settle({ code, signal })
-    }
-    child.once("exit", onExit)
+function exitWithin(child: ChildProcess, boundMs: number): Promise<ExitInfo> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve({ code: child.exitCode, signal: child.signalCode })
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`child ${String(child.pid)} did not exit within ${boundMs}ms`)), boundMs)
+    child.once("exit", (code, signal) => { clearTimeout(timer); resolve({ code, signal }) })
   })
 }
 
-/** Resolves once the holder prints its readiness line; rejects on timeout or early exit. */
-function readReady(child: ChildProcessWithoutNullStreams): Promise<void> {
+function waitForReady(child: ChildProcessWithoutNullStreams): Promise<void> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => finish(new Error("lock holder never reported ready")), READY_TIMEOUT_MS)
+    const timer = setTimeout(() => reject(new Error("lock holder never reported ready")), READY_TIMEOUT_MS)
     let output = ""
-    function finish(error?: Error): void {
+    const onData = (chunk: Buffer): void => {
+      output += chunk.toString("utf8")
+      if (!output.includes("held\n")) return
       clearTimeout(timer)
       child.stdout.off("data", onData)
-      child.off("exit", onExit)
-      error === undefined ? resolve() : reject(error)
-    }
-    function onData(chunk: Buffer): void {
-      output += chunk.toString("utf8")
-      if (output.includes("held\n")) finish()
-    }
-    function onExit(code: number | null, signal: NodeJS.Signals | null): void {
-      finish(new Error(`lock holder exited early: code=${String(code)} signal=${String(signal)}`))
+      resolve()
     }
     child.stdout.on("data", onData)
-    child.once("exit", onExit)
+    child.once("exit", () => reject(new Error("lock holder exited before readiness")))
   })
 }
 
-/** Polls a text marker written by a foreign writer; resolves with trimmed content once present. */
-async function readMarkerWhenWritten(path: string, boundMs: number): Promise<string> {
-  const deadline = Date.now() + boundMs
-  for (;;) {
-    try {
-      return (await readFile(path, "utf8")).trim()
-    } catch (error) {
-      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
-    }
-    if (Date.now() >= deadline) throw new Error(`marker never appeared at ${path}`)
-    await Bun.sleep(5)
+async function terminate(identity: ProcessIdentity | undefined, child: ChildProcess | undefined): Promise<void> {
+  if (identity !== undefined && identityMatches(identity)) killIfAlive(identity)
+  if (child !== undefined) {
+    try { await exitWithin(child, EXIT_TIMEOUT_MS) } catch { child.kill("SIGKILL") }
   }
 }
 
 describe("hold-lock fixture lifecycle", () => {
-  test("#given a hold-lock child holding its marker #when the parent-owned stdin pipe reports EOF #then the child exits within a bounded time", async () => {
-    // given
+  test("exits on the parent-owned stdin EOF event", async () => {
     const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-lifecycle-"))
-    const child = spawn(process.execPath, [holdLockFixture, join(root, "finalize.lock")], {
-      stdio: ["pipe", "pipe", "pipe"],
-    })
+    const child = spawn(process.execPath, [holdLockFixture, join(root, "finalize.lock")], { stdio: ["pipe", "pipe", "pipe"] })
     try {
-      await readReady(child)
-
-      // when: teardown closes its end of the control pipe instead of signalling the child.
-      child.stdin.destroy()
-
-      // then
-      const exit = await exitInfoWithin(child, EXIT_BOUND_MS)
-      expect(exit).not.toBeNull()
+      await waitForReady(child)
+      const exit = exitWithin(child, EXIT_TIMEOUT_MS)
+      child.stdin.end()
+      expect((await exit).signal).toBeNull()
     } finally {
-      // Fail-safe: a failed assertion above must not leak the holder.
       child.kill("SIGKILL")
-      await exitInfoWithin(child, FAILSAFE_BOUND_MS)
       await rm(root, { recursive: true, force: true })
     }
   }, 30_000)
 
-  test("#given a wrapper killed abruptly only after its holder reported held #when no teardown can run #then the holder still exits within a bounded time", async () => {
-    // given
+  test("an abruptly killed wrapper closes the holder ownership channel", async () => {
     const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-abrupt-"))
     const wrapperPath = join(root, "abrupt-wrapper.mjs")
-    const holderPidPath = join(root, "holder.pid")
-    const holderAliveAtDeathPath = join(root, "holder-alive-at-death.txt")
+    const control = createServer()
+    const connections = new Set<Socket>()
+    control.on("connection", (socket) => connections.add(socket))
+    await new Promise<void>((resolve) => control.listen(0, "127.0.0.1", resolve))
+    const address = control.address()
+    if (address === null || typeof address === "string") throw new Error("control server did not bind")
     await writeFile(wrapperPath, `
 import { spawn } from "node:child_process"
-import { writeFileSync } from "node:fs"
+import { connect } from "node:net"
 const child = spawn(process.execPath, [process.env.HOLDER_FIXTURE, process.env.LOCK_PATH], { stdio: ["pipe", "pipe", "ignore"] })
-writeFileSync(process.env.HOLDER_PID_PATH, String(child.pid))
-let output = ""
-child.stdout.on("data", (chunk) => {
-  output += chunk.toString("utf8")
-  if (!output.includes("held\\n")) return
-  void (async () => {
-    await new Promise((resolve) => setTimeout(resolve, 150))
-    const stillRunning = child.exitCode === null && child.signalCode === null
-    writeFileSync(process.env.HOLDER_ALIVE_PATH, stillRunning ? "alive" : "exited")
-    process.kill(process.pid, "SIGKILL")
-  })()
-})
+const control = connect({ host: "127.0.0.1", port: Number(process.env.CONTROL_PORT) })
+child.stdout.on("data", (chunk) => { if (chunk.toString().includes("held\\n")) process.kill(process.pid, "SIGKILL") })
 `, "utf8")
     const wrapper = spawn(process.execPath, [wrapperPath], {
-      stdio: ["ignore", "ignore", "ignore"],
-      env: {
-        ...process.env,
-        HOLDER_FIXTURE: holdLockFixture,
-        LOCK_PATH: join(root, "facts-runs.lock"),
-        HOLDER_PID_PATH: holderPidPath,
-        HOLDER_ALIVE_PATH: holderAliveAtDeathPath,
-      },
+      stdio: "ignore",
+      env: { ...process.env, HOLDER_FIXTURE: holdLockFixture, LOCK_PATH: join(root, "facts-runs.lock"), CONTROL_PORT: String(address.port) },
     })
-    let holderIdentity: import("./process-liveness.test-support").ProcessIdentity | undefined
     try {
-      // when: the wrapper registers the holder's pid ONLY after observing the readiness line, so
-      // the pid file's existence proves the marker lock was genuinely held when the wrapper then
-      // self-SIGKILLs - no teardown can ever run, and the OS closing the wrapper's end of the
-      // holder's stdin pipe is the only exit channel left.
-      holderIdentity = await readPidWhenWritten(holderPidPath, READY_TIMEOUT_MS)
-      const aliveAtWrapperDeath = await readMarkerWhenWritten(holderAliveAtDeathPath, READY_TIMEOUT_MS)
-
-      // then: the holder was still PARKED (not self-exited) at the instant the wrapper died, so
-      // its subsequent termination is attributable to the pipe EOF alone.
-      expect(aliveAtWrapperDeath).toBe("alive")
-      const holderGone = await pidTerminalWithin(holderIdentity, EXIT_BOUND_MS)
-      expect(holderGone).toBe(true)
+      const holderSocket = await new Promise<Socket>((resolve) => control.once("connection", resolve))
+      await exitWithin(wrapper, EXIT_TIMEOUT_MS)
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("holder ownership channel stayed open")), EXIT_TIMEOUT_MS)
+        holderSocket.once("close", () => { clearTimeout(timer); resolve() })
+      })
+      expect(holderSocket.destroyed).toBe(true)
     } finally {
-      // Fail-safe kills are attempted even when assertions failed; ESRCH races are fine.
-      if (holderIdentity !== undefined) {
-        killIfAlive(holderIdentity)
-        await pidTerminalWithin(holderIdentity, FAILSAFE_BOUND_MS)
-      }
-      wrapper.kill("SIGKILL")
-      await exitInfoWithin(wrapper, FAILSAFE_BOUND_MS)
+      await terminate(undefined, wrapper)
+      control.close()
+      for (const socket of connections) socket.destroy()
       await rm(root, { recursive: true, force: true })
     }
   }, 30_000)

--- a/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
@@ -6,8 +6,6 @@ import { createServer, type Socket } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { identityMatches, killIfAlive, type ProcessIdentity } from "./process-liveness.test-support"
-
 const holdLockFixture = join(import.meta.dir, "__fixtures__", "hold-lock.ts")
 const READY_TIMEOUT_MS = 10_000
 const EXIT_TIMEOUT_MS = 5_000
@@ -38,13 +36,6 @@ function waitForReady(child: ChildProcessWithoutNullStreams): Promise<void> {
   })
 }
 
-async function terminate(identity: ProcessIdentity | undefined, child: ChildProcess | undefined): Promise<void> {
-  if (identity !== undefined && identityMatches(identity)) killIfAlive(identity)
-  if (child !== undefined) {
-    try { await exitWithin(child, EXIT_TIMEOUT_MS) } catch { child.kill("SIGKILL") }
-  }
-}
-
 describe("hold-lock fixture lifecycle", () => {
   test("exits on the parent-owned stdin EOF event", async () => {
     const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-lifecycle-"))
@@ -60,39 +51,32 @@ describe("hold-lock fixture lifecycle", () => {
     }
   }, 30_000)
 
-  test("an abruptly killed wrapper closes the holder ownership channel", async () => {
+  test("an abruptly killed wrapper closes the holder stdin ownership channel", async () => {
     const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-abrupt-"))
     const wrapperPath = join(root, "abrupt-wrapper.mjs")
-    const control = createServer()
-    const connections = new Set<Socket>()
-    control.on("connection", (socket) => connections.add(socket))
-    await new Promise<void>((resolve) => control.listen(0, "127.0.0.1", resolve))
-    const address = control.address()
-    if (address === null || typeof address === "string") throw new Error("control server did not bind")
     await writeFile(wrapperPath, `
 import { spawn } from "node:child_process"
-import { connect } from "node:net"
 const child = spawn(process.execPath, [process.env.HOLDER_FIXTURE, process.env.LOCK_PATH], { stdio: ["pipe", "pipe", "ignore"] })
-const control = connect({ host: "127.0.0.1", port: Number(process.env.CONTROL_PORT) })
 child.stdout.on("data", (chunk) => { if (chunk.toString().includes("held\\n")) process.kill(process.pid, "SIGKILL") })
 `, "utf8")
-    const wrapper = spawn(process.execPath, [wrapperPath], {
-      stdio: "ignore",
-      env: { ...process.env, HOLDER_FIXTURE: holdLockFixture, LOCK_PATH: join(root, "facts-runs.lock"), CONTROL_PORT: String(address.port) },
-    })
+    const wrapper = spawn(process.execPath, [wrapperPath], { stdio: ["ignore", "ignore", "ignore"], env: { ...process.env, HOLDER_FIXTURE: holdLockFixture, LOCK_PATH: join(root, "facts-runs.lock") } })
     try {
-      const holderSocket = await new Promise<Socket>((resolve) => control.once("connection", resolve))
-      await exitWithin(wrapper, EXIT_TIMEOUT_MS)
       await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error("holder ownership channel stayed open")), EXIT_TIMEOUT_MS)
-        holderSocket.once("close", () => { clearTimeout(timer); resolve() })
+        const timer = setTimeout(() => reject(new Error("wrapper did not terminate after holder readiness")), READY_TIMEOUT_MS)
+        wrapper.once("exit", (code, signal) => { clearTimeout(timer); expect(code).toBeNull(); expect(signal).toBe("SIGKILL"); resolve() })
       })
-      expect(holderSocket.destroyed).toBe(true)
+      // Bun closes the wrapper-owned pipe on wrapper exit; the fixture's exact stdin close event is
+      // the terminal signal. The child is intentionally observed through its own exit event.
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("holder did not terminate after wrapper death")), EXIT_TIMEOUT_MS)
+        const probe = spawn(process.execPath, [holdLockFixture, join(root, "second.lock")], { stdio: ["pipe", "ignore", "ignore"] })
+        probe.once("exit", () => { clearTimeout(timer); resolve() })
+        probe.stdin.end()
+      })
     } finally {
-      await terminate(undefined, wrapper)
-      control.close()
-      for (const socket of connections) socket.destroy()
+      wrapper.kill("SIGKILL")
       await rm(root, { recursive: true, force: true })
     }
   }, 30_000)
+
 })

--- a/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test"
 import { spawn } from "node:child_process"
 import type { ChildProcess, ChildProcessWithoutNullStreams } from "node:child_process"
+import { existsSync, watch } from "node:fs"
+import type { FSWatcher } from "node:fs"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
-import { createServer, type Socket } from "node:net"
+import { createServer } from "node:net"
+import type { Server, Socket } from "node:net"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { basename, dirname, join } from "node:path"
+
+import { pidAlive, readPidFileWhenWritten } from "./process-liveness.test-support"
 
 const holdLockFixture = join(import.meta.dir, "__fixtures__", "hold-lock.ts")
 const READY_TIMEOUT_MS = 10_000
@@ -36,6 +41,38 @@ function waitForReady(child: ChildProcessWithoutNullStreams): Promise<void> {
   })
 }
 
+function waitForFile(path: string, boundMs: number): Promise<void> {
+  if (existsSync(path)) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    let watcher: FSWatcher
+    const timer = setTimeout(() => { watcher.close(); reject(new Error(`file never appeared: ${path}`)) }, boundMs)
+    try {
+      watcher = watch(dirname(path), (_event, name) => {
+        if (name !== basename(path)) return
+        clearTimeout(timer)
+        watcher.close()
+        resolve()
+      })
+    } catch (error) {
+      clearTimeout(timer)
+      reject(error as Error)
+      return
+    }
+    watcher.on("error", (error) => { clearTimeout(timer); reject(error) })
+  })
+}
+
+function listenOnLoopback(control: Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    control.once("error", reject)
+    control.listen(0, "127.0.0.1", () => {
+      const address = control.address()
+      if (address === null || typeof address === "string") return reject(new Error("control listener has no tcp port"))
+      resolve(address.port)
+    })
+  })
+}
+
 describe("hold-lock fixture lifecycle", () => {
   test("exits on the parent-owned stdin EOF event", async () => {
     const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-lifecycle-"))
@@ -51,32 +88,93 @@ describe("hold-lock fixture lifecycle", () => {
     }
   }, 30_000)
 
-  test("an abruptly killed wrapper closes the holder stdin ownership channel", async () => {
-    const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-abrupt-"))
-    const wrapperPath = join(root, "abrupt-wrapper.mjs")
-    await writeFile(wrapperPath, `
-import { spawn } from "node:child_process"
-const child = spawn(process.execPath, [process.env.HOLDER_FIXTURE, process.env.LOCK_PATH], { stdio: ["pipe", "pipe", "ignore"] })
-child.stdout.on("data", (chunk) => { if (chunk.toString().includes("held\\n")) process.kill(process.pid, "SIGKILL") })
-`, "utf8")
-    const wrapper = spawn(process.execPath, [wrapperPath], { stdio: ["ignore", "ignore", "ignore"], env: { ...process.env, HOLDER_FIXTURE: holdLockFixture, LOCK_PATH: join(root, "facts-runs.lock") } })
+  test("exits when ONLY the parent-owned control channel closes while stdin stays open", async () => {
+    // given: a holder whose stdin never closes; the fixture's CONTROL_PORT branch is the only
+    // possible exit path, so a fixture without it (origin/dev) can never produce the marker.
+    const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-control-"))
+    const marker = join(root, "holder-exited.marker")
+    const control = createServer()
+    const connections = new Set<Socket>()
+    control.on("connection", (socket) => connections.add(socket))
+    const port = await listenOnLoopback(control)
+    const child = spawn(process.execPath, [holdLockFixture, join(root, "control.lock")], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, CONTROL_PORT: String(port), EXIT_MARKER: marker },
+    })
     try {
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error("wrapper did not terminate after holder readiness")), READY_TIMEOUT_MS)
-        wrapper.once("exit", (code, signal) => { clearTimeout(timer); expect(code).toBeNull(); expect(signal).toBe("SIGKILL"); resolve() })
-      })
-      // Bun closes the wrapper-owned pipe on wrapper exit; the fixture's exact stdin close event is
-      // the terminal signal. The child is intentionally observed through its own exit event.
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error("holder did not terminate after wrapper death")), EXIT_TIMEOUT_MS)
-        const probe = spawn(process.execPath, [holdLockFixture, join(root, "second.lock")], { stdio: ["pipe", "ignore", "ignore"] })
-        probe.once("exit", () => { clearTimeout(timer); resolve() })
-        probe.stdin.end()
-      })
+      await waitForReady(child)
+      const exit = exitWithin(child, EXIT_TIMEOUT_MS)
+
+      // when
+      for (const socket of connections) socket.destroy()
+      control.close()
+
+      // then
+      await waitForFile(marker, EXIT_TIMEOUT_MS)
+      expect((await exit).signal).toBeNull()
     } finally {
-      wrapper.kill("SIGKILL")
+      child.kill("SIGKILL")
+      control.close()
       await rm(root, { recursive: true, force: true })
     }
   }, 30_000)
 
+  test("an abruptly killed wrapper takes the ORIGINAL holder down with it", async () => {
+    // given: a wrapper that spawns the real holder, records the holder's own pid, then SIGKILLs
+    // itself; the test observes THAT original holder (pid identity + exit marker + terminal
+    // state), never a substitute process.
+    const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-abrupt-"))
+    const holderPidPath = join(root, "holder.pid")
+    const marker = join(root, "holder-exited.marker")
+    const wrapperPath = join(root, "abrupt-wrapper.mjs")
+    await writeFile(wrapperPath, `
+import { spawn } from "node:child_process"
+import { writeFileSync } from "node:fs"
+const child = spawn(process.execPath, [process.env.HOLDER_FIXTURE, process.env.LOCK_PATH], { stdio: ["pipe", "pipe", "ignore"] })
+child.stdout.on("data", (chunk) => {
+  if (!chunk.toString().includes("held\\n")) return
+  writeFileSync(process.env.HOLDER_PID_PATH, String(child.pid))
+  process.kill(process.pid, "SIGKILL")
+})
+`, "utf8")
+    const wrapper = spawn(process.execPath, [wrapperPath], {
+      stdio: ["ignore", "ignore", "ignore"],
+      env: { ...process.env, HOLDER_FIXTURE: holdLockFixture, LOCK_PATH: join(root, "facts-runs.lock"), HOLDER_PID_PATH: holderPidPath, EXIT_MARKER: marker },
+    })
+    // Subscribe to the wrapper's death BEFORE it can fire: the wrapper SIGKILLs itself in the
+    // same tick it writes the pid file, so listening only after the read would miss the event.
+    const wrapperExit = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("wrapper did not terminate after holder readiness")), READY_TIMEOUT_MS)
+      const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+        clearTimeout(timer)
+        try {
+          expect(code).toBeNull()
+          expect(signal).toBe("SIGKILL")
+          resolve()
+        } catch (error) {
+          reject(error as Error)
+        }
+      }
+      if (wrapper.exitCode !== null || wrapper.signalCode !== null) { onExit(wrapper.exitCode, wrapper.signalCode); return }
+      wrapper.once("exit", onExit)
+    })
+    let holderPid: number | null = null
+    try {
+      holderPid = await readPidFileWhenWritten(holderPidPath, READY_TIMEOUT_MS)
+
+      // when
+      await wrapperExit
+
+      // then: the exit marker is the original holder's own terminal signal; the pid it wrote is
+      // gone afterwards. A substitute process could never produce either.
+      await waitForFile(marker, EXIT_TIMEOUT_MS)
+      expect(pidAlive(holderPid)).toBe(false)
+    } finally {
+      wrapper.kill("SIGKILL")
+      if (holderPid !== null && pidAlive(holderPid)) {
+        try { process.kill(holderPid, "SIGKILL") } catch { /* already gone */ }
+      }
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 30_000)
 })

--- a/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
@@ -1,0 +1,160 @@
+// Process-lifecycle regressions for the memory lock-holder fixture: a holder must be unable to
+// outlive its parent's control pipe, so an aborted test run can never strand CPU-burning orphans
+// holding marker locks (incident class: PPID-1 hold-lock processes spinning near 100% CPU).
+
+import { describe, expect, test } from "bun:test"
+import { spawn } from "node:child_process"
+import type { ChildProcess, ChildProcessWithoutNullStreams } from "node:child_process"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { killIfAlive, pidTerminalWithin, readPidWhenWritten } from "./process-liveness.test-support"
+
+const holdLockFixture = join(import.meta.dir, "__fixtures__", "hold-lock.ts")
+
+const READY_TIMEOUT_MS = 10_000
+const EXIT_BOUND_MS = 5_000
+const FAILSAFE_BOUND_MS = 5_000
+
+type ExitInfo = { readonly code: number | null; readonly signal: NodeJS.Signals | null }
+
+/** Resolves with exit info once the child exits, or null after `boundMs` (never rejects). */
+function exitInfoWithin(child: ChildProcess, boundMs: number): Promise<ExitInfo | null> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode })
+  }
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => settle(null), boundMs)
+    function settle(info: ExitInfo | null): void {
+      clearTimeout(timer)
+      child.off("exit", onExit)
+      resolve(info)
+    }
+    function onExit(code: number | null, signal: NodeJS.Signals | null): void {
+      settle({ code, signal })
+    }
+    child.once("exit", onExit)
+  })
+}
+
+/** Resolves once the holder prints its readiness line; rejects on timeout or early exit. */
+function readReady(child: ChildProcessWithoutNullStreams): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => finish(new Error("lock holder never reported ready")), READY_TIMEOUT_MS)
+    let output = ""
+    function finish(error?: Error): void {
+      clearTimeout(timer)
+      child.stdout.off("data", onData)
+      child.off("exit", onExit)
+      error === undefined ? resolve() : reject(error)
+    }
+    function onData(chunk: Buffer): void {
+      output += chunk.toString("utf8")
+      if (output.includes("held\n")) finish()
+    }
+    function onExit(code: number | null, signal: NodeJS.Signals | null): void {
+      finish(new Error(`lock holder exited early: code=${String(code)} signal=${String(signal)}`))
+    }
+    child.stdout.on("data", onData)
+    child.once("exit", onExit)
+  })
+}
+
+/** Polls a text marker written by a foreign writer; resolves with trimmed content once present. */
+async function readMarkerWhenWritten(path: string, boundMs: number): Promise<string> {
+  const deadline = Date.now() + boundMs
+  for (;;) {
+    try {
+      return (await readFile(path, "utf8")).trim()
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+    }
+    if (Date.now() >= deadline) throw new Error(`marker never appeared at ${path}`)
+    await Bun.sleep(5)
+  }
+}
+
+describe("hold-lock fixture lifecycle", () => {
+  test("#given a hold-lock child holding its marker #when the parent-owned stdin pipe reports EOF #then the child exits within a bounded time", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-lifecycle-"))
+    const child = spawn(process.execPath, [holdLockFixture, join(root, "finalize.lock")], {
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+    try {
+      await readReady(child)
+
+      // when: teardown closes its end of the control pipe instead of signalling the child.
+      child.stdin.destroy()
+
+      // then
+      const exit = await exitInfoWithin(child, EXIT_BOUND_MS)
+      expect(exit).not.toBeNull()
+    } finally {
+      // Fail-safe: a failed assertion above must not leak the holder.
+      child.kill("SIGKILL")
+      await exitInfoWithin(child, FAILSAFE_BOUND_MS)
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 30_000)
+
+  test("#given a wrapper killed abruptly only after its holder reported held #when no teardown can run #then the holder still exits within a bounded time", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-hold-lock-abrupt-"))
+    const wrapperPath = join(root, "abrupt-wrapper.mjs")
+    const holderPidPath = join(root, "holder.pid")
+    const holderAliveAtDeathPath = join(root, "holder-alive-at-death.txt")
+    await writeFile(wrapperPath, `
+import { spawn } from "node:child_process"
+import { writeFileSync } from "node:fs"
+const child = spawn(process.execPath, [process.env.HOLDER_FIXTURE, process.env.LOCK_PATH], { stdio: ["pipe", "pipe", "ignore"] })
+writeFileSync(process.env.HOLDER_PID_PATH, String(child.pid))
+let output = ""
+child.stdout.on("data", (chunk) => {
+  output += chunk.toString("utf8")
+  if (!output.includes("held\\n")) return
+  void (async () => {
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    const stillRunning = child.exitCode === null && child.signalCode === null
+    writeFileSync(process.env.HOLDER_ALIVE_PATH, stillRunning ? "alive" : "exited")
+    process.kill(process.pid, "SIGKILL")
+  })()
+})
+`, "utf8")
+    const wrapper = spawn(process.execPath, [wrapperPath], {
+      stdio: ["ignore", "ignore", "ignore"],
+      env: {
+        ...process.env,
+        HOLDER_FIXTURE: holdLockFixture,
+        LOCK_PATH: join(root, "facts-runs.lock"),
+        HOLDER_PID_PATH: holderPidPath,
+        HOLDER_ALIVE_PATH: holderAliveAtDeathPath,
+      },
+    })
+    let holderIdentity: import("./process-liveness.test-support").ProcessIdentity | undefined
+    try {
+      // when: the wrapper registers the holder's pid ONLY after observing the readiness line, so
+      // the pid file's existence proves the marker lock was genuinely held when the wrapper then
+      // self-SIGKILLs - no teardown can ever run, and the OS closing the wrapper's end of the
+      // holder's stdin pipe is the only exit channel left.
+      holderIdentity = await readPidWhenWritten(holderPidPath, READY_TIMEOUT_MS)
+      const aliveAtWrapperDeath = await readMarkerWhenWritten(holderAliveAtDeathPath, READY_TIMEOUT_MS)
+
+      // then: the holder was still PARKED (not self-exited) at the instant the wrapper died, so
+      // its subsequent termination is attributable to the pipe EOF alone.
+      expect(aliveAtWrapperDeath).toBe("alive")
+      const holderGone = await pidTerminalWithin(holderIdentity, EXIT_BOUND_MS)
+      expect(holderGone).toBe(true)
+    } finally {
+      // Fail-safe kills are attempted even when assertions failed; ESRCH races are fine.
+      if (holderIdentity !== undefined) {
+        killIfAlive(holderIdentity)
+        await pidTerminalWithin(holderIdentity, FAILSAFE_BOUND_MS)
+      }
+      wrapper.kill("SIGKILL")
+      await exitInfoWithin(wrapper, FAILSAFE_BOUND_MS)
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
@@ -9,7 +9,7 @@ import type { Server, Socket } from "node:net"
 import { tmpdir } from "node:os"
 import { basename, dirname, join } from "node:path"
 
-import { pidAlive, readPidFileWhenWritten } from "./process-liveness.test-support"
+import { captureIdentity, pidAlive, pidTerminalWithin, readPidFileWhenWritten } from "./process-liveness.test-support"
 
 const holdLockFixture = join(import.meta.dir, "__fixtures__", "hold-lock.ts")
 const READY_TIMEOUT_MS = 10_000
@@ -165,10 +165,17 @@ child.stdout.on("data", (chunk) => {
       // when
       await wrapperExit
 
-      // then: the exit marker is the original holder's own terminal signal; the pid it wrote is
-      // gone afterwards. A substitute process could never produce either.
+      // then: the exit marker is the original holder's own terminal signal. The marker write
+      // precedes the process's actual exit by a beat, so termination is awaited event-first
+      // (the /proc watcher on linux, a bounded liveness probe elsewhere) instead of being
+      // asserted from a single point-in-time probe.
+      const holderIdentity = captureIdentity(holderPid)
       await waitForFile(marker, EXIT_TIMEOUT_MS)
-      expect(pidAlive(holderPid)).toBe(false)
+      if (holderIdentity !== null) {
+        expect(await pidTerminalWithin(holderIdentity, EXIT_TIMEOUT_MS)).toBe(true)
+      } else {
+        expect(pidAlive(holderPid)).toBe(false)
+      }
     } finally {
       wrapper.kill("SIGKILL")
       if (holderPid !== null && pidAlive(holderPid)) {

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -302,7 +302,7 @@ control.once("error", () => process.exit(0))
         await pidTerminalWithin(grandchildIdentityForCleanup, HELPER_FAILSAFE_BOUND_MS)
       }
     }
-  })
+  }, 30_000)
 
   test("#given a failed child catalog probe #when candidates are preflighted #then it warns and preserves reactive fallback behavior", async () => {
     // given

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -1,12 +1,19 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { createServer } from "node:net"
+import type { Server, Socket } from "node:net"
 
 import { preflightMemoryModels, resetModelPreflightCacheForTests } from "./model-preflight"
 import type { MemoryModelChain } from "./memory-model-attempts"
+import { killIfAlive, pidTerminalWithin, readPidOnce, readPidWhenWritten } from "./process-liveness.test-support"
 
 const roots: string[] = []
+
+const HELPER_EXIT_BOUND_MS = 5_000
+const HELPER_FAILSAFE_BOUND_MS = 5_000
+
 afterEach(async () => {
   resetModelPreflightCacheForTests()
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
@@ -29,6 +36,18 @@ async function fixture(body: string): Promise<{
   await writeFile(launcher, `${body}\n`, "utf8")
   await writeFile(config, "{}\n", "utf8")
   return { root, launch: { command: process.execPath, prefixArgs: [launcher] }, config }
+}
+
+// Double server.close() raises ERR_SERVER_NOT_RUNNING under Node semantics; the try body closes
+// the channel and the fail-safe finally must stay a no-op then.
+const closedControlServers = new WeakSet<Server>()
+
+function closeControlChannel(control: Server, connections: Set<Socket>): void {
+  if (closedControlServers.has(control)) return
+  for (const socket of connections) socket.destroy()
+  connections.clear()
+  control.close()
+  closedControlServers.add(control)
 }
 
 describe("preflightMemoryModels", () => {
@@ -166,56 +185,95 @@ process.stdout.write("builtin/fallback\\n")
   })
 
   test("#given a launcher whose grandchild holds the output pipes #when the probe times out #then it degrades without waiting for the grandchild", async () => {
-    // given
+    // given: wrapper and grandchild park on a control socket owned by THIS test process, so both
+    // die when that socket closes - through teardown or through this process dying outright.
+    // The grandchild keeps holding the inherited output pipes even after the launcher itself is
+    // killed, which is exactly the hazard the probe must degrade past.
     const item = await fixture("")
     const wrapper = join(item.root, "wrapper.mjs")
+    const grandchildScript = join(item.root, "grandchild.mjs")
+    const wrapperPidPath = join(item.root, "wrapper.pid")
     const grandchildPidPath = join(item.root, "grandchild.pid")
     await writeFile(wrapper, `
 import { spawn } from "node:child_process"
+import { connect } from "node:net"
 import { writeFileSync } from "node:fs"
-const child = spawn(process.execPath, ["-e", "setInterval(() => undefined, 30_000)"], { stdio: ["ignore", "inherit", "inherit"] })
-writeFileSync(process.env.GRANDCHILD_PID, String(child.pid))
-setInterval(() => undefined, 30_000)
+writeFileSync(process.env.WRAPPER_PID_PATH, String(process.pid))
+const child = spawn(process.execPath, [process.env.GRANDCHILD_SCRIPT], { stdio: ["ignore", "inherit", "inherit"] })
+writeFileSync(process.env.GRANDCHILD_PID_PATH, String(child.pid))
+const control = connect({ host: "127.0.0.1", port: Number(process.env.CONTROL_PORT) })
+control.once("close", () => process.exit(0))
+control.once("error", () => process.exit(0))
 `, "utf8")
-    // Windows runners pay a far larger cost to spawn process.execPath plus a grandchild, so the outer
-    // wall-clock bound is platform-scoped. The injected probe timeout stays at 50ms on every platform,
-    // so an unbounded hang still blows past even the Windows budget.
-    const outerBoundMs = process.platform === "win32" ? 5000 : 500
-    const startedAt = Date.now()
-    const probe = preflightMemoryModels({
-      candidates,
-      launch: { command: process.execPath, prefixArgs: [wrapper] },
-      env: { PATH: process.env.PATH, GRANDCHILD_PID: grandchildPidPath },
-      configSources: [{ path: item.config, exists: true }],
-      timeoutMs: 50,
+    await writeFile(grandchildScript, `
+import { connect } from "node:net"
+import { writeFileSync } from "node:fs"
+writeFileSync(process.env.GRANDCHILD_PID_PATH, String(process.pid))
+const control = connect({ host: "127.0.0.1", port: Number(process.env.CONTROL_PORT) })
+control.once("close", () => process.exit(0))
+control.once("error", () => process.exit(0))
+`, "utf8")
+    const control = createServer()
+    const connections = new Set<Socket>()
+    control.on("connection", (socket) => connections.add(socket))
+    await new Promise<void>((resolve, reject) => {
+      control.once("error", reject)
+      control.listen(0, "127.0.0.1", resolve)
     })
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try {
-        await stat(grandchildPidPath)
-        break
-      } catch {
-        await new Promise<void>((resolve) => setTimeout(resolve, 1))
+    const address = control.address()
+    if (address === null || typeof address === "string") throw new Error("control listener has no tcp port")
+    const knownPids: import("./process-liveness.test-support").ProcessIdentity[] = []
+    try {
+      // The injected probe timeout doubles as the helpers' startup budget: both pid files must be
+      // registered before the probe's SIGKILL lands, so the pipe-holding premise holds even on a
+      // loaded or Windows runner (runtime boot costs far more than a tight budget would allow),
+      // while an unbounded hang still blows past the outer wall-clock bound. Windows runners pay
+      // far more to spawn process.execPath plus a grandchild, so the outer bound stays
+      // platform-scoped.
+      const probeTimeoutMs = 1_000
+      const outerBoundMs = process.platform === "win32" ? 10_000 : 2_500
+      const startedAt = Date.now()
+      const probe = preflightMemoryModels({
+        candidates,
+        launch: { command: process.execPath, prefixArgs: [wrapper] },
+        env: {
+          PATH: process.env.PATH,
+          CONTROL_PORT: String(address.port),
+          WRAPPER_PID_PATH: wrapperPidPath,
+          GRANDCHILD_PID_PATH: grandchildPidPath,
+          GRANDCHILD_SCRIPT: grandchildScript,
+        },
+        configSources: [{ path: item.config, exists: true }],
+        timeoutMs: probeTimeoutMs,
+      })
+
+      // when
+      const result = await Promise.race([
+        probe,
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), outerBoundMs)),
+      ])
+
+      // then
+      expect(result).toEqual({ kind: "unavailable", candidates })
+      expect(Date.now() - startedAt).toBeLessThan(outerBoundMs)
+
+      // and then: the grandchild registered itself (it parks holding the inherited pipes), and
+      // releasing the parent-owned control channel tears every helper down within a bounded
+      // window - none may outlive this test process on any path.
+      const grandchildIdentity = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS, "grandchild.mjs")
+      knownPids.push(grandchildIdentity)
+      const wrapperIdentity = await readPidOnce(wrapperPidPath, "wrapper.mjs")
+      if (wrapperIdentity !== null) knownPids.push(wrapperIdentity)
+      closeControlChannel(control, connections)
+      for (const identity of knownPids) {
+        expect(await pidTerminalWithin(identity, HELPER_EXIT_BOUND_MS)).toBe(true)
       }
+    } finally {
+      // Fail-safe: even when an assertion above failed, nothing this test spawned may survive it.
+      closeControlChannel(control, connections)
+      for (const identity of knownPids) killIfAlive(identity)
+      await Promise.all(knownPids.map((identity) => pidTerminalWithin(identity, HELPER_FAILSAFE_BOUND_MS)))
     }
-    let cleanupPid: number | undefined
-
-    // when
-    const result = await Promise.race([
-      probe,
-      new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), outerBoundMs)),
-    ]).finally(async () => {
-      try {
-        cleanupPid = Number((await readFile(grandchildPidPath, "utf8")).trim())
-        process.kill(cleanupPid, "SIGKILL")
-      } catch {
-        // The fixed path has already detached from the pipe-holding grandchild.
-      }
-    })
-
-    // then
-    expect(result).toEqual({ kind: "unavailable", candidates })
-    expect(Date.now() - startedAt).toBeLessThan(outerBoundMs)
-    if (cleanupPid !== undefined) await probe
   })
 
   test("#given a failed child catalog probe #when candidates are preflighted #then it warns and preserves reactive fallback behavior", async () => {

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -222,7 +222,7 @@ control.once("error", () => process.exit(0))
     })
     const address = control.address()
     if (address === null || typeof address === "string") throw new Error("control listener has no tcp port")
-    const knownPids: number[] = []
+    const knownPids: import("./process-liveness.test-support").ProcessIdentity[] = []
     try {
       // The injected probe timeout doubles as the helpers' startup budget: both pid files must be
       // registered before the probe's SIGKILL lands, so the pipe-holding premise holds even on a
@@ -260,19 +260,19 @@ control.once("error", () => process.exit(0))
       // and then: the grandchild registered itself (it parks holding the inherited pipes), and
       // releasing the parent-owned control channel tears every helper down within a bounded
       // window - none may outlive this test process on any path.
-      const grandchildPid = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS)
-      knownPids.push(grandchildPid)
-      const wrapperPid = await readPidOnce(wrapperPidPath)
-      if (wrapperPid !== null) knownPids.push(wrapperPid)
+      const grandchildIdentity = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS, "grandchild.mjs")
+      knownPids.push(grandchildIdentity)
+      const wrapperIdentity = await readPidOnce(wrapperPidPath, "wrapper.mjs")
+      if (wrapperIdentity !== null) knownPids.push(wrapperIdentity)
       closeControlChannel(control, connections)
-      for (const pid of knownPids) {
-        expect(await pidTerminalWithin(pid, HELPER_EXIT_BOUND_MS)).toBe(true)
+      for (const identity of knownPids) {
+        expect(await pidTerminalWithin(identity, HELPER_EXIT_BOUND_MS)).toBe(true)
       }
     } finally {
       // Fail-safe: even when an assertion above failed, nothing this test spawned may survive it.
       closeControlChannel(control, connections)
-      for (const pid of knownPids) killIfAlive(pid)
-      await Promise.all(knownPids.map((pid) => pidTerminalWithin(pid, HELPER_FAILSAFE_BOUND_MS)))
+      for (const identity of knownPids) killIfAlive(identity)
+      await Promise.all(knownPids.map((identity) => pidTerminalWithin(identity, HELPER_FAILSAFE_BOUND_MS)))
     }
   })
 

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm, stat, writeFile } from "node:fs/promises"
+import { watch } from "node:fs"
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { basename, dirname, join } from "node:path"
 import { createServer } from "node:net"
 import type { Server, Socket } from "node:net"
 
 import { preflightMemoryModels, resetModelPreflightCacheForTests } from "./model-preflight"
 import type { MemoryModelChain } from "./memory-model-attempts"
-import { killIfAlive, pidTerminalWithin, readPidOnce, readPidWhenWritten } from "./process-liveness.test-support"
+import { identityMatches, killIfAlive, pidAlive, pidTerminalWithin, readPidWhenWritten } from "./process-liveness.test-support"
 
 const roots: string[] = []
 
@@ -222,7 +223,27 @@ control.once("error", () => process.exit(0))
     })
     const address = control.address()
     if (address === null || typeof address === "string") throw new Error("control listener has no tcp port")
-    const knownPids: import("./process-liveness.test-support").ProcessIdentity[] = []
+    let grandchildIdentityForCleanup: import("./process-liveness.test-support").ProcessIdentity | null = null
+    const waitForPidFile = async (path: string, boundMs: number): Promise<number> => {
+      const startedAt = Date.now()
+      for (;;) {
+        try {
+          const raw = Number((await readFile(path, "utf8")).trim())
+          if (Number.isInteger(raw) && raw > 0) return raw
+        } catch (error) {
+          if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+        }
+        if (Date.now() - startedAt > boundMs) throw new Error(`pid file never appeared: ${path}`)
+        await new Promise<void>((resolve) => {
+          const watcher = watch(dirname(path), (_event, name) => {
+            if (name !== basename(path)) return
+            watcher.close()
+            resolve()
+          })
+          watcher.on("error", () => { watcher.close(); resolve() })
+        })
+      }
+    }
     try {
       // The injected probe timeout doubles as the helpers' startup budget: both pid files must be
       // registered before the probe's SIGKILL lands, so the pipe-holding premise holds even on a
@@ -257,25 +278,29 @@ control.once("error", () => process.exit(0))
       expect(result).toEqual({ kind: "unavailable", candidates })
       expect(Date.now() - startedAt).toBeLessThan(outerBoundMs)
 
-      // and then: the grandchild registered itself (it parks holding the inherited pipes), and
-      // releasing the parent-owned control channel tears every helper down within a bounded
-      // window - none may outlive this test process on any path.
+      // and then: the ORIGINAL wrapper and grandchild are observed through their own pid files.
+      // Production must have killed the launcher; the grandchild must still be alive holding the
+      // inherited pipes (otherwise the degradation premise never held); and releasing the
+      // parent-owned control channel must take the original grandchild down with it.
+      const wrapperPid = await waitForPidFile(wrapperPidPath, HELPER_EXIT_BOUND_MS)
       const grandchildIdentity = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS, "grandchild.mjs")
-      knownPids.push(grandchildIdentity)
-      const wrapperIdentity = await readPidOnce(wrapperPidPath, "wrapper.mjs")
-      if (wrapperIdentity !== null) knownPids.push(wrapperIdentity)
+      grandchildIdentityForCleanup = grandchildIdentity
+      expect(pidAlive(wrapperPid)).toBe(false)
+      expect(identityMatches(grandchildIdentity) && pidAlive(grandchildIdentity.pid)).toBe(true)
       const helperClosures = [...connections].map((socket) => new Promise<void>((resolve) => {
         if (socket.destroyed) return resolve()
         socket.once("close", () => resolve())
       }))
       closeControlChannel(control, connections)
       await Promise.all(helperClosures)
-      expect(knownPids.length).toBeGreaterThan(0)
+      expect(await pidTerminalWithin(grandchildIdentity, HELPER_EXIT_BOUND_MS)).toBe(true)
     } finally {
       // Fail-safe: even when an assertion above failed, nothing this test spawned may survive it.
       closeControlChannel(control, connections)
-      for (const identity of knownPids) killIfAlive(identity)
-      await Promise.all(knownPids.map((identity) => pidTerminalWithin(identity, HELPER_FAILSAFE_BOUND_MS)))
+      if (grandchildIdentityForCleanup !== null) {
+        killIfAlive(grandchildIdentityForCleanup)
+        await pidTerminalWithin(grandchildIdentityForCleanup, HELPER_FAILSAFE_BOUND_MS)
+      }
     }
   })
 

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -222,7 +222,7 @@ control.once("error", () => process.exit(0))
     })
     const address = control.address()
     if (address === null || typeof address === "string") throw new Error("control listener has no tcp port")
-    const knownPids: import("./process-liveness.test-support").ProcessIdentity[] = []
+    const knownPids: number[] = []
     try {
       // The injected probe timeout doubles as the helpers' startup budget: both pid files must be
       // registered before the probe's SIGKILL lands, so the pipe-holding premise holds even on a
@@ -260,19 +260,19 @@ control.once("error", () => process.exit(0))
       // and then: the grandchild registered itself (it parks holding the inherited pipes), and
       // releasing the parent-owned control channel tears every helper down within a bounded
       // window - none may outlive this test process on any path.
-      const grandchildIdentity = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS, "grandchild.mjs")
-      knownPids.push(grandchildIdentity)
-      const wrapperIdentity = await readPidOnce(wrapperPidPath, "wrapper.mjs")
-      if (wrapperIdentity !== null) knownPids.push(wrapperIdentity)
+      const grandchildPid = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS)
+      knownPids.push(grandchildPid)
+      const wrapperPid = await readPidOnce(wrapperPidPath)
+      if (wrapperPid !== null) knownPids.push(wrapperPid)
       closeControlChannel(control, connections)
-      for (const identity of knownPids) {
-        expect(await pidTerminalWithin(identity, HELPER_EXIT_BOUND_MS)).toBe(true)
+      for (const pid of knownPids) {
+        expect(await pidTerminalWithin(pid, HELPER_EXIT_BOUND_MS)).toBe(true)
       }
     } finally {
       // Fail-safe: even when an assertion above failed, nothing this test spawned may survive it.
       closeControlChannel(control, connections)
-      for (const identity of knownPids) killIfAlive(identity)
-      await Promise.all(knownPids.map((identity) => pidTerminalWithin(identity, HELPER_FAILSAFE_BOUND_MS)))
+      for (const pid of knownPids) killIfAlive(pid)
+      await Promise.all(knownPids.map((pid) => pidTerminalWithin(pid, HELPER_FAILSAFE_BOUND_MS)))
     }
   })
 

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -7,7 +7,7 @@ import type { Server, Socket } from "node:net"
 
 import { preflightMemoryModels, resetModelPreflightCacheForTests } from "./model-preflight"
 import type { MemoryModelChain } from "./memory-model-attempts"
-import { identityMatches, killIfAlive, pidAlive, pidTerminalWithin, readPidFileWhenWritten, readPidWhenWritten } from "./process-liveness.test-support"
+import { identityMatches, killIfAlive, pidAlive, pidTerminalWithin, readPidFileWhenWritten, readPidWhenWritten, waitForFileToExist } from "./process-liveness.test-support"
 
 const roots: string[] = []
 
@@ -194,6 +194,7 @@ process.stdout.write("builtin/fallback\\n")
     const grandchildScript = join(item.root, "grandchild.mjs")
     const wrapperPidPath = join(item.root, "wrapper.pid")
     const grandchildPidPath = join(item.root, "grandchild.pid")
+    const grandchildConnectedPath = join(item.root, "grandchild.connected")
     await writeFile(wrapper, `
 import { spawn } from "node:child_process"
 import { connect } from "node:net"
@@ -210,6 +211,7 @@ import { connect } from "node:net"
 import { writeFileSync } from "node:fs"
 writeFileSync(process.env.GRANDCHILD_PID_PATH, String(process.pid))
 const control = connect({ host: "127.0.0.1", port: Number(process.env.CONTROL_PORT) })
+control.once("connect", () => writeFileSync(process.env.GRANDCHILD_CONNECTED_PATH, "connected\\n"))
 control.once("close", () => process.exit(0))
 control.once("error", () => process.exit(0))
 `, "utf8")
@@ -241,6 +243,7 @@ control.once("error", () => process.exit(0))
           CONTROL_PORT: String(address.port),
           WRAPPER_PID_PATH: wrapperPidPath,
           GRANDCHILD_PID_PATH: grandchildPidPath,
+          GRANDCHILD_CONNECTED_PATH: grandchildConnectedPath,
           GRANDCHILD_SCRIPT: grandchildScript,
         },
         configSources: [{ path: item.config, exists: true }],
@@ -266,6 +269,9 @@ control.once("error", () => process.exit(0))
       grandchildIdentityForCleanup = grandchildIdentity
       expect(pidAlive(wrapperPid)).toBe(false)
       expect(identityMatches(grandchildIdentity) && pidAlive(grandchildIdentity.pid)).toBe(true)
+      // The grandchild writes its pid file BEFORE connect(); awaiting its explicit connected
+      // marker guarantees the control snapshot below contains its socket on every runner.
+      expect(await waitForFileToExist(grandchildConnectedPath, HELPER_EXIT_BOUND_MS)).toBe(true)
       const helperClosures = [...connections].map((socket) => new Promise<void>((resolve) => {
         if (socket.destroyed) return resolve()
         socket.once("close", () => resolve())

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -1,14 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { watch } from "node:fs"
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { basename, dirname, join } from "node:path"
+import { join } from "node:path"
 import { createServer } from "node:net"
 import type { Server, Socket } from "node:net"
 
 import { preflightMemoryModels, resetModelPreflightCacheForTests } from "./model-preflight"
 import type { MemoryModelChain } from "./memory-model-attempts"
-import { identityMatches, killIfAlive, pidAlive, pidTerminalWithin, readPidWhenWritten } from "./process-liveness.test-support"
+import { identityMatches, killIfAlive, pidAlive, pidTerminalWithin, readPidFileWhenWritten, readPidWhenWritten } from "./process-liveness.test-support"
 
 const roots: string[] = []
 
@@ -224,26 +223,6 @@ control.once("error", () => process.exit(0))
     const address = control.address()
     if (address === null || typeof address === "string") throw new Error("control listener has no tcp port")
     let grandchildIdentityForCleanup: import("./process-liveness.test-support").ProcessIdentity | null = null
-    const waitForPidFile = async (path: string, boundMs: number): Promise<number> => {
-      const startedAt = Date.now()
-      for (;;) {
-        try {
-          const raw = Number((await readFile(path, "utf8")).trim())
-          if (Number.isInteger(raw) && raw > 0) return raw
-        } catch (error) {
-          if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
-        }
-        if (Date.now() - startedAt > boundMs) throw new Error(`pid file never appeared: ${path}`)
-        await new Promise<void>((resolve) => {
-          const watcher = watch(dirname(path), (_event, name) => {
-            if (name !== basename(path)) return
-            watcher.close()
-            resolve()
-          })
-          watcher.on("error", () => { watcher.close(); resolve() })
-        })
-      }
-    }
     try {
       // The injected probe timeout doubles as the helpers' startup budget: both pid files must be
       // registered before the probe's SIGKILL lands, so the pipe-holding premise holds even on a
@@ -282,7 +261,7 @@ control.once("error", () => process.exit(0))
       // Production must have killed the launcher; the grandchild must still be alive holding the
       // inherited pipes (otherwise the degradation premise never held); and releasing the
       // parent-owned control channel must take the original grandchild down with it.
-      const wrapperPid = await waitForPidFile(wrapperPidPath, HELPER_EXIT_BOUND_MS)
+      const wrapperPid = await readPidFileWhenWritten(wrapperPidPath, HELPER_EXIT_BOUND_MS)
       const grandchildIdentity = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS, "grandchild.mjs")
       grandchildIdentityForCleanup = grandchildIdentity
       expect(pidAlive(wrapperPid)).toBe(false)

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -264,10 +264,13 @@ control.once("error", () => process.exit(0))
       knownPids.push(grandchildIdentity)
       const wrapperIdentity = await readPidOnce(wrapperPidPath, "wrapper.mjs")
       if (wrapperIdentity !== null) knownPids.push(wrapperIdentity)
+      const helperClosures = [...connections].map((socket) => new Promise<void>((resolve) => {
+        if (socket.destroyed) return resolve()
+        socket.once("close", () => resolve())
+      }))
       closeControlChannel(control, connections)
-      for (const identity of knownPids) {
-        expect(await pidTerminalWithin(identity, HELPER_EXIT_BOUND_MS)).toBe(true)
-      }
+      await Promise.all(helperClosures)
+      expect(knownPids.length).toBeGreaterThan(0)
     } finally {
       // Fail-safe: even when an assertion above failed, nothing this test spawned may survive it.
       closeControlChannel(control, connections)

--- a/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
@@ -66,16 +66,6 @@ function commandForPid(pid: number): string | null {
   }
 }
 
-export function waitForFileEvent(path: string, boundMs: number): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const watcher = watch(dirname(path), (_event, name) => {
-      if (name !== basename(path)) return
-      void readFile(path).then(() => { clearTimeout(timer); watcher.close(); resolve() }).catch(() => undefined)
-    })
-    const timer = setTimeout(() => { watcher.close(); reject(new Error(`file event never arrived for ${path}`)) }, boundMs)
-  })
-}
-
 export function identityMatches(identity: ProcessIdentity): boolean {
   const command = commandForPid(identity.pid)
   return command !== null && command === identity.command
@@ -86,10 +76,48 @@ export function pidTerminalWithin(identity: ProcessIdentity, boundMs: number): P
   if (process.platform !== "linux") return new Promise((resolve) => setTimeout(() => resolve(!pidAlive(identity.pid)), boundMs))
   return new Promise((resolve) => {
     let settled = false
-    const finish = (result: boolean): void => { if (settled) return; settled = true; clearTimeout(timer); watcher.close(); resolve(result) }
+    let watcher: ReturnType<typeof watch>
+    const finish = (result: boolean): void => { if (settled) return; settled = true; clearTimeout(timer); watcher?.close(); resolve(result) }
     const timer = setTimeout(() => finish(false), boundMs)
-    const watcher = watch(`/proc/${String(identity.pid)}`, () => { if (!identityMatches(identity) || !pidAlive(identity.pid)) finish(true) })
+    try {
+      watcher = watch(`/proc/${String(identity.pid)}`, () => { if (!identityMatches(identity) || !pidAlive(identity.pid)) finish(true) })
+    } catch {
+      // The target exited between the liveness probe and watcher creation; a missing /proc entry
+      // is itself the terminal signal.
+      finish(!pidAlive(identity.pid))
+      return
+    }
     watcher.on("error", () => finish(!pidAlive(identity.pid)))
+  })
+}
+
+/** Reads a pid file written by a foreign helper once it appears, without requiring the process to still be alive. */
+export function readPidFileWhenWritten(path: string, boundMs: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let watcher: ReturnType<typeof watch>
+    const finish = (error?: Error, pid?: number): void => {
+      clearTimeout(timer)
+      watcher?.close()
+      if (error !== undefined) reject(error)
+      else if (pid !== undefined) resolve(pid)
+    }
+    const timer = setTimeout(() => finish(new Error(`pid file never appeared: ${path}`)), boundMs)
+    const tryRead = (): void => {
+      void readFile(path, "utf8").then((content) => {
+        const raw = Number(content.trim())
+        if (Number.isInteger(raw) && raw > 0) finish(undefined, raw)
+      }).catch((error: unknown) => {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) finish(error as Error)
+      })
+    }
+    try {
+      watcher = watch(dirname(path), (_event, name) => { if (name === basename(path)) tryRead() })
+    } catch (error) {
+      finish(error as Error)
+      return
+    }
+    watcher.on("error", () => undefined)
+    tryRead()
   })
 }
 

--- a/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
@@ -2,10 +2,9 @@
 // probes, pid-file readers for foreign (non-child) writers, bounded child-termination waits,
 // and fail-safe kills so a failed assertion can never leak a spawned process.
 
-import { readFileSync, watch } from "node:fs"
+import { existsSync, readFileSync, watch } from "node:fs"
 import { readFile } from "node:fs/promises"
 import { execFileSync } from "node:child_process"
-import { dirname, basename } from "node:path"
 import type { ChildProcess } from "node:child_process"
 
 /**
@@ -97,62 +96,63 @@ export function pidTerminalWithin(identity: ProcessIdentity, boundMs: number): P
   })
 }
 
-/** Reads a pid file written by a foreign helper once it appears, without requiring the process to still be alive. */
-export function readPidFileWhenWritten(path: string, boundMs: number): Promise<number> {
-  return new Promise((resolve, reject) => {
-    let watcher: ReturnType<typeof watch>
-    const finish = (error?: Error, pid?: number): void => {
-      clearTimeout(timer)
-      watcher?.close()
-      if (error !== undefined) reject(error)
-      else if (pid !== undefined) resolve(pid)
-    }
-    const timer = setTimeout(() => finish(new Error(`pid file never appeared: ${path}`)), boundMs)
-    const tryRead = (): void => {
-      void readFile(path, "utf8").then((content) => {
-        const raw = Number(content.trim())
-        if (Number.isInteger(raw) && raw > 0) finish(undefined, raw)
-      }).catch((error: unknown) => {
-        if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) finish(error as Error)
-      })
-    }
-    try {
-      watcher = watch(dirname(path), (_event, name) => { if (name === basename(path)) tryRead() })
-    } catch (error) {
-      finish(error as Error)
-      return
-    }
-    watcher.on("error", () => undefined)
-    tryRead()
-  })
+/**
+ * Bounded condition probe: resolves true once `condition` holds, false once `boundMs` elapsed.
+ * This is the sanctioned fallback for waiting on FOREIGN processes/files, where no OS-level
+ * event exists (fs.watch is unreliable on some platforms - events can arrive late or never).
+ * It is never an ordering oracle: callers assert on the condition outcome, not on elapsed time.
+ */
+export async function probeUntil(condition: () => boolean | Promise<boolean>, boundMs: number, intervalMs = 25): Promise<boolean> {
+  const deadline = Date.now() + boundMs
+  for (;;) {
+    if (await condition()) return true
+    if (Date.now() >= deadline) return false
+    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs))
+  }
 }
 
-/** Polls a pid file written by a foreign helper and snapshots its command identity. */
-export function readPidWhenWritten(path: string, boundMs: number, expectedCommand?: string): Promise<ProcessIdentity> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => finish(new Error(`helper pid never appeared at ${path}`)), boundMs)
-    const directory = dirname(path)
-    const filename = basename(path)
-    const watcher = watch(directory, (_event, name) => {
-      if (name !== filename) return
-      void readIdentity().then((identity) => { if (identity !== null) finish(undefined, identity) }).catch(finish)
-    })
-    const finish = (error?: Error, identity?: ProcessIdentity): void => {
-      clearTimeout(timer)
-      watcher.close()
-      if (error !== undefined) reject(error)
-      else if (identity !== undefined) resolve(identity)
-    }
-    const readIdentity = async (): Promise<ProcessIdentity | null> => {
+/** Waits until a file exists (bounded probe; see probeUntil). */
+export function waitForFileToExist(path: string, boundMs: number): Promise<boolean> {
+  return probeUntil(() => existsSync(path), boundMs)
+}
+
+/** Reads a pid file written by a foreign helper once it appears, without requiring the process to still be alive. */
+export async function readPidFileWhenWritten(path: string, boundMs: number): Promise<number> {
+  let pid: number | null = null
+  const found = await probeUntil(async () => {
+    try {
       const raw = Number((await readFile(path, "utf8")).trim())
-      if (!Number.isInteger(raw) || raw <= 0) return null
-      const command = commandForPid(raw)
-      return command !== null && (expectedCommand === undefined || command.includes(expectedCommand)) ? { pid: raw, command } : null
+      if (Number.isInteger(raw) && raw > 0) {
+        pid = raw
+        return true
+      }
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
     }
-    void readIdentity().then((identity) => { if (identity !== null) finish(undefined, identity) }).catch((error: unknown) => {
-      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) finish(error as Error)
-    })
-  })
+    return false
+  }, boundMs)
+  if (!found || pid === null) throw new Error(`pid file never appeared: ${path}`)
+  return pid
+}
+
+/** Reads a pid file written by a foreign helper and snapshots its command identity. */
+export async function readPidWhenWritten(path: string, boundMs: number, expectedCommand?: string): Promise<ProcessIdentity> {
+  let identity: ProcessIdentity | null = null
+  const found = await probeUntil(() => {
+    let raw: number
+    try {
+      raw = Number(readFileSync(path, "utf8").trim())
+    } catch {
+      return false
+    }
+    if (!Number.isInteger(raw) || raw <= 0) return false
+    const command = commandForPid(raw)
+    if (command === null || (expectedCommand !== undefined && !command.includes(expectedCommand))) return false
+    identity = { pid: raw, command }
+    return true
+  }, boundMs)
+  if (!found || identity === null) throw new Error(`helper pid never appeared at ${path}`)
+  return identity
 }
 
 /** Single identity read; null when absent or the process no longer matches. */

--- a/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
@@ -1,0 +1,123 @@
+// Bounded liveness primitives for tests that spawn real helper processes: zombie-aware pid
+// probes, pid-file readers for foreign (non-child) writers, bounded child-termination waits,
+// and fail-safe kills so a failed assertion can never leak a spawned process.
+
+import { readFileSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+import { execFileSync } from "node:child_process"
+import type { ChildProcess } from "node:child_process"
+
+/**
+ * Resolves true once the child TERMINATED (`exit`, or the later `close`), false once `boundMs`
+ * elapsed. Deliberately NOT gated on stdio close alone: `close` lags `exit` indefinitely when a
+ * descendant inherited the child's stdio fds, and teardown must never stall - or report a false
+ * "survived teardown" - behind pipes that carry no liveness of their own.
+ */
+export function exitedWithin(child: ChildProcess, boundMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true)
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => settle(false), boundMs)
+    function settle(exited: boolean): void {
+      clearTimeout(timer)
+      child.off("exit", onDone)
+      child.off("close", onDone)
+      resolve(exited)
+    }
+    function onDone(): void {
+      settle(true)
+    }
+    child.once("exit", onDone)
+    child.once("close", onDone)
+  })
+}
+
+export function pidAlive(pid: number): boolean {
+  if (process.platform === "linux") {
+    try {
+      const statLine = readFileSync(`/proc/${String(pid)}/stat`, "utf8")
+      const stateIndex = statLine.lastIndexOf(")") + 2
+      // Z = zombie: exited but unreaped; signal liveness still succeeds against it.
+      if (statLine.slice(stateIndex, stateIndex + 1) === "Z") return false
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return false
+      // Unreadable /proc entry: fall through to signal liveness.
+    }
+  }
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // ESRCH means the process is gone; anything else (EPERM, ...) means it still exists.
+    if (error instanceof Error && "code" in error && error.code === "ESRCH") return false
+    return true
+  }
+}
+
+/** Resolves true once the pid is provably terminal (dead or zombie), false once `boundMs` elapsed. */
+export type ProcessIdentity = Readonly<{ pid: number; command: string }>
+
+function commandForPid(pid: number): string | null {
+  try {
+    if (process.platform === "linux") return readFileSync(`/proc/${String(pid)}/cmdline`, "utf8").replaceAll("\\0", " ").trim()
+    return execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf8" }).trim()
+  } catch {
+    return null
+  }
+}
+
+export function identityMatches(identity: ProcessIdentity): boolean {
+  const command = commandForPid(identity.pid)
+  return command !== null && command === identity.command
+}
+
+export async function pidTerminalWithin(identity: ProcessIdentity, boundMs: number): Promise<boolean> {
+  const deadline = Date.now() + boundMs
+  for (;;) {
+    if (!identityMatches(identity) || !pidAlive(identity.pid)) return true
+    if (Date.now() >= deadline) return false
+    await Bun.sleep(10)
+  }
+}
+
+/** Polls a pid file written by a foreign helper and snapshots its command identity. */
+export async function readPidWhenWritten(path: string, boundMs: number, expectedCommand?: string): Promise<ProcessIdentity> {
+  const deadline = Date.now() + boundMs
+  for (;;) {
+    try {
+      const raw = Number((await readFile(path, "utf8")).trim())
+      if (Number.isInteger(raw) && raw > 0) {
+        const command = commandForPid(raw)
+        if (command !== null && (expectedCommand === undefined || command.includes(expectedCommand))) {
+          return { pid: raw, command }
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+    }
+    if (Date.now() >= deadline) throw new Error(`helper pid never appeared at ${path}`)
+    await Bun.sleep(5)
+  }
+}
+
+/** Single identity read; null when absent or the process no longer matches. */
+export async function readPidOnce(path: string, expectedCommand?: string): Promise<ProcessIdentity | null> {
+  try {
+    const raw = Number((await readFile(path, "utf8")).trim())
+    if (!Number.isInteger(raw) || raw <= 0) return null
+    const command = commandForPid(raw)
+    return command !== null && (expectedCommand === undefined || command.includes(expectedCommand)) ? { pid: raw, command } : null
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+    return null
+  }
+}
+
+/** SIGKILL only when the target still has the command identity captured at registration. */
+export function killIfAlive(identity: ProcessIdentity): void {
+  if (!identityMatches(identity)) return
+  try {
+    process.kill(identity.pid, "SIGKILL")
+  } catch (error) {
+    if (pidAlive(identity.pid)) throw error
+  }
+}

--- a/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
@@ -2,7 +2,7 @@
 // probes, pid-file readers for foreign (non-child) writers, bounded child-termination waits,
 // and fail-safe kills so a failed assertion can never leak a spawned process.
 
-import { existsSync, readFileSync, watch } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import { execFileSync } from "node:child_process"
 import type { ChildProcess } from "node:child_process"
@@ -77,23 +77,10 @@ export function identityMatches(identity: ProcessIdentity): boolean {
 }
 
 export function pidTerminalWithin(identity: ProcessIdentity, boundMs: number): Promise<boolean> {
-  if (!identityMatches(identity) || !pidAlive(identity.pid)) return Promise.resolve(true)
-  if (process.platform !== "linux") return new Promise((resolve) => setTimeout(() => resolve(!pidAlive(identity.pid)), boundMs))
-  return new Promise((resolve) => {
-    let settled = false
-    let watcher: ReturnType<typeof watch>
-    const finish = (result: boolean): void => { if (settled) return; settled = true; clearTimeout(timer); watcher?.close(); resolve(result) }
-    const timer = setTimeout(() => finish(false), boundMs)
-    try {
-      watcher = watch(`/proc/${String(identity.pid)}`, () => { if (!identityMatches(identity) || !pidAlive(identity.pid)) finish(true) })
-    } catch {
-      // The target exited between the liveness probe and watcher creation; a missing /proc entry
-      // is itself the terminal signal.
-      finish(!pidAlive(identity.pid))
-      return
-    }
-    watcher.on("error", () => finish(!pidAlive(identity.pid)))
-  })
+  // Watching /proc/<pid> cannot detect termination: a zombie keeps its /proc entry present (and
+  // procfs does not deliver reliable fs events), so a watcher can sleep through the death it
+  // waits for. The zombie-aware liveness probe is the only correct oracle on every platform.
+  return probeUntil(() => !identityMatches(identity) || !pidAlive(identity.pid), boundMs)
 }
 
 /**

--- a/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
@@ -83,12 +83,13 @@ export function identityMatches(identity: ProcessIdentity): boolean {
 
 export function pidTerminalWithin(identity: ProcessIdentity, boundMs: number): Promise<boolean> {
   if (!identityMatches(identity) || !pidAlive(identity.pid)) return Promise.resolve(true)
+  if (process.platform !== "linux") return new Promise((resolve) => setTimeout(() => resolve(!pidAlive(identity.pid)), boundMs))
   return new Promise((resolve) => {
-    const timer = setTimeout(() => settle(false), boundMs)
-    const watcher = watch(dirname(`/proc/${String(identity.pid)}`), () => {
-      if (!identityMatches(identity) || !pidAlive(identity.pid)) settle(true)
-    })
-    const settle = (result: boolean): void => { clearTimeout(timer); watcher.close(); resolve(result) }
+    let settled = false
+    const finish = (result: boolean): void => { if (settled) return; settled = true; clearTimeout(timer); watcher.close(); resolve(result) }
+    const timer = setTimeout(() => finish(false), boundMs)
+    const watcher = watch(`/proc/${String(identity.pid)}`, () => { if (!identityMatches(identity) || !pidAlive(identity.pid)) finish(true) })
+    watcher.on("error", () => finish(!pidAlive(identity.pid)))
   })
 }
 

--- a/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
@@ -81,13 +81,15 @@ export function identityMatches(identity: ProcessIdentity): boolean {
   return command !== null && command === identity.command
 }
 
-export async function pidTerminalWithin(identity: ProcessIdentity, boundMs: number): Promise<boolean> {
-  const deadline = Date.now() + boundMs
-  for (;;) {
-    if (!identityMatches(identity) || !pidAlive(identity.pid)) return true
-    if (Date.now() >= deadline) return false
-    await Bun.sleep(10)
-  }
+export function pidTerminalWithin(identity: ProcessIdentity, boundMs: number): Promise<boolean> {
+  if (!identityMatches(identity) || !pidAlive(identity.pid)) return Promise.resolve(true)
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => settle(false), boundMs)
+    const watcher = watch(dirname(`/proc/${String(identity.pid)}`), () => {
+      if (!identityMatches(identity) || !pidAlive(identity.pid)) settle(true)
+    })
+    const settle = (result: boolean): void => { clearTimeout(timer); watcher.close(); resolve(result) }
+  })
 }
 
 /** Polls a pid file written by a foreign helper and snapshots its command identity. */

--- a/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
@@ -66,6 +66,12 @@ function commandForPid(pid: number): string | null {
   }
 }
 
+/** Snapshots a live process's command identity; null when the pid is gone or unreadable. */
+export function captureIdentity(pid: number): ProcessIdentity | null {
+  const command = commandForPid(pid)
+  return command === null ? null : { pid, command }
+}
+
 export function identityMatches(identity: ProcessIdentity): boolean {
   const command = commandForPid(identity.pid)
   return command !== null && command === identity.command

--- a/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/worker/process-liveness.test-support.ts
@@ -2,9 +2,10 @@
 // probes, pid-file readers for foreign (non-child) writers, bounded child-termination waits,
 // and fail-safe kills so a failed assertion can never leak a spawned process.
 
-import { readFileSync } from "node:fs"
+import { readFileSync, watch } from "node:fs"
 import { readFile } from "node:fs/promises"
 import { execFileSync } from "node:child_process"
+import { dirname, basename } from "node:path"
 import type { ChildProcess } from "node:child_process"
 
 /**
@@ -65,6 +66,16 @@ function commandForPid(pid: number): string | null {
   }
 }
 
+export function waitForFileEvent(path: string, boundMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const watcher = watch(dirname(path), (_event, name) => {
+      if (name !== basename(path)) return
+      void readFile(path).then(() => { clearTimeout(timer); watcher.close(); resolve() }).catch(() => undefined)
+    })
+    const timer = setTimeout(() => { watcher.close(); reject(new Error(`file event never arrived for ${path}`)) }, boundMs)
+  })
+}
+
 export function identityMatches(identity: ProcessIdentity): boolean {
   const command = commandForPid(identity.pid)
   return command !== null && command === identity.command
@@ -80,23 +91,31 @@ export async function pidTerminalWithin(identity: ProcessIdentity, boundMs: numb
 }
 
 /** Polls a pid file written by a foreign helper and snapshots its command identity. */
-export async function readPidWhenWritten(path: string, boundMs: number, expectedCommand?: string): Promise<ProcessIdentity> {
-  const deadline = Date.now() + boundMs
-  for (;;) {
-    try {
-      const raw = Number((await readFile(path, "utf8")).trim())
-      if (Number.isInteger(raw) && raw > 0) {
-        const command = commandForPid(raw)
-        if (command !== null && (expectedCommand === undefined || command.includes(expectedCommand))) {
-          return { pid: raw, command }
-        }
-      }
-    } catch (error) {
-      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+export function readPidWhenWritten(path: string, boundMs: number, expectedCommand?: string): Promise<ProcessIdentity> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => finish(new Error(`helper pid never appeared at ${path}`)), boundMs)
+    const directory = dirname(path)
+    const filename = basename(path)
+    const watcher = watch(directory, (_event, name) => {
+      if (name !== filename) return
+      void readIdentity().then((identity) => { if (identity !== null) finish(undefined, identity) }).catch(finish)
+    })
+    const finish = (error?: Error, identity?: ProcessIdentity): void => {
+      clearTimeout(timer)
+      watcher.close()
+      if (error !== undefined) reject(error)
+      else if (identity !== undefined) resolve(identity)
     }
-    if (Date.now() >= deadline) throw new Error(`helper pid never appeared at ${path}`)
-    await Bun.sleep(5)
-  }
+    const readIdentity = async (): Promise<ProcessIdentity | null> => {
+      const raw = Number((await readFile(path, "utf8")).trim())
+      if (!Number.isInteger(raw) || raw <= 0) return null
+      const command = commandForPid(raw)
+      return command !== null && (expectedCommand === undefined || command.includes(expectedCommand)) ? { pid: raw, command } : null
+    }
+    void readIdentity().then((identity) => { if (identity !== null) finish(undefined, identity) }).catch((error: unknown) => {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) finish(error as Error)
+    })
+  })
 }
 
 /** Single identity read; null when absent or the process no longer matches. */


### PR DESCRIPTION
## Root cause
Memory lock fixtures and the model-preflight pipe-holder regression harness could outlive an abruptly terminated test parent. The lock fixture's lifetime was not fully event-driven, and the preflight wrapper/grandchild used forever-running intervals. Facts-test teardown also removed temporary roots without awaiting tracked child termination. Numeric PID cleanup could signal a reused, unrelated process.

## Changes
- Bind `hold-lock.ts` to the parent-owned stdin channel (`end`/`close`/`error`) with no polling interval.
- Replace model-preflight wrapper/grandchild intervals with a parent-owned loopback control socket; closing it tears down both helpers.
- Add bounded liveness helpers with zombie-aware checks and command identity snapshots; cleanup signals only a still-matching PID.
- Make facts fixture teardown ordered and bounded: SIGTERM, await exit, SIGKILL escalation, await again, then remove roots.
- Add real-process lifecycle regressions while preserving the full pipe-holder degradation sensitivity.

## Test evidence
- Focused lifecycle + model-preflight: 12 pass, 0 fail.
- Facts pruning + failure streaks: 25 pass, 0 fail.
- `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json`: exit 0.
- `git diff --check`: pass.
- Full `bun run test:senpi` was started and produced extensive passing output but exceeded the 300s execution cap before completion; not claimed as passing.
- Baseline replay against `origin/dev` confirmed the old model-preflight interval harness remained present; the borrowed stdin fixture regression is not a valid RED discriminator under Bun/macOS because Bun closes inherited stdin when the wrapper exits.

Supersedes #7342.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `omo-senpi` memory lock fixtures and preflight pipe-holder helpers from outliving an abruptly terminated test parent, which previously stranded orphaned processes holding lock markers near 100% CPU.

- `hold-lock.ts` exits when its parent-owned stdin channel reports end, close, or error, replacing the PPID polling watchdog, and destroys stdin on every ownership-loss path so the process can terminate.
- The model-preflight wrapper and grandchild park on a parent-owned loopback control socket; closing it tears down both helpers.
- Facts fixture teardown is ordered and bounded: SIGTERM, await exit, SIGKILL escalation, await again, then remove temp roots.
- Lifecycle regression tests observe the original helpers through pid files and exit markers, asserting the wrapper dies on probe timeout, the grandchild survives holding the pipes, and neither outlives control-channel teardown.
- Liveness helpers are zombie-aware, verify PID command identity before signalling, and detect process state portably across Linux and macOS; `pidTerminalWithin` rides the same bounded probe on every platform because a zombie keeps its `/proc` entry and can sleep through a watcher.
- Foreign-process and file waits use bounded condition probes (`probeUntil`) because `fs.watch` file-creation events are unreliable on some platforms and caused CI timeouts.
- The model-preflight grandchild test awaits the grandchild's connected marker before closing the control channel and uses a 30s budget so Bun's 5s default can't cut off wrapper plus grandchild spawn on slow runners.

<sup>Written for commit a9f210d570a69c5ed96a2b1ebce24ac1a1270c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

