### PR TITLE
test(omo-native): reap signal-test fixture children

### DIFF
--- a/.omo/evidence/20260831-mem-signal-test-orphans/REPORT.md
+++ b/.omo/evidence/20260831-mem-signal-test-orphans/REPORT.md
@@ -1,0 +1,36 @@
+# Signal test fixture orphan cleanup
+
+Branch: `fix/mem-signal-test-orphans`
+
+## RED
+
+Commit `b607d24b5` recorded fixture parent and child PIDs and added the no-survivors assertion without kill teardown. Remote command:
+
+```text
+bun test v1.4.0 (34cbb9a40)
+...
+error: expect(received).toThrow()
+Received function did not throw
+Received value: true
+(fail) ... #then no fixture process survives any signal scenario
+6 pass
+3 fail
+```
+
+The assertion failure proves the recorded fixture child survived the scenarios.
+
+## GREEN
+
+Final commit `6f2a1673e` adds SIGKILL teardown, bounded process-gone verification, and tracks the re-exec fixture PID. Remote command:
+
+```text
+SHA=6f2a1673e
+bun test v1.4.0 (34cbb9a40)
+...
+8 pass
+0 fail
+15 expect() calls
+Ran 8 tests across 1 file. [3.08s]
+```
+
+The teardown kills all recorded parent and fixture child PIDs, verifies each is gone with `process.kill(pid, 0)`, then removes its temporary directory. The suite-level `afterAll` assertion independently verifies no recorded fixture PID remains alive.

--- a/packages/omo-native/test/child-process-signal.test.ts
+++ b/packages/omo-native/test/child-process-signal.test.ts
@@ -9,6 +9,7 @@ const SOURCE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
 const CHILD_PROCESS_MODULE = join(SOURCE_ROOT, "bin", "lib", "child-process.js")
 const BUN_RUNTIME_MODULE = join(SOURCE_ROOT, "bin", "lib", "bun-runtime.js")
 const roots: string[] = []
