### PR TITLE
fix(test): guard test-fast against re-entry and orphaned children

### DIFF
--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -18,7 +18,7 @@ Build, publish, QA, and repo-invariant automation. Run via `bun run <script>` fr
 | `build-omo-native.ts` | Build the native omo runtime artifacts |
 | `ensure-vendored-lsp-daemon.ts` | Build/watch the vendored LSP daemon (daemon bin + lock-dir watch) |
 | `verify-omo-ai-payload.mjs` | omo-ai npm payload gate: required artifact list, 18-skill minimum, 30 MB unpacked cap, no nested `node_modules`/source paths |
-| `test-fast.ts` | `bun run test:fast` partitioned suite: `opencode-memory` -> `senpi` -> root-rest via `bunfig.win2.toml` |
+| `test-fast.ts` | `bun run test:fast` partitioned suite: `opencode-memory` -> `senpi` -> root-rest via `bunfig.win2.toml`. Groups run detached (own process groups) and are killed with the parent on SIGINT/SIGTERM; a spawned group inherits `OMO_TEST_FAST_ACTIVE=1` and re-entry refuses to recurse |
 | `ci-fast-path.mjs` | CI skip classifier (`classifyCiMode`): platform-sensitive paths and the `ci:full-matrix` label force the full OS matrix |
 | `telemetry-schema-block.mjs` | Generate the telemetry schema doc block (`generateTelemetrySchemaBlock`) |
 | `remove-stale-self-package-tests.ts` | Prune self-package tests that reference deleted sources |

--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -105,10 +105,26 @@ describe("child registry", () => {
     expect(groupKills).toEqual([])
   })
 
