### PR TITLE
fix(omo-senpi): scope process-tree survival assertions to POSIX

### DIFF
--- a/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
@@ -149,16 +149,19 @@ child.stdout.on("data", (chunk) => {
       // when
       await wrapperExit
 
-      // then: the exit marker is the original holder's own terminal signal. The marker write
-      // precedes the process's actual exit by a beat, so termination is awaited event-first
-      // (the /proc watcher on linux, a bounded liveness probe elsewhere) instead of being
-      // asserted from a single point-in-time probe.
-      expect(await waitForFileToExist(marker, EXIT_TIMEOUT_MS)).toBe(true)
+      // then: the ORIGINAL holder is terminal. Termination is awaited event-first (a zombie-aware
+      // liveness probe against the captured identity) instead of being asserted from a single
+      // point-in-time probe, because the holder's death trails the wrapper's by a beat.
       if (holderIdentityForCleanup !== null) {
         expect(await pidTerminalWithin(holderIdentityForCleanup, EXIT_TIMEOUT_MS)).toBe(true)
       } else {
         expect(pidAlive(holderPid)).toBe(false)
       }
+      // and then (POSIX only): the holder observed its own ownership loss and shut down through
+      // its stdin-EOF path, which is what writes the marker. Windows tears the whole tree down
+      // with the wrapper, so the holder never gets to run that handler - the marker is a
+      // graceful-shutdown observable there, not a termination one.
+      if (process.platform !== "win32") expect(await waitForFileToExist(marker, EXIT_TIMEOUT_MS)).toBe(true)
     } finally {
       wrapper.kill("SIGKILL")
       if (holderIdentityForCleanup !== null) killIfAlive(holderIdentityForCleanup)

--- a/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/model-preflight.test.ts
@@ -7,7 +7,7 @@ import type { Server, Socket } from "node:net"
 
 import { preflightMemoryModels, resetModelPreflightCacheForTests } from "./model-preflight"
 import type { MemoryModelChain } from "./memory-model-attempts"
-import { identityMatches, killIfAlive, pidAlive, pidTerminalWithin, readPidFileWhenWritten, readPidWhenWritten, waitForFileToExist } from "./process-liveness.test-support"
+import { identityMatches, killIfAlive, pidAlive, pidTerminalWithin, readPidFileWhenWritten, readPidOnce, readPidWhenWritten, waitForFileToExist } from "./process-liveness.test-support"
 
 const roots: string[] = []
 
@@ -260,31 +260,40 @@ control.once("error", () => process.exit(0))
       expect(result).toEqual({ kind: "unavailable", candidates })
       expect(Date.now() - startedAt).toBeLessThan(outerBoundMs)
 
-      // and then: the ORIGINAL wrapper and grandchild are observed through their own pid files.
-      // Production must have killed the launcher; the grandchild must still be alive holding the
-      // inherited pipes (otherwise the degradation premise never held); and releasing the
-      // parent-owned control channel must take the original grandchild down with it.
+      // and then: the ORIGINAL wrapper is observed through its own pid file - production must
+      // have killed the launcher rather than merely abandoning it.
       const wrapperPid = await readPidFileWhenWritten(wrapperPidPath, HELPER_EXIT_BOUND_MS)
-      const grandchildIdentity = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS, "grandchild.mjs")
-      grandchildIdentityForCleanup = grandchildIdentity
       expect(pidAlive(wrapperPid)).toBe(false)
-      expect(identityMatches(grandchildIdentity) && pidAlive(grandchildIdentity.pid)).toBe(true)
-      // The grandchild writes its pid file BEFORE connect(); awaiting its explicit connected
-      // marker guarantees the control snapshot below contains its socket on every runner.
-      expect(await waitForFileToExist(grandchildConnectedPath, HELPER_EXIT_BOUND_MS)).toBe(true)
-      const helperClosures = [...connections].map((socket) => new Promise<void>((resolve) => {
-        if (socket.destroyed) return resolve()
-        socket.once("close", () => resolve())
-      }))
-      closeControlChannel(control, connections)
-      await Promise.all(helperClosures)
-      expect(await pidTerminalWithin(grandchildIdentity, HELPER_EXIT_BOUND_MS)).toBe(true)
+
+      // and then (POSIX only): the grandchild outlives the killed launcher while still holding the
+      // inherited pipes - the hazard this degradation is built for - and releasing the
+      // parent-owned control channel takes that ORIGINAL grandchild down with it. Windows kills
+      // the launcher's whole process tree (the same reason memory-run-supervisor's integration
+      // suite tree-kills there instead of asserting survival), so the surviving-grandchild
+      // premise cannot be staged on that platform at all.
+      if (process.platform !== "win32") {
+        const grandchildIdentity = await readPidWhenWritten(grandchildPidPath, HELPER_EXIT_BOUND_MS, "grandchild.mjs")
+        grandchildIdentityForCleanup = grandchildIdentity
+        expect(identityMatches(grandchildIdentity) && pidAlive(grandchildIdentity.pid)).toBe(true)
+        // The grandchild writes its pid file BEFORE connect(); awaiting its explicit connected
+        // marker guarantees the control snapshot below contains its socket on every runner.
+        expect(await waitForFileToExist(grandchildConnectedPath, HELPER_EXIT_BOUND_MS)).toBe(true)
+        const helperClosures = [...connections].map((socket) => new Promise<void>((resolve) => {
+          if (socket.destroyed) return resolve()
+          socket.once("close", () => resolve())
+        }))
+        closeControlChannel(control, connections)
+        await Promise.all(helperClosures)
+        expect(await pidTerminalWithin(grandchildIdentity, HELPER_EXIT_BOUND_MS)).toBe(true)
+      }
     } finally {
-      // Fail-safe: even when an assertion above failed, nothing this test spawned may survive it.
+      // Fail-safe: even when an assertion above failed - or when the win32 branch never captured an
+      // identity at all - nothing this test spawned may survive it.
       closeControlChannel(control, connections)
-      if (grandchildIdentityForCleanup !== null) {
-        killIfAlive(grandchildIdentityForCleanup)
-        await pidTerminalWithin(grandchildIdentityForCleanup, HELPER_FAILSAFE_BOUND_MS)
+      const leaked = grandchildIdentityForCleanup ?? await readPidOnce(grandchildPidPath, "grandchild.mjs")
+      if (leaked !== null) {
+        killIfAlive(leaked)
+        await pidTerminalWithin(leaked, HELPER_FAILSAFE_BOUND_MS)
       }
     }
   }, 30_000)


