### PR TITLE
ci(bot-merge): write the mandatory job summary and register the workflow expectation

### DIFF
--- a/.github/workflows/bot-merge.yml
+++ b/.github/workflows/bot-merge.yml
@@ -28,3 +28,17 @@ jobs:
             --json state,mergeable,statusCheckRollup \
             --jq '{state,mergeable,failing:[.statusCheckRollup[]|select(.conclusion=="FAILURE")|.name]}'
           gh pr merge "${{ inputs.pr }}" --repo "${{ github.repository }}" --merge
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## Bot Merge"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Result | \`${{ job.status }}\` |"
+            echo "| PR | \`#${{ inputs.pr }}\` |"
+            echo "| Workflow | \`${{ github.workflow }}\` |"
+            echo "| Event | \`${{ github.event_name }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -30,6 +30,7 @@ const workflowExpectations = [
     ],
   },
   { path: ".github/workflows/cla.yml", jobs: ["cla"] },
+  { path: ".github/workflows/bot-merge.yml", jobs: ["merge"] },
   { path: ".github/workflows/lint-workflows.yml", jobs: ["actionlint"] },
   { path: ".github/workflows/package-labels.yml", jobs: ["ensure-labels", "label-pull-request", "label-issue"] },
   { path: ".github/workflows/publish-platform.yml", jobs: ["build", "publish", "smoke-linux-arm64"] },


### PR DESCRIPTION
bot-merge.yml (merged in #7529) was missing from workflowExpectations in script/ci-job-summary-workflow.test.ts and lacked the mandatory Write job summary step, so every PR against dev fails test (ubuntu 2/2) on the meta-test. This adds the summary step and the expectation row. Unblocks PRs #7525 and #7526.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the mandatory job summary step to the `bot-merge` workflow and registers it in the CI workflow expectations so the meta-test passes again. This fixes the failing test that was blocking all PRs against `dev`.

<sup>Written for commit a169290844cc3d5cd6997859b73d33f6de00913d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

