### PR TITLE
fix(omo-opencode): unref tui mirror heartbeat and stop it on dispose

### DIFF
--- a/.omo/evidence/20260831-mem-tui-mirror/REPORT.md
+++ b/.omo/evidence/20260831-mem-tui-mirror/REPORT.md
@@ -46,3 +46,30 @@ Ran 65 tests across 11 files.
 
 - Heartbeat interval calls `unref?.()` after creation.
 - Plugin disposal accepts an optional TUI mirror and calls `stop()` inside the idempotent disposal promise.
+
+## Production assembly wiring correction
+
+### RED
+
+Command:
+
+```text
+bun /tmp/omo-mac-test.mjs fix/mem-tui-mirror-heartbeat -- packages/omo-opencode/src/features/tui-sidebar packages/omo-opencode/src/plugin-dispose.test.ts packages/omo-opencode/src/testing
+```
+
+```text
+(fail) createPluginModule() > #given bundled security skills are enabled > #then dispose stops the started TUI state mirror
+103 pass
+1 fail
+```
+
+### GREEN
+
+Same command after wiring the production call site:
+
+```text
+104 pass
+0 fail
+193 expect() calls
+Ran 104 tests across 14 files.
+```

--- a/.omo/evidence/20260831-mem-tui-mirror/REPORT.md
+++ b/.omo/evidence/20260831-mem-tui-mirror/REPORT.md
@@ -1,0 +1,48 @@
+# TuiStateMirror heartbeat lifecycle evidence
+
+Date: 2026-08-31
+Branch: fix/mem-tui-mirror-heartbeat
+
+## RED
+
+Command:
+
+```text
+bun /tmp/omo-mac-test.mjs fix/mem-tui-mirror-heartbeat -- packages/omo-opencode/src/features/tui-sidebar
+```
+
+Result: exit 1; 57 pass, 1 fail.
+
+```text
+error: expect(received).toHaveBeenCalledTimes(expected)
+Expected number of calls: 1
+Received number of calls: 0
+(fail) TuiStateMirror > #given a started mirror #when started #then heartbeat handle is unref'd
+1 tests failed:
+57 pass
+1 fail
+```
+
+## GREEN
+
+Command:
+
+```text
+bun /tmp/omo-mac-test.mjs fix/mem-tui-mirror-heartbeat -- packages/omo-opencode/src/features/tui-sidebar packages/omo-opencode/src/plugin-dispose.test.ts
+```
+
+Result: exit 0.
+
+```text
+(pass) TuiStateMirror > #given a started mirror #when started #then heartbeat handle is unref'd
+(pass) createPluginDispose > #given plugin with a TUI mirror #when dispose() is called #then the mirror is stopped
+65 pass
+0 fail
+124 expect() calls
+Ran 65 tests across 11 files.
+```
+
+## Changes
+
+- Heartbeat interval calls `unref?.()` after creation.
+- Plugin disposal accepts an optional TUI mirror and calls `stop()` inside the idempotent disposal promise.

--- a/packages/omo-opencode/src/features/tui-sidebar/mirror-manager.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/mirror-manager.test.ts
@@ -132,6 +132,22 @@ describe("TuiStateMirror", () => {
     mirror.stop()
   })
 