### PR DESCRIPTION
## Why

Push-triggered CI on `dev` has been red since run [33251948668](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33251948668), and it is still red at the current `dev` head b4e0094c0 (run [33253458831](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33253458831)).

`senpi-compatibility (windows-latest)` is the only failing job in both runs, on the same two memory-worker lifecycle tests:

- `hold-lock fixture lifecycle > an abruptly killed wrapper takes the ORIGINAL holder down with it`
- `preflightMemoryModels > #given a launcher whose grandchild holds the output pipes #when the probe times out #then it degrades without waiting for the grandchild`

This is push-lane-specific: `ci-fast-path.mjs` only sets `fullMatrix` unconditionally for `push`, and `senpi-compatibility` skips non-ubuntu legs unless `full_matrix == 'true'`. PRs therefore never ran the windows leg and stayed green while `dev` was broken.

## Root cause

Both tests assert POSIX-only process-tree semantics. Windows tears down a killed process's whole tree; POSIX reparents the descendants and lets them observe their own ownership loss.

The repo already encodes this exact asymmetry in `memory-run-supervisor.integration.test.ts`, which tree-kills on win32 instead of asserting that a grandchild outlives its killed parent.

- **hold-lock-lifecycle**: the abrupt-wrapper test waited on the holder's exit marker, but the holder only writes that marker from its own stdin-EOF handler. On win32 the holder dies with the wrapper before the handler can run, so `waitForFileToExist(marker)` burned its full 5s bound and returned false.
- **model-preflight**: the test staged a grandchild that must outlive its SIGKILLed launcher while holding the inherited pipes. On win32 that premise cannot be staged at all, so `readPidWhenWritten(..., "grandchild.mjs")` never found a live match and threw `helper pid never appeared`.

## What changed

Neither contract is weakened - only the platform-specific *observables* are scoped.

- The termination contract ("the original holder goes down with the wrapper") is now carried by the identity-scoped liveness probe on **every** platform; the exit marker stays a POSIX corroboration of the graceful shutdown path.
- Degradation (`kind: "unavailable"` within the outer bound) and "production killed the launcher" are still asserted on **every** platform; only the surviving-grandchild premise and its control-channel teardown are POSIX-scoped.
- The model-preflight fail-safe now resolves a leaked grandchild on its own via `readPidOnce`, so win32 still cannot orphan one even though the happy path no longer captures its identity.

No production code changed - these are test-only platform scopes.

## Verification

- `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json` clean.
- Both touched files green locally.
- `ci:full-matrix` label applied so this PR actually exercises the windows leg that push uses - without it `fullMatrix` is false for these paths and the regression would go unverified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows push-CI failures on `dev` by scoping process-tree survival assertions to POSIX in two memory-worker lifecycle tests.

- Windows tears down a killed process's whole tree, so a grandchild cannot outlive its killed launcher there.
- The termination and degradation contracts are still asserted on every platform; only the survival observables and marker checks are POSIX-scoped.
- The model-preflight fail-safe now resolves a leaked grandchild on its own, so Windows still can't orphan one.

<sup>Written for commit 0f8cee1b5451f7f3e96749ac4af36dcbce033fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

