### PR TITLE
feat(shared-skills): make the resident py kernel the default polars surface

### DIFF
--- a/packages/shared-skills/skills/data-scientist/SKILL.md
+++ b/packages/shared-skills/skills/data-scientist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-scientist
-description: "Expert data processing with a hybrid engine strategy: resident-kernel DuckDB first (persistent js/py eval kernels where the harness has them, bun/uv one-shots elsewhere), Python Polars/numpy/matplotlib through uv where they win, and per-action placement judgment (in-memory vs streaming vs remote-in-place). Triggers: 'analyze the data', 'what is in this CSV/parquet/json', 'summarize this', 'group by', 'filter rows', 'sort by', 'join these files', 'merge datasets', 'time series trend', 'compare yesterday and today', 'distribution/histogram', 'correlation', 'clean duplicates', 'handle missing values', 'dataset larger than RAM', 'SQL query on files', 'DataFrame operations', 'chart/plot this data', DuckDB vs Polars selection, quick data exploration CLI. NOT for plain text/code inspection, configs, or tiny inline math."
+description: "Expert data processing with a hybrid engine strategy: resident-kernel engines first - DuckDB plus a resident Python stack (Polars/numpy/matplotlib) in persistent js/py eval kernels where the harness has them, bun/uv one-shots elsewhere - and per-action placement judgment (in-memory vs streaming vs remote-in-place). Triggers: 'analyze the data', 'what is in this CSV/parquet/json', 'summarize this', 'group by', 'filter rows', 'sort by', 'join these files', 'merge datasets', 'time series trend', 'compare yesterday and today', 'distribution/histogram', 'correlation', 'clean duplicates', 'handle missing values', 'dataset larger than RAM', 'SQL query on files', 'DataFrame operations', 'chart/plot this data', DuckDB vs Polars selection, quick data exploration CLI. NOT for plain text/code inspection, configs, or tiny inline math."
 ---
 
 # Data Scientist: Hybrid-Engine Data Processing
@@ -18,11 +18,13 @@ difference dominates the session.
 
 1. **JavaScript kernel (Bun)**: run `scripts/ensure-js-deps.sh` once; it prints the absolute
    import path for `@duckdb/node-api`. Dynamic-import it, connect once, query across cells.
-2. **Python kernel**: `import duckdb` (plus numpy/matplotlib) directly when resident — probe
-   with a try-import and fall back to the uv lane instead of installing into the kernel's
-   interpreter.
-3. **uv lane** (`uv run --with ...`): escalate when the work needs Polars, a library the
-   kernel lacks, or isolation for a heavy one-shot.
+2. **Python kernel**: the default surface for Python work. duckdb/numpy/matplotlib are
+   typically resident; Polars and pyarrow come from `scripts/ensure-py-deps.sh`, which
+   installs them once into a user cache keyed to the kernel's interpreter —
+   `sys.path.insert` the printed directory and import. The interpreter itself is never
+   mutated.
+3. **uv lane** (`uv run --with ...`): isolation for a heavy or crash-prone one-shot that
+   should not take the kernel down.
 4. **No kernel** (plain-shell harness): the same engines as one-shots — `bun -e` for
    DuckDB-js, `uv run python -c` for the Python stack — batching several questions per
    process.
@@ -34,9 +36,10 @@ Per-surface patterns and pitfalls: read `references/execution-surfaces.md` befor
 - **DuckDB** for SQL-shaped work: direct file queries, joins, aggregation, subqueries,
   window functions. It queries CSV/Parquet/JSON in place without loading, spills to disk
   past its memory limit, and reads remote files with the same syntax.
-- **Polars (Python, uv lane)** when the pipeline is DataFrame-shaped: expression-chain
-  transforms, reshapes, streaming datasets past RAM. Read `references/polars-lane.md` —
-  the current 1.x API differs from widely-memorized older spellings.
+- **Polars** when the pipeline is DataFrame-shaped: expression-chain transforms, reshapes,
+  streaming datasets past RAM — resident in the Python kernel via `ensure-py-deps.sh`.
+  Read `references/polars-lane.md` — the current 1.x API differs from widely-memorized
+  older spellings.
 - **numpy** when numeric work goes beyond SQL/DataFrame aggregation: statistical tests,
   linear algebra, FFT, random sampling.
 - **matplotlib** for every chart — read `references/visualization.md` first; it carries the

--- a/packages/shared-skills/skills/data-scientist/references/execution-surfaces.md
+++ b/packages/shared-skills/skills/data-scientist/references/execution-surfaces.md
@@ -30,32 +30,43 @@ reader.getRowObjects();                  // array of plain row objects
   major versions (option objects that work in Python throw napi type errors). Polars work
   belongs to the uv lane.
 
