### PR TITLE
feat(ci): add review-claim label system and bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run_heavy: ${{ steps.classify.outputs.run_heavy }}
       full_matrix: ${{ steps.classify.outputs.full_matrix }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -163,9 +163,9 @@ jobs:
           - os: windows-latest
             shard: "2/2"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           node-version: "24"
@@ -178,7 +178,7 @@ jobs:
           bun-version: "1.4.0"
 
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         if: runner.os != 'Windows' && needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           path: ~/.bun/install/cache
@@ -244,9 +244,9 @@ jobs:
     needs: [ci-mode]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
@@ -256,7 +256,7 @@ jobs:
         with:
           bun-version: "1.4.0"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
@@ -296,9 +296,9 @@ jobs:
           - os: windows-latest
             suite: platform
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           node-version: "24"
@@ -308,7 +308,7 @@ jobs:
         with:
           bun-version: "1.4.0"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           path: ~/.bun/install/cache
@@ -383,9 +383,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           node-version: "24"
@@ -395,7 +395,7 @@ jobs:
         with:
           bun-version: "1.4.0"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         with:
           path: ~/.bun/install/cache
@@ -452,7 +452,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
@@ -520,7 +520,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -529,7 +529,7 @@ jobs:
         with:
           bun-version: "1.4.0"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
@@ -570,9 +570,9 @@ jobs:
     needs: [ci-mode]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           node-version: "24"
@@ -582,7 +582,7 @@ jobs:
         with:
           bun-version: "1.4.0"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         if: needs.ci-mode.outputs.run_heavy == 'true'
         with:
           path: ~/.bun/install/cache
@@ -625,7 +625,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -633,7 +633,7 @@ jobs:
         with:
           bun-version: "1.4.0"
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.4.0-${{ hashFiles('bun.lock') }}
@@ -678,7 +678,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check stored CLA signatures
         id: cla_state
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const signaturePath = "signatures/cla.json";

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -15,7 +15,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install actionlint
         run: |

--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         platform: [darwin-arm64, darwin-x64, darwin-x64-baseline, linux-x64, linux-x64-baseline, linux-arm64, linux-x64-musl, linux-x64-musl-baseline, linux-arm64-musl, windows-x64, windows-x64-baseline, windows-arm64]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -186,7 +186,7 @@ jobs:
 
       - name: Upload artifact
         if: steps.check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.platform }}
           path: |
@@ -383,7 +383,7 @@ jobs:
 
       - name: Upload release binary artifact
         if: steps.release-assets.outputs.binary_exists != 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: release-binary-${{ matrix.platform }}
           path: .omo/release-binaries/omo-*
@@ -471,7 +471,7 @@ jobs:
       - name: Download artifact
         id: download
         if: steps.check.outputs.skip_all != 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: binary-${{ matrix.platform }}
           path: .
@@ -493,7 +493,7 @@ jobs:
           ls -la "$PACKAGE_DIR/"
           ls -la "$PACKAGE_DIR/bin/"
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         if: steps.check.outputs.skip_all != 'true' && steps.download.outcome == 'success'
         with:
           node-version: "24"
@@ -593,7 +593,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Check release assets
         id: release-assets
@@ -615,14 +615,14 @@ jobs:
 
       - name: Download linux-arm64 release binary artifact
         if: steps.release-assets.outputs.linux_arm64_exists != 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: release-binary-linux-arm64
           path: .omo/release-binaries
 
       - name: Download linux-arm64-musl release binary artifact
         if: steps.release-assets.outputs.linux_arm64_musl_exists != 'true'
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: release-binary-linux-arm64-musl
           path: .omo/release-binaries

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Require successful CI for prepared release source
         shell: bash
@@ -259,7 +259,7 @@ jobs:
       already_published: ${{ steps.omo-ai.outputs.already_published }}
       previous_lazycodex_version: ${{ steps.version.outputs.previous_lazycodex_version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Assert omo bin ownership
         run: |
@@ -373,7 +373,7 @@ jobs:
       # generation below must never be able to read the release credential from
       # git config. The token is exported explicitly only when the generated
       # release state is ready to be pushed.
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
@@ -611,7 +611,7 @@ jobs:
       actions: write
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare-release-state.outputs.release_sha }}
@@ -680,7 +680,7 @@ jobs:
       needs.prepare-release-state.result == 'success' &&
       (inputs.skip_platform == true || needs.publish-platform.result == 'success')
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Publish the prepared release commit, not the workflow-dispatch SHA.
@@ -692,7 +692,7 @@ jobs:
         with:
           bun-version: "1.4.0"
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -1010,7 +1010,7 @@ jobs:
       needs.publish-main.result == 'success' &&
       (inputs.skip_platform == true || needs.publish-platform.result == 'success')
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare-release-state.outputs.release_sha }}
@@ -1037,7 +1037,7 @@ jobs:
 
       - name: Checkout LazyCodex marketplace
         if: needs.release-metadata.outputs.dist_tag == ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           repository: code-yeongyu/lazycodex
           path: lazycodex-marketplace
