### PR TITLE
fix(senpi): recover Claude SDK single-exchange overflow

### DIFF
--- a/packages/omo-native/test/senpi-overflow-compaction-patch.test.ts
+++ b/packages/omo-native/test/senpi-overflow-compaction-patch.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+// Senpi's package exports hide these compiled internals, so the regression loads them from the resolved runtime path.
+const senpiDistDir = dirname(fileURLToPath(import.meta.resolve("@code-yeongyu/senpi")))
+const agentSessionModule = await import(pathToFileURL(join(senpiDistDir, "core", "agent-session.js")).href) as {
+  AgentSession: {
+    prototype: {
+      _runPrePromptCompaction: (...args: unknown[]) => Promise<boolean>
+      _runAutoCompaction: (...args: unknown[]) => Promise<boolean>
+    }
+  }
+}
+const compactionExtensionModule = await import(
+  pathToFileURL(join(senpiDistDir, "core", "extensions", "builtin", "compaction", "index.js")).href
+) as { default: (api: CompactionApi) => void }
+const compactionSettingsModule = await import(
+  pathToFileURL(join(senpiDistDir, "core", "compaction", "compaction-settings.js")).href
+) as { DEFAULT_COMPACTION_SETTINGS: Record<string, unknown> }
+
+const temporaryDirectories: string[] = []
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+type CompactionRequest = {
+  allowSummaryOnly?: boolean
+  reason?: string
+}
+
+type CompactionApi = {
+  on: (event: string, handler: (event: Record<string, unknown>, context: Record<string, unknown>) => unknown) => void
+  appendEntry: () => void
+  getActiveTools: () => string[]
+  getAllTools: () => unknown[]
+  events: { emit: () => void }
+}
+
+function createCompactionHook() {
+  let handler: ((event: Record<string, unknown>, context: Record<string, unknown>) => unknown) | undefined
+  const api: CompactionApi = {
+    on: (event, candidate) => {
+      if (event === "session_before_compact") handler = candidate
+    },
+    appendEntry: () => {},
+    getActiveTools: () => [],
+    getAllTools: () => [],
+    events: { emit: () => {} },
+  }
+  compactionExtensionModule.default(api)
+  if (!handler) throw new Error("Senpi compaction extension did not register session_before_compact")
+  return handler
+}
+
+function createSdkLaneContext() {
+  const agentDir = mkdtempSync(join(tmpdir(), "omo-senpi-overflow-test-"))
+  temporaryDirectories.push(agentDir)
+  let modelReads = 0
+  return {
+    agentDir,
+    cwd: agentDir,
+    sessionManager: { getBranch: () => [], getEntries: () => [] },
+    get model() {
+      modelReads += 1
+      return modelReads <= 2
+        ? { provider: "claude-sdk-oauth", id: "fable-5", contextWindow: 1_000_000 }
+        : undefined
+    },
+  }
+}
+
+function compactionEvent(reason: "threshold" | "overflow") {
+  return {
+    type: "session_before_compact",
+    reason,
+    willRetry: reason === "overflow",
+    requestId: `request-${reason}`,
+    preparation: { messages: [], settings: compactionSettingsModule.DEFAULT_COMPACTION_SETTINGS },
+    branchEntries: [],
+    signal: new AbortController().signal,
+  }
+}
+
+describe("patched Senpi overflow compaction", () => {
+  test("keeps normal Claude SDK compaction delegated but admits emergency overflow recovery", async () => {
+    const hook = createCompactionHook()
+
+    const thresholdResult = await hook(compactionEvent("threshold"), createSdkLaneContext())
+    const overflowResult = await hook(compactionEvent("overflow"), createSdkLaneContext())
+
+    expect(thresholdResult).toMatchObject({ cancel: true, rejectionCause: "external-owner" })
+    expect(overflowResult).toBeUndefined()
+  })
+
+  test("bypasses sticky delegation and enables recursive summary regeneration for pre-prompt overflow", async () => {
+    const requests: CompactionRequest[] = []
+    const delegatedSession = {
+      _isCompactionDelegated: () => true,
+      _claimCompactionController: () => {},
+      _emit: () => {},
+      _executeCompaction: async (request: CompactionRequest) => {
+        requests.push(request)
+        return { accepted: true }
+      },
+      _compactionLifecycle: { state: { status: "succeeded" } },
+      _compactionAbortController: undefined,
+    }
+
+    const accepted = await agentSessionModule.AgentSession.prototype._runPrePromptCompaction.call(
+      delegatedSession,
+      undefined,
+      true,
+      "overflow",
+      true,
+    )
+
+    expect(accepted).toBe(true)
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toMatchObject({ reason: "overflow", allowSummaryOnly: true })
+  })
+
+  test("admits summary-only automatic overflow after sticky SDK delegation", async () => {
+    const requests: CompactionRequest[] = []
+    let continuationScheduled = false
+    const previousSummary = {
+      type: "compaction",
+      id: "summary-1",
+      parentId: null,
+      timestamp: "2026-08-30T00:00:00.000Z",
+      summary: "durable goal and current state",
+      firstKeptEntryId: "user-2",
+      tokensBefore: 535_486,
+    }
+    const latestUser = {
+      type: "message",
+      id: "user-2",
+      parentId: "summary-1",
+      timestamp: "2026-08-30T00:00:01.000Z",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "continue" }],
+        timestamp: 2,
+      },
+    }
+    const delegatedSession = {
+      _isCompactionDelegated: () => true,
+      _sessionWorkBarrier: { begin: () => () => {} },
+      agent: { state: { messages: [] }, hasQueuedMessages: () => false },
+      _autoCompactionAbortController: undefined as AbortController | undefined,
+      _claimCompactionController(controller: AbortController) {
+        this._autoCompactionAbortController = controller
+      },
+      _ownsCompactionController(controller: AbortController) {
+        return this._autoCompactionAbortController === controller
+      },
+      model: { provider: "claude-sdk-oauth", id: "fable-5", contextWindow: 1_000_000 },
+      _modelRuntime: { getAuth: async () => "fixture-key" },
+      sessionManager: { getBranch: () => [previousSummary, latestUser] },
+      settingsManager: {
+        getCompactionSettings: () => ({
+          ...compactionSettingsModule.DEFAULT_COMPACTION_SETTINGS,
+          keepRecentTokens: 20_000,
+        }),
+      },
+      _emit: () => {},
+      _executeCompaction: async (request: CompactionRequest) => {
+        requests.push(request)
+        return { accepted: true }
+      },
+      _scheduleContinuationAfterCurrentEvent: () => {
+        continuationScheduled = true
+      },
+      pendingMessageCount: 0,
+      _overflowRecoveryAttempted: true,
+    }
+
+    const accepted = await agentSessionModule.AgentSession.prototype._runAutoCompaction.call(
+      delegatedSession,
+      "overflow",
+      true,
+    )
+
+    expect(accepted).toBe(true)
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toMatchObject({ reason: "overflow", allowSummaryOnly: true })
+    expect(continuationScheduled).toBe(true)
+  })
+})