-## Persistent kernel, Python
+## Persistent kernel, Python (the default Python surface)
 
-Probe first, then use what is resident:
+duckdb, numpy, and matplotlib are typically resident — import and use them directly.
+Polars and pyarrow rarely ship with a kernel, so inject them once per session (run from the
+skill directory; the script installs on first use, then just prints the path):
 
 ```python
-import importlib.util
-have = {m: importlib.util.find_spec(m) is not None for m in ("duckdb", "numpy", "matplotlib", "polars", "pyarrow")}
+import subprocess, sys
+site = subprocess.run(["bash", "scripts/ensure-py-deps.sh", sys.executable],
+                      capture_output=True, text=True, check=True).stdout.strip()
+sys.path.insert(0, site)
+import polars as pl
+import pyarrow
 ```
 
-- `duckdb.sql("SELECT ... FROM 'data.csv'")` queries files in place. `.pl()` converts to
-  Polars via Arrow only when polars and pyarrow are both present; in a bare kernel keep
-  results in DuckDB or fetch plain Python values (`.fetchall()`).
+- The install goes to a user cache keyed to the kernel's interpreter version; the
+  interpreter itself is never mutated (it is frequently an externally-managed system
+  Python, and mutating it breaks other tools).
+- After injection the whole Python stack is resident: `duckdb.sql(...).pl()` hands off via
+  Arrow, `duckdb.register(name, df)` goes the other way, and Polars lazy pipelines run
+  in-kernel across cells.
+- `duckdb.sql("SELECT ... FROM 'data.csv'")` queries files in place; without the injection,
+  keep results in DuckDB or fetch plain Python values (`.fetchall()`).
 - matplotlib figures render natively in kernels that display rich output; also save a PNG so
   the artifact survives the session.
-- A missing module means: use the uv lane. Do not install into the kernel's interpreter —
-  it is frequently an externally-managed system Python, and mutating it breaks other tools.
 
-## uv lane (any surface)
+## uv lane (fallback and isolation)
 
 ```bash
 uv run --with duckdb --with polars --with pyarrow --with numpy python -c "<code>"
 ```
 
+- Reach for it when there is no kernel, or when a heavy, crash-prone one-shot should not
+  run inside (and possibly take down) the kernel.
 - Include exactly the packages the code imports, plus pyarrow whenever `.pl()` is used.
-- The first run resolves packages (seconds); later runs hit the cache and pay roughly half a
-  second of process overhead — acceptable for one-shots, wasteful for exploration loops.
+- Each invocation pays process spawn plus imports (~0.5s warm) and re-reads its inputs —
+  fine for one-shots, wasteful for exploration loops.
 - Past a few lines, a temp file beats `-c` quoting: write the script, `uv run script.py`.
 
 ## No kernel at all
@@ -72,8 +83,9 @@ uv run scripts/quick-query.py data.csv "SELECT ..."    # zero-code CLI fallback
 
 Start on the resident kernel. Move a step down when a concrete need appears:
 
-- Polars API needed (see `polars-lane.md`) — uv lane.
-- Library missing from the kernel — uv lane.
+- polars/pyarrow missing from the kernel — inject via `ensure-py-deps.sh` (above), not a
+  uv one-shot.
 - Crash-prone or memory-hungry one-shot that should not take the kernel down — uv lane.
+- No kernel on this harness — one-shot recipes above.
 - Data lives remotely or exceeds local RAM — read `placement.md` and move the query, not
   the data.

--- a/packages/shared-skills/skills/data-scientist/references/placement.md
+++ b/packages/shared-skills/skills/data-scientist/references/placement.md
@@ -44,7 +44,7 @@ so the resident table is the working set, not the raw file.
 
   Aggregations, sorts, and window functions run out-of-core: slower, but bounded.
 - Bigger than RAM, DataFrame-shaped: Polars streaming (`collect(engine="streaming")` on a
-  lazy plan) in the uv lane.
+  lazy plan) in the resident kernel — or a uv one-shot on kernel-less harnesses.
 - Manual chunked loops (read N rows, process, repeat) are the last resort — the engines'
   own out-of-core paths are faster and simpler than hand-rolled chunking.
 

--- a/packages/shared-skills/skills/data-scientist/references/polars-lane.md
+++ b/packages/shared-skills/skills/data-scientist/references/polars-lane.md
@@ -1,8 +1,20 @@
-# Polars lane (Python via uv)
+# Polars lane (resident Python kernel)
 
