### PR TITLE
fix(test): make test-fast assertions Windows-safe

### DIFF
--- a/script/test-fast.test.ts
+++ b/script/test-fast.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import {
   childEnv,
   createChildRegistry,
@@ -381,7 +382,10 @@ describe("spawnInheritingStdio", () => {
     expect(calls.length).toBe(1)
     expect(call?.args).toEqual(["test", "packages/omo-senpi"])
     expect(call?.options.env?.[REENTRY_ENV_VAR]).toBe("1")
-    expect(call?.options.env?.PATH).toBe(process.env.PATH)
+    const spawnEnv = call?.options.env ?? {}
+    const pathKey = Object.keys(spawnEnv).find((key) => key.toUpperCase() === "PATH") ?? "PATH"
+    expect(spawnEnv[pathKey]).toBeDefined()
+    expect(spawnEnv[pathKey]).toBe(process.env[pathKey])
     expect(call?.options.detached).toBe(process.platform !== "win32")
     expect(call?.options.stdio).toBe("inherit")
   })
@@ -408,7 +412,7 @@ describe("spawnInheritingStdio", () => {
 describe("main entry re-entry guard", () => {
   it("#given the active marker in the environment #when the script runs as a real subprocess #then it exits 1 without spawning a group", async () => {
     // given
-    const script = new URL("./test-fast.ts", import.meta.url).pathname
+    const script = fileURLToPath(new URL("./test-fast.ts", import.meta.url))
 
     // when — a real process, so a deleted guard would actually launch the groups
     const child = Bun.spawn([process.execPath, "run", script], {


### PR DESCRIPTION
## What

Two assertions in `script/test-fast.test.ts` were platform-blind and fail deterministically whenever the file lands in a Windows CI shard. This blocks every release dispatch (the publish gate requires a green `ci.yml` on the prepared SHA).

- **Spawn wiring PATH assertion (`:384`)**: `call?.options.env?.PATH` reads the captured spawn env with a case-sensitive key. `childEnv()` spreads `process.env`, which carries `Path` on Windows, so the assertion compared the real value against `undefined`. Now the PATH key is resolved from the captured env case-insensitively and must be present (`toBeDefined`), keeping the inheritance contract intact on both platforms.
- **Re-entry guard entry path (`:411`)**: `new URL("./test-fast.ts", import.meta.url).pathname` yields `/D:/a/...` on Windows, which bun cannot load ("Module not found"), so the guard test never saw `re-entry blocked`. Now resolved with `fileURLToPath`.

## Why

Windows `test (windows-latest, 2/2)` failed identically on three consecutive dev runs (33313752677, 33314473483, 33315395733) with:

- `expect(env?.PATH).toBe(...)` → `Received: undefined` at `test-fast.test.ts:384`
- `Expected to contain: "re-entry blocked" / Received: error: Module not found "/D:/a/oh-my-openagent/oh-my-openagent/script/test-fast.ts"` at `:427` (earlier runs)

The last green dev run (33308569753, e885b64f) never executed this file in a Windows shard — the failure surfaces via shard reshuffling, not via any commit that touched the file.

## QA / evidence

- RED: the three failing CI runs above (deterministic, same assertions).
- GREEN: this PR's own `test (windows-latest, *)` legs are the faithful surface (no Windows box in the fleet); POSIX proof via `bun test script/test-fast.test.ts` on macOS (run on mengmotaMac, result posted in comments).

## Residual risk / notes

- Test-only change; `script/` is not a senpi-plugin bundle input, so no `omo.js` regeneration is needed.
- `script/test-fast.test.ts` exceeds the 250-LOC file ceiling already; splitting it collides with the quarantine/partition pins (`root-test-serial-quarantine.ts`) and is out of scope for this release-unblocking fix — flagging the smell instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Windows-only failures in `script/test-fast.test.ts` that blocked release dispatches. The spawn PATH assertion now resolves the PATH key case-insensitively from the captured env, and the re-entry guard test now uses `fileURLToPath` to load the entry module correctly on Windows. Test-only change; POSIX behavior is unchanged.

<sup>Written for commit fda71c56c0cf5b11a1e1ef54738ff5a09b921506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

