### PR TITLE
feat: report OpenAI Codex plan and quota usage

### DIFF
--- a/packages/omo-codex/src/index.ts
+++ b/packages/omo-codex/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./telemetry"
 export * from "./install"
+export * from "./usage"

--- a/packages/omo-codex/src/usage/codex-usage-client.test.ts
+++ b/packages/omo-codex/src/usage/codex-usage-client.test.ts
@@ -1,0 +1,133 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import {
+  fetchCodexUsage,
+  type CodexUsageProtocolMessage,
+  type CodexUsageTransport,
+} from "./codex-usage-client"
+
+class FakeTransport implements CodexUsageTransport {
+  readonly sent: CodexUsageProtocolMessage[] = []
+  closed = false
+  private messageListener: ((message: CodexUsageProtocolMessage) => void) | undefined
+  private errorListener: ((error: Error) => void) | undefined
+  private exitListener: ((code: number | null) => void) | undefined
+
+  constructor(
+    private readonly respond: (message: CodexUsageProtocolMessage) => readonly CodexUsageProtocolMessage[],
+  ) {}
+
+  send(message: CodexUsageProtocolMessage): void {
+    this.sent.push(message)
+    for (const response of this.respond(message)) {
+      queueMicrotask(() => this.messageListener?.(response))
+    }
+  }
+
+  onMessage(listener: (message: CodexUsageProtocolMessage) => void): void {
+    this.messageListener = listener
+  }
+
+  onError(listener: (error: Error) => void): void {
+    this.errorListener = listener
+  }
+
+  onExit(listener: (code: number | null) => void): void {
+    this.exitListener = listener
+  }
+
+  close(): void {
+    this.closed = true
+  }
+
+  emitError(error: Error): void {
+    this.errorListener?.(error)
+  }
+
+  emitExit(code: number | null): void {
+    this.exitListener?.(code)
+  }
+}
+
+function successfulResponse(message: CodexUsageProtocolMessage): readonly CodexUsageProtocolMessage[] {
+  if (message.method === "initialize") {
+    return [{ id: message.id, result: { userAgent: "codex-cli" } }]
+  }
+  if (message.method === "account/read") {
+    return [{ id: message.id, result: { account: { type: "chatgpt" } } }]
+  }
+  if (message.method === "account/rateLimits/read") {
+    return [
+      {
+        id: message.id,
+        result: {
+          rateLimits: {
+            limitId: "codex",
+            primary: {
+              usedPercent: 8,
+              windowDurationMins: 10080,
+              resetsAt: 1788663080,
+            },
+            secondary: null,
+            credits: {
+              hasCredits: false,
+              unlimited: false,
+              balance: "0",
+            },
+            planType: "pro",
+            rateLimitReachedType: null,
+          },
+          rateLimitResetCredits: {
+            availableCount: 1,
+          },
+        },
+      },
+    ]
+  }
+  return []
+}
+
+describe("Codex usage app-server client", () => {
+  test("#given a responding transport #when usage is fetched #then performs the handshake and closes after both reads", async () => {
+    // given
+    const transport = new FakeTransport(successfulResponse)
+
+    // when
+    const report = await fetchCodexUsage({
+      createTransport: () => transport,
+      now: () => new Date("2026-08-30T16:00:00.000Z"),
+    })
+
+    // then
+    expect(transport.sent.map((message) => message.method)).toEqual([
+      "initialize",
+      "initialized",
+      "account/read",
+      "account/rateLimits/read",
+    ])
+    expect(report.planType).toBe("pro")
+    expect(report.limits[0]?.primary?.remainingPercent).toBe(92)
+    expect(transport.closed).toBe(true)
+  })
+
+  test("#given a rate-limit request error #when usage is fetched #then returns an actionable failure and closes", async () => {
+    // given
+    const transport = new FakeTransport((message) => {
+      if (message.method === "account/rateLimits/read") {
+        return [{ id: message.id, error: { code: -32000, message: "not logged in" } }]
+      }
+      return successfulResponse(message)
+    })
+
+    // when
+    const fetch = fetchCodexUsage({
+      createTransport: () => transport,
+      now: () => new Date("2026-08-30T16:00:00.000Z"),
+    })
+
+    // then
+    await expect(fetch).rejects.toThrow("Codex usage request failed: not logged in")
+    expect(transport.closed).toBe(true)
+  })
+})

