### PR TITLE
perf(omo-native): answer launcher fast paths before the provisioning re-exec

### DIFF
--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -1,9 +1,19 @@
-import { createHash } from "node:crypto"
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync } from "node:fs"
 import { homedir } from "node:os"
-import { dirname, join, resolve } from "node:path"
+import { dirname, join } from "node:path"
 import { spawn } from "node:child_process"
 import { fileURLToPath } from "node:url"
+import {
+  embeddedText,
+  isProvisionedExecutable,
+  materializeProvisionedExecutable,
+  provisionEmbeddedRuntime,
+  runningExecutablePath,
+  selectRuntimeManifest,
+  shouldReexecAfterProvisioning,
+  type EmbeddedFile,
+  type EmbeddedManifest,
+} from "./compile-runtime"
 import { migrateLegacyBunGlobalManifest } from "./bin/lib/legacy-bun-global-migration.js"
 import { adoptLegacyFlatState, canonicalAgentDir } from "./bin/lib/agent-dir.js"
 import { nearestNodeBin, readJson } from "./bin/lib/package-paths.js"
@@ -11,15 +21,6 @@ import { runDoctor } from "./bin/lib/doctor.js"
 import { detectHarnesses, needsSetupSuggestion } from "./bin/lib/setup-detect.js"
 import { printSetupReport } from "./bin/lib/setup-report.js"
 import { delimiter } from "node:path"
-
-type EmbeddedFile = Blob & {
-  name: string
-  arrayBuffer?: () => Promise<ArrayBuffer>
-  bytes?: () => Promise<Uint8Array>
-  text?: () => Promise<string>
-}
-export type EmbeddedManifestEntry = { relPath: string; sha256: string; mode: number; size: number }
-export type EmbeddedManifest = { omoAiVersion: string; enginePin: string; manifestSha: string; entries: EmbeddedManifestEntry[] }
 
 // The engine is imported via a RELATIVE string LITERAL, inlined at both import
 // sites, and both properties are load-bearing:
@@ -65,48 +66,6 @@ export function updateLine(platform: NodeJS.Platform, arch: string): string {
   return `omo is updated via curl: curl -fsSL https://github.com/code-yeongyu/oh-my-openagent/releases/latest/download/${asset} -o ${dest} && chmod +x ${dest}`
 }
 
