### PR TITLE
fix(hooks): evict unbounded in-memory hook caches

### DIFF
--- a/.omo/evidence/20260831-mem-hook-evictions/REPORT.md
+++ b/.omo/evidence/20260831-mem-hook-evictions/REPORT.md
@@ -1,0 +1,60 @@
+# Hook cache eviction TDD evidence (2026-08-31)
+
+Branch: `fix/mem-hook-cache-evictions`
+Remote runner: `bun /tmp/omo-mac-test.mjs <branch> -- <paths>`
+Local `bun test` was not used.
+
+## RED (SHA `0bf2bbe29`)
+
+Command:
+
+```bash
+bun /tmp/omo-mac-test.mjs fix/mem-hook-cache-evictions -- \
+  packages/omo-opencode/src/hooks/claude-code-hooks/transcript-prune.test.ts \
+  packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/hook.test.ts \
+  packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts \
+  packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler.test.ts \
+  packages/omo-opencode/src/hooks/keyword-detector/default-mode-session-eviction.test.ts \
+  packages/omo-opencode/src/hooks/fsync-skip-warning/eviction.test.ts
+```
+
+Result: **9 pass / 9 fail / 1 error** (exit 1)
+
+Snippets:
+
+- transcript: `expect(harness.unrefCalls()).toBe(1)` Expected 1, Received 0
+- hashline sweep: `expect(harness.unrefCalls()).toBe(1)` Expected 1, Received 0
+- hashline dispose: `expect(afterOutput.metadata).not.toHaveProperty("diff")` received unified diff
+- anthropic dispose maps: `expect(executeCompactMock).not.toHaveBeenCalled()` Received 1 call
+- session.deleted flags: `sessionFirstMessageProcessed.has("ses_end_flags")` Expected false, Received true
+- keyword session.deleted / dispose / cap: toast length Expected 1, Received 0
+- fsync: `Export named 'FSYNC_SKIP_START_TTL_MS' not found`
+- idle first-message flag test already passed (must not clear on `session.idle`)
+
+## GREEN (SHA `43edd7803`)
+
+Same six files:
+
+```
+19 pass
+0 fail
+Ran 19 tests across 6 files. [384.00ms]
+```
+
+Snippets:
+
+- transcript: `(pass) transcript cache idle prune > #given a cached transcript snapshot #when the TTL elapses without another build #then a background sweep drops the entry and temp file`
+- hashline: `(pass) hashline pendingCaptures eviction > #given a captured Write old-file body #when the TTL elapses without another Write #then a background sweep drops the capture`
+- anthropic: `(pass) ... #given session error payloads retained in maps #when dispose is called #then idle recovery does not keep those payloads`
+- session flags: `(pass) ... #given first-message and stop-hook flags #when session.deleted arrives #then both session-id sets are drained`
+- keyword: `(pass) ... #when session.deleted arrives #then the next prompt can inject again`
+- fsync: `(pass) ... #when the TTL elapses #then a background sweep drops the entry`
+
+## Full hooks scope
+
+Command: `bun /tmp/omo-mac-test.mjs fix/mem-hook-cache-evictions -- packages/omo-opencode/src/hooks`
+
+- this branch SHA `43edd7803`: **2118 pass / 46 fail / 276 files**
+- `origin/dev` SHA `3abc23c23`: **2107 pass / 46 fail / 272 files**
+
+The 46 failures are pre-existing on `dev` (same names: runtime-fallback index suite, directory-readme truncation log, sanitizeEmptyMessagesBeforeSummarize). They pass in isolation (`runtime-fallback/index.test.ts` 67 pass / 0 fail) and are cross-file pollution on the shared remote runner, not caused by these cache evictions. New tests: +11 pass.

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.test.ts
@@ -172,4 +172,32 @@ describe("createAnthropicContextWindowLimitRecoveryHook", () => {
     }
   })
 
+  test("#given session error payloads retained in maps #when dispose is called #then idle recovery does not keep those payloads", async () => {
+    //#given
+    const { restore } = setupDelayedTimeoutMocks()
+    const hook = createRecoveryHook()
+
+    try {
+      await hook.event({
+        event: {
+          type: "session.error",
+          properties: { sessionID: "session-dispose-maps", error: "prompt is too long" },
+        },
+      })
+
+      //#when
+      hook.dispose()
+      await hook.event({
+        event: {
+          type: "session.idle",
+          properties: { sessionID: "session-dispose-maps" },
+        },
+      })
+
+      //#then
+      expect(executeCompactMock).not.toHaveBeenCalled()
+    } finally {
+      restore()
+    }
+  })
 })

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.ts
@@ -5,7 +5,7 @@ import type { ExperimentalConfig, OhMyOpenCodeConfig } from "../../config"
 import { parseAnthropicTokenLimitError } from "./parser"
 import { executeCompact, getLastAssistant } from "./executor"
 import { attemptDeduplicationRecovery } from "./deduplication-recovery"
-import { clearSessionState } from "./state"
+import { clearAllSessionState, clearSessionState } from "./state"
 import { clearAllSessionTimeouts, clearSessionTimeout } from "./session-timeout-map"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
 import { log } from "../../shared/logger"
@@ -197,7 +197,7 @@ export function createAnthropicContextWindowLimitRecoveryHook(
     event: eventHandler,
     dispose: (): void => {
       clearAllSessionTimeouts(pendingCompactionTimeoutBySession)
-      clearAllSessionTimeouts(autoCompactState.retryTimerBySession)
+      clearAllSessionState(autoCompactState)
     },
   }
 }

--- a/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/state.ts
+++ b/packages/omo-opencode/src/hooks/anthropic-context-window-limit-recovery/state.ts
@@ -1,4 +1,5 @@
 import type { AutoCompactState, RetryState, TruncateState } from "./types"
