### PR TITLE
fix(codex): bind executor evidence to deliverables (fixes #5970)

### DIFF
--- a/.omo/evidence/20260829-issue-5970-executor-evidence-validation/README.md
+++ b/.omo/evidence/20260829-issue-5970-executor-evidence-validation/README.md
@@ -1,0 +1,35 @@
+# Issue 5970 Executor Evidence Validation
+
+## What was tested
+
+- Component red/green coverage for generic versus task-bound receipts, plus
+  existing containment, retry, and context-pressure cases.
+- Built verifier CLI, repository Codex gate, hook probe, and real isolated
+  `codex app-server` wiring.
+
+## What was observed before the fix
+
+```text
+generic receipt without deliverable: 1 failed, 25 passed
+```
+
+The hook returned empty stdout instead of the expected block decision.
+
+## What was observed after the fix
+
+- Component: `26 passed`; build, typecheck, and Biome clean.
+- `bun run test:codex` with npm 11.12.1: clean; final Node gate `493 pass`.
+- Generic CLI receipt blocked; task-bound receipt passed with empty stdout.
+- Live app-server turn completed with no missing/failed hooks.
+- Hook QA and harness self-check passed.
+- Real `~/.codex/config.toml` hash stayed `6f9a9998e39f4f8c47e225e81801ecb2c183136a`.
+
+## Why this evidence is enough
+
+The red/green test proves the defect, the built CLI proves the exact changed
+surface, and app-server QA proves the local plugin remains live-wired.
+
+## What was omitted
+
+Sandbox paths were summarized; no credentials, tokens, real Codex home, model
+requests, or private task content were captured.

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/directive.md
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/directive.md
@@ -4,6 +4,18 @@
 
 직접 검증하라. 관련 명령을 실제로 실행하고, 출력과 판단 근거를 `.omo/evidence/` 아래 파일로 기록하라. 실패한 항목이 있으면 완료했다고 말하지 말고 고쳐라. `stop_hook_active` 상태여도 이 검증은 생략되지 않는다. 반복은 제한되어 있지만, 증거 없는 완료 주장은 막힌다.
 
+증거 파일은 아래 JSON 형식이어야 한다. `deliverables`에는 `.omo/evidence/` 밖에 있는 실제 결과 파일을 기록하라.
+
+```json
+{
+  "verdict": "confirmed",
+  "session_id": "{{SESSION_ID}}",
+  "agent_id": "{{AGENT_ID}}",
+  "turn_id": {{TURN_ID_JSON}},
+  "deliverables": ["path/to/deliverable"]
+}
+```
+
 마지막 assistant 메시지:
 {{LAST_ASSISTANT_MESSAGE}}
 

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/src/codex-hook.ts
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/src/codex-hook.ts
@@ -8,6 +8,14 @@ import { SUBAGENT_STOP_EVENT } from "./types.js";
 
 const RECEIPT_ENFORCED_AGENTS = new Set(["lazycodex-worker-low", "lazycodex-worker-medium", "lazycodex-worker-high"]);
 
+type EvidenceReceipt = {
+	readonly verdict: "confirmed";
+	readonly session_id: string;
+	readonly agent_id: string;
+	readonly turn_id: string | null;
+	readonly deliverables: readonly string[];
+};
+
 export function runSubagentStopHook(input: unknown, fs: HookFileSystem): string {
 	if (!isSubagentStopInput(input)) return "";
 	if (!RECEIPT_ENFORCED_AGENTS.has(input.agent_type)) return "";
@@ -25,7 +33,10 @@ export function runSubagentStopHook(input: unknown, fs: HookFileSystem): string 
 	writeAttemptState(input.cwd, input.session_id, input.agent_id, { attempts }, fs);
 	return JSON.stringify({
 		decision: "block",
-		reason: renderDirective(attempts, input.last_assistant_message),
+		reason: renderDirective(attempts, input.last_assistant_message)
+			.replaceAll("{{SESSION_ID}}", input.session_id)
+			.replaceAll("{{AGENT_ID}}", input.agent_id)
+			.replaceAll("{{TURN_ID_JSON}}", JSON.stringify(input.turn_id ?? null)),
 	} satisfies StopHookOutput);
 }
 
@@ -56,7 +67,41 @@ function hasValidEvidenceReceipt(input: SubagentStopInput, fs: HookFileSystem): 
 	const resolvedPath = isAbsolute(receiptPath) ? resolve(receiptPath) : resolve(input.cwd, receiptPath);
 	if (!isPathInsideDirectory(resolvedPath, evidenceRoot)) return false;
 	try {
-		return isNonEmptyFileInsideEvidenceRoot(resolvedPath, evidenceRoot, input.cwd, fs);
+		if (!isNonEmptyFileInsideEvidenceRoot(resolvedPath, evidenceRoot, input.cwd, fs)) return false;
+		const receipt: unknown = JSON.parse(fs.readFileSync(resolvedPath, "utf8"));
+		if (!isEvidenceReceiptForInput(receipt, input)) return false;
+		return receipt.deliverables.every((path) => isValidDeliverable(path, evidenceRoot, input.cwd, fs));
+	} catch (error) {
+		if (error instanceof Error) return false;
+		throw error;
+	}
+}
+
+function isEvidenceReceiptForInput(value: unknown, input: SubagentStopInput): value is EvidenceReceipt {
+	if (!isRecord(value)) return false;
+	const deliverables = value["deliverables"];
+	return (
+		value["verdict"] === "confirmed" &&
+		value["session_id"] === input.session_id &&
+		value["agent_id"] === input.agent_id &&
+		value["turn_id"] === (input.turn_id ?? null) &&
+		Array.isArray(deliverables) &&
+		deliverables.length > 0 &&
+		deliverables.every((path) => typeof path === "string" && path.length > 0)
+	);
+}
+
+function isValidDeliverable(path: string, evidenceRoot: string, cwd: string, fs: HookFileSystem): boolean {
+	const resolvedPath = isAbsolute(path) ? resolve(path) : resolve(cwd, path);
+	if (!isPathInsideDirectory(resolvedPath, cwd) || isPathInsideDirectory(resolvedPath, evidenceRoot)) return false;
+	try {
+		if (!fs.existsSync(resolvedPath)) return false;
+		const realCwd = realPath(cwd, fs);
+		const realEvidenceRoot = realPath(evidenceRoot, fs);
+		const realFilePath = realPath(resolvedPath, fs);
+		if (!isPathInsideDirectory(realFilePath, realCwd)) return false;
+		if (isPathInsideDirectory(realFilePath, realEvidenceRoot)) return false;
+		return isNonEmptyFile(resolvedPath, fs);
 	} catch (error) {
 		if (error instanceof Error) return false;
 		throw error;

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/test/cli.test.ts
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/test/cli.test.ts
@@ -57,9 +57,21 @@ describe("lazycodex executor verify CLI", () => {
 	it("#given receipt artifact stdin #when CLI runs #then stdout is empty and exit is zero", () => {
 		// given
 		const cwd = createWorkspace();
-		const artifactPath = join(cwd, ".omo", "evidence", "receipt.txt");
+		const artifactPath = join(cwd, ".omo", "evidence", "receipt.json");
+		const deliverablePath = join(cwd, "dist", "output.txt");
 		mkdirSync(join(cwd, ".omo", "evidence"), { recursive: true });
-		writeFileSync(artifactPath, "verified\n");
+		mkdirSync(join(cwd, "dist"), { recursive: true });
+		writeFileSync(deliverablePath, "done\n");
+		writeFileSync(
+			artifactPath,
+			JSON.stringify({
+				verdict: "confirmed",
+				session_id: "sess.1",
+				agent_id: "agent_1",
+				turn_id: null,
+				deliverables: ["dist/output.txt"],
+			}),
+		);
 		const payload = JSON.stringify(
 			createPayload(cwd, { last_assistant_message: `EVIDENCE_RECORDED: ${artifactPath}` }),
 		);

--- a/packages/omo-codex/plugin/components/lazycodex-executor-verify/test/codex-hook.test.ts
+++ b/packages/omo-codex/plugin/components/lazycodex-executor-verify/test/codex-hook.test.ts
@@ -69,19 +69,51 @@ describe("lazycodex executor SubagentStop verifier", () => {
 		// given
 		const cwd = createWorkspace();
 		runSubagentStopHook(createInput(cwd), nodeFileSystem);
-		const artifactPath = join(cwd, ".omo", "evidence", "receipt.txt");
+		const artifactPath = join(cwd, ".omo", "evidence", "receipt.json");
+		const deliverablePath = join(cwd, "dist", "output.txt");
 		mkdirSync(join(cwd, ".omo", "evidence"), { recursive: true });
-		writeFileSync(artifactPath, "verified\n");
+		mkdirSync(join(cwd, "dist"), { recursive: true });
+		writeFileSync(deliverablePath, "done\n");
+		writeFileSync(
+			artifactPath,
+			JSON.stringify({
+				verdict: "confirmed",
+				session_id: "sess.1",
+				agent_id: "agent_1",
+				turn_id: "turn.1",
+				deliverables: ["dist/output.txt"],
+			}),
+		);
 
 		// when
 		const output = runSubagentStopHook(
-			createInput(cwd, { last_assistant_message: "done\nEVIDENCE_RECORDED: .omo/evidence/receipt.txt" }),
+			createInput(cwd, {
+				turn_id: "turn.1",
+				last_assistant_message: "done\nEVIDENCE_RECORDED: .omo/evidence/receipt.json",
+			}),
 			nodeFileSystem,
 		);
 
 		// then
 		expect(output).toBe("");
 		expect(existsSync(join(cwd, ".omo", "lazycodex-executor-verify", "sess.1-agent_1.json"))).toBe(false);
+	});
+
+	it("#given a generic non-empty receipt without a deliverable #when executor stops #then blocks", () => {
+		// given
+		const cwd = createWorkspace();
+		const artifactPath = join(cwd, ".omo", "evidence", "placeholder.txt");
+		mkdirSync(join(cwd, ".omo", "evidence"), { recursive: true });
+		writeFileSync(artifactPath, "verified\n");
+
+		// when
+		const output = runSubagentStopHook(
+			createInput(cwd, { last_assistant_message: "done\nEVIDENCE_RECORDED: .omo/evidence/placeholder.txt" }),
+			nodeFileSystem,
+		);
+
+		// then
+		expect(parseBlockOutput(output).decision).toBe("block");
 	});
 
 	it("#given a zero-byte evidence receipt #when lazycodex executor stops #then blocks", () => {


### PR DESCRIPTION
## Summary
- replace the generic non-empty-file receipt pass condition with a structured JSON contract
- bind receipts to the current session, agent, and turn
- require at least one real non-evidence deliverable inside the workspace while preserving all existing containment checks

## Root Cause
The SubagentStop verifier treated any non-empty regular file under `.omo/evidence/` as sufficient proof. A worker could therefore reference a stale or generic placeholder receipt and advance `$start-work` even when its actual deliverable was absent.

## Changes
| File | Change |
|------|--------|
| `.omo/evidence/20260829-issue-5970-executor-evidence-validation/README.md` | Record failing-first, component, gate, CLI, and live Codex evidence |
| `packages/omo-codex/plugin/components/lazycodex-executor-verify/directive.md` | Give blocked workers the exact structured receipt shape |
| `.../src/codex-hook.ts` | Validate task identity and real deliverable files in addition to receipt containment |
| `.../test/codex-hook.test.ts` | Pin generic-receipt rejection and task-bound receipt acceptance |
| `.../test/cli.test.ts` | Exercise the structured contract through the built CLI |

## Reproduction (before fix)
```text
generic receipt without deliverable: 1 failed, 25 passed
```

The hook returned empty stdout instead of the expected block decision.

## Verification (after fix)
```text
26 passed
```

The built CLI returned `{"decision":"block"}` for the generic receipt and empty stdout for a task-bound receipt with a real deliverable.

## Test
- Component build, typecheck, Biome, and Vitest - clean
- Full Codex gate with repository-required npm 11.12.1 - clean; final Node gate 493 pass
- Codex QA hook self-test - pass
- Real isolated `codex app-server` turn - completed; no missing/failed hooks
- Real `~/.codex/config.toml` hash unchanged

Fixes #5970

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5970 by requiring executor evidence receipts to be bound to the current session, agent, and turn, and to point to a real deliverable file outside `.omo/evidence/`. Previously any non-empty file under evidence passed, allowing stale or generic receipts to unblock `$start-work`.

**Bug Fixes**
- Receipts must now be JSON with `verdict`, `session_id`, `agent_id`, `turn_id`, and `deliverables`.
- `deliverables` entries must exist, be inside the workspace, and outside evidence.
- Directive updated to give blocked workers the exact receipt shape.
- Added tests for generic receipt rejection and task-bound acceptance.

<sup>Written for commit f44b9fbe6cfcd530d5e364dacb3b0838ddb7cdce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