+const fixturePids: number[] = []
 
 function writeFile(path: string, content: string): void {
   mkdirSync(dirname(path), { recursive: true })
@@ -28,7 +29,8 @@ function createRoot(): string {
  */
 function gracefulChildSource(options: { exitCode: number; drainMs: number }): string {
   return `
-import { appendFileSync } from "node:fs"
+import { appendFileSync, writeFileSync } from "node:fs"
+writeFileSync(process.env.PID_FILE, String(process.pid))
 const record = process.env.SIGNAL_LOG
 for (const signal of ["SIGTERM", "SIGHUP", "SIGINT"]) {
   process.on(signal, () => {
@@ -46,7 +48,8 @@ setInterval(() => {}, 1000)
  */
 function ignoringChildSource(): string {
   return `
-import { appendFileSync } from "node:fs"
+import { appendFileSync, writeFileSync } from "node:fs"
+writeFileSync(process.env.PID_FILE, String(process.pid))
 for (const signal of ["SIGTERM", "SIGHUP"]) {
   process.on(signal, () => {
     appendFileSync(process.env.SIGNAL_LOG, signal + "\\n")
@@ -63,7 +66,8 @@ setInterval(() => {}, 1000)
  */
 function signalDeathChildSource(): string {
   return `
-import { appendFileSync } from "node:fs"
+import { appendFileSync, writeFileSync } from "node:fs"
+writeFileSync(process.env.PID_FILE, String(process.pid))
 appendFileSync(process.env.READY_FILE, "ready\\n")
 setInterval(() => {}, 1000)
 `
@@ -125,6 +129,7 @@ type Harness = {
   signalLog: string
   readyFile: string
   parentLog: string
+  pidFile: string
   env: NodeJS.ProcessEnv
 }
 
@@ -137,12 +142,14 @@ function createHarness(childSource: string): Harness {
   const signalLog = join(root, "signals.log")
   const readyFile = join(root, "ready")
   const parentLog = join(root, "parent.log")
+  const pidFile = join(root, "child.pid")
   return {
     parentPath,
     signalLog,
     readyFile,
     parentLog,
-    env: { SIGNAL_LOG: signalLog, READY_FILE: readyFile, PARENT_LOG: parentLog },
+    pidFile,
+    env: { SIGNAL_LOG: signalLog, READY_FILE: readyFile, PARENT_LOG: parentLog, PID_FILE: pidFile },
   }
 }
 
@@ -175,6 +182,7 @@ describePosix("launcher child signal forwarding", () => {
         const harness = createHarness(ignoringChildSource())
         const parent = startParent(harness.parentPath, { ...harness.env, OMO_SIGNAL_GRACE_MS: "400" })
         await waitForFile(harness.readyFile)
+        fixturePids.push(parent.pid, Number(readFileSync(harness.pidFile, "utf8")))
 
         process.kill(parent.pid, signal)
 
@@ -194,6 +202,7 @@ describePosix("launcher child signal forwarding", () => {
       const harness = createHarness(gracefulChildSource({ exitCode: 0, drainMs: 200 }))
       const parent = startParent(harness.parentPath, harness.env)
       await waitForFile(harness.readyFile)
+      fixturePids.push(parent.pid, Number(readFileSync(harness.pidFile, "utf8")))
 
       process.kill(parent.pid, "SIGINT")
       await new Promise((resolveWait) => setTimeout(resolveWait, 500))
@@ -205,6 +214,10 @@ describePosix("launcher child signal forwarding", () => {
       process.kill(parent.pid, "SIGKILL")
       await parent.exit
     }, 30_000)
+  })
+
+  test("#then no fixture process survives any signal scenario", () => {
+    for (const pid of fixturePids) expect(() => process.kill(pid, 0)).toThrow()
   })
 
   describe("#given an engine child that exits on its own #when it returns a non-zero code", () => {

--- a/packages/omo-native/test/child-process-signal.test.ts
+++ b/packages/omo-native/test/child-process-signal.test.ts
@@ -311,8 +311,11 @@ await maybeReexecUnderBun({
         SIGNAL_LOG: signalLog,
         READY_FILE: readyFile,
         PARENT_LOG: join(root, "parent.log"),
+        PID_FILE: join(root, "child.pid"),
       })
       await waitForFile(readyFile)
+      fixturePids.push(parent.pid, Number(readFileSync(join(root, "child.pid"), "utf8")))
+      allFixturePids.push(...fixturePids.slice(-2))
 
       process.kill(parent.pid, "SIGTERM")
 

--- a/packages/omo-native/test/child-process-signal.test.ts
+++ b/packages/omo-native/test/child-process-signal.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterAll, afterEach, describe, expect, test } from "bun:test"
 import { spawn } from "node:child_process"
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -10,6 +10,7 @@ const CHILD_PROCESS_MODULE = join(SOURCE_ROOT, "bin", "lib", "child-process.js")
 const BUN_RUNTIME_MODULE = join(SOURCE_ROOT, "bin", "lib", "bun-runtime.js")
 const roots: string[] = []
 const fixturePids: number[] = []
+const allFixturePids: number[] = []
 
 function writeFile(path: string, content: string): void {
   mkdirSync(dirname(path), { recursive: true })
@@ -154,6 +155,13 @@ function createHarness(childSource: string): Harness {
 }
 
 afterEach(() => {
+  for (const pid of fixturePids) {
+    try {
+      process.kill(pid, "SIGKILL")
+    } catch {}
+    expect(() => process.kill(pid, 0)).toThrow()
+  }
+  fixturePids.splice(0)
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
 
@@ -183,6 +191,7 @@ describePosix("launcher child signal forwarding", () => {
         const parent = startParent(harness.parentPath, { ...harness.env, OMO_SIGNAL_GRACE_MS: "400" })
         await waitForFile(harness.readyFile)
         fixturePids.push(parent.pid, Number(readFileSync(harness.pidFile, "utf8")))
+        allFixturePids.push(...fixturePids.slice(-2))
 
         process.kill(parent.pid, signal)
 
@@ -203,6 +212,7 @@ describePosix("launcher child signal forwarding", () => {
       const parent = startParent(harness.parentPath, harness.env)
       await waitForFile(harness.readyFile)
       fixturePids.push(parent.pid, Number(readFileSync(harness.pidFile, "utf8")))
+      allFixturePids.push(...fixturePids.slice(-2))
 
       process.kill(parent.pid, "SIGINT")
       await new Promise((resolveWait) => setTimeout(resolveWait, 500))
@@ -216,8 +226,8 @@ describePosix("launcher child signal forwarding", () => {
     }, 30_000)
   })
 
-  test("#then no fixture process survives any signal scenario", () => {
-    for (const pid of fixturePids) expect(() => process.kill(pid, 0)).toThrow()
+  afterAll(() => {
+    for (const pid of allFixturePids) expect(() => process.kill(pid, 0)).toThrow()
   })
 
   describe("#given an engine child that exits on its own #when it returns a non-zero code", () => {
@@ -242,8 +252,11 @@ describePosix("launcher child signal forwarding", () => {
       const parentPath = join(root, "parent.mjs")
       writeFile(parentPath, parentSource(childPath))
       const readyFile = join(root, "ready")
-      const parent = startParent(parentPath, { READY_FILE: readyFile, PARENT_LOG: join(root, "parent.log") })
+      const pidFile = join(root, "child.pid")
+      const parent = startParent(parentPath, { READY_FILE: readyFile, PARENT_LOG: join(root, "parent.log"), PID_FILE: pidFile })
       await waitForFile(readyFile)
+      fixturePids.push(parent.pid, Number(readFileSync(pidFile, "utf8")))
+      allFixturePids.push(...fixturePids.slice(-2))
 
       // The child is the only member of the launcher's descendant tree here, so killing it by pid
       // exercises the death-by-signal path without signaling the launcher.

--- a/packages/omo-native/test/child-process-signal.test.ts
+++ b/packages/omo-native/test/child-process-signal.test.ts
@@ -163,7 +163,7 @@ function createHarness(childSource: string): Harness {
   }
 }
 
-afterEach(() => {
+afterEach(async () => {
   for (const pid of fixturePids) {
     try {
       process.kill(pid, "SIGKILL")

--- a/packages/omo-native/test/child-process-signal.test.ts
+++ b/packages/omo-native/test/child-process-signal.test.ts
@@ -104,6 +104,15 @@ function startParent(parentPath: string, env: NodeJS.ProcessEnv): ParentRun {
   return { pid: child.pid ?? -1, exit }
 }
 
+async function waitForProcessGone(pid: number, timeoutMs = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try { process.kill(pid, 0) } catch { return }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 10))
+  }
+  throw new Error(`process ${pid} is still alive`)
+}
+
 async function waitForFile(path: string, timeoutMs = 15_000): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
@@ -159,7 +168,7 @@ afterEach(() => {
     try {
       process.kill(pid, "SIGKILL")
     } catch {}
-    expect(() => process.kill(pid, 0)).toThrow()
+    await waitForProcessGone(pid)
   }
   fixturePids.splice(0)
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
@@ -226,8 +235,8 @@ describePosix("launcher child signal forwarding", () => {
     }, 30_000)
   })
 
-  afterAll(() => {
-    for (const pid of allFixturePids) expect(() => process.kill(pid, 0)).toThrow()
+  afterAll(async () => {
+    for (const pid of allFixturePids) await waitForProcessGone(pid)
   })
 
   describe("#given an engine child that exits on its own #when it returns a non-zero code", () => {
@@ -290,7 +299,7 @@ import { maybeReexecUnderBun } from ${JSON.stringify(BUN_RUNTIME_MODULE)}
 await maybeReexecUnderBun({
   scriptPath: ${JSON.stringify(childPath)},
   argv: ["node", ${JSON.stringify(childPath)}],
-  env: { OMO_RUNTIME: "bun", PATH: ${JSON.stringify(binDir)} },
+  env: { OMO_RUNTIME: "bun", PATH: ${JSON.stringify(binDir)}, PID_FILE: ${JSON.stringify(join(root, "child.pid"))} },
   versions: {},
   homedir: () => ${JSON.stringify(join(root, "home"))},
 })


### PR DESCRIPTION
Prevents child-process-signal.test.ts fixture processes from surviving test scenarios. Records fixture PIDs, kills parent and child processes in teardown, verifies disappearance before temp directory removal, and retains a suite-level no-survivors assertion.

Remote verification: 8 pass, 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents child-process-signal.test.ts fixture processes from leaking after test scenarios by recording their PIDs, killing parent and child processes in teardown, and verifying they are gone before removing temporary directories. Adds a suite-level assertion to catch any survivors and documents the fix in an evidence report.

<sup>Written for commit 5d7bad4b1275720f1cb9ac65f1a887546d583fa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