-  it("#given a child that already exited #when the registry kills all #then the reaped child is not signalled", () => {
-    // given
+  it("#given a POSIX group whose leader already exited #when the registry kills all #then the retained process group is still signalled", () => {
+    // given — a detached group outlives its leader, so the PGID must survive the exit event
     const registry = createChildRegistry("linux")
     const groupKills: number[] = []
+    const selfKills: string[] = []
+    const leader = fakeChild(101, selfKills)
+    registry.add(leader)
+    registry.add(fakeChild(202, selfKills))
+    registry.remove(leader)
+
+    // when
+    registry.killAll("SIGTERM", (pid) => groupKills.push(pid))
+
+    // then
+    expect(groupKills).toEqual([-101, -202])
+  })
+
+  it("#given a win32 child that already exited #when the registry kills all #then the reaped handle is not signalled", () => {
+    // given — win32 has no process groups, so a dead handle really is nothing left to kill
+    const registry = createChildRegistry("win32")
     const selfKills: string[] = []
     const first = fakeChild(101, selfKills)
     registry.add(first)
@@ -116,10 +132,10 @@ describe("child registry", () => {
     registry.remove(first)
 
     // when
-    registry.killAll("SIGTERM", (pid) => groupKills.push(pid))
+    registry.killAll("SIGTERM", () => {})
 
     // then
-    expect(groupKills).toEqual([-202])
+    expect(selfKills).toEqual(["202:SIGTERM"])
   })
 
   it("#given a kill that throws ESRCH for a raced child #when the registry kills all #then the remaining children are still signalled", () => {
@@ -142,19 +158,39 @@ describe("child registry", () => {
 })
 
 describe("shutdownChildren", () => {
-  it("#given children that exit during the grace period #when the parent shuts down #then no SIGKILL escalation happens", async () => {
-    // given
+  it("#given a leader that exits while a descendant ignores the signal #when the grace period elapses #then the retained group is SIGKILLed", async () => {
+    // given — the leader's "exit" fires first; its process group still holds a live descendant
     const registry = createChildRegistry("linux")
     const sent: string[] = []
-    const child = { pid: 101, kill: () => true }
-    registry.add(child)
+    const leader = { pid: 101, kill: () => true }
+    registry.add(leader)
     const kill: KillProcessGroup = (pid, signal) => void sent.push(`${pid}:${signal}`)
 
-    // when — the grace wait is where a real child's "exit" event lands
-    await shutdownChildren(registry, "SIGINT", kill, async () => registry.remove(child))
+    // when — the grace wait is where the leader's exit event lands
+    await shutdownChildren(registry, "SIGTERM", kill, async () => registry.remove(leader))
 
     // then
-    expect(sent).toEqual(["-101:SIGINT"])
+    expect(sent).toEqual(["-101:SIGTERM", "-101:SIGKILL"])
+  })
+
+  it("#given win32 children that exited during the grace period #when the parent shuts down #then nothing is escalated", async () => {
+    // given
+    const registry = createChildRegistry("win32")
+    const selfKills: string[] = []
+    const child = {
+      pid: 101,
+      kill: (signal: NodeJS.Signals) => {
+        selfKills.push(`101:${signal}`)
+        return true
+      },
+    }
+    registry.add(child)
+
+    // when
+    await shutdownChildren(registry, "SIGTERM", () => {}, async () => registry.remove(child))
+
+    // then
+    expect(selfKills).toEqual(["101:SIGTERM"])
   })
 
   it("#given a child still alive after the grace period #when the parent shuts down #then it is SIGKILLed before the parent exits", async () => {

--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -465,6 +465,46 @@ describe("runTestFast", () => {
     expect(exit).toBe(1)
   })
 
+  it("#given one group whose spawn errors #when the run aborts #then the surviving sibling groups are shut down before the error propagates", async () => {
+    // given — detached siblings keep running unless someone signals them
+    const shutdownAt: string[] = []
+    const running = new Set<string>()
+    const spawnFailure = new Error("spawn ENOENT")
+    const spawnGroup = async (group: TestFastGroup) => {
+      if (group.name === "root-rest") throw spawnFailure
+      running.add(group.name)
+      // Never settles: a detached sibling is still running when the failure lands.
+      await new Promise<never>(() => {})
+      return 0
+    }
+
+    // when
+    const failure = await runTestFast(spawnGroup, capturingLogger([]), () => {
+      shutdownAt.push([...running].sort().join(","))
+    }).then(
+      (exit) => `resolved:${exit}`,
+      (error: unknown) => error,
+    )
+
+    // then
+    expect(failure).toBe(spawnFailure)
+    expect(shutdownAt).toEqual(["opencode-memory,senpi"])
+  })
+
+  it("#given every group exits normally #when the run completes #then no shutdown is triggered", async () => {
+    // given
+    const shutdowns: string[] = []
+
+    // when
+    const exit = await runTestFast(async () => 0, capturingLogger([]), () =>
+      void shutdowns.push("shutdown"),
+    )
+
+    // then
+    expect(exit).toBe(0)
+    expect(shutdowns).toEqual([])
+  })
+
   it("#given an injected logger #when the runner starts #then the banner goes to the logger and never to stdout", async () => {
     // given
     const lines: string[] = []

--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -3,12 +3,17 @@ import { readFileSync } from "node:fs"
 import {
   childEnv,
   createChildRegistry,
+  type ChildHandle,
+  type ChildLifecycleEvents,
   isReentry,
   type KillProcessGroup,
   REENTRY_ENV_VAR,
   runTestFast,
   shutdownChildren,
   signalExitCode,
+  type SpawnChildProcess,
+  spawnInheritingStdio,
+  type SpawnGroupOptions,
   testFastGroups,
   type TestFastGroup,
 } from "./test-fast"
@@ -317,6 +322,110 @@ describe("partition tiling", () => {
 
     // then
     expect(unique.size).toBe(siblingScopes.length)
+  })
+})
+
+describe("spawnInheritingStdio", () => {
+  /** Records the spawn contract and lets the test drive the child's lifecycle events. */
+  const recordingSpawner = () => {
+    const calls: {
+      command: string
+      args: readonly string[]
+      options: SpawnGroupOptions
+    }[] = []
+    const listeners: {
+      [E in keyof ChildLifecycleEvents]: ((payload: ChildLifecycleEvents[E]) => void)[]
+    } = { error: [], exit: [] }
+    const spawner: SpawnChildProcess = (command, args, options) => {
+      calls.push({ command, args, options })
+      const once = <E extends keyof ChildLifecycleEvents>(
+        event: E,
+        listener: (payload: ChildLifecycleEvents[E]) => void,
+      ): unknown => {
+        listeners[event].push(listener)
+        return undefined
+      }
+      return { pid: 4242, kill: () => true, once }
+    }
+    return { calls, listeners, spawner }
+  }
+
+  const trackingRegistry = () => {
+    const added: ChildHandle[] = []
+    const removed: ChildHandle[] = []
+    return {
+      added,
+      removed,
+      registry: {
+        add: (child: ChildHandle) => void added.push(child),
+        remove: (child: ChildHandle) => void removed.push(child),
+        hasSignalTargets: () => added.length > removed.length,
+        killAll: () => {},
+      },
+    }
+  }
+
+  it("#given a group to run #when the child is spawned #then it carries the re-entry marker, platform detach and inherited stdio", () => {
+    // given
+    const { calls, spawner } = recordingSpawner()
+    const { registry } = trackingRegistry()
+
+    // when
+    void spawnInheritingStdio(registry, () => {}, spawner)({
+      name: "senpi",
+      args: ["test", "packages/omo-senpi"],
+    })
+
+    // then
+    const call = calls[0]
+    expect(calls.length).toBe(1)
+    expect(call?.args).toEqual(["test", "packages/omo-senpi"])
+    expect(call?.options.env?.[REENTRY_ENV_VAR]).toBe("1")
+    expect(call?.options.env?.PATH).toBe(process.env.PATH)
+    expect(call?.options.detached).toBe(process.platform !== "win32")
+    expect(call?.options.stdio).toBe("inherit")
+  })
+
+  it("#given a spawned group #when the child starts #then it is registered and deregistered on exit", async () => {
+    // given
+    const { listeners, spawner } = recordingSpawner()
+    const { added, removed, registry } = trackingRegistry()
+
+    // when
+    const exit = spawnInheritingStdio(registry, () => {}, spawner)({
+      name: "senpi",
+      args: ["test"],
+    })
+    expect(added.map((child) => child.pid)).toEqual([4242])
+    for (const notifyExit of listeners.exit) notifyExit(7)
+
+    // then
+    expect(await exit).toBe(7)
+    expect(removed.map((child) => child.pid)).toEqual([4242])
+  })
+})
+
+describe("main entry re-entry guard", () => {
+  it("#given the active marker in the environment #when the script runs as a real subprocess #then it exits 1 without spawning a group", async () => {
+    // given
+    const script = new URL("./test-fast.ts", import.meta.url).pathname
+
+    // when — a real process, so a deleted guard would actually launch the groups
+    const child = Bun.spawn([process.execPath, "run", script], {
+      env: { ...process.env, [REENTRY_ENV_VAR]: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ])
+
+    // then
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain("re-entry blocked")
+    expect(stdout).not.toContain("running 3 groups")
   })
 })
 

--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -244,6 +244,8 @@ describe("partition tiling", () => {
 })
 
 describe("runTestFast", () => {
+  const capturingLogger = (lines: string[]) => (line: string) => void lines.push(line)
+
   it("#given three fixed test groups #when the runner starts #then every group is launched before any exit is released", async () => {
     // given
     const order: string[] = []
@@ -255,7 +257,7 @@ describe("runTestFast", () => {
     }
 
     // when
-    const exit = await runTestFast(spawnGroup)
+    const exit = await runTestFast(spawnGroup, capturingLogger([]))
 
     // then
     expect(testFastGroups().length).toBe(3)
@@ -271,9 +273,33 @@ describe("runTestFast", () => {
       group.name === "root-rest" ? 3 : 0
 
     // when
-    const exit = await runTestFast(spawnGroup)
+    const exit = await runTestFast(spawnGroup, capturingLogger([]))
 
     // then
     expect(exit).toBe(1)
+  })
+
+  it("#given an injected logger #when the runner starts #then the banner goes to the logger and never to stdout", async () => {
+    // given
+    const lines: string[] = []
+    const stdoutWrites: string[] = []
+    const originalWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdoutWrites.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+
+    // when
+    try {
+      await runTestFast(async () => 0, capturingLogger(lines))
+    } finally {
+      process.stdout.write = originalWrite
+    }
+
+    // then
+    expect(lines).toEqual([
+      "[test-fast] running 3 groups in parallel: opencode-memory, root-rest, senpi",
+    ])
+    expect(stdoutWrites.join("")).not.toContain("[test-fast]")
   })
 })

--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test"
+import { readFileSync } from "node:fs"
 import {
   childEnv,
   createChildRegistry,
@@ -180,6 +181,65 @@ describe("signalExitCode", () => {
     // given / when / then
     expect(signalExitCode("SIGINT")).toBe(130)
     expect(signalExitCode("SIGTERM")).toBe(143)
+  })
+})
+
+describe("partition tiling", () => {
+  const quotedPatterns = (config: string): readonly string[] =>
+    [...config.matchAll(/"([^"]+\/\*\*)"/g)].map((match) => match[1] ?? "")
+
+  const packageDir = (value: string): string | undefined =>
+    /^(packages\/[^/]+)/.exec(value)?.[1]
+
+  it("#given win2 hides what the sibling groups own #when the two configs are diffed #then the extra ignores tile the non-root-rest groups exactly", () => {
+    // given
+    const base = readFileSync(new URL("../bunfig.toml", import.meta.url), "utf8")
+    const win2 = readFileSync(new URL("../bunfig.win2.toml", import.meta.url), "utf8")
+    const basePatterns = new Set(quotedPatterns(base))
+
+    // when
+    const extraDirs = new Set(
+      quotedPatterns(win2)
+        .filter((pattern) => !basePatterns.has(pattern))
+        .map(packageDir)
+        .filter((dir): dir is string => dir !== undefined),
+    )
+    const groupDirs = new Set(
+      testFastGroups()
+        .filter((group) => group.name !== "root-rest")
+        .flatMap((group) => group.args.map(packageDir))
+        .filter((dir): dir is string => dir !== undefined),
+    )
+
+    // then — no gap (a package no group runs) and no overlap (a package two groups run)
+    expect([...extraDirs].sort()).toEqual([...groupDirs].sort())
+    expect(groupDirs.size).toBeGreaterThan(0)
+  })
+
+  it("#given every base ignore is unconditional #when win2 is read #then it keeps all of them", () => {
+    // given
+    const base = readFileSync(new URL("../bunfig.toml", import.meta.url), "utf8")
+    const win2 = readFileSync(new URL("../bunfig.win2.toml", import.meta.url), "utf8")
+
+    // when
+    const win2Patterns = quotedPatterns(win2)
+
+    // then
+    for (const pattern of quotedPatterns(base)) expect(win2Patterns).toContain(pattern)
+  })
+
+  it("#given each package is owned by one group #when the sibling groups are listed #then no package dir repeats", () => {
+    // given
+    const siblingArgs = testFastGroups()
+      .filter((group) => group.name !== "root-rest")
+      .flatMap((group) => group.args.map(packageDir))
+      .filter((dir): dir is string => dir !== undefined)
+
+    // when
+    const unique = new Set(siblingArgs)
+
+    // then
+    expect(unique.size).toBe(siblingArgs.length)
   })
 })
 

--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -224,32 +224,76 @@ describe("partition tiling", () => {
   const quotedPatterns = (config: string): readonly string[] =>
     [...config.matchAll(/"([^"]+\/\*\*)"/g)].map((match) => match[1] ?? "")
 
-  const packageDir = (value: string): string | undefined =>
-    /^(packages\/[^/]+)/.exec(value)?.[1]
+  /**
+   * Scopes are compared verbatim, never collapsed to their package dir: a win2
+   * ignore of `packages/x/src/**` while a group runs all of `packages/x` is a
+   * real overlap, and the reverse is a real coverage gap. Collapsing to
+   * `packages/x` reports both as a perfect tiling.
+   */
+  const ignoredScopes = (base: string, win2: string): readonly string[] => {
+    const basePatterns = new Set(quotedPatterns(base))
+    return quotedPatterns(win2).filter((pattern) => !basePatterns.has(pattern))
+  }
+
+  const groupScopes = (groups: readonly TestFastGroup[]): readonly string[] =>
+    groups
+      .filter((group) => group.name !== "root-rest")
+      .flatMap((group) => group.args)
+      .filter((arg) => arg.startsWith("packages/"))
+      .map((arg) => (arg.endsWith("/**") ? arg : `${arg}/**`))
+
+  const sorted = (values: readonly string[]): readonly string[] => [...values].sort()
 
   it("#given win2 hides what the sibling groups own #when the two configs are diffed #then the extra ignores tile the non-root-rest groups exactly", () => {
     // given
     const base = readFileSync(new URL("../bunfig.toml", import.meta.url), "utf8")
     const win2 = readFileSync(new URL("../bunfig.win2.toml", import.meta.url), "utf8")
-    const basePatterns = new Set(quotedPatterns(base))
 
     // when
-    const extraDirs = new Set(
-      quotedPatterns(win2)
-        .filter((pattern) => !basePatterns.has(pattern))
-        .map(packageDir)
-        .filter((dir): dir is string => dir !== undefined),
-    )
-    const groupDirs = new Set(
-      testFastGroups()
-        .filter((group) => group.name !== "root-rest")
-        .flatMap((group) => group.args.map(packageDir))
-        .filter((dir): dir is string => dir !== undefined),
+    const ignored = ignoredScopes(base, win2)
+    const owned = groupScopes(testFastGroups())
+
+    // then — the canonical tiling is whole packages on both sides, compared verbatim
+    expect(sorted(owned)).toEqual([
+      "packages/memory-core/**",
+      "packages/omo-opencode/**",
+      "packages/omo-senpi/**",
+    ])
+    expect(sorted(ignored)).toEqual(sorted(owned))
+  })
+
+  it("#given a win2 ignore narrowed below a package a group runs whole #when the tiling is checked #then the overlap outside that subtree is reported", () => {
+    // given — win2 hides only src/, so packages/omo-senpi/test/** runs in BOTH groups
+    const base = readFileSync(new URL("../bunfig.toml", import.meta.url), "utf8")
+    const win2 = readFileSync(new URL("../bunfig.win2.toml", import.meta.url), "utf8").replace(
+      '"packages/omo-senpi/**"',
+      '"packages/omo-senpi/src/**"',
     )
 
-    // then — no gap (a package no group runs) and no overlap (a package two groups run)
-    expect([...extraDirs].sort()).toEqual([...groupDirs].sort())
-    expect(groupDirs.size).toBeGreaterThan(0)
+    // when
+    const ignored = ignoredScopes(base, win2)
+
+    // then
+    expect(ignored).toContain("packages/omo-senpi/src/**")
+    expect(sorted(ignored)).not.toEqual(sorted(groupScopes(testFastGroups())))
+  })
+
+  it("#given a group argument narrowed below the package win2 hides whole #when the tiling is checked #then the uncovered subtree is reported", () => {
+    // given — the senpi group runs only src/, so packages/omo-senpi/test/** runs NOWHERE
+    const base = readFileSync(new URL("../bunfig.toml", import.meta.url), "utf8")
+    const win2 = readFileSync(new URL("../bunfig.win2.toml", import.meta.url), "utf8")
+    const narrowed = testFastGroups().map((group) =>
+      group.name === "senpi"
+        ? { ...group, args: ["test", "packages/omo-senpi/src"] }
+        : group,
+    )
+
+    // when
+    const owned = groupScopes(narrowed)
+
+    // then
+    expect(owned).toContain("packages/omo-senpi/src/**")
+    expect(sorted(owned)).not.toEqual(sorted(ignoredScopes(base, win2)))
   })
 
   it("#given every base ignore is unconditional #when win2 is read #then it keeps all of them", () => {
@@ -264,18 +308,15 @@ describe("partition tiling", () => {
     for (const pattern of quotedPatterns(base)) expect(win2Patterns).toContain(pattern)
   })
 
-  it("#given each package is owned by one group #when the sibling groups are listed #then no package dir repeats", () => {
+  it("#given each scope is owned by one group #when the sibling groups are listed #then no scope repeats", () => {
     // given
-    const siblingArgs = testFastGroups()
-      .filter((group) => group.name !== "root-rest")
-      .flatMap((group) => group.args.map(packageDir))
-      .filter((dir): dir is string => dir !== undefined)
+    const siblingScopes = groupScopes(testFastGroups())
 
     // when
-    const unique = new Set(siblingArgs)
+    const unique = new Set(siblingScopes)
 
     // then
-    expect(unique.size).toBe(siblingArgs.length)
+    expect(unique.size).toBe(siblingScopes.length)
   })
 })
 

--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "bun:test"
 import {
   childEnv,
+  createChildRegistry,
   isReentry,
+  type KillProcessGroup,
   REENTRY_ENV_VAR,
   runTestFast,
+  shutdownChildren,
+  signalExitCode,
   testFastGroups,
   type TestFastGroup,
 } from "./test-fast"
@@ -57,6 +61,125 @@ describe("childEnv", () => {
     expect(env.CI).toBe("true")
     expect(env[REENTRY_ENV_VAR]).toBe("1")
     expect(isReentry(env)).toBe(true)
+  })
+})
+
+describe("child registry", () => {
+  const fakeChild = (pid: number, selfKills: string[]) => ({
+    pid,
+    kill: (signal: NodeJS.Signals) => {
+      selfKills.push(`${pid}:${signal}`)
+      return true
+    },
+  })
+
+  it("#given two live POSIX children #when the registry kills all #then each process group receives the negated pid", () => {
+    // given
+    const registry = createChildRegistry("linux")
+    const groupKills: string[] = []
+    const selfKills: string[] = []
+    registry.add(fakeChild(101, selfKills))
+    registry.add(fakeChild(202, selfKills))
+
+    // when
+    registry.killAll("SIGINT", (pid, signal) => groupKills.push(`${pid}:${signal}`))
+
+    // then
+    expect(groupKills).toEqual(["-101:SIGINT", "-202:SIGINT"])
+    expect(selfKills).toEqual([])
+  })
+
+  it("#given win32 has no process groups #when the registry kills all #then it falls back to killing each child handle", () => {
+    // given
+    const registry = createChildRegistry("win32")
+    const groupKills: string[] = []
+    const selfKills: string[] = []
+    registry.add(fakeChild(101, selfKills))
+
+    // when
+    registry.killAll("SIGTERM", (pid, signal) => groupKills.push(`${pid}:${signal}`))
+
+    // then
+    expect(selfKills).toEqual(["101:SIGTERM"])
+    expect(groupKills).toEqual([])
+  })
+
+  it("#given a child that already exited #when the registry kills all #then the reaped child is not signalled", () => {
+    // given
+    const registry = createChildRegistry("linux")
+    const groupKills: number[] = []
+    const selfKills: string[] = []
+    const first = fakeChild(101, selfKills)
+    registry.add(first)
+    registry.add(fakeChild(202, selfKills))
+    registry.remove(first)
+
+    // when
+    registry.killAll("SIGTERM", (pid) => groupKills.push(pid))
+
+    // then
+    expect(groupKills).toEqual([-202])
+  })
+
+  it("#given a kill that throws ESRCH for a raced child #when the registry kills all #then the remaining children are still signalled", () => {
+    // given
+    const registry = createChildRegistry("linux")
+    const groupKills: number[] = []
+    const selfKills: string[] = []
+    registry.add(fakeChild(101, selfKills))
+    registry.add(fakeChild(202, selfKills))
+
+    // when
+    registry.killAll("SIGINT", (pid) => {
+      if (pid === -101) throw Object.assign(new Error("ESRCH"), { code: "ESRCH" })
+      groupKills.push(pid)
+    })
+
+    // then
+    expect(groupKills).toEqual([-202])
+  })
+})
+
+describe("shutdownChildren", () => {
+  it("#given children that exit during the grace period #when the parent shuts down #then no SIGKILL escalation happens", async () => {
+    // given
+    const registry = createChildRegistry("linux")
+    const sent: string[] = []
+    const child = { pid: 101, kill: () => true }
+    registry.add(child)
+    const kill: KillProcessGroup = (pid, signal) => void sent.push(`${pid}:${signal}`)
+
+    // when — the grace wait is where a real child's "exit" event lands
+    await shutdownChildren(registry, "SIGINT", kill, async () => registry.remove(child))
+
+    // then
+    expect(sent).toEqual(["-101:SIGINT"])
+  })
+
+  it("#given a child still alive after the grace period #when the parent shuts down #then it is SIGKILLed before the parent exits", async () => {
+    // given
+    const registry = createChildRegistry("linux")
+    const sent: string[] = []
+    registry.add({ pid: 101, kill: () => true })
+
+    // when
+    await shutdownChildren(
+      registry,
+      "SIGTERM",
+      (pid, signal) => sent.push(`${pid}:${signal}`),
+      async () => {},
+    )
+
+    // then
+    expect(sent).toEqual(["-101:SIGTERM", "-101:SIGKILL"])
+  })
+})
+
+describe("signalExitCode", () => {
+  it("#given a termination signal #when the exit code is derived #then it follows the 128+n convention", () => {
+    // given / when / then
+    expect(signalExitCode("SIGINT")).toBe(130)
+    expect(signalExitCode("SIGTERM")).toBe(143)
   })
 })
 

--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -1,5 +1,64 @@
 import { describe, expect, it } from "bun:test"
-import { runTestFast, testFastGroups, type TestFastGroup } from "./test-fast"
+import {
+  childEnv,
+  isReentry,
+  REENTRY_ENV_VAR,
+  runTestFast,
+  testFastGroups,
+  type TestFastGroup,
+} from "./test-fast"
+
+describe("isReentry", () => {
+  it("#given an env without the active marker #when the guard is asked #then it reports no re-entry", () => {
+    // given
+    const env = { PATH: "/usr/bin" }
+
+    // when
+    const reentry = isReentry(env)
+
+    // then
+    expect(reentry).toBe(false)
+  })
+
+  it("#given an env carrying the active marker #when the guard is asked #then it reports re-entry", () => {
+    // given
+    const env = { [REENTRY_ENV_VAR]: "1" }
+
+    // when
+    const reentry = isReentry(env)
+
+    // then
+    expect(REENTRY_ENV_VAR).toBe("OMO_TEST_FAST_ACTIVE")
+    expect(reentry).toBe(true)
+  })
+
+  it("#given the marker set to an empty string #when the guard is asked #then it reports no re-entry", () => {
+    // given
+    const env = { [REENTRY_ENV_VAR]: "" }
+
+    // when
+    const reentry = isReentry(env)
+
+    // then
+    expect(reentry).toBe(false)
+  })
+})
+
+describe("childEnv", () => {
+  it("#given a parent env #when a group child env is built #then the parent entries survive and the marker is added", () => {
+    // given
+    const parent = { PATH: "/usr/bin", CI: "true" }
+
+    // when
+    const env = childEnv(parent)
+
+    // then
+    expect(env.PATH).toBe("/usr/bin")
+    expect(env.CI).toBe("true")
+    expect(env[REENTRY_ENV_VAR]).toBe("1")
+    expect(isReentry(env)).toBe(true)
+  })
+})
 
 describe("runTestFast", () => {
   it("#given three fixed test groups #when the runner starts #then every group is launched before any exit is released", async () => {

--- a/script/test-fast.ts
+++ b/script/test-fast.ts
@@ -52,6 +52,9 @@ export interface ChildRegistry {
 const SIGNAL_NUMBERS = { SIGINT: 2, SIGTERM: 15 } as const
 export type TerminationSignal = keyof typeof SIGNAL_NUMBERS
 
+const isErrnoException = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error && typeof error.code === "string"
+
 export function signalExitCode(signal: TerminationSignal): number {
   return 128 + SIGNAL_NUMBERS[signal]
 }
@@ -99,7 +102,7 @@ export function createChildRegistry(platform: NodeJS.Platform): ChildRegistry {
           kill(-child.pid, signal)
         } catch (error) {
           // The child raced us to exit; nothing left to signal.
-          if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+          if (!isErrnoException(error) || error.code !== "ESRCH") throw error
         }
       }
     },

--- a/script/test-fast.ts
+++ b/script/test-fast.ts
@@ -31,22 +31,100 @@ export function testFastGroups(): TestFastGroup[] {
   ]
 }
 
-const spawnInheritingStdio: SpawnTestGroup = (group) =>
-  new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, group.args, {
-      stdio: "inherit",
-      env: childEnv(process.env),
-    })
-    child.once("error", reject)
-    child.once("exit", (code) => {
-      console.log(`[test-fast] ${group.name}: exit ${code ?? 1}`)
-      resolve(code ?? 1)
-    })
-  })
+/** Minimal view of a spawned child the registry needs; keeps fakes cheap in tests. */
+export interface ChildHandle {
+  readonly pid?: number | undefined
+  kill(signal: NodeJS.Signals): boolean
+}
 
-export async function runTestFast(
-  spawnGroup: SpawnTestGroup = spawnInheritingStdio,
-): Promise<number> {
+export type KillProcessGroup = (negatedPid: number, signal: NodeJS.Signals) => void
+
+export interface ChildRegistry {
+  add(child: ChildHandle): void
+  remove(child: ChildHandle): void
+  hasLiveChildren(): boolean
+  killAll(signal: NodeJS.Signals, kill: KillProcessGroup): void
+}
+
+const SIGNAL_NUMBERS = { SIGINT: 2, SIGTERM: 15 } as const
+export type TerminationSignal = keyof typeof SIGNAL_NUMBERS
+
+export function signalExitCode(signal: TerminationSignal): number {
+  return 128 + SIGNAL_NUMBERS[signal]
+}
+
+const SHUTDOWN_GRACE_MS = 5_000
+
+/**
+ * Forwards the parent's termination signal to every group, waits out a grace
+ * period, then SIGKILLs whatever is still running. Without the escalation a
+ * `bun test` child drains its own shutdown for seconds after the parent has
+ * already exited, which is exactly the orphan this guards against.
+ */
+export async function shutdownChildren(
+  registry: ChildRegistry,
+  signal: TerminationSignal,
+  kill: KillProcessGroup,
+  waitGrace: () => Promise<void> = () =>
+    new Promise((resolve) => void setTimeout(resolve, SHUTDOWN_GRACE_MS)),
+): Promise<void> {
+  registry.killAll(signal, kill)
+  await waitGrace()
+  if (registry.hasLiveChildren()) registry.killAll("SIGKILL", kill)
+}
+
+/**
+ * Tracks live group children so a parent signal takes the whole tree down with
+ * it. POSIX children are spawned detached, so signalling `-pid` reaches the
+ * bun process AND everything it spawned; win32 has no process groups, so the
+ * child handle kills itself.
+ */
+export function createChildRegistry(platform: NodeJS.Platform): ChildRegistry {
+  const live = new Set<ChildHandle>()
+  return {
+    add: (child) => void live.add(child),
+    remove: (child) => void live.delete(child),
+    hasLiveChildren: () => live.size > 0,
+    killAll: (signal, kill) => {
+      for (const child of live) {
+        if (child.pid === undefined) continue
+        if (platform === "win32") {
+          child.kill(signal)
+          continue
+        }
+        try {
+          kill(-child.pid, signal)
+        } catch (error) {
+          // The child raced us to exit; nothing left to signal.
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error
+        }
+      }
+    },
+  }
+}
+
+function spawnInheritingStdio(registry: ChildRegistry): SpawnTestGroup {
+  return (group) =>
+    new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, group.args, {
+        stdio: "inherit",
+        env: childEnv(process.env),
+        detached: process.platform !== "win32",
+      })
+      registry.add(child)
+      child.once("error", (error) => {
+        registry.remove(child)
+        reject(error)
+      })
+      child.once("exit", (code) => {
+        registry.remove(child)
+        console.log(`[test-fast] ${group.name}: exit ${code ?? 1}`)
+        resolve(code ?? 1)
+      })
+    })
+}
+
+export async function runTestFast(spawnGroup: SpawnTestGroup): Promise<number> {
   const groups = testFastGroups()
   console.log(
     `[test-fast] running ${groups.length} groups in parallel: ${groups
@@ -64,5 +142,14 @@ if (import.meta.main) {
     )
     process.exit(1)
   }
-  process.exitCode = await runTestFast()
+  const registry = createChildRegistry(process.platform)
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      console.error(`[test-fast] ${signal} received: terminating group children`)
+      void shutdownChildren(registry, signal, (pid, forwarded) =>
+        void process.kill(pid, forwarded),
+      ).then(() => process.exit(signalExitCode(signal)))
+    })
+  }
+  process.exitCode = await runTestFast(spawnInheritingStdio(registry))
 }

--- a/script/test-fast.ts
+++ b/script/test-fast.ts
@@ -7,6 +7,19 @@ export interface TestFastGroup {
 
 export type SpawnTestGroup = (group: TestFastGroup) => Promise<number>
 
+/** Marker exported to every spawned group so a nested run refuses to recurse. */
+export const REENTRY_ENV_VAR = "OMO_TEST_FAST_ACTIVE"
+
+export function isReentry(env: Readonly<Record<string, string | undefined>>): boolean {
+  return (env[REENTRY_ENV_VAR] ?? "") !== ""
+}
+
+export function childEnv(
+  parent: Readonly<Record<string, string | undefined>>,
+): Record<string, string | undefined> {
+  return { ...parent, [REENTRY_ENV_VAR]: "1" }
+}
+
 export function testFastGroups(): TestFastGroup[] {
   return [
     {
@@ -20,7 +33,10 @@ export function testFastGroups(): TestFastGroup[] {
 
 const spawnInheritingStdio: SpawnTestGroup = (group) =>
   new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, group.args, { stdio: "inherit" })
+    const child = spawn(process.execPath, group.args, {
+      stdio: "inherit",
+      env: childEnv(process.env),
+    })
     child.once("error", reject)
     child.once("exit", (code) => {
       console.log(`[test-fast] ${group.name}: exit ${code ?? 1}`)
@@ -42,5 +58,11 @@ export async function runTestFast(
 }
 
 if (import.meta.main) {
+  if (isReentry(process.env)) {
+    console.error(
+      `[test-fast] re-entry blocked: ${REENTRY_ENV_VAR} is set; refusing to recurse`,
+    )
+    process.exit(1)
+  }
   process.exitCode = await runTestFast()
 }

--- a/script/test-fast.ts
+++ b/script/test-fast.ts
@@ -45,7 +45,7 @@ export type KillProcessGroup = (negatedPid: number, signal: NodeJS.Signals) => v
 export interface ChildRegistry {
   add(child: ChildHandle): void
   remove(child: ChildHandle): void
-  hasLiveChildren(): boolean
+  hasSignalTargets(): boolean
   killAll(signal: NodeJS.Signals, kill: KillProcessGroup): void
 }
 
@@ -63,9 +63,10 @@ const SHUTDOWN_GRACE_MS = 5_000
 
 /**
  * Forwards the parent's termination signal to every group, waits out a grace
- * period, then SIGKILLs whatever is still running. Without the escalation a
- * `bun test` child drains its own shutdown for seconds after the parent has
- * already exited, which is exactly the orphan this guards against.
+ * period, then SIGKILLs whatever is still running. Escalation keys off the
+ * registry's retained signal targets, not leader liveness: a POSIX group leader
+ * routinely exits while a descendant that swallowed SIGTERM keeps draining, and
+ * that descendant is exactly the orphan this guards against.
  */
 export async function shutdownChildren(
   registry: ChildRegistry,
@@ -76,32 +77,38 @@ export async function shutdownChildren(
 ): Promise<void> {
   registry.killAll(signal, kill)
   await waitGrace()
-  if (registry.hasLiveChildren()) registry.killAll("SIGKILL", kill)
+  if (registry.hasSignalTargets()) registry.killAll("SIGKILL", kill)
 }
 
 /**
- * Tracks live group children so a parent signal takes the whole tree down with
- * it. POSIX children are spawned detached, so signalling `-pid` reaches the
- * bun process AND everything it spawned; win32 has no process groups, so the
- * child handle kills itself.
+ * Tracks group children so a parent signal takes the whole tree down with it.
+ * POSIX children are spawned detached, so signalling `-pid` reaches the bun
+ * process AND everything it spawned. The PGID is retained past the leader's
+ * exit because the group outlives its leader; dropping it there is what lets a
+ * SIGTERM-ignoring descendant escape the SIGKILL escalation. win32 has no
+ * process groups, so only the live handle can kill itself.
  */
 export function createChildRegistry(platform: NodeJS.Platform): ChildRegistry {
   const live = new Set<ChildHandle>()
+  const retainedGroups = new Set<number>()
+  const isPosix = platform !== "win32"
   return {
-    add: (child) => void live.add(child),
+    add: (child) => {
+      live.add(child)
+      if (isPosix && child.pid !== undefined) retainedGroups.add(child.pid)
+    },
     remove: (child) => void live.delete(child),
-    hasLiveChildren: () => live.size > 0,
+    hasSignalTargets: () => (isPosix ? retainedGroups.size > 0 : live.size > 0),
     killAll: (signal, kill) => {
-      for (const child of live) {
-        if (child.pid === undefined) continue
-        if (platform === "win32") {
-          child.kill(signal)
-          continue
-        }
+      if (!isPosix) {
+        for (const child of live) if (child.pid !== undefined) child.kill(signal)
+        return
+      }
+      for (const pid of retainedGroups) {
         try {
-          kill(-child.pid, signal)
+          kill(-pid, signal)
         } catch (error) {
-          // The child raced us to exit; nothing left to signal.
+          // The group raced us to exit; nothing left to signal.
           if (!isErrnoException(error) || error.code !== "ESRCH") throw error
         }
       }

--- a/script/test-fast.ts
+++ b/script/test-fast.ts
@@ -174,9 +174,16 @@ export function spawnInheritingStdio(
     })
 }
 
+/**
+ * Runs every group in parallel. A rejected group (a failed spawn) aborts the
+ * `Promise.all` while its detached siblings are still running, so the failure
+ * path shuts the survivors down before the error propagates and the parent
+ * exits; otherwise those siblings outlive the run as orphans.
+ */
 export async function runTestFast(
   spawnGroup: SpawnTestGroup,
   log: LogLine = console.log,
+  shutdownSurvivors: () => void | Promise<void> = () => {},
 ): Promise<number> {
   const groups = testFastGroups()
   log(
@@ -184,8 +191,13 @@ export async function runTestFast(
       .map((group) => group.name)
       .join(", ")}`,
   )
-  const exits = await Promise.all(groups.map(spawnGroup))
-  return exits.every((exit) => exit === 0) ? 0 : 1
+  try {
+    const exits = await Promise.all(groups.map(spawnGroup))
+    return exits.every((exit) => exit === 0) ? 0 : 1
+  } catch (error) {
+    await shutdownSurvivors()
+    throw error
+  }
 }
 
 if (import.meta.main) {
@@ -196,13 +208,21 @@ if (import.meta.main) {
     process.exit(1)
   }
   const registry = createChildRegistry(process.platform)
+  const killGroup: KillProcessGroup = (pid, forwarded) => void process.kill(pid, forwarded)
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     process.once(signal, () => {
       console.error(`[test-fast] ${signal} received: terminating group children`)
-      void shutdownChildren(registry, signal, (pid, forwarded) =>
-        void process.kill(pid, forwarded),
-      ).then(() => process.exit(signalExitCode(signal)))
+      void shutdownChildren(registry, signal, killGroup).then(() =>
+        process.exit(signalExitCode(signal)),
+      )
     })
   }
-  process.exitCode = await runTestFast(spawnInheritingStdio(registry, console.log))
+  process.exitCode = await runTestFast(
+    spawnInheritingStdio(registry, console.log),
+    console.log,
+    () => {
+      console.error("[test-fast] group failed to start: terminating surviving groups")
+      return shutdownChildren(registry, "SIGTERM", killGroup)
+    },
+  )
 }

--- a/script/test-fast.ts
+++ b/script/test-fast.ts
@@ -7,6 +7,9 @@ export interface TestFastGroup {
 
 export type SpawnTestGroup = (group: TestFastGroup) => Promise<number>
 
+/** Injected so unit tests capture progress lines instead of printing production output. */
+export type LogLine = (line: string) => void
+
 /** Marker exported to every spawned group so a nested run refuses to recurse. */
 export const REENTRY_ENV_VAR = "OMO_TEST_FAST_ACTIVE"
 
@@ -103,7 +106,7 @@ export function createChildRegistry(platform: NodeJS.Platform): ChildRegistry {
   }
 }
 
-function spawnInheritingStdio(registry: ChildRegistry): SpawnTestGroup {
+function spawnInheritingStdio(registry: ChildRegistry, log: LogLine): SpawnTestGroup {
   return (group) =>
     new Promise((resolve, reject) => {
       const child = spawn(process.execPath, group.args, {
@@ -118,15 +121,18 @@ function spawnInheritingStdio(registry: ChildRegistry): SpawnTestGroup {
       })
       child.once("exit", (code) => {
         registry.remove(child)
-        console.log(`[test-fast] ${group.name}: exit ${code ?? 1}`)
+        log(`[test-fast] ${group.name}: exit ${code ?? 1}`)
         resolve(code ?? 1)
       })
     })
 }
 
-export async function runTestFast(spawnGroup: SpawnTestGroup): Promise<number> {
+export async function runTestFast(
+  spawnGroup: SpawnTestGroup,
+  log: LogLine = console.log,
+): Promise<number> {
   const groups = testFastGroups()
-  console.log(
+  log(
     `[test-fast] running ${groups.length} groups in parallel: ${groups
       .map((group) => group.name)
       .join(", ")}`,
@@ -151,5 +157,5 @@ if (import.meta.main) {
       ).then(() => process.exit(signalExitCode(signal)))
     })
   }
-  process.exitCode = await runTestFast(spawnInheritingStdio(registry))
+  process.exitCode = await runTestFast(spawnInheritingStdio(registry, console.log))
 }

--- a/script/test-fast.ts
+++ b/script/test-fast.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process"
+import { spawn, type SpawnOptions } from "node:child_process"
 
 export interface TestFastGroup {
   readonly name: string
@@ -116,10 +116,47 @@ export function createChildRegistry(platform: NodeJS.Platform): ChildRegistry {
   }
 }
 
-function spawnInheritingStdio(registry: ChildRegistry, log: LogLine): SpawnTestGroup {
+/** The spawn contract this script depends on; the seam unit tests substitute. */
+export type SpawnGroupOptions = SpawnOptions
+
+/** The two lifecycle events this script subscribes to, with their payloads. */
+export interface ChildLifecycleEvents {
+  readonly error: Error
+  readonly exit: number | null
+}
+
+export interface SpawnedChild extends ChildHandle {
+  once<E extends keyof ChildLifecycleEvents>(
+    event: E,
+    listener: (payload: ChildLifecycleEvents[E]) => void,
+  ): unknown
+}
+
+export type SpawnChildProcess = (
+  command: string,
+  args: readonly string[],
+  options: SpawnGroupOptions,
+) => SpawnedChild
+
+/** Selects node's three-argument overload; the bare `spawn` symbol carries a
+ * two-argument overload that is not assignable to the seam. */
+const spawnChildProcess: SpawnChildProcess = (command, args, options) =>
+  spawn(command, args, options)
+
+/**
+ * Every group child inherits the parent's stdio, carries the re-entry marker so
+ * a nested run refuses to recurse, and is detached on POSIX so the registry can
+ * signal its whole process group. All three are load-bearing, so the spawn call
+ * is injectable and asserted rather than trusted.
+ */
+export function spawnInheritingStdio(
+  registry: ChildRegistry,
+  log: LogLine,
+  spawnChild: SpawnChildProcess = spawnChildProcess,
+): SpawnTestGroup {
   return (group) =>
     new Promise((resolve, reject) => {
-      const child = spawn(process.execPath, group.args, {
+      const child = spawnChild(process.execPath, group.args, {
         stdio: "inherit",
         env: childEnv(process.env),
         detached: process.platform !== "win32",


### PR DESCRIPTION
## Problem

A 2026-08-30 sandbox run of `bun run test:fast` surfaced three structural defects in the parallel local runner:

1. **No re-entry guard.** Nothing structurally prevents a nested `test:fast` from recursing: the `root-rest` group runs the root suite (which includes `script/test-fast.test.ts`), and the unit test's production-identical banner made the run look like real recursion — an operator misdiagnosed it as an infinite loop.
2. **Orphaned children.** Group children were spawned with no signal forwarding; killing the parent (CI timeout, Ctrl-C, sandbox TTL) left `bun test` processes running — 6 zombies observed.
3. **Unpinned partition.** `testFastGroups()` and `bunfig.win2.toml`'s extra ignores could drift silently, double-running or silently skipping packages.

## Fix (TDD, each behavior RED->GREEN)

- Spawned children get `OMO_TEST_FAST_ACTIVE=1`; the `import.meta.main` entry refuses to run when it is already set (explicit message, exit 1).
- POSIX children spawn `detached` into their own process groups; SIGINT/SIGTERM kill every live child's group (`kill(-pid)`), exit `128+signal`; win32 falls back to `child.kill()`.
- New tiling contract test: win2's extra `pathIgnorePatterns` over `bunfig.toml` must exactly equal the non-root groups' package scopes (no gap, no overlap; drift fails the suite).
- `runTestFast` takes an injectable logger; unit tests capture the banner instead of emitting production-shaped output.

## Evidence

- `OMO_TEST_FAST_ACTIVE=1 bun run script/test-fast.ts` -> exit 1, `[test-fast] re-entry blocked`, zero children.
- SIGTERM mid-run: parent exit 143, scoped pgrep survivors `[]`.
- Mutation proof: dropping `packages/memory-core/**` from win2 -> tiling test fails; restore -> 17/17 green.
- `script/ci-root-test-partition.test.ts` + `script/root-test-config.test.ts`: 14/14 green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three structural defects in the `test:fast` runner: nested runs could recurse, orphaned children survived a killed parent, and the package partition could drift silently.

- Spawned children carry `OMO_TEST_FAST_ACTIVE=1`; a re-entered entry exits 1, and the spawn wiring (marker, detached flag, inherited stdio) is pinned by tests.
- POSIX children run detached in their own process groups; SIGINT/SIGTERM signal each group (PGID retained past leader exit) and SIGKILL whatever ignores the signal after the grace period. win32 falls back to killing child handles, and a failed spawn shuts down surviving groups before the error propagates.
- A tiling test compares `bunfig.win2.toml`'s extra ignores against canonical full-package globs verbatim, so subtree overlaps and coverage gaps both fail the suite.
- `runTestFast` logs through an injectable logger so unit tests capture the banner instead of emitting it.

<sup>Written for commit 35784893fae74ffd0d1a3c8c55b26bb107238a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

