### PR TITLE
fix(librarian): update legacy context7 tool name and remove orphaned table syntax

### DIFF
--- a/packages/omo-opencode/src/agents/librarian.ts
+++ b/packages/omo-opencode/src/agents/librarian.ts
@@ -154,7 +154,7 @@ Step 4: Construct permalink
 Tool 1: gh repo clone owner/repo \${TMPDIR:-/tmp}/repo -- --depth 1
 Tool 2: grep_app_searchGitHub(query: "function_name", repo: "owner/repo")
 Tool 3: gh api repos/owner/repo/commits/HEAD --jq '.sha'
-Tool 4: context7_get-library-docs(id, topic: "relevant-api")
+Tool 4: context7_query-docs(libraryId: id, query: "relevant-api")
 \`\`\`
 
 ---
@@ -275,7 +275,6 @@ Use OS-appropriate temp directory:
 - **TYPE B (Implementation)**: Suggested Calls 2-3 - Doc Discovery Required NO
 - **TYPE C (Context)**: Suggested Calls 2-3 - Doc Discovery Required NO
 - **TYPE D (Comprehensive)**: Suggested Calls 3-5 - Doc Discovery Required YES (Phase 0.5 first)
-| Request Type | Minimum Parallel Calls
 
 **Doc Discovery is SEQUENTIAL** (websearch → version check → sitemap → investigate).
 **Main phase is PARALLEL** once you know where to look.

--- a/packages/omo-opencode/src/hooks/agent-usage-reminder/constants.ts
+++ b/packages/omo-opencode/src/hooks/agent-usage-reminder/constants.ts
@@ -15,7 +15,6 @@ export const TARGET_TOOLS = new Set([
   "context7_resolve-library-id",
   "context7_query-docs",
   "websearch_web_search_exa",
-  "context7_get-library-docs",
   "grep_app_searchgithub",
 ]);
 


### PR DESCRIPTION
## Summary

- Fixes outdated `context7_get-library-docs` reference in `librarian.ts` and `agent-usage-reminder/constants.ts` by updating to the official Context7 MCP tool `context7_query-docs`.
- Cleans up an orphaned table header line (`| Request Type | Minimum Parallel Calls`) left dangling after the parallel execution requirements list in `librarian.ts`.

## Changes

### Librarian Agent (`packages/omo-opencode/src/agents/librarian.ts`)
- Replaces `context7_get-library-docs(id, topic: "relevant-api")` with `context7_query-docs(libraryId: id, query: "relevant-api")` in Type B parallel acceleration examples.
- Removes orphaned markdown table header `| Request Type | Minimum Parallel Calls` left after bullet points.

### Agent Usage Reminder Hook (`packages/omo-opencode/src/hooks/agent-usage-reminder/constants.ts`)
- Removes legacy `"context7_get-library-docs"` entry from `TARGET_TOOLS` set.

## QA & Evidence

- **What was tested:** Verified Context7 MCP tool exports and prompt references.
  **Observed result:** Context7 server exports `resolve-library-id` and `query-docs`; all references now match the active tool schema.
  **Why sufficient:** Eliminates potential "tool not found" runtime failures when the Librarian agent attempts to query Context7 documentation during Type B searches.

## Risks & Residuals

- None. Strictly a prompt/constants fix aligning tool names with the Context7 MCP server specification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Librarian agent's Context7 tool reference so doc discovery matches the active MCP server schema, preventing "tool not found" runtime failures.

- Replaces `context7_get-library-docs(id, topic: ...)` with `context7_query-docs(libraryId: id, query: ...)` in `librarian.ts`.
- Removes the legacy `context7_get-library-docs` entry from `TARGET_TOOLS` in `agent-usage-reminder/constants.ts`.
- Deletes an orphaned markdown table header from `librarian.ts`.

<sup>Written for commit f9840d4ba1180e53dcdc59563cd23e285d706c8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