--- a/patches/@code-yeongyu%2Fsenpi@2026.8.30-3.patch
+++ b/patches/@code-yeongyu%2Fsenpi@2026.8.30-3.patch
@@ -22,3 +22,55 @@ diff --git a/dist/core/extensions/builtin/claude-sdk-oauth/session-registry-pump
          }
          return false;
      }
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -4840,8 +4840,8 @@
+             this._delegatedCompactionKey.provider === model.provider &&
+             this._delegatedCompactionKey.id === model.id);
+     }
+-    async _runPrePromptCompaction(lastAssistantMessage, skipAbortedCheck, reason = "pre_prompt", willRetry = false, allowSummaryOnly = false) {
+-        if (this._isCompactionDelegated())
++    async _runPrePromptCompaction(lastAssistantMessage, skipAbortedCheck, reason = "pre_prompt", willRetry = false, allowSummaryOnly = reason === "overflow") {
++        if (reason !== "overflow" && this._isCompactionDelegated())
+             return false;
+         const controller = new AbortController();
+         const requestId = randomUUID();
+@@ -5015,7 +5015,7 @@
+      * @returns Whether the post-run loop should call `agent.continue()`
+      */
+     async _runAutoCompaction(reason, willRetry) {
+-        if (this._isCompactionDelegated())
++        if (reason !== "overflow" && this._isCompactionDelegated())
+             return false;
+         const finishCompactionWork = this._sessionWorkBarrier.begin();
+         const agentMessagesAtStart = this.agent.state.messages.slice();
+@@ -5062,7 +5062,7 @@
+             }
+             if (!this._ownsCompactionController(autoCompactionController, "auto"))
+                 return false;
+-            const preparation = prepareCompaction(this.sessionManager.getBranch(), cursorOverflowCompactionSettings(this.settingsManager.getCompactionSettings(), this.model?.provider, reason), reason === "overflow");
++            const preparation = prepareCompaction(this.sessionManager.getBranch(), cursorOverflowCompactionSettings(this.settingsManager.getCompactionSettings(), this.model?.provider, reason), reason === "overflow", reason === "overflow");
+             if (!preparation) {
+                 return endBeforeExecution();
+             }
+@@ -5075,6 +5075,7 @@
+                 reason,
+                 requestId,
+                 willRetry,
++                allowSummaryOnly: reason === "overflow",
+                 agentMessagesAtStart,
+             });
+             if (!execution.accepted) {
+diff --git a/dist/core/extensions/builtin/compaction/index.js b/dist/core/extensions/builtin/compaction/index.js
+--- a/dist/core/extensions/builtin/compaction/index.js
++++ b/dist/core/extensions/builtin/compaction/index.js
+@@ -448,7 +448,7 @@
+         let warmJobConsumed = false;
+         invalidateSpeculativeCompaction(ctx);
+         try {
+-            if (lanePolicy.disablesSenpiCompaction(ctx)) {
++            if (lanePolicy.disablesSenpiCompaction(ctx) && event.reason !== "overflow") {
+                 return {
+                     cancel: true,
+                     rejectionCause: "external-owner",


### PR DESCRIPTION
## Summary

Recover Anthropic/Fable sessions that exceed the provider limit after Claude Agent SDK system, tool, and attachment injection. Senpi normally delegates compaction to the SDK, but the SDK cannot compact an oversized single flattened exchange; this patch permits Senpi's emergency overflow path to recursively regenerate the existing synthetic summary and retry the interrupted turn.

Normal threshold and speculative compaction remain delegated to the Claude Agent SDK. Only provider-reported overflow uses the Senpi fallback.

## Changes

- Extend the pinned `@code-yeongyu/senpi@2026.8.30-2` patch so overflow bypasses both sticky SDK-delegation guards and the builtin external-owner hook.
- Enable `allowSummaryOnly` for pre-prompt and automatic overflow preparation, allowing a prior synthetic summary to be summarized again when no older exchange remains.
- Add installed-runtime regression coverage for normal delegation, overflow admission, recursive summary regeneration, and one retry continuation.

## QA & Evidence

- **What was tested:** `bun test packages/omo-native/test/senpi-overflow-compaction-patch.test.ts`
  - **Observed result:** 3 passed, 0 failed, 9 assertions.
  - **Artifact:** `.omo/evidence/omo-senpi-adapter/20260830-anthropic-overflow-recovery/overflow-regression-test.log`
  - **Why sufficient:** Exercises the compiled patched Senpi runtime, including sticky delegation and summary-only auto-overflow.
- **What was tested:** isolated real Senpi driver with the OMO plugin and mock provider.
  - **Observed result:** PASS; ultrawork injection PASS; comment-checker PASS; `realSenpiUntouched: true`.
  - **Artifact:** `.omo/evidence/omo-senpi-adapter/20260830-anthropic-overflow-recovery/live-driver.json`
  - **Why sufficient:** Proves the patched CLI starts and the adapter loads without touching the real Senpi home.
- **What was tested:** `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json && bun run test:senpi`
  - **Observed result:** 2,423 passed, 7 skipped, 0 failed; evidence resolver 10 passed, 0 failed.
- **What was tested:** `bun run typecheck` and `bun run build`
  - **Observed result:** both passed.
- **What was tested:** full `bun test`
  - **Observed result:** 16,862 passed, 44 skipped, 7 failed. Six unrelated concurrent-suite failures passed in isolation (22/22). The remaining embedded-manifest parity probe explicitly requires Bun >=1.4 directory-asset support; this workstation has Bun 1.3.14.
  - **Artifact:** `.omo/evidence/omo-senpi-adapter/20260830-anthropic-overflow-recovery/full-test.log`

## Risks & Residuals

- Emergency overflow now uses Senpi summarization even on the SDK-native lane. Scope is limited to `reason === "overflow"`; ordinary ownership is unchanged.
- A paid 1M-token Anthropic request was not run because no task-scoped credential is available. The regression drives the exact installed-runtime recovery state instead.
- The dependency patch should be removed when an equivalent Senpi release is pinned.

## Related Issues

Fixes https://github.com/code-yeongyu/oh-my-openagent/issues/7497

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude Agent SDK sessions that overflow after system, tool, and attachment injection. The SDK cannot compact an oversized single flattened exchange, so provider-reported overflow now routes through Senpi's emergency compact path to regenerate the existing synthetic summary and retry the interrupted turn. Fixes #7497.

**Bug Fixes**
- Overflow bypasses Senpi's sticky SDK-delegation guards and the builtin external-owner hook.
- Enables `allowSummaryOnly` for pre-prompt and automatic overflow, letting a prior synthetic summary be summarized again when no older exchange remains.
- Adds installed-runtime regression coverage for normal delegation, overflow admission, recursive summary regeneration, and one retry continuation.
- Emergency overflow now uses Senpi summarization on the SDK-native lane, limited to `reason === "overflow"`; remove the patch when an equivalent Senpi release is pinned.

<sup>Written for commit 6a0a2b3dd7e761f52ce2517c2cac7b271b8d95a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

