### PR TITLE
test(memory-core): gate recall file-mode pins to POSIX platforms

### DIFF
--- a/packages/memory-core/src/recall/ledger.test.ts
+++ b/packages/memory-core/src/recall/ledger.test.ts
@@ -98,7 +98,9 @@ describe("RecallLedger", () => {
     expect(Object.keys(parsed.surfaced)).toEqual(["reference/a.md"])
     expect(parsed.surfaced["reference/a.md"]?.hash).toBe("aaaa")
     expect(parsed.surfaced["reference/a.md"]?.at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
-    expect((await stat(filePath)).mode & 0o777).toBe(0o600)
+    if (process.platform !== "win32") {
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600)
+    }
   })
 
   it("#given a second mark on the same session #when the ledger is read #then earlier entries persist and repeats update", async () => {

--- a/packages/memory-core/src/recall/receipts.test.ts
+++ b/packages/memory-core/src/recall/receipts.test.ts
@@ -102,6 +102,10 @@ describe("appendRecallReceipt", () => {
     })
 
     // then
-    expect((await stat(filePath)).mode & 0o777).toBe(0o600)
+    if (process.platform === "win32") {
+      expect(await stat(filePath)).toBeDefined()
+    } else {
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600)
+    }
   })
 })


### PR DESCRIPTION
## Summary

The v5.0.0-beta.31 release-state gate failed on `test (windows-latest, 1/2)` (run 33389748207): the two recall file-mode pins assert `(stat.mode & 0o777) === 0o600`, which win32 cannot express — Windows reports 0o666 (438), so the failure is deterministic, not flake.

- `packages/memory-core/src/recall/ledger.test.ts`: keep the 0o600 mode pin POSIX-only (shape/content pins still run everywhere), following the existing platform-gate convention in `memfs/hooks.test.ts:105`.
- `packages/memory-core/src/recall/receipts.test.ts`: assert the receipts file exists on win32; keep the owner-private 0o600 pin on POSIX.

Production behavior is untouched — the 0o600 open modes stay; POSIX legs keep enforcing the privacy contract.

## QA

- RED: release-state PR #7547 windows leg failure captured (job 99480456984, `Expected: 384 / Received: 438` at ledger.test.ts:101 + receipts.test.ts:105).
- GREEN (POSIX): `bun test packages/memory-core/src/recall/` → 50 pass / 0 fail (mengmotaHost, /tmp/ulw-b31-recall-test.log).
- `bun run --cwd packages/memory-core typecheck` → clean.
- Windows GREEN lands via the re-dispatched release-state gate (full windows matrix runs there).

Per CLA.md, contributions are under the repository license.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates POSIX file-mode assertions in recall tests so Windows CI no longer fails deterministically.

- Windows reports file modes as `0o666`, so the `0o600` pins in `ledger.test.ts` and `receipts.test.ts` always failed on that platform.
- POSIX legs keep the `0o600` privacy contract; the receipts test now just asserts the file exists on win32.

<sup>Written for commit 6e3b1ed723e906f74542a3c2a230b81db98e90a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