--- a/packages/omo-codex/src/usage/codex-usage-client.ts
+++ b/packages/omo-codex/src/usage/codex-usage-client.ts
@@ -1,0 +1,136 @@
+import {
+  createCodexUsageTransport,
+  type CodexUsageProtocolMessage,
+  type CodexUsageTransport,
+} from "./codex-usage-transport"
+import { parseCodexUsageResponses } from "./parse-codex-usage"
+import type { CodexUsageReport } from "./types"
+
+export { createCodexUsageTransport }
+export type { CodexUsageProtocolMessage, CodexUsageTransport }
+
+export type FetchCodexUsageOptions = {
+  readonly createTransport?: () => CodexUsageTransport
+  readonly now?: () => Date
+  readonly timeoutMs?: number
+}
+
+const INITIALIZE_ID = 1
+const ACCOUNT_READ_ID = 2
+const RATE_LIMITS_READ_ID = 3
+const DEFAULT_TIMEOUT_MS = 10_000
+
+export function fetchCodexUsage(options: FetchCodexUsageOptions = {}): Promise<CodexUsageReport> {
+  const createTransport = options.createTransport ?? createCodexUsageTransport
+  const now = options.now ?? (() => new Date())
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  return new Promise((resolve, reject) => {
+    const transport = createTransport()
+    let settled = false
+    let initialized = false
+    let accountResponse: unknown
+    let rateLimitsResponse: unknown
+
+    const timer = setTimeout(() => {
+      fail(new Error(`Codex usage request timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    function finish(report: CodexUsageReport): void {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      transport.close()
+      resolve(report)
+    }
+
+    function fail(error: Error): void {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      transport.close()
+      reject(error)
+    }
+
+    function tryFinish(): void {
+      if (accountResponse === undefined || rateLimitsResponse === undefined) return
+      try {
+        finish(parseCodexUsageResponses(accountResponse, rateLimitsResponse, now()))
+      } catch (error) {
+        fail(toError(error))
+      }
+    }
+
+    transport.onMessage((message) => {
+      if (message.id === INITIALIZE_ID) {
+        if (message.error !== undefined) {
+          fail(protocolError("Codex app-server initialization failed", message.error))
+          return
+        }
+        if (initialized) return
+        initialized = true
+        transport.send({ method: "initialized" })
+        transport.send({
+          id: ACCOUNT_READ_ID,
+          method: "account/read",
+          params: { refreshToken: false },
+        })
+        transport.send({
+          id: RATE_LIMITS_READ_ID,
+          method: "account/rateLimits/read",
+          params: {},
+        })
+        return
+      }
+
+      if (message.id === ACCOUNT_READ_ID) {
+        if (message.error !== undefined) {
+          fail(protocolError("Codex account request failed", message.error))
+          return
+        }
+        accountResponse = message.result
+        tryFinish()
+        return
+      }
+
+      if (message.id === RATE_LIMITS_READ_ID) {
+        if (message.error !== undefined) {
+          fail(protocolError("Codex usage request failed", message.error))
+          return
+        }
+        rateLimitsResponse = message.result
+        tryFinish()
+      }
+    })
+    transport.onError((error) => {
+      const message =
+        "code" in error && error.code === "ENOENT"
+          ? "Codex CLI was not found. Install Codex or add it to PATH."
+          : `Codex app-server failed: ${error.message}`
+      fail(new Error(message))
+    })
+    transport.onExit((code) => {
+      fail(new Error(`Codex app-server exited before returning usage${code === null ? "" : ` (code ${code})`}`))
+    })
+
+    transport.send({
+      id: INITIALIZE_ID,
+      method: "initialize",
+      params: {
+        clientInfo: {
+          name: "oh-my-openagent",
+          title: "oh-my-openagent",
+          version: "1.0.0",
+        },
+      },
+    })
+  })
+}
+
+function protocolError(prefix: string, error: { readonly message: string }): Error {
+  return new Error(`${prefix}: ${error.message}`)
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/packages/omo-codex/src/usage/codex-usage-transport.ts
+++ b/packages/omo-codex/src/usage/codex-usage-transport.ts
@@ -1,0 +1,80 @@
+import { spawn } from "node:child_process"
+
+export type CodexUsageProtocolMessage = {
+  readonly id?: number
+  readonly method?: string
+  readonly params?: unknown
+  readonly result?: unknown
+  readonly error?: {
+    readonly code?: number
+    readonly message: string
+  }
+}
+
+export type CodexUsageTransport = {
+  send(message: CodexUsageProtocolMessage): void
+  onMessage(listener: (message: CodexUsageProtocolMessage) => void): void
+  onError(listener: (error: Error) => void): void
+  onExit(listener: (code: number | null) => void): void
+  close(): void
+}
+
+export function createCodexUsageTransport(): CodexUsageTransport {
+  const child = spawn("codex", ["app-server", "--stdio"], {
+    env: process.env,
+    stdio: ["pipe", "pipe", "pipe"],
+  })
+  let buffer = ""
+  let messageListener: ((message: CodexUsageProtocolMessage) => void) | undefined
+  let errorListener: ((error: Error) => void) | undefined
+  let exitListener: ((code: number | null) => void) | undefined
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    buffer += chunk.toString("utf8")
+    while (true) {
+      const newline = buffer.indexOf("\n")
+      if (newline < 0) return
+      const line = buffer.slice(0, newline).trim()
+      buffer = buffer.slice(newline + 1)
+      if (line.length === 0) continue
+      try {
+        messageListener?.(parseProtocolMessage(line))
+      } catch (error) {
+        errorListener?.(toError(error))
+      }
+    }
+  })
+  child.on("error", (error) => errorListener?.(error))
+  child.on("exit", (code) => exitListener?.(code))
+
+  return {
+    send(message) {
+      child.stdin.write(`${JSON.stringify(message)}\n`)
+    },
+    onMessage(listener) {
+      messageListener = listener
+    },
+    onError(listener) {
+      errorListener = listener
+    },
+    onExit(listener) {
+      exitListener = listener
+    },
+    close() {
+      child.stdin.end()
+      child.kill()
+    },
+  }
+}
+
+function parseProtocolMessage(line: string): CodexUsageProtocolMessage {
+  const value: unknown = JSON.parse(line)
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Codex app-server returned a malformed protocol message")
+  }
+  return Object.fromEntries(Object.entries(value))
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}

--- a/packages/omo-codex/src/usage/format-codex-usage.test.ts
+++ b/packages/omo-codex/src/usage/format-codex-usage.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { formatCodexUsage, formatCodexUsageJson } from "./format-codex-usage"
+import type { CodexUsageReport } from "./types"
+
+const report: CodexUsageReport = {
+  fetchedAt: "2026-08-30T16:00:00.000Z",
+  authType: "chatgpt",
+  planType: "pro",
+  limits: [
+    {
+      id: "codex",
+      label: "Codex",
+      planType: "pro",
+      primary: {
+        usedPercent: 8,
+        remainingPercent: 92,
+        windowDurationMins: 10080,
+        resetsAt: "2026-09-06T02:51:20.000Z",
+      },
+      secondary: null,
+      credits: {
+        hasCredits: false,
+        unlimited: false,
+        balance: "0",
+      },
+      rateLimitReachedType: null,
+    },
+    {
+      id: "codex_bengalfox",
+      label: "Spark",
+      planType: "pro",
+      primary: {
+        usedPercent: 0,
+        remainingPercent: 100,
+        windowDurationMins: 300,
+        resetsAt: "2026-08-30T17:40:46.000Z",
+      },
+      secondary: {
+        usedPercent: 0,
+        remainingPercent: 100,
+        windowDurationMins: 10080,
+        resetsAt: "2026-09-06T12:40:46.000Z",
+      },
+      credits: null,
+      rateLimitReachedType: null,
+    },
+  ],
+  resetCredits: {
+    availableCount: 1,
+  },
+}
+
+describe("Codex usage formatting", () => {
+  test("#given a normalized report #when formatted for humans #then shows plan meters resets credits and availability", () => {
+    // when
+    const output = formatCodexUsage(report)
+
+    // then
+    expect(output).toBe([
+      "OpenAI Codex Usage",
+      "Plan: Pro",
+      "Authentication: ChatGPT",
+      "",
+      "Codex",
+      "  7 days: 8% used, 92% remaining",
+      "  Resets: 2026-09-06T02:51:20.000Z",
+      "  Credits: none",
+      "",
+      "Spark",
+      "  5 hours: 0% used, 100% remaining",
+      "  Resets: 2026-08-30T17:40:46.000Z",
+      "  7 days: 0% used, 100% remaining",
+      "  Resets: 2026-09-06T12:40:46.000Z",
+      "",
+      "Saved resets: 1",
+      "Status: available",
+    ].join("\n"))
+  })
+
+  test("#given a normalized report #when formatted as JSON #then preserves machine-consumed quota fields", () => {
+    // when
+    const output = JSON.parse(formatCodexUsageJson(report))
+
+    // then
+    expect(output.planType).toBe("pro")
+    expect(output.limits[0].primary.remainingPercent).toBe(92)
+    expect(output.limits[1].id).toBe("codex_bengalfox")
+    expect(output.resetCredits.availableCount).toBe(1)
+  })
+})

--- a/packages/omo-codex/src/usage/format-codex-usage.ts
+++ b/packages/omo-codex/src/usage/format-codex-usage.ts
@@ -1,0 +1,66 @@
+import type { CodexUsageCredits, CodexUsageReport, CodexUsageWindow } from "./types"
+
+export function formatCodexUsage(report: CodexUsageReport): string {
+  const lines = [
+    "OpenAI Codex Usage",
+    `Plan: ${displayName(report.planType)}`,
+    `Authentication: ${displayName(report.authType)}`,
+  ]
+
+  for (const limit of report.limits) {
+    lines.push("", limit.label)
+    appendWindow(lines, limit.primary)
+    appendWindow(lines, limit.secondary)
+    if (limit.credits !== null) {
+      lines.push(`  Credits: ${formatCredits(limit.credits)}`)
+    }
+  }
+
+  const reachedTypes = report.limits
+    .map((limit) => limit.rateLimitReachedType)
+    .filter((value): value is string => value !== null)
+  lines.push(
+    "",
+    `Saved resets: ${report.resetCredits?.availableCount ?? "unavailable"}`,
+    reachedTypes.length === 0 ? "Status: available" : `Status: limited (${[...new Set(reachedTypes)].join(", ")})`,
+  )
+  return lines.join("\n")
+}
+
+export function formatCodexUsageJson(report: CodexUsageReport): string {
+  return JSON.stringify(report, null, 2)
+}
+
+function appendWindow(lines: string[], window: CodexUsageWindow | null): void {
+  if (window === null) return
+  lines.push(
+    `  ${formatDuration(window.windowDurationMins)}: ${formatPercent(window.usedPercent)} used, ${formatPercent(window.remainingPercent)} remaining`,
+    `  Resets: ${window.resetsAt}`,
+  )
+}
+
+function formatDuration(minutes: number): string {
+  if (minutes % 1440 === 0) return plural(minutes / 1440, "day")
+  if (minutes % 60 === 0) return plural(minutes / 60, "hour")
+  return plural(minutes, "minute")
+}
+
+function plural(value: number, unit: string): string {
+  return `${value} ${unit}${value === 1 ? "" : "s"}`
+}
+
+function formatPercent(value: number): string {
+  return `${Number.isInteger(value) ? value : value.toFixed(1)}%`
+}
+
+function formatCredits(credits: CodexUsageCredits): string {
+  if (credits.unlimited) return "unlimited"
+  if (!credits.hasCredits) return "none"
+  return credits.balance
+}
+
+function displayName(value: string | null): string {
+  if (value === null) return "Unknown"
+  if (value.toLowerCase() === "chatgpt") return "ChatGPT"
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}

--- a/packages/omo-codex/src/usage/index.ts
+++ b/packages/omo-codex/src/usage/index.ts
@@ -1,0 +1,17 @@
+export {
+  createCodexUsageTransport,
+  fetchCodexUsage,
+} from "./codex-usage-client"
+export type {
+  CodexUsageProtocolMessage,
+  CodexUsageTransport,
+  FetchCodexUsageOptions,
+} from "./codex-usage-client"
+export { formatCodexUsage, formatCodexUsageJson } from "./format-codex-usage"
+export { parseCodexUsageResponses } from "./parse-codex-usage"
+export type {
+  CodexUsageCredits,
+  CodexUsageLimit,
+  CodexUsageReport,
+  CodexUsageWindow,
+} from "./types"

--- a/packages/omo-codex/src/usage/parse-codex-usage.test.ts
+++ b/packages/omo-codex/src/usage/parse-codex-usage.test.ts
@@ -1,0 +1,145 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { parseCodexUsageResponses } from "./parse-codex-usage"
+
+describe("Codex usage response parsing", () => {
+  test("#given account and multi-meter rate limits #when parsed #then normalizes plan windows credits and saved resets", () => {
+    // given
+    const accountResponse = {
+      account: {
+        type: "chatgpt",
+        email: "private@example.com",
+      },
+    }
+    const rateLimitsResponse = {
+      rateLimits: {
+        limitId: "codex",
+        primary: {
+          usedPercent: 8,
+          windowDurationMins: 10080,
+          resetsAt: 1788663080,
+        },
+        secondary: null,
+        credits: {
+          hasCredits: false,
+          unlimited: false,
+          balance: "0",
+        },
+        planType: "pro",
+        rateLimitReachedType: null,
+      },
+      rateLimitsByLimitId: {
+        codex_bengalfox: {
+          limitId: "codex_bengalfox",
+          primary: {
+            usedPercent: 0,
+            windowDurationMins: 300,
+            resetsAt: 1788111646,
+          },
+          secondary: {
+            usedPercent: 0,
+            windowDurationMins: 10080,
+            resetsAt: 1788698446,
+          },
+          planType: "pro",
+          rateLimitReachedType: null,
+        },
+        codex: {
+          limitId: "codex",
+          primary: {
+            usedPercent: 8,
+            windowDurationMins: 10080,
+            resetsAt: 1788663080,
+          },
+          secondary: null,
+          credits: {
+            hasCredits: false,
+            unlimited: false,
+            balance: "0",
+          },
+          planType: "pro",
+          rateLimitReachedType: null,
+        },
+      },
+      rateLimitResetCredits: {
+        availableCount: 1,
+      },
+    }
+
+    // when
+    const report = parseCodexUsageResponses(
+      accountResponse,
+      rateLimitsResponse,
+      new Date("2026-08-30T16:00:00.000Z"),
+    )
+
+    // then
+    expect(report).toEqual({
+      fetchedAt: "2026-08-30T16:00:00.000Z",
+      authType: "chatgpt",
+      planType: "pro",
+      limits: [
+        {
+          id: "codex",
+          label: "Codex",
+          planType: "pro",
+          primary: {
+            usedPercent: 8,
+            remainingPercent: 92,
+            windowDurationMins: 10080,
+            resetsAt: "2026-09-06T02:51:20.000Z",
+          },
+          secondary: null,
+          credits: {
+            hasCredits: false,
+            unlimited: false,
+            balance: "0",
+          },
+          rateLimitReachedType: null,
+        },
+        {
+          id: "codex_bengalfox",
+          label: "Spark",
+          planType: "pro",
+          primary: {
+            usedPercent: 0,
+            remainingPercent: 100,
+            windowDurationMins: 300,
+            resetsAt: "2026-08-30T17:40:46.000Z",
+          },
+          secondary: {
+            usedPercent: 0,
+            remainingPercent: 100,
+            windowDurationMins: 10080,
+            resetsAt: "2026-09-06T12:40:46.000Z",
+          },
+          credits: null,
+          rateLimitReachedType: null,
+        },
+      ],
+      resetCredits: {
+        availableCount: 1,
+      },
+    })
+    expect(JSON.stringify(report)).not.toContain("private@example.com")
+  })
+
+  test("#given a malformed rate-limit payload #when parsed #then rejects it instead of inventing empty usage", () => {
+    // given
+    const malformedResponse = {
+      rateLimits: {
+        planType: "pro",
+        primary: {
+          usedPercent: "eight",
+        },
+      },
+    }
+
+    // when
+    const parse = () => parseCodexUsageResponses({ account: { type: "chatgpt" } }, malformedResponse)
+
+    // then
+    expect(parse).toThrow("Codex app-server returned no valid usage limits")
+  })
+})

--- a/packages/omo-codex/src/usage/parse-codex-usage.ts
+++ b/packages/omo-codex/src/usage/parse-codex-usage.ts
@@ -1,0 +1,131 @@
+import type {
+  CodexUsageCredits,
+  CodexUsageLimit,
+  CodexUsageReport,
+  CodexUsageWindow,
+} from "./types"
+
+const LIMIT_LABELS: Readonly<Record<string, string>> = {
+  codex: "Codex",
+  codex_bengalfox: "Spark",
+}
+
+export function parseCodexUsageResponses(
+  accountResponse: unknown,
+  rateLimitsResponse: unknown,
+  fetchedAt = new Date(),
+): CodexUsageReport {
+  const account = nestedRecord(accountResponse, "account")
+  const response = asRecord(rateLimitsResponse)
+  const current = nestedRecord(response, "rateLimits")
+  const currentId = stringValue(current?.limitId) ?? "codex"
+  const limitsById = nestedRecord(response, "rateLimitsByLimitId")
+  const parsedById = new Map<string, CodexUsageLimit>()
+
+  if (limitsById !== null) {
+    for (const [id, value] of Object.entries(limitsById)) {
+      const parsed = parseUsageLimit(id, value)
+      if (parsed !== null) parsedById.set(id, parsed)
+    }
+  }
+
+  if (!parsedById.has(currentId)) {
+    const parsedCurrent = parseUsageLimit(currentId, current)
+    if (parsedCurrent !== null) parsedById.set(currentId, parsedCurrent)
+  }
+
+  const limits = [...parsedById.values()].sort(compareLimits)
+  if (limits.length === 0) {
+    throw new Error("Codex app-server returned no valid usage limits")
+  }
+
+  const primaryLimit = limits.find((limit) => limit.id === currentId) ?? limits[0]
+  const accountPlanType = stringValue(account?.planType)
+  const resetCredits = nestedRecord(response, "rateLimitResetCredits")
+  const availableCount = numberValue(resetCredits?.availableCount)
+
+  return {
+    fetchedAt: fetchedAt.toISOString(),
+    authType: stringValue(account?.type),
+    planType: primaryLimit?.planType ?? accountPlanType,
+    limits,
+    resetCredits:
+      availableCount === null
+        ? null
+        : {
+            availableCount: Math.max(0, Math.trunc(availableCount)),
+          },
+  }
+}
+
+function parseUsageLimit(id: string, value: unknown): CodexUsageLimit | null {
+  const limit = asRecord(value)
+  if (limit === null) return null
+  const primary = parseUsageWindow(limit.primary)
+  const secondary = parseUsageWindow(limit.secondary)
+  if (primary === null && secondary === null) return null
+
+  return {
+    id,
+    label: stringValue(limit.limitName) ?? LIMIT_LABELS[id] ?? id,
+    planType: stringValue(limit.planType),
+    primary,
+    secondary,
+    credits: parseCredits(limit.credits),
+    rateLimitReachedType: stringValue(limit.rateLimitReachedType),
+  }
+}
+
+function parseUsageWindow(value: unknown): CodexUsageWindow | null {
+  const window = asRecord(value)
+  if (window === null) return null
+  const usedPercent = numberValue(window.usedPercent)
+  const windowDurationMins = numberValue(window.windowDurationMins)
+  const resetsAt = numberValue(window.resetsAt)
+  if (usedPercent === null || windowDurationMins === null || resetsAt === null) return null
+
+  return {
+    usedPercent,
+    remainingPercent: Math.max(0, Math.min(100, 100 - usedPercent)),
+    windowDurationMins,
+    resetsAt: new Date(resetsAt * 1000).toISOString(),
+  }
+}
+
+function parseCredits(value: unknown): CodexUsageCredits | null {
+  const credits = asRecord(value)
+  if (credits === null || typeof credits.hasCredits !== "boolean" || typeof credits.unlimited !== "boolean") {
+    return null
+  }
+  const balance = credits.balance
+  if (typeof balance !== "string" && typeof balance !== "number") return null
+  return {
+    hasCredits: credits.hasCredits,
+    unlimited: credits.unlimited,
+    balance: String(balance),
+  }
+}
+
+function compareLimits(left: CodexUsageLimit, right: CodexUsageLimit): number {
+  if (left.id === "codex") return right.id === "codex" ? 0 : -1
+  if (right.id === "codex") return 1
+  return left.id.localeCompare(right.id)
+}
+
+function nestedRecord(value: unknown, key: string): Record<string, unknown> | null {
+  return asRecord(asRecord(value)?.[key])
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? Object.fromEntries(Object.entries(value))
+    : null
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}

--- a/packages/omo-codex/src/usage/types.ts
+++ b/packages/omo-codex/src/usage/types.ts
@@ -1,0 +1,32 @@
+export type CodexUsageWindow = {
+  readonly usedPercent: number
+  readonly remainingPercent: number
+  readonly windowDurationMins: number
+  readonly resetsAt: string
+}
+
+export type CodexUsageCredits = {
+  readonly hasCredits: boolean
+  readonly unlimited: boolean
+  readonly balance: string
+}
+
+export type CodexUsageLimit = {
+  readonly id: string
+  readonly label: string
+  readonly planType: string | null
+  readonly primary: CodexUsageWindow | null
+  readonly secondary: CodexUsageWindow | null
+  readonly credits: CodexUsageCredits | null
+  readonly rateLimitReachedType: string | null
+}
+
+export type CodexUsageReport = {
+  readonly fetchedAt: string
+  readonly authType: string | null
+  readonly planType: string | null
+  readonly limits: readonly CodexUsageLimit[]
+  readonly resetCredits: {
+    readonly availableCount: number
+  } | null
+}

--- a/packages/omo-opencode/src/cli/cli-program.test.ts
+++ b/packages/omo-opencode/src/cli/cli-program.test.ts
@@ -129,3 +129,22 @@ test("program registers runtime commands", async () => {
   // then
   expect(registersRuntimeCommands).toBe(true)
 })
+
+test("runtime commands register Codex usage with machine-readable output", async () => {
+  // given
+  const runtimeCommandsSource = await readFile(
+    path.resolve(import.meta.dir, "runtime-commands.ts"),
+    "utf-8",
+  )
+
+  // when
+  const usageBlock = runtimeCommandsSource.match(
+    /program\s*\n\s*\.command\("usage"\)([\s\S]*?)\.action\(/,
+  )
+
+  // then
+  expect(usageBlock).not.toBeNull()
+  expect(usageBlock?.[1]).toContain('.option("--json"')
+  expect(runtimeCommandsSource).toContain('import { codexUsage } from "./codex-usage"')
+  expect(runtimeCommandsSource).toContain("await codexUsage({ json: options.json ?? false })")
+})

--- a/packages/omo-opencode/src/cli/codex-usage.test.ts
+++ b/packages/omo-opencode/src/cli/codex-usage.test.ts
@@ -1,0 +1,104 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import type { CodexUsageReport } from "@oh-my-opencode/omo-codex"
+import { codexUsage } from "./codex-usage"
+
+const report: CodexUsageReport = {
+  fetchedAt: "2026-08-30T16:00:00.000Z",
+  authType: "chatgpt",
+  planType: "pro",
+  limits: [
+    {
+      id: "codex",
+      label: "Codex",
+      planType: "pro",
+      primary: {
+        usedPercent: 8,
+        remainingPercent: 92,
+        windowDurationMins: 10080,
+        resetsAt: "2026-09-06T02:51:20.000Z",
+      },
+      secondary: null,
+      credits: {
+        hasCredits: false,
+        unlimited: false,
+        balance: "0",
+      },
+      rateLimitReachedType: null,
+    },
+  ],
+  resetCredits: {
+    availableCount: 1,
+  },
+}
+
+describe("Codex usage command", () => {
+  test("#given JSON output requested #when usage loads #then writes a machine-readable report", async () => {
+    // given
+    const stdout: string[] = []
+    const stderr: string[] = []
+
+    // when
+    const exitCode = await codexUsage(
+      { json: true },
+      {
+        fetchUsage: async () => report,
+        writeStdout: (value) => stdout.push(value),
+        writeStderr: (value) => stderr.push(value),
+      },
+    )
+
+    // then
+    expect(exitCode).toBe(0)
+    expect(stderr).toEqual([])
+    expect(JSON.parse(stdout.join("")).limits[0].primary.remainingPercent).toBe(92)
+  })
+
+  test("#given app-server failure #when text output is requested #then writes an actionable error and fails", async () => {
+    // given
+    const stdout: string[] = []
+    const stderr: string[] = []
+
+    // when
+    const exitCode = await codexUsage(
+      { json: false },
+      {
+        fetchUsage: async () => {
+          throw new Error("Codex usage request failed: not logged in")
+        },
+        writeStdout: (value) => stdout.push(value),
+        writeStderr: (value) => stderr.push(value),
+      },
+    )
+
+    // then
+    expect(exitCode).toBe(1)
+    expect(stdout).toEqual([])
+    expect(stderr.join("")).toBe("Codex usage unavailable: Codex usage request failed: not logged in\n")
+  })
+
+  test("#given app-server failure #when JSON output is requested #then writes a structured error to stdout", async () => {
+    // given
+    const stdout: string[] = []
+
+    // when
+    const exitCode = await codexUsage(
+      { json: true },
+      {
+        fetchUsage: async () => {
+          throw new Error("Codex CLI was not found")
+        },
+        writeStdout: (value) => stdout.push(value),
+        writeStderr: () => undefined,
+      },
+    )
+
+    // then
+    expect(exitCode).toBe(1)
+    expect(JSON.parse(stdout.join(""))).toEqual({
+      ok: false,
+      error: "Codex CLI was not found",
+    })
+  })
+})

--- a/packages/omo-opencode/src/cli/codex-usage.ts
+++ b/packages/omo-opencode/src/cli/codex-usage.ts
@@ -1,0 +1,40 @@
+import {
+  fetchCodexUsage,
+  formatCodexUsage,
+  formatCodexUsageJson,
+  type CodexUsageReport,
+} from "@oh-my-opencode/omo-codex"
+
+export type CodexUsageOptions = {
+  readonly json: boolean
+}
+
+type CodexUsageDependencies = {
+  readonly fetchUsage?: () => Promise<CodexUsageReport>
+  readonly writeStdout?: (value: string) => void
+  readonly writeStderr?: (value: string) => void
+}
+
+export async function codexUsage(
+  options: CodexUsageOptions,
+  dependencies: CodexUsageDependencies = {},
+): Promise<number> {
+  const fetchUsage = dependencies.fetchUsage ?? fetchCodexUsage
+  const writeStdout = dependencies.writeStdout ?? ((value: string) => process.stdout.write(value))
+  const writeStderr = dependencies.writeStderr ?? ((value: string) => process.stderr.write(value))
+
+  try {
+    const report = await fetchUsage()
+    const output = options.json ? formatCodexUsageJson(report) : formatCodexUsage(report)
+    writeStdout(`${output}\n`)
+    return 0
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (options.json) {
+      writeStdout(`${JSON.stringify({ ok: false, error: message }, null, 2)}\n`)
+    } else {
+      writeStderr(`Codex usage unavailable: ${message}\n`)
+    }
+    return 1
+  }
+}

--- a/packages/omo-opencode/src/cli/runtime-commands.ts
+++ b/packages/omo-opencode/src/cli/runtime-commands.ts
@@ -1,6 +1,7 @@
 import { InvalidArgumentError, type Command } from "commander"
 
 import { boulder } from "./boulder"
+import { codexUsage } from "./codex-usage"
 import { codexUlwLoop } from "./codex-ulw-loop"
 import { refreshModelCapabilities } from "./refresh-model-capabilities"
 import { worktreeSweep } from "./worktree-sweep"
@@ -32,6 +33,20 @@ export function configureRuntimeCommands(program: Command): void {
     .description("Show version information")
     .action(() => {
       console.log(`${PLUGIN_NAME} v${VERSION}`)
+    })
+
+  program
+    .command("usage")
+    .description("Show OpenAI Codex plan, quota windows, credits, and reset times")
+    .option("--json", "Output structured JSON result")
+    .addHelpText("after", `
+Examples:
+  $ omo-agent-toolkit usage
+  $ omo-agent-toolkit usage --json
+`)
+    .action(async (options: { readonly json?: boolean }) => {
+      const exitCode = await codexUsage({ json: options.json ?? false })
+      process.exit(exitCode)
     })
 
   program


### PR DESCRIPTION
## Summary
Add a first-class `omo-agent-toolkit usage` command for OpenAI Codex subscription and quota information. It uses the supported Codex app-server account methods, does not read OAuth files, and does not call private ChatGPT backend endpoints.

## Changes
- Add a typed Codex usage adapter that normalizes plan, quota windows, reset times, credit state, saved reset count, and separate Spark meters.
- Add a bounded stdio app-server client with deterministic cleanup and actionable missing-auth, malformed-response, missing-binary, and timeout failures.
- Add human and JSON output through `omo-agent-toolkit usage [--json]` in both Bun and Node CLI bundles.
- Add failing-first parser, protocol, formatter, command, and registration coverage.

## QA & Evidence
- **Focused tests:** 17 passed, 0 failed across five files. Covers normalization, protocol handshake, cleanup, formatting, errors, and registration.
- **Codex gate:** `bun run test:codex` passed 493 tests.
- **Types:** Codex package typecheck and full `bun run typecheck` passed.
- **Build:** `bun run build` completed, including `dist/cli` and `dist/cli-node`.
- **Built CLI:** Help, text output, JSON output, malformed payload, and logged-out real app-server paths were driven directly.
- **Codex live QA:** isolated `app-server-drive.sh --plugin` completed a mock-model turn and proved `sessionStart` and `userPromptSubmit` hooks. Real `~/.codex/config.toml` remained unchanged.
- **OpenCode live QA:** isolated TUI smoke rendered, accepted input, tore down tmux, and kept the real DB session count at 49 before and after.
- **Evidence:** `.omo/evidence/20260830-codex-usage/README.md` with sanitized artifacts and isolation proof.

## Risks & Residuals
- The command depends on Codex app-server protocol methods available in current Codex releases. Protocol failures fail closed with exit code 1.
- Account identity and tokens are deliberately excluded from output and evidence.
- The OpenCode server-smoke helper was attempted but its existing health curl hung without a request timeout. It was terminated in isolation; the independent OpenCode TUI smoke passed.

## Related Issues
None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `omo-agent-toolkit usage` command that reports OpenAI Codex plan, quota windows, credits, and reset times from the Codex app-server.

- Reads usage through the supported `codex app-server --stdio` protocol instead of OAuth files or private ChatGPT endpoints.
- Returns human-readable or JSON output (`--json`) in both Bun and Node CLI bundles.
- Fails closed with exit code 1 on missing auth, malformed responses, missing binary, or timeout.
- Keeps account identity and tokens out of output and evidence.

<sup>Written for commit 587a5cf1a3959bd74eb849e40e52a1a3ab267f31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