+  it("#given a started mirror #when started #then heartbeat handle is unref'd", () => {
+    jest.useFakeTimers()
+    const mirror = createMirror()
+    const unref = jest.fn()
+    const originalSetInterval = globalThis.setInterval
+    globalThis.setInterval = jest.fn(() => ({ unref })) as unknown as typeof setInterval
+
+    try {
+      mirror.start()
+      expect(unref).toHaveBeenCalledTimes(1)
+    } finally {
+      mirror.stop()
+      globalThis.setInterval = originalSetInterval
+    }
+  })
+
   it("#given a started mirror #when stopped #then timers are cleared and no later write occurs", async () => {
     jest.useFakeTimers()
     // given

--- a/packages/omo-opencode/src/features/tui-sidebar/mirror-manager.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/mirror-manager.ts
@@ -81,6 +81,7 @@ export class TuiStateMirror {
     this.heartbeatID = setInterval(() => {
       void this.flush()
     }, HEARTBEAT_MS)
+    this.heartbeatID.unref?.()
   }
 
   stop(): void {

--- a/packages/omo-opencode/src/plugin-dispose.test.ts
+++ b/packages/omo-opencode/src/plugin-dispose.test.ts
@@ -26,6 +26,24 @@ describe("createPluginDispose", () => {
     expect(shutdownSpy).toHaveBeenCalledTimes(1)
   })
 
+  test("#given plugin with a TUI mirror #when dispose() is called #then the mirror is stopped", async () => {
+    // given
+    const tuiStateMirror = { stop: (): void => {} }
+    const stopSpy = spyOn(tuiStateMirror, "stop")
+    const dispose = createPluginDispose({
+      backgroundManager: { shutdown: async (): Promise<void> => {} },
+      skillMcpManager: { disconnectAll: async (): Promise<void> => {} },
+      tuiStateMirror,
+      disposeHooks: (): void => {},
+    })
+
+    // when
+    await dispose()
+
+    // then
+    expect(stopSpy).toHaveBeenCalledTimes(1)
+  })
+
   test("#given plugin with active MCP connections #when dispose() is called #then skillMcpManager.disconnectAll() is called", async () => {
     // given
     const backgroundManager = {

--- a/packages/omo-opencode/src/plugin-dispose.ts
+++ b/packages/omo-opencode/src/plugin-dispose.ts
@@ -9,9 +9,12 @@ export function createPluginDispose(args: {
   skillMcpManager: {
     disconnectAll: () => Promise<void>
   }
+  tuiStateMirror?: {
+    stop: () => void
+  }
   disposeHooks: () => void
 }): PluginDispose {
-  const { backgroundManager, skillMcpManager, disposeHooks } = args
+  const { backgroundManager, skillMcpManager, tuiStateMirror, disposeHooks } = args
   let disposePromise: Promise<void> | null = null
 
   return async (): Promise<void> => {
@@ -21,6 +24,11 @@ export function createPluginDispose(args: {
     }
 
     disposePromise = (async (): Promise<void> => {
+      try {
+        tuiStateMirror?.stop()
+      } catch (error) {
+        log("[plugin-dispose] tuiStateMirror.stop() error:", error)
+      }
       try {
         await backgroundManager.shutdown()
       } catch (error) {

--- a/packages/omo-opencode/src/testing/create-plugin-module.test.ts
+++ b/packages/omo-opencode/src/testing/create-plugin-module.test.ts
@@ -46,9 +46,11 @@ const mockCreateRuntimeTmuxConfig = mock(() => ({
   agent_pane_min_width: 40,
   isolation: "inline" as const,
 }))
+const mockTuiStateMirrorStop = mock(() => {})
 const mockCreateManagers = mock(() => ({
   backgroundManager: { shutdown: async () => {} },
   skillMcpManager: { disconnectAll: async () => {} },
+  tuiStateMirror: { stop: mockTuiStateMirrorStop },
   configHandler: async () => {},
 }))
 const mockRuntimeSkillSourceStop = mock(() => {})
@@ -123,6 +125,7 @@ describe("createPluginModule()", () => {
     mockLoadConfigChain.mockClear()
     mockRunOpenCodeStartupMigration.mockClear()
     mockCreateManagers.mockClear()
+    mockTuiStateMirrorStop.mockClear()
     mockRuntimeSkillSourceStop.mockClear()
     mockCreateRuntimeSkillSourceServer.mockClear()
     mockCreateTools.mockClear()
@@ -275,6 +278,23 @@ describe("createPluginModule()", () => {
       } finally {
         console.warn = originalWarn
       }
+    })
+
+    it("#then dispose stops the started TUI state mirror", async () => {
+      // given
+      const pluginModule = createTestPluginModule()
+
+      // when
+      const hooks: Awaited<ReturnType<typeof pluginModule.server>> & {
+        dispose?: () => Promise<void>
+      } = await pluginModule.server({
+        directory: "/tmp/project",
+        client: {},
+      } as Parameters<typeof pluginModule.server>[0])
+      await hooks.dispose?.()
+
+      // then
+      expect(mockTuiStateMirrorStop).toHaveBeenCalledTimes(1)
     })
 
     it("#then dispose stops the runtime skill source", async () => {

--- a/packages/omo-opencode/src/testing/create-plugin-module.ts
+++ b/packages/omo-opencode/src/testing/create-plugin-module.ts
@@ -326,6 +326,7 @@ export function createPluginModule(overrides: Partial<PluginModuleDeps> = {}): P
     const dispose = createPluginDispose({
       backgroundManager: managers.backgroundManager,
       skillMcpManager: managers.skillMcpManager,
+      tuiStateMirror: managers.tuiStateMirror,
       disposeHooks: hooks.disposeHooks,
     })
 


### PR DESCRIPTION
Fixes the TuiStateMirror heartbeat lifecycle by unref-ing its interval and stopping the mirror during plugin disposal. Remote test RED/GREEN evidence is committed in `.omo/evidence/20260831-mem-tui-mirror/REPORT.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI mirror heartbeat so it no longer keeps the process alive and stops the mirror when the plugin is disposed.

- The heartbeat interval calls `unref()` after creation so it doesn't hold the event loop open.
- Plugin disposal now accepts an optional `tuiStateMirror` and calls `stop()` inside the idempotent disposal promise.
- Covers unref behavior, disposal stop, module-level wiring, and commits RED/GREEN evidence in `.omo/evidence/20260831-mem-tui-mirror/REPORT.md`.

<sup>Written for commit 179bab3ed3545e5f0c0fe1a9521d0708de63fe4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