-export function isProvisionedExecutable(execPath: string, expectedPath: string): boolean {
-  try {
-    return realpathSync(execPath) === realpathSync(expectedPath)
-  } catch {
-    return resolve(execPath) === resolve(expectedPath)
-  }
-}
-
-export function materializeProvisionedExecutable(
-  sourcePath: string,
-  destinationPath: string,
-  platform = process.platform,
-): void {
-  if (platform === "win32") {
-    if (existsSync(destinationPath)) return
-    copyFileSync(sourcePath, destinationPath)
-    chmodSync(destinationPath, 0o755)
-    return
-  }
-  const temporaryPath = `${destinationPath}.tmp-${process.pid}`
-  try {
-    rmSync(temporaryPath, { force: true })
-    copyFileSync(sourcePath, temporaryPath)
-    chmodSync(temporaryPath, 0o755)
-    renameSync(temporaryPath, destinationPath)
-  } finally {
-    rmSync(temporaryPath, { force: true })
-  }
-}
-
-export function runningExecutablePath(
-  argv0 = process.argv[0],
-  execPath = process.execPath,
-  platform = process.platform,
-): string {
-  return platform === "win32" && argv0.toLowerCase().endsWith(".exe") ? argv0 : execPath
-}
-
-export function shouldReexecAfterProvisioning(platform = process.platform): boolean {
-  return platform !== "win32"
-}
-
 export function remapSenpiEnvironment(source: NodeJS.ProcessEnv = process.env, execDir: string): NodeJS.ProcessEnv {
   const env = { ...source }
   delete env.OMO_BIN
@@ -133,60 +92,6 @@ export function remapSenpiEnvironment(source: NodeJS.ProcessEnv = process.env, e
   }
   env.OMO_BIN = join(execDir, process.platform === "win32" ? "omo.exe" : "omo")
   return env
-}
-
-async function embeddedText(file: EmbeddedFile): Promise<string> {
-  if (file.text) return file.text()
-  if (file.arrayBuffer) return Buffer.from(await file.arrayBuffer()).toString("utf8")
-  throw new Error(`embedded asset ${file.name} cannot be read`)
-}
-
-async function embeddedBytes(file: EmbeddedFile): Promise<Uint8Array> {
-  if (file.bytes) return file.bytes()
-  if (file.arrayBuffer) return new Uint8Array(await file.arrayBuffer())
-  throw new Error(`embedded asset ${file.name} cannot be read as bytes`)
-}
-
-export async function selectRuntimeManifest(embedded: EmbeddedFile[]): Promise<EmbeddedFile | undefined> {
-  const exact = embedded.find((file) => file.name === "omo-runtime/runtime-manifest.json")
-  if (exact) return exact
-  for (const file of embedded) {
-    if (!file.name.endsWith("runtime-manifest.json")) continue
-    try {
-      const parsed = JSON.parse(await embeddedText(file))
-      if (typeof parsed?.omoAiVersion === "string" && typeof parsed?.enginePin === "string") return file
-    } catch {
-      // Non-manifest assets with a similar name are not candidates.
-    }
-  }
-  return undefined
-}
-
-export async function provisionEmbeddedRuntime(manifest: EmbeddedManifest, embedded: EmbeddedFile[], runtimeDir: string): Promise<void> {
-  mkdirSync(runtimeDir, { recursive: true })
-  const marker = join(runtimeDir, ".provisioned")
-  if (readFileIfExists(marker)?.trim() === manifest.manifestSha) return
-  const byPath = new Map(embedded.map((file) => [
-    file.name.replace(/^\.\//, "").replace(/^omo-runtime\//, ""),
-    file,
-  ]))
-  for (const entry of manifest.entries) {
-    const file = byPath.get(entry.relPath.replace(/^\.\//, ""))
-    if (!file) throw new Error(`embedded asset missing: ${entry.relPath}`)
-    const bytes = await embeddedBytes(file)
-    if (bytes.byteLength !== entry.size || createHash("sha256").update(bytes).digest("hex") !== entry.sha256) {
-      throw new Error(`embedded asset integrity mismatch: ${entry.relPath}`)
-    }
-    const destination = join(runtimeDir, entry.relPath)
-    mkdirSync(dirname(destination), { recursive: true })
-    writeFileSync(destination, bytes, { mode: entry.mode })
-    chmodSync(destination, entry.mode)
-  }
-  writeFileSync(marker, `${manifest.manifestSha}\n`, { mode: 0o644 })
-}
-
-function readFileIfExists(path: string): string | undefined {
-  try { return readFileSync(path, "utf8") } catch { return undefined }
 }
 
 function runCompiledDoctor(inventory: Awaited<ReturnType<typeof detectHarnesses>>, execDir: string, enginePin: string): void {

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -119,6 +119,29 @@ function isSelfUpdate(args: string[]): boolean {
   return rest.every((arg) => arg.startsWith("-") || selfUpdateTargets.has(arg))
 }
 
+export function answerCompiledFastPath(args: string[], manifest: Pick<EmbeddedManifest, "omoAiVersion" | "enginePin">): boolean {
+  if ((args[0] === "--version" || args[0] === "-v") && args.length === 1) {
+    console.log(versionLine({ version: manifest.omoAiVersion }, manifest.enginePin))
+    return true
+  }
+  if (isSelfUpdate(args)) {
+    console.log(updateLine(process.platform, process.arch))
+    return true
+  }
+  return false
+}
+
+export function shouldPrintCompiledBanner(args: string[], stderrIsTTY: boolean): boolean {
+  if (!stderrIsTTY) return false
+  if (args.includes("-p") || args.includes("--print") || args.includes("--mode")) return false
+  const command = args[0]
+  if (command === undefined) return true
+  if (earlyCommands.has(command)) return false
+  if (command === "update" || command === "doctor" || command === "setup" || command === "ulw-loop") return false
+  if (command === "--version" || command === "-v") return false
+  return true
+}
+
 export async function runCompiledLauncher(args: string[], execDir: string, enginePin = "unknown", compiledPackageRoot?: string): Promise<boolean> {
   const packageJson = readJson(join(execDir, "package.json"))
   migrateLegacyBunGlobalManifest(execDir)
@@ -150,6 +173,7 @@ async function main(): Promise<void> {
   const manifestFile = await selectRuntimeManifest(embedded)
   if (!manifestFile) throw new Error("embedded runtime-manifest.json is missing")
   const manifest = JSON.parse(await embeddedText(manifestFile)) as EmbeddedManifest
+  if (answerCompiledFastPath(process.argv.slice(2), manifest)) return
   const runningExecutable = runningExecutablePath()
   const expected = join(homedir(), ".omo", "binary-runtime", manifest.omoAiVersion, process.platform === "win32" ? "omo.exe" : "omo")
   let execDir = dirname(runningExecutable)
@@ -166,6 +190,9 @@ async function main(): Promise<void> {
   // Inspector and custom execArgv isolation is unsupported in compiled binaries; the provisioned
   // executable delegates to the engine in-process as required by the native startup contract.
   if (await runCompiledLauncher(process.argv.slice(2), execDir, manifest.enginePin, execDir)) return
+  if (shouldPrintCompiledBanner(process.argv.slice(2), process.stderr.isTTY === true)) {
+    console.error(`omo (omo-ai beta ${manifest.omoAiVersion})`)
+  }
   process.argv.splice(2, process.argv.length - 2, ...buildSenpiArgs(process.argv.slice(2), execDir))
   Object.assign(process.env, remapSenpiEnvironment(process.env, execDir))
   await import("../../node_modules/@code-yeongyu/senpi/dist/cli.js") // literal: see import note above

--- a/packages/omo-native/compile-runtime.ts
+++ b/packages/omo-native/compile-runtime.ts
@@ -1,0 +1,108 @@
+import { createHash } from "node:crypto"
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+
+export type EmbeddedFile = Blob & {
+  name: string
+  arrayBuffer?: () => Promise<ArrayBuffer>
+  bytes?: () => Promise<Uint8Array>
+  text?: () => Promise<string>
+}
+export type EmbeddedManifestEntry = { relPath: string; sha256: string; mode: number; size: number }
+export type EmbeddedManifest = { omoAiVersion: string; enginePin: string; manifestSha: string; entries: EmbeddedManifestEntry[] }
+
+export function isProvisionedExecutable(execPath: string, expectedPath: string): boolean {
+  try {
+    return realpathSync(execPath) === realpathSync(expectedPath)
+  } catch {
+    return resolve(execPath) === resolve(expectedPath)
+  }
+}
+
+export function materializeProvisionedExecutable(
+  sourcePath: string,
+  destinationPath: string,
+  platform = process.platform,
+): void {
+  if (platform === "win32") {
+    if (existsSync(destinationPath)) return
+    copyFileSync(sourcePath, destinationPath)
+    chmodSync(destinationPath, 0o755)
+    return
+  }
+  const temporaryPath = `${destinationPath}.tmp-${process.pid}`
+  try {
+    rmSync(temporaryPath, { force: true })
+    copyFileSync(sourcePath, temporaryPath)
+    chmodSync(temporaryPath, 0o755)
+    renameSync(temporaryPath, destinationPath)
+  } finally {
+    rmSync(temporaryPath, { force: true })
+  }
+}
+
+export function runningExecutablePath(
+  argv0 = process.argv[0],
+  execPath = process.execPath,
+  platform = process.platform,
+): string {
+  return platform === "win32" && argv0.toLowerCase().endsWith(".exe") ? argv0 : execPath
+}
+
+export function shouldReexecAfterProvisioning(platform = process.platform): boolean {
+  return platform !== "win32"
+}
+
+export async function embeddedText(file: EmbeddedFile): Promise<string> {
+  if (file.text) return file.text()
+  if (file.arrayBuffer) return Buffer.from(await file.arrayBuffer()).toString("utf8")
+  throw new Error(`embedded asset ${file.name} cannot be read`)
+}
+
+async function embeddedBytes(file: EmbeddedFile): Promise<Uint8Array> {
+  if (file.bytes) return file.bytes()
+  if (file.arrayBuffer) return new Uint8Array(await file.arrayBuffer())
+  throw new Error(`embedded asset ${file.name} cannot be read as bytes`)
+}
+
+export async function selectRuntimeManifest(embedded: EmbeddedFile[]): Promise<EmbeddedFile | undefined> {
+  const exact = embedded.find((file) => file.name === "omo-runtime/runtime-manifest.json")
+  if (exact) return exact
+  for (const file of embedded) {
+    if (!file.name.endsWith("runtime-manifest.json")) continue
+    try {
+      const parsed = JSON.parse(await embeddedText(file))
+      if (typeof parsed?.omoAiVersion === "string" && typeof parsed?.enginePin === "string") return file
+    } catch {
+      // Non-manifest assets with a similar name are not candidates.
+    }
+  }
+  return undefined
+}
+
+export async function provisionEmbeddedRuntime(manifest: EmbeddedManifest, embedded: EmbeddedFile[], runtimeDir: string): Promise<void> {
+  mkdirSync(runtimeDir, { recursive: true })
+  const marker = join(runtimeDir, ".provisioned")
+  if (readFileIfExists(marker)?.trim() === manifest.manifestSha) return
+  const byPath = new Map(embedded.map((file) => [
+    file.name.replace(/^\.\//, "").replace(/^omo-runtime\//, ""),
+    file,
+  ]))
+  for (const entry of manifest.entries) {
+    const file = byPath.get(entry.relPath.replace(/^\.\//, ""))
+    if (!file) throw new Error(`embedded asset missing: ${entry.relPath}`)
+    const bytes = await embeddedBytes(file)
+    if (bytes.byteLength !== entry.size || createHash("sha256").update(bytes).digest("hex") !== entry.sha256) {
+      throw new Error(`embedded asset integrity mismatch: ${entry.relPath}`)
+    }
+    const destination = join(runtimeDir, entry.relPath)
+    mkdirSync(dirname(destination), { recursive: true })
+    writeFileSync(destination, bytes, { mode: entry.mode })
+    chmodSync(destination, entry.mode)
+  }
+  writeFileSync(marker, `${manifest.manifestSha}\n`, { mode: 0o644 })
+}
+
+function readFileIfExists(path: string): string | undefined {
+  try { return readFileSync(path, "utf8") } catch { return undefined }
+}

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -3,20 +3,16 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, sym
 import { createHash } from "node:crypto"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { buildSenpiArgs, remapSenpiEnvironment, runCompiledLauncher, updateLine, versionLine } from "../compile-entry"
 import {
-  buildSenpiArgs,
   isProvisionedExecutable,
   materializeProvisionedExecutable,
   provisionEmbeddedRuntime,
-  remapSenpiEnvironment,
   runningExecutablePath,
-  runCompiledLauncher,
   selectRuntimeManifest,
   shouldReexecAfterProvisioning,
-  versionLine,
-  updateLine,
   type EmbeddedManifest,
-} from "../compile-entry"
+} from "../compile-runtime"
 
 const roots: string[] = []
 const temp = () => { const root = mkdtempSync(join(homedir(), "omo-compile-entry-test-")); roots.push(root); return root }

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -3,7 +3,15 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, sym
 import { createHash } from "node:crypto"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import { buildSenpiArgs, remapSenpiEnvironment, runCompiledLauncher, updateLine, versionLine } from "../compile-entry"
+import {
+  answerCompiledFastPath,
+  buildSenpiArgs,
+  remapSenpiEnvironment,
+  runCompiledLauncher,
+  shouldPrintCompiledBanner,
+  updateLine,
+  versionLine,
+} from "../compile-entry"
 import {
   isProvisionedExecutable,
   materializeProvisionedExecutable,
@@ -63,6 +71,75 @@ describe("compiled omo entry launcher parity", () => {
     expect(env.OMO_AGENT_TOOLKIT_BIN).toBe(join("/provisioned", "plugin", "runtime", "agent-toolkit", process.platform === "win32" ? "omo-agent-toolkit.cmd" : "omo-agent-toolkit"))
     expect(env.OMO_BIN).toBe(join("/provisioned", process.platform === "win32" ? "omo.exe" : "omo"))
     expect(env.OMO_CODING_AGENT_DIR).toBeDefined()
+  })
+})
+
+describe("pre-provisioning fast paths", () => {
+  const manifest: EmbeddedManifest = { omoAiVersion: "9.9.9", enginePin: "2026.1.1", manifestSha: "m", entries: [] }
+
+  const captureLog = (run: () => boolean): { handled: boolean; output: string[] } => {
+    const output: string[] = []
+    const originalLog = console.log
+    console.log = (value?: unknown) => { output.push(String(value)) }
+    try {
+      return { handled: run(), output }
+    } finally {
+      console.log = originalLog
+    }
+  }
+
+  test("answers --version from the embedded manifest before provisioning", () => {
+    const { handled, output } = captureLog(() => answerCompiledFastPath(["--version"], manifest))
+    expect(handled).toBe(true)
+    expect(output).toEqual(["omo 9.9.9 (engine: senpi 2026.1.1)"])
+  })
+
+  test("-v answers while --version with extra arguments falls through", () => {
+    expect(captureLog(() => answerCompiledFastPath(["-v"], manifest)).handled).toBe(true)
+    const extra = captureLog(() => answerCompiledFastPath(["--version", "--json"], manifest))
+    expect(extra.handled).toBe(false)
+    expect(extra.output).toEqual([])
+  })
+
+  test("self-update spellings answer with the curl line while engine updates fall through", () => {
+    const selfUpdate = captureLog(() => answerCompiledFastPath(["update"], manifest))
+    expect(selfUpdate.handled).toBe(true)
+    expect(selfUpdate.output[0]).toContain("curl")
+    expect(captureLog(() => answerCompiledFastPath(["update", "self"], manifest)).handled).toBe(true)
+    expect(captureLog(() => answerCompiledFastPath(["update", "--extensions"], manifest)).handled).toBe(false)
+  })
+
+  test("ordinary commands never fast-path", () => {
+    const result = captureLog(() => answerCompiledFastPath(["chat"], manifest))
+    expect(result.handled).toBe(false)
+    expect(result.output).toEqual([])
+  })
+
+  test("fast-path version line matches the provisioned launcher's line for the same stamp", async () => {
+    const root = temp()
+    writeFileSync(join(root, "package.json"), JSON.stringify({ version: manifest.omoAiVersion }))
+    const fast = captureLog(() => answerCompiledFastPath(["--version"], manifest))
+    const provisionedOutput: string[] = []
+    const originalLog = console.log
+    console.log = (value?: unknown) => { provisionedOutput.push(String(value)) }
+    try {
+      await runCompiledLauncher(["--version"], root, manifest.enginePin)
+    } finally {
+      console.log = originalLog
+    }
+    expect(fast.output).toEqual(provisionedOutput)
+  })
+
+  test("banner gate requires a tty and an interactive-default launch", () => {
+    expect(shouldPrintCompiledBanner(["chat"], true)).toBe(true)
+    expect(shouldPrintCompiledBanner([], true)).toBe(true)
+    expect(shouldPrintCompiledBanner(["chat"], false)).toBe(false)
+    expect(shouldPrintCompiledBanner(["-p", "hi"], true)).toBe(false)
+    expect(shouldPrintCompiledBanner(["--print", "hi"], true)).toBe(false)
+    expect(shouldPrintCompiledBanner(["--mode", "rpc"], true)).toBe(false)
+    expect(shouldPrintCompiledBanner(["install", "x"], true)).toBe(false)
+    expect(shouldPrintCompiledBanner(["--version"], true)).toBe(false)
+    expect(shouldPrintCompiledBanner(["update"], true)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Problem

Today's omob startup profiling (sisyphuslabs dossier `omob-startup-profile-20260830`) measured two compiled-channel costs this PR removes or mitigates:

1. **Duplicate boot on every PATH launch**: `~/.bun/bin/omob` is never the provisioned copy, so `main()` re-execs `~/.omo/binary-runtime/<ver>/omo` as a child on every invocation. `--version` measured 452-462ms vs 226-233ms running the provisioned copy directly — exactly 2x.
2. **Silent launch window**: the compiled channel printed nothing until the engine spinner (0.9-2.8s under load), while the npm channel prints its launcher banner at ~50ms.

A third measured cost — the ~200ms eager pre-parse of the 4093-module engine bundle per boot — is **not fixable by entry shape** on bun 1.4.0: probes proved a reachable-as-called `await import(literal)` is inlined into the eagerly-parsed unit, while an unreachable call site DCEs the engine graph out of the binary entirely (63.9MB vs 91.9MB, zero engine strings, despite the "4093 modules" pre-DCE build log). `--bytecode` also still fails to build this graph. That cost stays upstream-owned; evidence in the dossier's `entry-shape-errata.json`.

## Changes

- `refactor(omo-native)`: split the embedded-runtime provisioning unit (manifest select/parse, integrity-verified provisioning, executable identity/materialization) out of `compile-entry.ts` into `compile-runtime.ts` — pure move, keeps compile-entry under the 250-LOC ceiling; the two load-bearing engine import literals stay byte-identical in the entry.
- `perf(omo-native)`: `answerCompiledFastPath()` answers exact `--version`/`-v` and self-update spellings from the embedded manifest BEFORE the provisioning/re-exec branch (both parent and provisioned copies), so those commands stop paying the duplicate boot; `shouldPrintCompiledBanner()` prints the npm-parity banner `omo (omo-ai beta <version>)` to stderr, TTY-gated, interactive-default args only, from the provisioned process right before the engine import (re-exec parent returns earlier → exactly once; Windows in-process path verified once too).

## Evidence

- TDD: RED captured (missing exports) → GREEN 22/22 `packages/omo-native/test/compile-entry.test.ts`, including a cross-implementation pin: fast-path line === provisioned launcher's `--version` line for the same stamp. tsc clean.
- Full package suite on a clean mengmotaMac clone: **215/215 pass** (20 files).
- Independent build on mengmotaMac reproduced a **byte-identical** binary (113,941,874 bytes, 1164 sidecars, engine-graph gate passed).
- Real-binary E2E (this machine): `--version` answers **without creating** `~/.omo/binary-runtime/<ver>/` (pre-provisioning proof); interleaved A/B built-vs-installed ≈ **half** the wall time (single vs double boot; absolute numbers load-inflated, ratio stable); TUI smoke over a real PTY: banner is the first output → spinner → full prompt render (engine import intact); provisioning still happens on the TUI path; probe runtime dir cleaned.
- Ultrabrain strict review: **VERDICT: APPROVE** (pure-move parity, fast-path semantics, banner exactly-once incl. Windows, `--mode` exact-element gate, engine-graph safety, no export-surface breakage).

## Deferred (documented, not dropped)

- **B1 post-render shared-host attach**: NEEDS-DESIGN — requires an attach transaction + reconciliation for input typed before attach (risk: first message lost/duplicated at runtime swap).
- **B2 PATH shim/symlink**: NEEDS-DESIGN — the PATH file is user-owned (`curl -Lo`); a symlink corrupts the versioned runtime dir on re-download, a plain-file reinstall silently restores the slow path, and a deleted runtime dir dangles the entry. This PR's fast paths capture the safe subset of that win; the rest needs an install/update ownership contract.
- The 10s shared-host stall (senpi-owned `$bunfs` spawn defect) is fixed separately: senpi PR #1200 (spawn route) + stacked PR #1201 (fail-fast + honest readiness diagnostics, linux+mac validated).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the compiled `omo` binary from paying a duplicate boot on `--version`/`-v` and self-update launches from a PATH copy — those commands previously re-exec'd the provisioned copy every time (measured 452ms vs 233ms direct). Interactive TTY launches also now print the launch banner before the engine import, matching the npm channel's ~50ms feedback instead of staying silent until the spinner (0.9–2.8s under load).

- Moves manifest selection, provisioning, and executable materialization into new `compile-runtime.ts`; pure move, keeps `compile-entry.ts` under 250 LOC.
- `--version`/`-v` and self-update are answered from the embedded manifest before the provisioning/re-exec branch; a test pins the fast-path version line to the provisioned launcher's output.
- Interactive-default launches print the banner to stderr (TTY-gated) exactly once from the provisioned process before the engine import.
- Deferred: PATH shim/symlink and shared-host attach need design; the 10s shared-host spawn stall is fixed in a separate PR.

<sup>Written for commit c5dca00b08f067b3b8bb48949e1b9c779c501ea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