@@ -1139,7 +1139,7 @@ jobs:
 
       - name: Download release-binary artifacts
         if: inputs.skip_platform != true
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: release-binary-*
           path: .omo/release-binaries
@@ -1236,12 +1236,12 @@ jobs:
       needs.publish-main.result == 'success' &&
       needs.release.result == 'success'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare-release-state.outputs.release_sha }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/refresh-model-capabilities.yml
+++ b/.github/workflows/refresh-model-capabilities.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'code-yeongyu/oh-my-openagent'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/review-claims.yml
+++ b/.github/workflows/review-claims.yml
@@ -41,7 +41,7 @@ jobs:
             } else {
               core.info('No active review claim labels. Gate is green.');
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -91,7 +91,7 @@ jobs:
             }
             await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [claimer] });
             core.info(`Requested review from claimer ${claimer}.`);
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -144,7 +144,7 @@ jobs:
                 core.info(`Kept ${name}: claimed by ${latestLabeler[name] ?? 'unknown'}, review came from ${reviewer}.`);
               }
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -208,7 +208,7 @@ jobs:
                 core.info(`PR #${pr.number}: applied ${STALE}.`);
               }
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |

--- a/.github/workflows/review-claims.yml
+++ b/.github/workflows/review-claims.yml
@@ -1,0 +1,222 @@
+name: Review Claims
+
+# Review-claim label automation:
+# - will-review / in-review block merge via the "Review claim gate" required check
+# - labeling one of them auto-requests the labeler as reviewer and clears stale-review
+# - the claim label is removed ONLY when the claimer submits a real review (approve / request changes)
+# - claims idle for 3+ days are swept to stale-review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+  schedule:
+    - cron: "23 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gate:
+    name: Review claim gate
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: review-claim-gate-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Fail while a review claim label is present
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((l) => l.name);
+            const claims = labels.filter((l) => l === 'will-review' || l === 'in-review');
+            if (claims.length > 0) {
+              core.setFailed(`Merge blocked: active review claim label(s): ${claims.join(', ')}. The claimer must submit their review (approve or request changes) to release the claim.`);
+            } else {
+              core.info('No active review claim labels. Gate is green.');
+            }
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Review claim gate"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| PR | #${{ github.event.pull_request.number }} |"
+            echo "| Event | ${{ github.event.action }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  claim:
+    name: Register claimer as reviewer
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      (github.event.label.name == 'will-review' || github.event.label.name == 'in-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Request review from the claimer and clear stale-review
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const claimer = context.payload.sender.login;
+            const { owner, repo } = context.repo;
+            if (pr.labels.some((l) => l.name === 'stale-review')) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name: 'stale-review' })
+                .then(() => core.info('Removed stale-review: superseded by a fresh claim.'))
+                .catch((e) => core.info(`stale-review removal skipped: ${e.message}`));
+            }
+            if (context.payload.sender.type === 'Bot') {
+              core.info(`Label applied by bot ${claimer}; skipping reviewer request.`);
+              return;
+            }
+            if (claimer === pr.user.login) {
+              core.info('Claimer is the PR author; skipping self review request.');
+              return;
+            }
+            const requested = (pr.requested_reviewers ?? []).map((r) => r.login);
+            if (requested.includes(claimer)) {
+              core.info(`${claimer} is already a requested reviewer.`);
+              return;
+            }
+            await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [claimer] });
+            core.info(`Requested review from claimer ${claimer}.`);
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Review claim registered"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| PR | #${{ github.event.pull_request.number }} |"
+            echo "| Label | ${{ github.event.label.name }} |"
+            echo "| Claimer | ${{ github.event.sender.login }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release-claim:
+    name: Release claim on claimer review
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      (github.event.review.state == 'approved' || github.event.review.state == 'changes_requested')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Remove claim labels owned by this reviewer
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const CLAIMS = ['will-review', 'in-review'];
+            const pr = context.payload.pull_request;
+            const reviewer = context.payload.review.user.login;
+            const { owner, repo } = context.repo;
+            const present = pr.labels.map((l) => l.name).filter((n) => CLAIMS.includes(n));
+            if (present.length === 0) {
+              core.info('No claim labels on this PR.');
+              return;
+            }
+            const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+              owner, repo, issue_number: pr.number, per_page: 100,
+            });
+            const latestLabeler = {};
+            for (const ev of events) {
+              if (ev.event === 'labeled' && ev.label && CLAIMS.includes(ev.label.name)) {
+                latestLabeler[ev.label.name] = ev.actor ? ev.actor.login : undefined;
+              }
+            }
+            for (const name of present) {
+              if (latestLabeler[name] === reviewer) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+                core.info(`Removed ${name}: claimer ${reviewer} submitted their review.`);
+              } else {
+                core.info(`Kept ${name}: claimed by ${latestLabeler[name] ?? 'unknown'}, review came from ${reviewer}.`);
+              }
+            }
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Review claim release"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| PR | #${{ github.event.pull_request.number }} |"
+            echo "| Reviewer | ${{ github.event.review.user.login }} |"
+            echo "| Review state | ${{ github.event.review.state }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  stale-sweep:
+    name: Sweep stale review claims
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Move 3+ day old claims to stale-review
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const CLAIMS = ['will-review', 'in-review'];
+            const STALE = 'stale-review';
+            const MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+            const { owner, repo } = context.repo;
+            const prs = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
+            for (const pr of prs) {
+              const names = pr.labels.map((l) => l.name);
+              const present = names.filter((n) => CLAIMS.includes(n));
+              if (present.length === 0) continue;
+              const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              const latest = {};
+              for (const ev of events) {
+                if (ev.event === 'labeled' && ev.label && CLAIMS.includes(ev.label.name)) {
+                  latest[ev.label.name] = { actor: ev.actor ? ev.actor.login : undefined, at: Date.parse(ev.created_at) };
+                }
+              }
+              const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: pr.number, per_page: 100 });
+              const now = Date.now();
+              let removedAny = false;
+              for (const name of present) {
+                const info = latest[name];
+                if (!info || now - info.at < MAX_AGE_MS) continue;
+                const reviewedSince = reviews.some((r) =>
+                  r.user && r.user.login === info.actor &&
+                  Date.parse(r.submitted_at) > info.at &&
+                  (r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED'));
+                if (reviewedSince) continue;
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name })
+                  .catch((e) => core.info(`PR #${pr.number}: ${name} removal skipped: ${e.message}`));
+                removedAny = true;
+                core.info(`PR #${pr.number}: removed stale ${name} (claimed by ${info.actor ?? 'unknown'}).`);
+              }
+              if (removedAny && !names.includes(STALE)) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [STALE] });
+                core.info(`PR #${pr.number}: applied ${STALE}.`);
+              }
+            }
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Stale review claim sweep"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| Trigger | ${{ github.event_name }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sisyphus-agent.yml
+++ b/.github/workflows/sisyphus-agent.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       # Checkout with sisyphus-dev-ai's PAT
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
@@ -66,7 +66,7 @@ jobs:
           bun-version: "1.4.0"
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'code-yeongyu/oh-my-openagent'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -28,7 +28,7 @@ jobs:
       run:
         working-directory: packages/web
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -38,7 +38,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Restore Next.js build cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: packages/web/.next/cache
           key: ${{ runner.os }}-web-next-${{ hashFiles('packages/web/bun.lock', 'packages/web/package.json', 'packages/web/next.config.ts', 'packages/web/open-next.config.ts', 'packages/web/postcss.config.mjs') }}-${{ hashFiles('packages/web/app/**', 'packages/web/components/**', 'packages/web/lib/**', 'packages/web/messages/**', 'packages/web/i18n/**', 'docs/**') }}

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -451,3 +451,17 @@ Cross-harness, one-command dev setup. The **single source of truth** is [`script
 - **Agent state directory:** ONE canonical location, `~/.omo/agent`, resolved through `canonicalAgentDir()` in [`packages/omo-native/bin/lib/agent-dir.js`](packages/omo-native/bin/lib/agent-dir.js) (and its adapter-side twin `resolveAgentHome()` in `packages/omo-senpi/src/components/agent-home/`). EVERY omo entry point - the spawned engine, `omo doctor`, `omo setup`, the local launcher, the local installer - MUST resolve the directory through that helper instead of composing its own default; an explicit `OMO_CODING_AGENT_DIR` (or the legacy `SENPI_CODING_AGENT_DIR` / `PI_CODING_AGENT_DIR`) still wins. Composing a private default is what made settings look erased on update.
 - **Workspace migration:** Runtime state migrated from `.sisyphus/` → `.omo/`. Legacy `.sisyphus/` still exists during transition; `packages/omo-opencode/src/shared/legacy-workspace-migration.ts` copies it forward on first load.
 - **CI nuance:** PRs targeting `master` are hard-blocked — they MUST target `dev`. CI auto-commits schema changes on master push and creates a draft "next" release on dev push.
+
+## Review claim labels (merge-gating)
+
+Three PR labels drive the review workflow; automation lives in `.github/workflows/review-claims.yml`:
+
+- `will-review` — a reviewer claims the PR ("I will review this"). Applying it auto-requests the labeler as reviewer and BLOCKS merge via the required `Review claim gate` check.
+- `in-review` — the claimer is actively reviewing. Same merge-blocking + auto-reviewer-request effects.
+- `stale-review` — a claim sat 3+ days without the claimer's review; the sweep removes the claim labels and applies this one. A fresh claim clears it.
+
+Rules:
+- Apply `will-review` when you plan to review a PR; switch to `in-review` when you start.
+- NEVER merge a PR carrying `will-review` or `in-review`; the gate check enforces this.
+- Claim labels are removed automatically ONLY when the claimer (the person who applied the label) submits an approve or request-changes review. Do not remove someone else's claim label by hand.
+- If a PR shows `stale-review`, it needs a (new) reviewer: claim it.

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -47,6 +47,10 @@ const workflowExpectations = [
       "post-publish-verify",
     ],
   },
+  {
+    path: ".github/workflows/review-claims.yml",
+    jobs: ["gate", "claim", "release-claim", "stale-sweep"],
+  },
   { path: ".github/workflows/refresh-model-capabilities.yml", jobs: ["refresh"] },
   { path: ".github/workflows/sisyphus-agent.yml", jobs: ["agent"] },
   { path: ".github/workflows/stats.yml", jobs: ["stats"] },

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -134,7 +134,7 @@ describe("root test CI partition", () => {
 
   test("#given Windows cache restore costs more than install #when the root matrix runs #then only non-Windows jobs restore Bun cache", () => {
     const job = rootTestJob()
-    const cacheStart = job.indexOf("      - uses: actions/cache@v5")
+    const cacheStart = job.indexOf("      - uses: actions/cache@v6")
     const cacheEnd = job.indexOf("      - name: Install dependencies", cacheStart)
     const cacheStep = job.slice(cacheStart, cacheEnd)
 

--- a/script/omo-ai-ci-job.test.ts
+++ b/script/omo-ai-ci-job.test.ts
@@ -57,8 +57,8 @@ describe("omo-ai payload check CI job", () => {
 
     // then
     expect(runsOn).toBe("ubuntu-latest")
-    expect(stepByUses("omo-ai-payload-check", "actions/checkout@v5")).toBeDefined()
-    expect(stepByUses("omo-ai-payload-check", "actions/setup-node@v6")).toBeDefined()
+    expect(stepByUses("omo-ai-payload-check", "actions/checkout@v7")).toBeDefined()
+    expect(stepByUses("omo-ai-payload-check", "actions/setup-node@v7")).toBeDefined()
     expect(stepByUses("omo-ai-payload-check", "oven-sh/setup-bun@v2")).toBeDefined()
   })
 

--- a/script/omo-ai-publish-shape.test.ts
+++ b/script/omo-ai-publish-shape.test.ts
@@ -117,7 +117,7 @@ describe("omo-ai publish workflow shape", () => {
 
   test("checks out before asserting root bin ownership", () => {
     const metadataSteps = steps("release-metadata")
-    const checkoutIndex = metadataSteps.findIndex((step) => step.uses === "actions/checkout@v5")
+    const checkoutIndex = metadataSteps.findIndex((step) => step.uses === "actions/checkout@v7")
     const assertionIndex = metadataSteps.findIndex((step) => step.name === "Assert omo bin ownership")
     const assertionRun = metadataSteps[assertionIndex]?.run ?? ""
 

--- a/script/publish-release-platform-workflow.test.ts
+++ b/script/publish-release-platform-workflow.test.ts
@@ -330,7 +330,7 @@ describe("release binary asset lane in the platform publish workflow", () => {
 
     // upload shape: bare binaries + SHA256SUMS under .omo/release-binaries, npm-artifact parity on retention
     const uploadStep = binarySteps[2]!
-    expect(uploadStep).toContain("uses: actions/upload-artifact@v6")
+    expect(uploadStep).toContain("uses: actions/upload-artifact@v7")
     expect(uploadStep).toContain("name: release-binary-${{ matrix.platform }}")
     expect(uploadStep).toContain("path: .omo/release-binaries/")
     expect(uploadStep).toContain("retention-days: 1")


### PR DESCRIPTION
## Review-claim labels

Three PR labels drive the review handshake (live on the repo already, applied via `gh label`):

| Label | Color | Meaning |
| --- | --- | --- |
| `will-review` | `fbca04` | A reviewer claims the PR ("I will review this"). Applying it auto-requests the labeler as reviewer. Blocks merge. |
| `in-review` | `1d76db` | The claimer is actively reviewing. Same blocking + auto-request effects. |
| `stale-review` | `d93f0b` | A claim sat 3+ days without the claimer's review; the sweep cleared the claim labels and applied this one. A fresh claim clears it. |

Label migration performed alongside this PR: the legacy `in review` (with a space, `82ce7b`, no description) was migrated to `in-review` on all 4 open issues (#4035, #2737, #2600, #2553) and then deleted; `in-review` was re-colored/described to spec.

## Merge gate

`.github/workflows/review-claims.yml` adds the `Review claim gate` job. It fails whenever an open PR carries `will-review` or `in-review`, so a claimed PR cannot be merged until the claimer submits a real review. This job name is intended to become a required branch-protection context (not changed in this PR).

## Automation jobs

| Job | Trigger | Behavior |
| --- | --- | --- |
| `Review claim gate` | `pull_request_target` (opened/reopened/synchronize/ready_for_review/labeled/unlabeled) | Fails while a claim label is present; green otherwise. |
| `Register claimer as reviewer` | claim label added | Requests review from the labeler (skips bots and self-review) and clears `stale-review`. |
| `Release claim on claimer review` | `pull_request_review` submitted (approved / changes_requested) | Removes only the claim label whose most recent labeler is the submitting reviewer; other people's claims are kept. |
| `Sweep stale review claims` | cron `23 */6 * * *` + `workflow_dispatch` | Removes claims older than 3 days with no review from the claimer since, then applies `stale-review`. |

`AGENTS.md` gains a "Review claim labels (merge-gating)" section documenting the same rules for agents.

## Action version bumps

Second commit, across all of `.github/workflows/`; only version strings changed.

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | v5 | v7 |
| `actions/setup-node` | v6 | v7 |
| `actions/github-script` | v8 | v9 |
| `actions/upload-artifact` | v6 | v7 |
| `actions/download-artifact` | v7 | v8 |
| `actions/cache` | v5 | v6 |

Already on their latest tag and left untouched: `oven-sh/setup-bun@v2`, `cloudflare/wrangler-action@v4`, `peter-evans/create-pull-request@v8`, `nick-fields/retry@v4`, `contributor-assistant/github-action@v2.6.1`. No runner labels or unrelated lines touched.

`actionlint` + the mandatory workflow-summary check both pass (13/13 workflows write a job summary).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a review-claim label system so claimed PRs cannot merge until the claimer submits a real review, and bumps GitHub Actions to their latest major versions.

**Review-claim labels**
- `will-review` and `in-review` claim a PR; applying one auto-requests the labeler as reviewer.
- The `Review claim gate` job fails while either claim label is present; add it to branch protection to enforce blocking.
- A real review (approve or request changes) removes only that reviewer's claim label; others' claims stay.
- Claims idle 3+ days are swept to `stale-review`; a fresh claim clears it.
- The legacy `in review` label was migrated to `in-review` on open issues and deleted.
- All four new jobs write a step literally named "Write job summary" to satisfy the repo-wide job-summary contract.

**Dependencies**
- Bumps the version strings of six `actions/*` packages to their latest majors across all workflows; no other changes.
- Actions already on their latest tag are left untouched.
- Workflow shape tests updated to pin the bumped action versions.

<sup>Written for commit b63ea2609283036405e15431231d238bc9e26e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

