### PR TITLE
fix(native): resolve Windows standalone sidecars

### DIFF
--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -107,6 +107,16 @@ export function shouldReexecAfterProvisioning(platform = process.platform): bool
   return platform !== "win32"
 }
 
+export function remapCompiledExecutableIdentity(
+  expectedPath: string,
+  platform = process.platform,
+  target: { execPath: string } = process,
+): void {
+  // Windows stays in-process to avoid Bun's self-reexec hang, so make sidecar
+  // lookups observe the provisioned executable that would otherwise be re-execed.
+  if (platform === "win32") target.execPath = expectedPath
+}
+
 export function remapSenpiEnvironment(source: NodeJS.ProcessEnv = process.env, execDir: string): NodeJS.ProcessEnv {
   const env = { ...source }
   delete env.OMO_BIN
@@ -260,6 +270,7 @@ async function main(): Promise<void> {
   }
   // Inspector and custom execArgv isolation is unsupported in compiled binaries; the provisioned
   // executable delegates to the engine in-process as required by the native startup contract.
+  remapCompiledExecutableIdentity(expected)
   if (await runCompiledLauncher(process.argv.slice(2), execDir, manifest.enginePin, execDir)) return
   process.argv.splice(2, process.argv.length - 2, ...buildSenpiArgs(process.argv.slice(2), execDir))
   Object.assign(process.env, remapSenpiEnvironment(process.env, execDir))

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -8,6 +8,7 @@ import {
   isProvisionedExecutable,
   materializeProvisionedExecutable,
   provisionEmbeddedRuntime,
+  remapCompiledExecutableIdentity,
   remapSenpiEnvironment,
   runningExecutablePath,
   runCompiledLauncher,
@@ -33,6 +34,15 @@ describe("compiled omo entry launcher parity", () => {
     expect(runningExecutablePath("/runtime/omo", "/usr/local/bin/bun", "darwin")).toBe("/usr/local/bin/bun")
     expect(shouldReexecAfterProvisioning("win32")).toBe(false)
     expect(shouldReexecAfterProvisioning("darwin")).toBe(true)
+  })
+
+  test("maps Windows in-process dependency lookups to the provisioned executable", () => {
+    const target = { execPath: "B:\\~BUN\\root\\omo.exe" }
+    remapCompiledExecutableIdentity("C:\\Users\\test\\.omo\\binary-runtime\\5.0.0\\omo.exe", "win32", target)
+    expect(target.execPath).toBe("C:\\Users\\test\\.omo\\binary-runtime\\5.0.0\\omo.exe")
+
+    remapCompiledExecutableIdentity("/home/test/.omo/binary-runtime/5.0.0/omo", "linux", target)
+    expect(target.execPath).toBe("C:\\Users\\test\\.omo\\binary-runtime\\5.0.0\\omo.exe")
   })
 
   test("early commands pass through without an extension", () => {


### PR DESCRIPTION
## Summary

Raw Windows release binaries provision their embedded runtime but stay in-process to avoid the Bun self-reexec hang fixed in #7447. Runtime dependencies still saw Bun's virtual `process.execPath`, so their sibling `package.json`, theme, and native-sidecar lookups failed. This maps the in-process Windows executable identity to the already-provisioned `omo.exe` before importing Senpi; POSIX behavior is unchanged.

## Changes

- Remap `process.execPath` to the provisioned Windows executable at the compiled launcher boundary.
- Add a regression test covering the Windows mapping and the non-Windows no-op behavior.

## QA & Evidence

- **Focused test:** `bun test packages/omo-native/test/compile-entry.test.ts -t "maps Windows in-process"` — 1 passed, 0 failed.
- **Typecheck:** `bunx tsgo --noEmit -p packages/omo-native/tsconfig.json` — passed with no diagnostics.
- **Real binary build:** Windows x64 artifact built at 137,531,904 bytes with 1,163 embedded sidecars.
- **Before/after empty-directory launch:** the published `v5.0.0-beta.26` binary reproduced `@earendil-works/pi-pty package.json is missing a string version` and exited 1; the patched binary, under a separate isolated profile/config root, provisioned its package/theme/plugin sidecars, printed the complete `--help` surface, and exited 0.
- **Local evidence:** `.omo/evidence/20260829-windows-standalone-assets/README.md`.

## Risks & Residuals

- The mapping is Windows-only and preserves the no-reexec behavior from #7447. The mapped path is the real provisioned executable, so later child launches continue to target a valid binary.
- The full compile-entry test file had 16 passes plus one pre-existing Windows symlink-privilege failure; the new regression was rerun independently and passed.
- The separate shared-host Unix `ps` warning reported in the issue is not changed.

## Related Issues

Fixes #7485


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows standalone sidecar lookups failing after provisioning by remapping `process.execPath` to the already-provisioned `omo.exe` at the compiled launcher boundary. Windows builds stay in-process to avoid the Bun self-reexec hang fixed in #7447; POSIX behavior is unchanged.

- Runtime dependencies like `package.json`, theme, and native sidecars now resolve against the real executable instead of Bun's virtual path.
- Adds a regression test covering the Windows mapping and the non-Windows no-op.
- Fixes #7485.

<sup>Written for commit f28721a0ee5ce3d54ccf5d4e0bca8b8918b5687b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

