### PR TITLE
ci(sisyphus-agent): clear token env vars for the gh auth login call

### DIFF
--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -41,9 +41,13 @@ jobs:
       # gh CLI auth as sisyphus-dev-ai
       - name: Authenticate gh CLI as sisyphus-dev-ai
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          # gh auth login refuses to run while GITHUB_TOKEN/GH_TOKEN are set
+          # ("The value of the GITHUB_TOKEN environment variable is being used
+          # for authentication"), so the PAT is passed under a different name
+          # and the conflicting variables are cleared for the login call only.
+          SISYPHUS_GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          echo "$GITHUB_TOKEN" | gh auth login --with-token
+          echo "$SISYPHUS_GH_PAT" | env -u GITHUB_TOKEN -u GH_TOKEN gh auth login --with-token
           gh auth status
 
       - name: Ensure tmux is available (Linux)

--- a/.omo/evidence/20260831-sisyphus-agent-gh-login/REPORT.md
+++ b/.omo/evidence/20260831-sisyphus-agent-gh-login/REPORT.md
@@ -1,0 +1,4 @@
+# sisyphus-agent gh login repair
+WHAT: run 33353537198 (issue_comment on PR #7522) failed in the 'Authenticate gh CLI as sisyphus-dev-ai' step: modern gh refuses 'gh auth login' while GITHUB_TOKEN is set ("The value of the GITHUB_TOKEN environment variable is being used for authentication", exit 1) — agent never started.
+FIX: pass the PAT as SISYPHUS_GH_PAT and clear GITHUB_TOKEN/GH_TOKEN for the login call only (env -u).
+VALIDATION: actionlint clean on the edited workflow. Real-surface QA = post-merge re-trigger of @sisyphus-dev-ai on PR #7522 (recorded in the memleak session ledger).


### PR DESCRIPTION
The @sisyphus-dev-ai agent workflow fails during setup: current gh CLI refuses `gh auth login --with-token` while GITHUB_TOKEN is exported (run 33353537198, exit 1 before the agent starts). Pass the PAT under SISYPHUS_GH_PAT and strip GITHUB_TOKEN/GH_TOKEN for the login invocation only; later steps keep env-var auth. Evidence: .omo/evidence/20260831-sisyphus-agent-gh-login/REPORT.md. Real-surface QA: re-trigger of the mention flow after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `@sisyphus-dev-ai` agent workflow failing during setup because `gh auth login` refuses to run while `GITHUB_TOKEN` is set. The PAT is now passed as `SISYPHUS_GH_PAT` and `GITHUB_TOKEN`/`GH_TOKEN` are cleared only for the login call, so later steps keep using env-var auth.

<sup>Written for commit b83de56f72a74fd43a30206361aab742ad4c6a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