-When the work is DataFrame-shaped, Python Polars is the right engine — and it runs in the uv
-lane, not in a resident kernel: kernels rarely ship polars/pyarrow, and a kernel's
-interpreter must not be mutated to add them.
+When the work is DataFrame-shaped, Polars is the right engine — and it runs in the resident
+Python kernel by default. Kernels rarely ship polars/pyarrow preinstalled, so inject them
+once per session; the install lands in a user cache keyed to the kernel's interpreter, and
+the interpreter itself is never mutated:
+
+```python
+import subprocess, sys
+site = subprocess.run(["bash", "scripts/ensure-py-deps.sh", sys.executable],
+                      capture_output=True, text=True, check=True).stdout.strip()
+sys.path.insert(0, site)
+import polars as pl
+```
+
+After this, Polars lives across cells like every other resident engine: lazy frames,
+intermediate results, and the DuckDB handoff all persist with no per-call process cost.
 
 ## When Polars wins over DuckDB SQL
 
@@ -30,49 +42,53 @@ Training data is full of the pre-1.0 API. Current names:
 Lazy first: `scan_*` builds a plan, pushes filters and projections down to the file read, and
 executes once at `.collect()`. Eager `read_*` is for small files mutated interactively.
 
-```bash
-uv run --with polars python -c "
-import polars as pl
-out = (pl.scan_csv('data.csv')
-       .filter(pl.col('value') > 100)
-       .group_by('category')
-       .agg(pl.col('value').sum().alias('total'), pl.len().alias('n'))
-       .sort('total', descending=True)
+```python
+out = (pl.scan_csv("data.csv")
+       .filter(pl.col("value") > 100)
+       .group_by("category")
+       .agg(pl.col("value").sum().alias("total"), pl.len().alias("n"))
+       .sort("total", descending=True)
        .collect())
-print(out)
-"
 ```
 
 ## Zero-copy handoff with DuckDB
 
-Both engines speak Arrow, so mixed pipelines pay no serialization cost:
+Both engines speak Arrow, so mixed pipelines pay no serialization cost — all in-kernel:
+
+```python
+import duckdb
+df = duckdb.sql("SELECT * FROM 'orders.csv' o JOIN 'items.csv' i USING (id)").pl()
+shaped = df.with_columns((pl.col("qty") * pl.col("price")).alias("rev"))
+duckdb.register("shaped", shaped)
+out = duckdb.sql("SELECT category, SUM(rev) AS total FROM shaped GROUP BY 1").pl()
+```
+
+- `.pl()` requires pyarrow — the injection above provides it; without it, it raises
+  `ModuleNotFoundError`.
+- Never `.df()`: it requires pandas (raising without it), and pandas is banned and absent.
+
+## Streaming past RAM
+
+```python
+out = (pl.scan_parquet("huge.parquet")
+       .filter(pl.col("status") == "active")
+       .group_by("region").agg(pl.len())
+       .collect(engine="streaming"))
+```
+
+Streaming executes lazy plans only — keep the plan lazy end-to-end, with no intermediate
+`.collect()` breaking it into eager pieces.
+
+## Kernel-less fallback (uv one-shot)
+
+On a harness with no persistent kernel, the same code runs as one-shots — batch several
+questions per process, since each invocation pays spawn plus imports:
 
 ```bash
 uv run --with duckdb --with polars --with pyarrow python -c "
 import duckdb
 import polars as pl