+import { clearAllSessionTimeouts } from "./session-timeout-map"
 
 export function getOrCreateRetryState(
   autoCompactState: AutoCompactState,
@@ -39,6 +40,16 @@ export function clearSessionState(
   autoCompactState.truncateStateBySession.delete(sessionID)
   autoCompactState.emptyContentAttemptBySession.delete(sessionID)
   autoCompactState.compactionInProgress.delete(sessionID)
+}
+
+export function clearAllSessionState(autoCompactState: AutoCompactState): void {
+  clearAllSessionTimeouts(autoCompactState.retryTimerBySession)
+  autoCompactState.pendingCompact.clear()
+  autoCompactState.errorDataBySession.clear()
+  autoCompactState.retryStateBySession.clear()
+  autoCompactState.truncateStateBySession.clear()
+  autoCompactState.emptyContentAttemptBySession.clear()
+  autoCompactState.compactionInProgress.clear()
 }
 
 export function setRetryTimer(

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 
 import { ContextCollector } from "../../../features/context-injector"
 import { cacheToolInput, getToolInput, stopToolInputCacheCleanup } from "../tool-input-cache"
 import { buildTranscriptFromSession, hasTranscriptCacheEntry } from "../transcript"
+import {
+  clearAllSessionHookState,
+  sessionFirstMessageProcessed,
+} from "../session-hook-state"
+import { getStopHookActive, setStopHookActive } from "../stop"
 import { createSessionEventHandler, disposeSessionEventHandler } from "./session-event-handler"
 
 function createMockClient() {
@@ -16,6 +21,10 @@ function createMockClient() {
 }
 
 describe("createSessionEventHandler", () => {
+  afterEach(() => {
+    clearAllSessionHookState()
+  })
+
   test("#given deleted session with retained caches #when session deleted arrives #then per-session resources are cleared", async () => {
     //#given
     const collector = new ContextCollector()
@@ -135,5 +144,35 @@ describe("createSessionEventHandler", () => {
 
     //#then
     expect(getCallCount).toBe(2)
+  })
+
+  test("#given first-message and stop-hook flags #when session.deleted arrives #then both session-id sets are drained", async () => {
+    //#given
+    sessionFirstMessageProcessed.add("ses_end_flags")
+    setStopHookActive("ses_end_flags", true)
+    const handler = createSessionEventHandler(createMockClient() as never, {})
+
+    //#when
+    await handler({
+      event: { type: "session.deleted", properties: { info: { id: "ses_end_flags" } } },
+    })
+
+    //#then
+    expect(sessionFirstMessageProcessed.has("ses_end_flags")).toBe(false)
+    expect(getStopHookActive("ses_end_flags")).toBe(false)
+  })
+
+  test("#given first-message already processed #when session.idle arrives #then the first-message flag stays set", async () => {
+    //#given
+    sessionFirstMessageProcessed.add("ses_idle_flags")
+    const handler = createSessionEventHandler(createMockClient() as never, {})
+
+    //#when
+    await handler({
+      event: { type: "session.idle", properties: { sessionID: "ses_idle_flags" } },
+    })
+
+    //#then
+    expect(sessionFirstMessageProcessed.has("ses_idle_flags")).toBe(true)
   })
 })

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 
 import { ContextCollector } from "../../../features/context-injector"
 import { cacheToolInput, getToolInput, stopToolInputCacheCleanup } from "../tool-input-cache"
-import { buildTranscriptFromSession, hasTranscriptCacheEntry } from "../transcript"
+import { buildTranscriptFromSession, hasTranscriptCacheEntry, stopTranscriptCacheCleanup } from "../transcript"
 import {
   clearAllSessionHookState,
   sessionFirstMessageProcessed,
@@ -23,6 +23,7 @@ function createMockClient() {
 describe("createSessionEventHandler", () => {
   afterEach(() => {
     clearAllSessionHookState()
+    stopTranscriptCacheCleanup()
   })
 
   test("#given deleted session with retained caches #when session deleted arrives #then per-session resources are cleared", async () => {

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/handlers/session-event-handler.ts
@@ -3,7 +3,7 @@ import type { ContextCollector } from "../../../features/context-injector"
 import { clearClaudeHooksConfigCache, loadClaudeHooksConfig } from "../config"
 import { clearPluginExtendedConfigCache, loadPluginExtendedConfig } from "../config-loader"
 import { executeStopHooks, type StopContext } from "../stop"
-import { clearTranscriptCache, getTranscriptPath } from "../transcript"
+import { clearTranscriptCache, getTranscriptPath, stopTranscriptCacheCleanup } from "../transcript"
 import { clearToolInputCache, stopToolInputCacheCleanup } from "../tool-input-cache"
 import type { PluginConfig } from "../types"
 import { createInternalAgentTextPart, isHookDisabled, log } from "../../../shared"
@@ -12,6 +12,7 @@ import { isAmbiguousPostDispatchPromptFailure } from "../../../shared/prompt-fai
 import { dispatchInternalPrompt, isInternalPromptDispatchAccepted } from "../../../shared/prompt-async-gate"
 import {
 	clearAllSessionHookState,
+	clearSessionEndHookState,
 	clearSessionHookState,
 	sessionErrorState,
 	sessionInterruptState,
@@ -47,7 +48,7 @@ export function createSessionEventHandler(
 				clearTranscriptCache(sessionID)
 				clearToolInputCache(sessionID)
 				contextCollector?.clear(sessionID)
-				clearSessionHookState(sessionID)
+				clearSessionEndHookState(sessionID)
 			}
 			return
 		}
@@ -152,7 +153,7 @@ export function createSessionEventHandler(
 }
 
 export function disposeSessionEventHandler(contextCollector?: ContextCollector): void {
-	clearTranscriptCache()
+	stopTranscriptCacheCleanup()
 	clearClaudeHooksConfigCache()
 	clearPluginExtendedConfigCache()
 	stopToolInputCacheCleanup()

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/session-hook-state.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/session-hook-state.ts
@@ -1,3 +1,5 @@
+import { clearAllStopHookActive, clearStopHookActive } from "./stop"
+
 export const sessionFirstMessageProcessed = new Set<string>()
 
 export const sessionErrorState = new Map<string, { hasError: boolean; errorMessage?: string }>()
@@ -15,8 +17,15 @@ export function clearSessionHookState(sessionID: string): void {
 	// prompt instead of only the first one.
 }
 
+export function clearSessionEndHookState(sessionID: string): void {
+	clearSessionHookState(sessionID)
+	sessionFirstMessageProcessed.delete(sessionID)
+	clearStopHookActive(sessionID)
+}
+
 export function clearAllSessionHookState(): void {
 	sessionErrorState.clear()
 	sessionInterruptState.clear()
 	sessionFirstMessageProcessed.clear()
+	clearAllStopHookActive()
 }

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/stop.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/stop.ts
@@ -20,6 +20,14 @@ export function getStopHookActive(sessionId: string): boolean {
   return stopHookActiveState.get(sessionId) ?? false
 }
 
+export function clearStopHookActive(sessionId: string): void {
+  stopHookActiveState.delete(sessionId)
+}
+
+export function clearAllStopHookActive(): void {
+  stopHookActiveState.clear()
+}
+
 export interface StopContext {
   sessionId: string
   parentSessionId?: string

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/transcript-prune.test.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/transcript-prune.test.ts
@@ -3,8 +3,8 @@ import { existsSync } from "fs"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import {
   buildTranscriptFromSession,
-  clearTranscriptCache,
   hasTranscriptCacheEntry,
+  stopTranscriptCacheCleanup,
 } from "./transcript"
 
 const TRANSCRIPT_CACHE_TTL_MS = 5 * 60 * 1000
@@ -59,9 +59,9 @@ describe("transcript cache idle prune", () => {
   let restore: (() => void) | undefined
 
   afterEach(() => {
+    stopTranscriptCacheCleanup()
     restore?.()
     restore = undefined
-    clearTranscriptCache()
   })
 
   test("#given a cached transcript snapshot #when the TTL elapses without another build #then a background sweep drops the entry and temp file", async () => {

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/transcript-prune.test.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/transcript-prune.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync } from "fs"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import {
+  buildTranscriptFromSession,
+  clearTranscriptCache,
+  hasTranscriptCacheEntry,
+} from "./transcript"
+
+const TRANSCRIPT_CACHE_TTL_MS = 5 * 60 * 1000
+
+function createMockClient() {
+  return {
+    session: {
+      messages: () => Promise.resolve({ data: [] }),
+    },
+  }
+}
+
+function installSweepHarness() {
+  const originalSetInterval = globalThis.setInterval
+  const originalClearInterval = globalThis.clearInterval
+  const originalNow = Date.now
+  let now = 1_700_000_000_000
+  let sweep: (() => void) | undefined
+  let unrefCalls = 0
+  const handle = unsafeTestValue<ReturnType<typeof setInterval>>({
+    unref: () => {
+      unrefCalls += 1
+    },
+  })
+
+  globalThis.setInterval = unsafeTestValue<typeof setInterval>((callback: TimerHandler) => {
+    sweep = callback as () => void
+    return handle
+  })
+  globalThis.clearInterval = unsafeTestValue<typeof clearInterval>((timer) => {
+    if (timer === handle) sweep = undefined
+  })
+  Date.now = () => now
+
+  return {
+    advance(ms: number) {
+      now += ms
+    },
+    runSweep() {
+      sweep?.()
+    },
+    unrefCalls: () => unrefCalls,
+    restore() {
+      globalThis.setInterval = originalSetInterval
+      globalThis.clearInterval = originalClearInterval
+      Date.now = originalNow
+    },
+  }
+}
+
+describe("transcript cache idle prune", () => {
+  let restore: (() => void) | undefined
+
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+    clearTranscriptCache()
+  })
+
+  test("#given a cached transcript snapshot #when the TTL elapses without another build #then a background sweep drops the entry and temp file", async () => {
+    //#given
+    const harness = installSweepHarness()
+    restore = harness.restore
+    const path = await buildTranscriptFromSession(
+      createMockClient(),
+      "ses_idle_prune",
+      "/tmp",
+      "write",
+      { filePath: "/tmp/idle.txt", content: "stale-body" },
+    )
+
+    expect(path).not.toBeNull()
+    expect(hasTranscriptCacheEntry("ses_idle_prune")).toBe(true)
+    expect(path && existsSync(path)).toBe(true)
+    expect(harness.unrefCalls()).toBe(1)
+
+    //#when
+    harness.advance(TRANSCRIPT_CACHE_TTL_MS + 1)
+    harness.runSweep()
+
+    //#then
+    expect(hasTranscriptCacheEntry("ses_idle_prune")).toBe(false)
+    expect(path && existsSync(path)).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/transcript.test.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/transcript.test.ts
@@ -4,6 +4,7 @@ import {
   buildTranscriptFromSession,
   deleteTempTranscript,
   clearTranscriptCache,
+  stopTranscriptCacheCleanup,
 } from "./transcript"
 
 function createMockClient(messages: unknown[] = []) {
@@ -20,7 +21,7 @@ function createMockClient(messages: unknown[] = []) {
 
 describe("transcript caching", () => {
   afterEach(() => {
-    clearTranscriptCache()
+    stopTranscriptCacheCleanup()
   })
 
   // #given same session called twice

--- a/packages/omo-opencode/src/hooks/claude-code-hooks/transcript.ts
+++ b/packages/omo-opencode/src/hooks/claude-code-hooks/transcript.ts
@@ -62,9 +62,11 @@ interface TranscriptCacheEntry {
   createdAt: number
 }
 
-const TRANSCRIPT_CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+export const TRANSCRIPT_CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+const TRANSCRIPT_CACHE_PRUNE_INTERVAL_MS = TRANSCRIPT_CACHE_TTL_MS
 
 const transcriptCache = new Map<string, TranscriptCacheEntry>()
+let cleanupInterval: ReturnType<typeof setInterval> | null = null
 
 function logTranscriptError(message: string, error: unknown): void {
   log(message, { error })
@@ -109,6 +111,31 @@ export function clearTranscriptCache(sessionId?: string): void {
 
 export function hasTranscriptCacheEntry(sessionId: string): boolean {
   return transcriptCache.has(sessionId)
+}
+
+function pruneExpiredTranscriptCache(): void {
+  const now = Date.now()
+  for (const sessionId of [...transcriptCache.keys()]) {
+    const entry = transcriptCache.get(sessionId)
+    if (!entry || now - entry.createdAt >= TRANSCRIPT_CACHE_TTL_MS) {
+      clearTranscriptCache(sessionId)
+    }
+  }
+}
+
+function ensureTranscriptCacheCleanup(): void {
+  if (cleanupInterval) return
+  cleanupInterval = setInterval(pruneExpiredTranscriptCache, TRANSCRIPT_CACHE_PRUNE_INTERVAL_MS)
+  if (typeof cleanupInterval === "object" && "unref" in cleanupInterval) {
+    cleanupInterval.unref()
+  }
+}
+
+export function stopTranscriptCacheCleanup(): void {
+  clearTranscriptCache()
+  if (!cleanupInterval) return
+  clearInterval(cleanupInterval)
+  cleanupInterval = null
 }
 
 function isCacheValid(entry: TranscriptCacheEntry): boolean {
@@ -212,6 +239,7 @@ export async function buildTranscriptFromSession(
         tempPath: null,
         createdAt: Date.now(),
       })
+      ensureTranscriptCacheCleanup()
     }
 
     const allEntries = [...baseEntries, buildCurrentEntry(currentToolName, currentToolInput)]

--- a/packages/omo-opencode/src/hooks/fsync-skip-warning/eviction.test.ts
+++ b/packages/omo-opencode/src/hooks/fsync-skip-warning/eviction.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import {
   createFsyncSkipWarningHook,
@@ -47,6 +47,10 @@ function installSweepHarness() {
 
 describe("fsync-skip-warning startTimesByCallId eviction", () => {
   let restore: (() => void) | undefined
+
+  beforeEach(() => {
+    stopFsyncSkipWarningCleanup()
+  })
 
   afterEach(() => {
     stopFsyncSkipWarningCleanup()

--- a/packages/omo-opencode/src/hooks/fsync-skip-warning/eviction.test.ts
+++ b/packages/omo-opencode/src/hooks/fsync-skip-warning/eviction.test.ts
@@ -4,6 +4,7 @@ import {
   createFsyncSkipWarningHook,
   FSYNC_SKIP_START_TTL_MS,
   hasFsyncSkipStartTime,
+  stopFsyncSkipWarningCleanup,
 } from "./index"
 
 function installSweepHarness() {
@@ -48,6 +49,7 @@ describe("fsync-skip-warning startTimesByCallId eviction", () => {
   let restore: (() => void) | undefined
 
   afterEach(() => {
+    stopFsyncSkipWarningCleanup()
     restore?.()
     restore = undefined
   })

--- a/packages/omo-opencode/src/hooks/fsync-skip-warning/eviction.test.ts
+++ b/packages/omo-opencode/src/hooks/fsync-skip-warning/eviction.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import {
+  createFsyncSkipWarningHook,
+  FSYNC_SKIP_START_TTL_MS,
+  hasFsyncSkipStartTime,
+} from "./index"
+
+function installSweepHarness() {
+  const originalSetInterval = globalThis.setInterval
+  const originalClearInterval = globalThis.clearInterval
+  const originalNow = Date.now
+  let now = 1_700_000_000_000
+  let sweep: (() => void) | undefined
+  let unrefCalls = 0
+  const handle = unsafeTestValue<ReturnType<typeof setInterval>>({
+    unref: () => {
+      unrefCalls += 1
+    },
+  })
+
+  globalThis.setInterval = unsafeTestValue<typeof setInterval>((callback: TimerHandler) => {
+    sweep = callback as () => void
+    return handle
+  })
+  globalThis.clearInterval = unsafeTestValue<typeof clearInterval>((timer) => {
+    if (timer === handle) sweep = undefined
+  })
+  Date.now = () => now
+
+  return {
+    advance(ms: number) {
+      now += ms
+    },
+    runSweep() {
+      sweep?.()
+    },
+    unrefCalls: () => unrefCalls,
+    restore() {
+      globalThis.setInterval = originalSetInterval
+      globalThis.clearInterval = originalClearInterval
+      Date.now = originalNow
+    },
+  }
+}
+
+describe("fsync-skip-warning startTimesByCallId eviction", () => {
+  let restore: (() => void) | undefined
+
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+  })
+
+  test("#given a before-hook start time whose after-hook never runs #when the TTL elapses #then a background sweep drops the entry", async () => {
+    //#given
+    const harness = installSweepHarness()
+    restore = harness.restore
+    const hook = createFsyncSkipWarningHook() as ReturnType<typeof createFsyncSkipWarningHook> & {
+      dispose?: () => void
+    }
+    const input = { tool: "write", sessionID: "ses_fsync", callID: "call_orphan" }
+
+    await hook["tool.execute.before"](input, { args: {} })
+    expect(hasFsyncSkipStartTime("call_orphan")).toBe(true)
+    expect(harness.unrefCalls()).toBe(1)
+
+    //#when
+    harness.advance(FSYNC_SKIP_START_TTL_MS + 1)
+    harness.runSweep()
+
+    //#then
+    expect(hasFsyncSkipStartTime("call_orphan")).toBe(false)
+    hook.dispose?.()
+  })
+
+  test("#given unmatched before-hook start times #when dispose runs #then tracked call IDs are cleared", async () => {
+    //#given
+    const hook = createFsyncSkipWarningHook() as ReturnType<typeof createFsyncSkipWarningHook> & {
+      dispose?: () => void
+    }
+    await hook["tool.execute.before"](
+      { tool: "write", sessionID: "ses_fsync", callID: "call_dispose" },
+      { args: {} },
+    )
+    expect(hasFsyncSkipStartTime("call_dispose")).toBe(true)
+
+    //#when
+    hook.dispose?.()
+
+    //#then
+    expect(hasFsyncSkipStartTime("call_dispose")).toBe(false)
+  })
+})

--- a/packages/omo-opencode/src/hooks/fsync-skip-warning/index.test.ts
+++ b/packages/omo-opencode/src/hooks/fsync-skip-warning/index.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "bun:test"
 
 import { classifyPathEnvironment } from "../../shared/classify-path-environment"
 import { clearAllSkips, recordFsyncSkip } from "../../shared/fsync-skip-tracker"
-import { createFsyncSkipWarningHook } from "./index"
+import { createFsyncSkipWarningHook, stopFsyncSkipWarningCleanup } from "./index"
 
 /**
  * The hook drains skips with a strict `timestamp > startTimestamp` comparison against `Date.now()`.
@@ -18,6 +18,7 @@ async function advanceClockPastNow(): Promise<void> {
 describe("createFsyncSkipWarningHook", () => {
   beforeEach(() => {
     clearAllSkips()
+    stopFsyncSkipWarningCleanup()
   })
 
   it("records callID start timestamp in tool.execute.before", async () => {

--- a/packages/omo-opencode/src/hooks/fsync-skip-warning/index.test.ts
+++ b/packages/omo-opencode/src/hooks/fsync-skip-warning/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 
 import { classifyPathEnvironment } from "../../shared/classify-path-environment"
 import { clearAllSkips, recordFsyncSkip } from "../../shared/fsync-skip-tracker"
@@ -18,6 +18,10 @@ async function advanceClockPastNow(): Promise<void> {
 describe("createFsyncSkipWarningHook", () => {
   beforeEach(() => {
     clearAllSkips()
+    stopFsyncSkipWarningCleanup()
+  })
+
+  afterEach(() => {
     stopFsyncSkipWarningCleanup()
   })
 

--- a/packages/omo-opencode/src/hooks/fsync-skip-warning/index.ts
+++ b/packages/omo-opencode/src/hooks/fsync-skip-warning/index.ts
@@ -17,13 +17,44 @@ type ToolAfterOutput = {
   metadata: unknown
 }
 
-export function createFsyncSkipWarningHook() {
-  const startTimesByCallId = new Map<string, number>()
+export const FSYNC_SKIP_START_TTL_MS = 60_000
 
+const startTimesByCallId = new Map<string, number>()
+let cleanupInterval: ReturnType<typeof setInterval> | null = null
+
+function pruneStaleStartTimes(now = Date.now()): void {
+  for (const [callID, startedAt] of startTimesByCallId) {
+    if (now - startedAt > FSYNC_SKIP_START_TTL_MS) {
+      startTimesByCallId.delete(callID)
+    }
+  }
+}
+
+function ensureCleanupInterval(): void {
+  if (cleanupInterval) return
+  cleanupInterval = setInterval(() => pruneStaleStartTimes(), FSYNC_SKIP_START_TTL_MS)
+  if (typeof cleanupInterval === "object" && "unref" in cleanupInterval) {
+    cleanupInterval.unref()
+  }
+}
+
+export function hasFsyncSkipStartTime(callID: string): boolean {
+  return startTimesByCallId.has(callID)
+}
+
+export function stopFsyncSkipWarningCleanup(): void {
+  startTimesByCallId.clear()
+  if (!cleanupInterval) return
+  clearInterval(cleanupInterval)
+  cleanupInterval = null
+}
+
+export function createFsyncSkipWarningHook() {
   const toolExecuteBefore = async (
     input: ToolExecuteInput,
     _output: ToolBeforeOutput,
   ): Promise<void> => {
+    ensureCleanupInterval()
     startTimesByCallId.set(input.callID, Date.now())
   }
 
@@ -31,10 +62,9 @@ export function createFsyncSkipWarningHook() {
     input: ToolExecuteInput,
     output: ToolAfterOutput,
   ): Promise<void> => {
-    if (typeof output.output !== "string") return
-
     const startTimestamp = startTimesByCallId.get(input.callID) ?? 0
     startTimesByCallId.delete(input.callID)
+    if (typeof output.output !== "string") return
 
     const skips = drainSkipsAfter(startTimestamp)
     const warning = formatFsyncSkipWarning(skips)
@@ -46,5 +76,6 @@ export function createFsyncSkipWarningHook() {
   return {
     "tool.execute.before": toolExecuteBefore,
     "tool.execute.after": toolExecuteAfter,
+    dispose: stopFsyncSkipWarningCleanup,
   }
 }

--- a/packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/hook.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, writeFileSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { createHashlineEditDiffEnhancerHook } from "./hook"
+
+const STALE_TIMEOUT_MS = 5 * 60 * 1000
+
+function installSweepHarness() {
+  const originalSetInterval = globalThis.setInterval
+  const originalClearInterval = globalThis.clearInterval
+  const originalNow = Date.now
+  let now = 1_700_000_000_000
+  let sweep: (() => void) | undefined
+  let unrefCalls = 0
+  const handle = unsafeTestValue<ReturnType<typeof setInterval>>({
+    unref: () => {
+      unrefCalls += 1
+    },
+  })
+
+  globalThis.setInterval = unsafeTestValue<typeof setInterval>((callback: TimerHandler) => {
+    sweep = callback as () => void
+    return handle
+  })
+  globalThis.clearInterval = unsafeTestValue<typeof clearInterval>((timer) => {
+    if (timer === handle) sweep = undefined
+  })
+  Date.now = () => now
+
+  return {
+    advance(ms: number) {
+      now += ms
+    },
+    runSweep() {
+      sweep?.()
+    },
+    unrefCalls: () => unrefCalls,
+    restore() {
+      globalThis.setInterval = originalSetInterval
+      globalThis.clearInterval = originalClearInterval
+      Date.now = originalNow
+    },
+  }
+}
+
+function writeTempFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), "hashline-capture-"))
+  const filePath = join(dir, "target.txt")
+  writeFileSync(filePath, "old-file-body\n")
+  return filePath
+}
+
+describe("hashline pendingCaptures eviction", () => {
+  let restore: (() => void) | undefined
+
+  afterEach(() => {
+    restore?.()
+    restore = undefined
+  })
+
+  test("#given a captured Write old-file body #when the TTL elapses without another Write #then a background sweep drops the capture", async () => {
+    //#given
+    const harness = installSweepHarness()
+    restore = harness.restore
+    const filePath = writeTempFile()
+    const hook = createHashlineEditDiffEnhancerHook({ hashline_edit: { enabled: true } })
+    const input = { tool: "write", sessionID: "ses_hashline", callID: "call_stale" }
+
+    await hook["tool.execute.before"](input, { args: { path: filePath } })
+    expect(harness.unrefCalls()).toBe(1)
+
+    //#when
+    harness.advance(STALE_TIMEOUT_MS + 1)
+    harness.runSweep()
+
+    const afterOutput = { title: "write", output: "ok", metadata: {} as Record<string, unknown> }
+    await hook["tool.execute.after"](input, afterOutput)
+
+    //#then
+    expect(afterOutput.metadata).not.toHaveProperty("diff")
+  })
+
+  test("#given a captured Write old-file body #when dispose runs #then the after hook has nothing left to enhance", async () => {
+    //#given
+    const filePath = writeTempFile()
+    const hook = createHashlineEditDiffEnhancerHook({ hashline_edit: { enabled: true } })
+    const input = { tool: "write", sessionID: "ses_hashline_dispose", callID: "call_dispose" }
+    await hook["tool.execute.before"](input, { args: { path: filePath } })
+
+    //#when
+    const disposable = hook as { dispose?: () => void }
+    disposable.dispose?.()
+
+    const afterOutput = { title: "write", output: "ok", metadata: {} as Record<string, unknown> }
+    await hook["tool.execute.after"](input, afterOutput)
+
+    //#then
+    expect(afterOutput.metadata).not.toHaveProperty("diff")
+  })
+})

--- a/packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/hook.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "os"
 import { join } from "path"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import { createHashlineEditDiffEnhancerHook } from "./hook"
+import { stopPendingCaptureCleanup } from "./pending-captures"
 
 const STALE_TIMEOUT_MS = 5 * 60 * 1000
 
@@ -56,6 +57,7 @@ describe("hashline pendingCaptures eviction", () => {
   let restore: (() => void) | undefined
 
   afterEach(() => {
+    stopPendingCaptureCleanup()
     restore?.()
     restore = undefined
   })

--- a/packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/hook.ts
+++ b/packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/hook.ts
@@ -1,6 +1,12 @@
 import { log } from "../../shared"
 import { bunFile } from "../../shared/bun-file-shim"
 import { generateUnifiedDiff, countLineDiffs } from "../../tools/hashline-edit/diff-utils"
+import {
+	pruneStalePendingCaptures,
+	setPendingCapture,
+	stopPendingCaptureCleanup,
+	takePendingCapture,
+} from "./pending-captures"
 
 interface HashlineEditDiffEnhancerConfig {
 	hashline_edit?: { enabled: boolean }
@@ -10,23 +16,6 @@ type BeforeInput = { tool: string; sessionID: string; callID: string }
 type BeforeOutput = { args: Record<string, unknown> }
 type AfterInput = { tool: string; sessionID: string; callID: string }
 type AfterOutput = { title: string; output: string; metadata: Record<string, unknown> }
-
-const STALE_TIMEOUT_MS = 5 * 60 * 1000
-
-const pendingCaptures = new Map<string, { content: string; filePath: string; storedAt: number }>()
-
-function makeKey(sessionID: string, callID: string): string {
-	return `${sessionID}:${callID}`
-}
-
-function cleanupStaleEntries(): void {
-	const now = Date.now()
-	for (const [key, entry] of pendingCaptures) {
-		if (now - entry.storedAt > STALE_TIMEOUT_MS) {
-			pendingCaptures.delete(key)
-		}
-	}
-}
 
 function isWriteTool(toolName: string): boolean {
 	return toolName.toLowerCase() === "write"
@@ -62,22 +51,19 @@ export function createHashlineEditDiffEnhancerHook(config: HashlineEditDiffEnhan
 			const filePath = extractFilePath(output.args)
 			if (!filePath) return
 
-			cleanupStaleEntries()
+			pruneStalePendingCaptures()
 			const oldContent = await captureOldContent(filePath)
-			pendingCaptures.set(makeKey(input.sessionID, input.callID), {
+			setPendingCapture(input.sessionID, input.callID, {
 				content: oldContent,
 				filePath,
-				storedAt: Date.now(),
 			})
 		},
 
 		"tool.execute.after": async (input: AfterInput, output: AfterOutput) => {
 			if (!enabled || !isWriteTool(input.tool)) return
 
-			const key = makeKey(input.sessionID, input.callID)
-			const captured = pendingCaptures.get(key)
+			const captured = takePendingCapture(input.sessionID, input.callID)
 			if (!captured) return
-			pendingCaptures.delete(key)
 
 			const { content: oldContent, filePath } = captured
 
@@ -108,6 +94,10 @@ export function createHashlineEditDiffEnhancerHook(config: HashlineEditDiffEnhan
 			output.metadata.diff = unifiedDiff
 
 			output.title = filePath
+		},
+
+		dispose: (): void => {
+			stopPendingCaptureCleanup()
 		},
 	}
 }

--- a/packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/pending-captures.ts
+++ b/packages/omo-opencode/src/hooks/hashline-edit-diff-enhancer/pending-captures.ts
@@ -1,0 +1,59 @@
+export const HASHLINE_PENDING_CAPTURE_TTL_MS = 5 * 60 * 1000
+const HASHLINE_PENDING_CAPTURE_PRUNE_INTERVAL_MS = HASHLINE_PENDING_CAPTURE_TTL_MS
+
+export type PendingCapture = {
+  content: string
+  filePath: string
+  storedAt: number
+}
+
+const pendingCaptures = new Map<string, PendingCapture>()
+let cleanupInterval: ReturnType<typeof setInterval> | null = null
+
+function makeKey(sessionID: string, callID: string): string {
+  return `${sessionID}:${callID}`
+}
+
+export function pruneStalePendingCaptures(now = Date.now()): void {
+  for (const [key, entry] of pendingCaptures) {
+    if (now - entry.storedAt > HASHLINE_PENDING_CAPTURE_TTL_MS) {
+      pendingCaptures.delete(key)
+    }
+  }
+}
+
+function ensureCleanupInterval(): void {
+  if (cleanupInterval) return
+  cleanupInterval = setInterval(() => pruneStalePendingCaptures(), HASHLINE_PENDING_CAPTURE_PRUNE_INTERVAL_MS)
+  if (typeof cleanupInterval === "object" && "unref" in cleanupInterval) {
+    cleanupInterval.unref()
+  }
+}
+
+export function setPendingCapture(
+  sessionID: string,
+  callID: string,
+  capture: { content: string; filePath: string },
+): void {
+  ensureCleanupInterval()
+  pendingCaptures.set(makeKey(sessionID, callID), {
+    content: capture.content,
+    filePath: capture.filePath,
+    storedAt: Date.now(),
+  })
+}
+
+export function takePendingCapture(sessionID: string, callID: string): PendingCapture | undefined {
+  const key = makeKey(sessionID, callID)
+  const captured = pendingCaptures.get(key)
+  if (!captured) return undefined
+  pendingCaptures.delete(key)
+  return captured
+}
+
+export function stopPendingCaptureCleanup(): void {
+  pendingCaptures.clear()
+  if (!cleanupInterval) return
+  clearInterval(cleanupInterval)
+  cleanupInterval = null
+}

--- a/packages/omo-opencode/src/hooks/keyword-detector/default-mode-session-eviction.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/default-mode-session-eviction.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { _resetForTesting } from "../../features/claude-code-session-state"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { createKeywordDetectorHook } from "./hook"
+
+type KeywordHook = ReturnType<typeof createKeywordDetectorHook> & {
+  event?: (input: { event: { type: string; properties?: unknown } }) => void | Promise<void>
+  dispose?: () => void
+}
+
+const DEFAULT_MODE = { ultrawork: true, goal: false }
+const SESSION_CAP = 256
+
+function createHook(toastMessages: string[]): KeywordHook {
+  return createKeywordDetectorHook(
+    unsafeTestValue({
+      client: {
+        tui: {
+          showToast: async (opts: { body: { message: string } }) => {
+            toastMessages.push(opts.body.message)
+          },
+        },
+      },
+    }),
+    undefined,
+    undefined,
+    undefined,
+    DEFAULT_MODE,
+  ) as KeywordHook
+}
+
+async function sendPlainPrompt(hook: KeywordHook, sessionID: string): Promise<void> {
+  await hook["chat.message"](
+    { sessionID, agent: "sisyphus" },
+    {
+      message: {},
+      parts: [{ type: "text", text: "please help with this task" }],
+    },
+  )
+}
+
+describe("keyword-detector defaultModeUltraworkInjectedSessions eviction", () => {
+  beforeEach(() => {
+    _resetForTesting()
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+  })
+
+  test("#given default ultrawork already injected #when session.deleted arrives #then the next prompt can inject again", async () => {
+    //#given
+    const toastMessages: string[] = []
+    const hook = createHook(toastMessages)
+    const sessionID = "ses_default_ulw_deleted"
+
+    await sendPlainPrompt(hook, sessionID)
+    expect(toastMessages).toHaveLength(1)
+    toastMessages.length = 0
+    await sendPlainPrompt(hook, sessionID)
+    expect(toastMessages).toHaveLength(0)
+
+    //#when
+    await hook.event?.({
+      event: { type: "session.deleted", properties: { sessionID } },
+    })
+    await sendPlainPrompt(hook, sessionID)
+
+    //#then
+    expect(toastMessages).toHaveLength(1)
+  })
+
+  test("#given default ultrawork already injected #when dispose runs #then later sessions are not pinned by the old set", async () => {
+    //#given
+    const toastMessages: string[] = []
+    const hook = createHook(toastMessages)
+    const sessionID = "ses_default_ulw_dispose"
+
+    await sendPlainPrompt(hook, sessionID)
+    expect(toastMessages).toHaveLength(1)
+    toastMessages.length = 0
+
+    //#when
+    hook.dispose?.()
+    await sendPlainPrompt(hook, sessionID)
+
+    //#then
+    expect(toastMessages).toHaveLength(1)
+  })
+
+  test("#given more injected sessions than the cap #when another session is injected #then the oldest session can inject again", async () => {
+    //#given
+    const toastMessages: string[] = []
+    const hook = createHook(toastMessages)
+
+    for (let index = 0; index <= SESSION_CAP; index += 1) {
+      await sendPlainPrompt(hook, `ses_default_ulw_cap_${index}`)
+    }
+    toastMessages.length = 0
+
+    //#when
+    await sendPlainPrompt(hook, "ses_default_ulw_cap_0")
+
+    //#then
+    expect(toastMessages).toHaveLength(1)
+  })
+})

--- a/packages/omo-opencode/src/hooks/keyword-detector/default-mode-session-eviction.test.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/default-mode-session-eviction.test.ts
@@ -40,31 +40,35 @@ async function sendPlainPrompt(hook: KeywordHook, sessionID: string): Promise<vo
 }
 
 describe("keyword-detector defaultModeUltraworkInjectedSessions eviction", () => {
+  let hook: KeywordHook | undefined
+
   beforeEach(() => {
     _resetForTesting()
   })
 
   afterEach(() => {
+    hook?.dispose?.()
+    hook = undefined
     _resetForTesting()
   })
 
   test("#given default ultrawork already injected #when session.deleted arrives #then the next prompt can inject again", async () => {
     //#given
     const toastMessages: string[] = []
-    const hook = createHook(toastMessages)
+    hook = createHook(toastMessages)
     const sessionID = "ses_default_ulw_deleted"
 
-    await sendPlainPrompt(hook, sessionID)
+    await sendPlainPrompt(hook!, sessionID)
     expect(toastMessages).toHaveLength(1)
     toastMessages.length = 0
-    await sendPlainPrompt(hook, sessionID)
+    await sendPlainPrompt(hook!, sessionID)
     expect(toastMessages).toHaveLength(0)
 
     //#when
-    await hook.event?.({
+    await hook!.event?.({
       event: { type: "session.deleted", properties: { sessionID } },
     })
-    await sendPlainPrompt(hook, sessionID)
+    await sendPlainPrompt(hook!, sessionID)
 
     //#then
     expect(toastMessages).toHaveLength(1)
@@ -73,16 +77,16 @@ describe("keyword-detector defaultModeUltraworkInjectedSessions eviction", () =>
   test("#given default ultrawork already injected #when dispose runs #then later sessions are not pinned by the old set", async () => {
     //#given
     const toastMessages: string[] = []
-    const hook = createHook(toastMessages)
+    hook = createHook(toastMessages)
     const sessionID = "ses_default_ulw_dispose"
 
-    await sendPlainPrompt(hook, sessionID)
+    await sendPlainPrompt(hook!, sessionID)
     expect(toastMessages).toHaveLength(1)
     toastMessages.length = 0
 
     //#when
-    hook.dispose?.()
-    await sendPlainPrompt(hook, sessionID)
+    hook!.dispose?.()
+    await sendPlainPrompt(hook!, sessionID)
 
     //#then
     expect(toastMessages).toHaveLength(1)
@@ -91,15 +95,15 @@ describe("keyword-detector defaultModeUltraworkInjectedSessions eviction", () =>
   test("#given more injected sessions than the cap #when another session is injected #then the oldest session can inject again", async () => {
     //#given
     const toastMessages: string[] = []
-    const hook = createHook(toastMessages)
+    hook = createHook(toastMessages)
 
     for (let index = 0; index <= SESSION_CAP; index += 1) {
-      await sendPlainPrompt(hook, `ses_default_ulw_cap_${index}`)
+      await sendPlainPrompt(hook!, `ses_default_ulw_cap_${index}`)
     }
     toastMessages.length = 0
 
     //#when
-    await sendPlainPrompt(hook, "ses_default_ulw_cap_0")
+    await sendPlainPrompt(hook!, "ses_default_ulw_cap_0")
 
     //#then
     expect(toastMessages).toHaveLength(1)

--- a/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
+++ b/packages/omo-opencode/src/hooks/keyword-detector/hook.ts
@@ -12,6 +12,7 @@ import {
   isSyntheticOrInternalOnlyTextParts,
   log,
 } from "../../shared"
+import { resolveSessionEventID } from "../../shared/event-session-id"
 import {
   isSystemDirective,
   removeSystemReminders,
@@ -21,6 +22,24 @@ import type { DetectedKeyword } from "./detector"
 import { detectKeywordsWithType, extractPromptText, looksLikeSlashCommand } from "./detector"
 
 const defaultModeUltraworkInjectedSessions = new Set<string>()
+const DEFAULT_MODE_ULTRAWORK_SESSION_CAP = 256
+
+function rememberDefaultModeUltraworkInjectedSession(sessionID: string): void {
+  if (defaultModeUltraworkInjectedSessions.has(sessionID)) return
+  if (defaultModeUltraworkInjectedSessions.size >= DEFAULT_MODE_ULTRAWORK_SESSION_CAP) {
+    const oldest = defaultModeUltraworkInjectedSessions.values().next().value
+    if (oldest !== undefined) defaultModeUltraworkInjectedSessions.delete(oldest)
+  }
+  defaultModeUltraworkInjectedSessions.add(sessionID)
+}
+
+function clearDefaultModeUltraworkInjectedSession(sessionID: string): void {
+  defaultModeUltraworkInjectedSessions.delete(sessionID)
+}
+
+function clearAllDefaultModeUltraworkInjectedSessions(): void {
+  defaultModeUltraworkInjectedSessions.clear()
+}
 
 function suppressComboStandalones(detected: DetectedKeyword[]): DetectedKeyword[] {
   const hasCombo = detected.some((k) => k.type === "hyperplan-ultrawork")
@@ -118,7 +137,7 @@ export function createKeywordDetectorHook(
 
       if (detectedKeywords.length === 0) {
         if (defaultMode?.ultrawork && !isNonMainSession && !defaultModeUltraworkInjectedSessions.has(input.sessionID)) {
-          defaultModeUltraworkInjectedSessions.add(input.sessionID)
+          rememberDefaultModeUltraworkInjectedSession(input.sessionID)
 
           log(`[keyword-detector] Default ultrawork mode auto-activated (injected via system prompt)`, { sessionID: input.sessionID })
 
@@ -243,6 +262,14 @@ export function createKeywordDetectorHook(
         sessionID: input.sessionID,
         types: detectedKeywords.map((k) => k.type),
       })
+    },
+    event: ({ event }: { event: { type: string; properties?: unknown } }): void => {
+      if (event.type !== "session.deleted") return
+      const sessionID = resolveSessionEventID(event.properties)
+      if (sessionID) clearDefaultModeUltraworkInjectedSession(sessionID)
+    },
+    dispose: (): void => {
+      clearAllDefaultModeUltraworkInjectedSessions()
     },
   }
 }


### PR DESCRIPTION
## Summary

Apply the Atlas eviction/dispose pattern to five confirmed unbounded in-memory caches in `packages/omo-opencode/src/hooks/**`. Idle sessions and dropped after-hooks no longer pin full tool-input JSON or file bodies until process exit.

- Transcript cache now has an unref'd TTL sweep, so idle sessions drop the last `session.messages()` snapshot without waiting for another build
- Hashline pending Write captures prune on an interval independent of later Writes, and clear on dispose
- Anthropic recovery `dispose()` clears error-payload maps, not only timeouts
- Session-id flag sets drain on session end (first-message + stop-hook); default-ultrawork injection is capped and disposable
- Fsync-skip start timestamps expire when the after-hook never runs

## Changes

### 1. `transcriptCache` (`hooks/claude-code-hooks/transcript.ts`)

| | Before | After |
|---|---|---|
| Bound | None for idle sessions. 5 min TTL evaluated only on the next `buildTranscriptFromSession` | 5 min TTL + unref'd interval sweep; `stopTranscriptCacheCleanup()` on plugin dispose |
| Trigger | Next build / `session.deleted` / process exit | Background prune, `session.deleted`, plugin dispose |

### 2. `pendingCaptures` (`hooks/hashline-edit-diff-enhancer`)

| | Before | After |
|---|---|---|
| Bound | 5 min TTL swept only on the next Write | 5 min TTL + unref'd interval; `dispose()` clears the map |
| Trigger | Next Write | Background prune independent of Writes, hook dispose |

### 3. Anthropic recovery maps (`hooks/anthropic-context-window-limit-recovery`)

| | Before | After |
|---|---|---|
| Bound | Cleared on `session.deleted` / `compacted`; `dispose()` only cleared timeouts | `dispose()` also `clearAllSessionState()` (error payloads, pending sets, retry/truncate maps) |
| Trigger | Session end events | Session end events **and** plugin dispose (Atlas-style) |

### 4. Unbounded session-id sets

| Cache | Before | After | Trigger |
|---|---|---|---|
| `sessionFirstMessageProcessed` | `clearSessionHookState` skipped it (idle must not reset it) | `clearSessionEndHookState` deletes it; idle path unchanged | `session.deleted`, plugin dispose |
| `stopHookActiveState` | No delete | Deleted via the same session-end family | `session.deleted`, plugin dispose |
| `defaultModeUltraworkInjectedSessions` | Add-only | FIFO cap 256 + `event(session.deleted)` + `dispose()` | Cap always; session.deleted/dispose when the hook methods are invoked |

### 5. `startTimesByCallId` (`hooks/fsync-skip-warning`)

| | Before | After |
|---|---|---|
| Bound | Deleted only on matching after-hook | 60s TTL + unref'd interval; `dispose()` clears |
| Trigger | Matching after-hook | Background prune when after-hook is dropped, dispose |

## QA & Evidence

- **What was tested:** remote TDD RED then GREEN on the six new/updated eviction files.
  **Observed result:** RED SHA `0bf2bbe29` 9 pass / 9 fail / 1 error. GREEN SHA `43edd7803` 19 pass / 0 fail.
  **Artifact:** `.omo/evidence/20260831-mem-hook-evictions/REPORT.md`
  **Why sufficient:** each cache has a deterministic assertion for prune-without-new-work and/or dispose. Fake timers only.

- **What was tested:** full `packages/omo-opencode/src/hooks` on this branch and on `origin/dev`.
  **Observed result:** this branch 2118 pass / 46 fail; `origin/dev` 2107 pass / 46 fail (same 46 names). New tests +11 pass.
  **Artifact:** REPORT.md
  **Why sufficient:** the 46 failures are pre-existing cross-file pollution on the remote runner, not caused by these evictions. `runtime-fallback/index.test.ts` is 67 pass / 0 fail in isolation.

## Risks & Residuals

Hook-internal only. These plugin files were **not** edited (`event-session-lifecycle.ts`, `plugin-dispose.ts`, `create-managers.ts`, `create-hooks.ts`):

- **keyword-detector `event` / `dispose`:** plugin currently invokes only `chat.message`. Runtime bound without that wiring is the 256 FIFO cap. Residual: `disposeCreatedHooks` does not call keyword-detector dispose.
- **hashline-edit-diff-enhancer:** still unwired in composers. Interval + dispose exist on the hook object; `disposeCreatedHooks` does not call it. Residual until the hook is registered.
- **fsync-skip-warning `dispose`:** not listed in `disposeCreatedHooks`. The unref'd 60s sweep is the process-lifetime bound while the hook instance lives.
- **pre-existing 46 hooks-suite failures on `dev`:** accepted; unchanged by this PR.

## Automated Checks

```bash
bun /tmp/omo-mac-test.mjs fix/mem-hook-cache-evictions -- packages/omo-opencode/src/hooks
```

Eviction files: 19 pass / 0 fail. Full hooks scope: 2118 pass / 46 fail, matching origin/dev.

## Related Issues

Memory audit of v5.0.0-beta.30 (Discord: 4+ parallel omo-on-opencode processes saturating 64GB). Atlas pattern from PR #7329.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five unbounded in-memory caches in `packages/omo-opencode/src/hooks` so idle sessions and dropped after-hooks no longer retain full tool-input JSON, file bodies, or error payloads until process exit.

- Adds unref'd TTL sweeps for transcript cache, hashline pending captures, and fsync-skip start times.
- Clears anthropic recovery maps, keyword-detector default-mode session set, and fsync start times on `dispose()`.
- Drains session-id flag sets (first-message, stop-hook) on `session.deleted` and plugin dispose.
- Caps the default-ultrawork injected-session set at 256 entries with FIFO eviction.
- Transcript cache cleanup now also runs on plugin dispose instead of only on the next build.

<sup>Written for commit 2325af33ad18555c2843d4e1e9a4a0c4fb95b2a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

