### PR TITLE
fix(omo-native): register bundled cursor OAuth flows

### DIFF
--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -21,6 +21,11 @@ import { runDoctor } from "./bin/lib/doctor.js"
 import { detectHarnesses, needsSetupSuggestion } from "./bin/lib/setup-detect.js"
 import { printSetupReport } from "./bin/lib/setup-report.js"
 import { delimiter } from "node:path"
+import { registerBunOAuthFlows } from "../../node_modules/@code-yeongyu/senpi/node_modules/@earendil-works/pi-ai/dist/bun-oauth.js"
+
+// Register statically bundled OAuth flows before loading senpi's CLI graph.
+// Bun's compiled filesystem cannot resolve the opaque dynamic cursor loader.
+registerBunOAuthFlows()
 
 // The engine is imported via a RELATIVE string LITERAL, inlined at both import
 // sites, and both properties are load-bearing:


### PR DESCRIPTION
## Summary

Register senpi's statically bundled OAuth loaders at the omo compiled-binary entry before either senpi CLI import. This makes Cursor OAuth derivation use `bundledLoaders.cursor()` instead of Bunfs-unresolvable dynamic import `./cursor.js`.

## Evidence (mengmotaMac)

All build/test commands below ran remotely on mengmotaMac via bunshin.

### Failing-first / fixed source proof

Before patch, from fresh `origin/dev` (354a66883):

```
origin/dev compile-entry lacks static bun-oauth registration
```

After patch:

```
24:import { registerBunOAuthFlows } from "../../node_modules/@code-yeongyu/senpi/node_modules/@earendil-works/pi-ai/dist/bun-oauth.js"
28:registerBunOAuthFlows()
182:    await import("../../node_modules/@code-yeongyu/senpi/dist/cli.js")
210:  await import("../../node_modules/@code-yeongyu/senpi/dist/cli.js")
```

The registration call is module-level and precedes both CLI imports.

### Compiled binary probe

```
built darwin-arm64: /tmp/omo-cursor-oauth-20260830/build/omo-darwin-arm64 (114453746 bytes, 1164 embedded sidecar files)
```

The binary was compiled on darwin-arm64 with Bun 1.4.0 from the fixed entry graph.

### Focused gates

```
25 pass
0 fail
Ran 25 tests across 1 file.

# bunx tsc -p packages/omo-native/tsconfig.json --noEmit
# exit 0
```

### Cleanup

```
removed=/tmp/omo-cursor-oauth-20260830
verified=absent
```

The worktree was rebased onto updated `origin/dev` 354a66883 before implementation/push; no senpi files were modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the compiled `omo-native` binary's Cursor OAuth flow by registering statically bundled OAuth loaders before the senpi CLI imports, so Cursor OAuth uses `bundledLoaders.cursor()` instead of a dynamic import that fails under Bun's compiled filesystem.

<sup>Written for commit 59f56836a05fc825f0f03dc245de3785d59204eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