-df = duckdb.sql(\"SELECT * FROM 'orders.csv' o JOIN 'items.csv' i USING (id)\").pl()
-shaped = df.with_columns((pl.col('qty') * pl.col('price')).alias('rev'))
-duckdb.register('shaped', shaped)
-print(duckdb.sql('SELECT category, SUM(rev) AS total FROM shaped GROUP BY 1').pl())
+df = duckdb.sql(\"SELECT * FROM 'data.csv'\").pl()
+print(df.group_by('category').agg(pl.len()).sort('category'))
 "
 ```
-
-- `.pl()` requires pyarrow in the package set, or it raises `ModuleNotFoundError`.
-- Never `.df()`: it requires pandas (raising without it), and pandas is banned and absent.
-
-## Streaming past RAM
-
-```bash
-uv run --with polars python -c "
-import polars as pl
-out = (pl.scan_parquet('huge.parquet')
-       .filter(pl.col('status') == 'active')
-       .group_by('region').agg(pl.len())
-       .collect(engine='streaming'))
-print(out)
-"
-```
-
-Streaming executes lazy plans only — keep the plan lazy end-to-end, with no intermediate
-`.collect()` breaking it into eager pieces.

--- a/packages/shared-skills/skills/data-scientist/scripts/ensure-py-deps.sh
+++ b/packages/shared-skills/skills/data-scientist/scripts/ensure-py-deps.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Install polars + pyarrow for a given Python interpreter into a user-level cache
+# (never mutating the interpreter itself) and print the site directory as the ONLY
+# stdout line. Idempotent: re-runs reuse the install. arg1 = python executable
+# (default: python3); pass the kernel's sys.executable for kernel use.
+set -euo pipefail
+
+log() { printf '[ensure-py-deps] %s\n' "$*" >&2; }
+
+PYTHON_BIN="${1:-python3}"
+
+if ! command -v uv >/dev/null 2>&1; then
+  log "uv is required (see references/uv-setup.md); install it first."
+  exit 1
+fi
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1 && [ ! -x "$PYTHON_BIN" ]; then
+  log "python executable not found: $PYTHON_BIN"
+  exit 1
+fi
+
+TAG="$("$PYTHON_BIN" -c 'import sys; print(f"cp{sys.version_info[0]}{sys.version_info[1]}")')"
+CACHE_DIR="${OMO_DATA_SCIENTIST_CACHE:-$HOME/.cache/omo-data-scientist}"
+SITE_DIR="$CACHE_DIR/py-$TAG"
+
+if [ ! -d "$SITE_DIR/polars" ] || [ ! -d "$SITE_DIR/pyarrow" ]; then
+  log "installing polars + pyarrow for $TAG into $SITE_DIR"
+  mkdir -p "$SITE_DIR"
+  uv pip install --python "$PYTHON_BIN" --target "$SITE_DIR" polars pyarrow 1>&2
+fi
+
+if [ ! -d "$SITE_DIR/polars" ]; then
+  log "install finished but $SITE_DIR/polars is missing; inspect $SITE_DIR"
+  exit 1
+fi
+
+printf '%s\n' "$SITE_DIR"


### PR DESCRIPTION
## What

Follow-up to #7480. The skill still framed Polars as uv-subprocess work; this PR makes the **persistent Python eval kernel the stated default for all Python work, Polars included** — not an add-on lane.

- New `scripts/ensure-py-deps.sh`: idempotent `uv pip install --python <interp> --target $HOME/.cache/omo-data-scientist/py-cp<ver> polars pyarrow`; prints the injectable site dir as its only stdout line; mirrors the `ensure-js-deps.sh` contract; never mutates the interpreter (PEP 668 stays intact).
- `SKILL.md`: description + ladder item 2 now state the py kernel runs duckdb/numpy/matplotlib resident AND Polars via site-dir injection; the uv lane shrinks to isolation one-shots; the engine bullet drops "(Python, uv lane)".
- `execution-surfaces.md`: canonical injection cell (`subprocess.run(ensure-py-deps.sh, sys.executable)` → `sys.path.insert` → import); escalation rules route missing polars/pyarrow to injection, not uv.
- `polars-lane.md`: examples rewritten as resident-kernel cells; single uv fallback section for kernel-less harnesses.
- `placement.md`: streaming guidance updated accordingly.

## Why (measured, this machine, kernel python 3.14.7)

- `--target` install resolves against the kernel interpreter in 0.17s (warm uv cache) with zero system-python mutation.
- Warm `import polars` from the injected dir: ~70–110ms once per session; resident 2M-row pipeline (filter+group_by+streaming collect): 89ms vs 384ms wall for the same pipeline as a `uv run` one-shot, every call.
- `.pl()` Arrow handoff and `duckdb.register` both work in-kernel with injected pyarrow 25.0.1.

## QA evidence (`.omo/evidence/20260829-ds-eval-py-default/`, local)

- Gates after rewrite + both sync-skills runs: **18 pass / 0 fail**; mutation proof: personal token planted in the NEW script → depersonalization gate RED → removed → GREEN (script is inside the scanned set); natural RED for the script captured before creation (exit 127).
- `ensure-py-deps.sh` run twice with the kernel interpreter arg: exit 0 both, identical single-line stdout.
- The canonical cell from `execution-surfaces.md` executed **verbatim** in a live Python eval kernel (polars 1.44.1, streaming pipeline shape correct) and again in a fresh interpreter (`COLD_OK`).
- Every example block in the revised `polars-lane.md` ran with `-W error::DeprecationWarning`: python blocks `BLOCKS_OK`, bash fallback exit 0.
- Diff scope: only `data-scientist` paths; description line 849 chars (≤1024); personal-token scan clean.

## Residual risk

The injected site dir is keyed to the interpreter version (`py-cp<maj><min>`), so a kernel python upgrade triggers a clean re-install rather than an ABI mismatch. Prose remains review-gated by design.

Plan: `.omo/plans/ds-eval-py-default.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the resident Python eval kernel the default for Polars work in the `data-scientist` skill, instead of framing Polars as uv-subprocess work. The new `ensure-py-deps.sh` installs polars/pyarrow into a user cache keyed to the kernel interpreter and prints an injectable site dir, so Polars runs resident with no per-call process overhead.

<sup>Written for commit 35dbdda50289ad47bcd0d5827cfbcd177c275672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

