### PR TITLE
ci: add deterministic bot-merge workflow for sisyphus-dev-ai merges

### DIFF
--- a/.github/workflows/bot-merge.yml
+++ b/.github/workflows/bot-merge.yml
@@ -1,0 +1,30 @@
+name: Bot Merge
+
+# Deterministic merge-as-bot: merges one PR with the sisyphus-dev-ai PAT so the
+# merge commit is authored by the bot identity. Exists because the full
+# sisyphus-agent pipeline is an LLM agent and cannot be relied on for the
+# mechanical act of merging (see run 33353727892: plugin load failure).
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to merge (merge commit)"
+        required: true
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    # workflow_dispatch is already restricted to users with write access;
+    # this guard additionally pins it to the repository owner.
+    if: github.actor == 'code-yeongyu'
+    permissions:
+      contents: read
+    steps:
+      - name: Merge PR as sisyphus-dev-ai
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh pr view "${{ inputs.pr }}" --repo "${{ github.repository }}" \
+            --json state,mergeable,statusCheckRollup \
+            --jq '{state,mergeable,failing:[.statusCheckRollup[]|select(.conclusion=="FAILURE")|.name]}'
+          gh pr merge "${{ inputs.pr }}" --repo "${{ github.repository }}" --merge


### PR DESCRIPTION
The @sisyphus-dev-ai mention flow cannot reliably perform mechanical merges: run 33353727892 got past the (just-fixed) gh login but the omo plugin failed to load in the runner opencode (Agent not found: sisyphus), so agent-driven merging is not dependable today. This adds a 20-line workflow_dispatch workflow that merges ONE pr with the GH_PAT (sisyphus-dev-ai) identity, owner-gated by actor. Usage: gh workflow run bot-merge.yml -f pr=<n>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic `workflow_dispatch` workflow that merges one PR as the `sisyphus-dev-ai` bot. The old `@sisyphus-dev-ai` mention flow relied on the agent pipeline, which failed to load in the runner (Agent not found) and could not be trusted for mechanical merges.

- Trigger manually with `gh workflow run bot-merge.yml -f pr=<n>`.
- Merges exactly one PR per run with a merge commit using the `GH_PAT` secret.
- Restricted to the repository owner via the actor guard.

<sup>Written for commit 892edfbac46549f373c12fd38493ffd7c74f27f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

