### PR TITLE
fix(shared-skills): purge stale uv-default wording after py-kernel change

### DIFF
--- a/packages/shared-skills/skills/data-scientist/SKILL.md
+++ b/packages/shared-skills/skills/data-scientist/SKILL.md
@@ -60,7 +60,7 @@ a direct scan. Then place the work:
   re-scan into milliseconds.
 - **Query in place / stream** when the question is single-pass, or the data exceeds RAM:
   DuckDB reads files directly (`FROM 'data.csv'`); past RAM, cap DuckDB's memory and let it
-  spill, or use Polars' streaming engine in the uv lane. NEVER load a larger-than-RAM
+  spill, or use Polars' streaming engine in the Python kernel. NEVER load a larger-than-RAM
   dataset fully into memory — swapping stalls the whole machine, while streaming merely
   takes longer.
 - **Query remotely, in place** when the data lives elsewhere: DuckDB reads http(s)/S3

--- a/packages/shared-skills/skills/data-scientist/references/execution-surfaces.md
+++ b/packages/shared-skills/skills/data-scientist/references/execution-surfaces.md
@@ -28,7 +28,7 @@ reader.getRowObjects();                  // array of plain row objects
   `Bun.XML.parse`, `Bun.TOML.parse`, `Bun.Archive` for tarballs.
 - nodejs-polars is NOT part of this skill's toolkit: its API lags the Python release by
   major versions (option objects that work in Python throw napi type errors). Polars work
-  belongs to the uv lane.
+  belongs to the Python kernel (below).
 
 ## Persistent kernel, Python (the default Python surface)
 
@@ -65,7 +65,7 @@ uv run --with duckdb --with polars --with pyarrow --with numpy python -c "<code>
 - Reach for it when there is no kernel, or when a heavy, crash-prone one-shot should not
   run inside (and possibly take down) the kernel.
 - Include exactly the packages the code imports, plus pyarrow whenever `.pl()` is used.
-- Each invocation pays process spawn plus imports (~0.5s warm) and re-reads its inputs —
+- Each invocation pays process spawn plus imports (roughly 0.3s warm) and re-reads its inputs —
   fine for one-shots, wasteful for exploration loops.
 - Past a few lines, a temp file beats `-c` quoting: write the script, `uv run script.py`.
 

--- a/packages/shared-skills/skills/data-scientist/references/polars-lane.md
+++ b/packages/shared-skills/skills/data-scientist/references/polars-lane.md
@@ -3,7 +3,8 @@
 When the work is DataFrame-shaped, Polars is the right engine — and it runs in the resident
 Python kernel by default. Kernels rarely ship polars/pyarrow preinstalled, so inject them
 once per session; the install lands in a user cache keyed to the kernel's interpreter, and
-the interpreter itself is never mutated:
+the interpreter itself is never mutated (run with the skill directory as cwd, or spell out
+the script's absolute path):
 
 ```python
 import subprocess, sys

--- a/packages/shared-skills/skills/data-scientist/references/uv-setup.md
+++ b/packages/shared-skills/skills/data-scientist/references/uv-setup.md
@@ -1,6 +1,6 @@
 # uv Setup — Per-Platform
 
-This skill's uv lane (Polars work, libraries missing from the resident kernel, isolated one-shots) runs through `uv run --with ...`. If `uv --version` fails, set uv up with the automated scripts or the manual commands below, then verify.
+This skill's uv lane (kernel-less harnesses, isolated one-shots) runs through `uv run --with ...`, and `scripts/ensure-py-deps.sh` uses uv as its installer. If `uv --version` fails, set uv up with the automated scripts or the manual commands below, then verify.
 
 ## Automated (recommended)
 

--- a/packages/shared-skills/skills/data-scientist/scripts/ensure-py-deps.sh
+++ b/packages/shared-skills/skills/data-scientist/scripts/ensure-py-deps.sh
@@ -18,7 +18,8 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1 && [ ! -x "$PYTHON_BIN" ]; then
   exit 1
 fi
 
-TAG="$("$PYTHON_BIN" -c 'import sys; print(f"cp{sys.version_info[0]}{sys.version_info[1]}")')"
+TAG="$("$PYTHON_BIN" -c 'import sys; print(f"cp{sys.version_info[0]}{sys.version_info[1]}")')" \
+  || { log "not a working python interpreter: $PYTHON_BIN"; exit 1; }
 CACHE_DIR="${OMO_DATA_SCIENTIST_CACHE:-$HOME/.cache/omo-data-scientist}"
 SITE_DIR="$CACHE_DIR/py-$TAG"
 


### PR DESCRIPTION
## What

Follow-up to #7481, which auto-merged in a race with its adversarial review: three reviewer-cited sentences still framing the uv lane as the Polars default survived the merge. This PR lands the reviewer's prescribed fixes plus two of its notes:

- `execution-surfaces.md`: "Polars work belongs to the uv lane" → "belongs to the Python kernel (below)"; one-shot overhead figure corrected to the measured ~0.3s.
- `SKILL.md`: placement bullet's "Polars' streaming engine in the uv lane" → "in the Python kernel" (the reference copy was already correct).
- `uv-setup.md`: lane redefined as "(kernel-less harnesses, isolated one-shots)" with uv also credited as the `ensure-py-deps.sh` installer.
- `polars-lane.md`: injection-cell cwd premise made explicit (skill dir or absolute path).
- `scripts/ensure-py-deps.sh`: non-python interpreter arg now fails with a clear stderr message instead of a silent `set -e` death (`/usr/bin/false` → logged, exit 1).

## QA (`.omo/evidence/20260829-ds-eval-py-default/review-blocker-fixes.txt`)

- Gates after both sync runs: 18 pass / 0 fail.
- Script: `bash -n` clean; idempotency re-verified (exit 0/0, identical stdout); bad-interpreter path logs and exits 1.
- Post-fix contradiction scan: no remaining sentence routes Polars or kernel-covered work to the uv lane.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow-up fixing stale docs that still routed Polars work to the uv lane after the Python kernel became the default, and hardening `ensure-py-deps.sh` against non-python interpreter arguments.

- Corrects `execution-surfaces.md`, `SKILL.md`, and `uv-setup.md` to route Polars and streaming work to the Python kernel instead of the uv lane.
- Redefines the uv lane in `uv-setup.md` as kernel-less harnesses and isolated one-shots, with uv as the `ensure-py-deps.sh` installer.
- Documents in `polars-lane.md` that the injection cell runs with the skill directory as cwd or an absolute path.
- `ensure-py-deps.sh` now logs a clear error and exits 1 when passed a non-python interpreter, replacing the silent `set -e` failure.
- Corrects the one-shot overhead figure in `execution-surfaces.md` from ~0.5s to the measured ~0.3s.

<sup>Written for commit 89cd17c14cb9927a106605c99700b3a0916d5049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

