### PR TITLE
feat(omo-opencode): category-chain fallback verifier for ultrawork verification

### DIFF
--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-builder.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-builder.test.ts
@@ -1,0 +1,41 @@
+/// <reference types="bun-types" />
+// Failure mode decision: a fallback verifier without an Agent line inherits the
+// existing 30-minute stuck-verification timeout, just like a non-compliant Oracle.
+// No new state-machine branch is introduced for that case.
+import { describe, expect, test } from "bun:test"
+import { buildContinuationPrompt, buildVerificationFailurePrompt } from "./continuation-prompt-builder"
+import type { RalphLoopState } from "./types"
+
+const state: RalphLoopState = {
+	active: true,
+	iteration: 2,
+	max_iterations: 10,
+	completion_promise: "<promise>DONE</promise>",
+	initial_completion_promise: "<promise>DONE</promise>",
+	started_at: "2026-09-01T00:00:00.000Z",
+	prompt: "Finish the task",
+	ultrawork: true,
+	verification_pending: true,
+}
+
+describe("ultrawork verification fallback prompts", () => {
+	test("#given initial verification prompt #then includes category fallback chain tokens", () => {
+		const prompt = buildContinuationPrompt(state)
+
+		expect(prompt).toContain("task(subagent_type=\"oracle\"")
+		expect(prompt).toContain("gate-verifier")
+		expect(prompt).toContain('category: "deep"')
+		expect(prompt).toContain("unspecified-high")
+		expect(prompt).toContain("unspecified-low")
+	})
+
+	test("#given failed verification prompt #then includes category fallback chain tokens", () => {
+		const prompt = buildVerificationFailurePrompt({ ...state, verification_pending: undefined })
+
+		expect(prompt).toContain("task(subagent_type=\"oracle\"")
+		expect(prompt).toContain("gate-verifier")
+		expect(prompt).toContain('category: "deep"')
+		expect(prompt).toContain("unspecified-high")
+		expect(prompt).toContain("unspecified-low")
+	})
+})

--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-builder.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-builder.ts
@@ -18,6 +18,7 @@ REQUIRED NOW:
 - Ask Oracle to verify whether the original task is actually complete
 - Include the original task in the Oracle request
 - Explicitly tell Oracle to review skeptically and critically, and to look for reasons the task may still be incomplete or wrong
+- If the Oracle spawn fails because its model/agent is unavailable, spawn a verifier with the identical verification instructions using task(category: "deep", load_skills=[], run_in_background=false, ...), then retry with category: "unspecified-high", then category: "unspecified-low" on the same failure; require its reply to end with the literal line \`Agent: gate-verifier\` immediately above the promise tag
 - The system will inspect the Oracle session directly for the verification result
 - If Oracle does not verify, continue fixing the task and do not consider it complete
 
@@ -34,6 +35,7 @@ REQUIRED NOW:
 - Do not claim completion early or argue with the failed verification
 - After fixing the remaining issues, request Oracle review again using task(subagent_type="oracle", load_skills=[], run_in_background=false, ...)
 - Include the original task in the Oracle request and tell Oracle to review skeptically and critically
+- If the Oracle spawn fails because its model/agent is unavailable, spawn a verifier with the identical verification instructions using task(category: "deep", load_skills=[], run_in_background=false, ...), then retry with category: "unspecified-high", then category: "unspecified-low" on the same failure; require its reply to end with the literal line \`Agent: gate-verifier\` immediately above the promise tag
 - Only when the work is ready for review again, output: <promise>{{PROMISE}}</promise>
 
 Original task:

--- a/packages/omo-opencode/src/hooks/ralph-loop/oracle-verification-detector.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/oracle-verification-detector.test.ts
@@ -152,6 +152,19 @@ other_field: value
 })
 
 describe("isOracleVerified", () => {
+	test("#given valid gate-verifier verification #then should return true", () => {
+		// #given
+		const text = `Agent: gate-verifier
+
+<promise>${ULTRAWORK_VERIFICATION_PROMISE}</promise>`
+
+		// #when
+		const result = isOracleVerified(text)
+
+		// #then
+		expect(result).toBe(true)
+	})
+
 	test("#given valid oracle verification #then should return true", () => {
 		// #given
 		const text = `Agent: oracle
@@ -217,6 +230,23 @@ describe("isOracleVerified", () => {
 })
 
 describe("extractOracleSessionID", () => {
+	test("#given valid gate-verifier verification with session_id #then should return session_id", () => {
+		// #given
+		const text = `Agent: GATE-VERIFIER
+
+<promise>${ULTRAWORK_VERIFICATION_PROMISE}</promise>
+
+<task_metadata>
+session_id: ses_gate_verifier_123
+</task_metadata>`
+
+		// #when
+		const sessionID = extractOracleSessionID(text)
+
+		// #then
+		expect(sessionID).toBe("ses_gate_verifier_123")
+	})
+
 	test("#given valid oracle verification with session_id #then should return session_id", () => {
 		// #given
 		const text = `Agent: oracle

--- a/packages/omo-opencode/src/hooks/ralph-loop/oracle-verification-detector.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/oracle-verification-detector.ts
@@ -10,6 +10,7 @@ export interface OracleVerificationEvidence {
 
 const AGENT_LINE_PATTERN = /^Agent:[ \t]*(\S+)$/im
 const PROMISE_TAG_PATTERN = /<promise>[ \t]*(\S+?)[ \t]*<\/promise>/is
+const VERIFICATION_AGENTS = new Set(["oracle", "gate-verifier"])
 
 export function parseOracleVerificationEvidence(text: string): OracleVerificationEvidence | undefined {
 	const trimmedText = text.trim()
@@ -46,15 +47,16 @@ export function isOracleVerified(text: string): boolean {
 		return false
 	}
 
-	const isOracleAgent = stripInvisibleAgentCharacters(evidence.agent).toLowerCase() === "oracle"
+	const agent = stripInvisibleAgentCharacters(evidence.agent).toLowerCase()
+	const isVerificationAgent = VERIFICATION_AGENTS.has(agent)
 	const isVerifiedPromise = evidence.promise === ULTRAWORK_VERIFICATION_PROMISE
 
-	return isOracleAgent && isVerifiedPromise
+	return isVerificationAgent && isVerifiedPromise
 }
 
 export function extractOracleSessionID(text: string): string | undefined {
 	const evidence = parseOracleVerificationEvidence(text)
-	if (!evidence || stripInvisibleAgentCharacters(evidence.agent).toLowerCase() !== "oracle") {
+	if (!evidence || !VERIFICATION_AGENTS.has(stripInvisibleAgentCharacters(evidence.agent).toLowerCase())) {
 		return undefined
 	}
 


### PR DESCRIPTION
## What
Minimal category-chain fallback for ultrawork verification in the ralph-loop hook: the verification-agent allowlist now accepts \`gate-verifier\` beside \`oracle\`, and both ultrawork verification prompts instruct spawning the verifier via \`task(category: "deep")\` -> \`unspecified-high\` -> \`unspecified-low\` when the oracle agent/model is unavailable, with the fallback verifier identifying via a literal \`Agent: gate-verifier\` line.

## Why
Part of the approved ulw-loop gate simplification: opencode keeps its oracle flow and ALL model config untouched (zero diffs outside ralph-loop), gaining only a fallback identity so verification can proceed when oracle cannot run. A fallback verifier that omits the Agent line inherits the existing 30-min stuck-verification timeout (documented in tests) - no new state machine.

## QA
- TDD: RED captured before implementation (evidence in session ledger)
- \`bun test src/hooks/ralph-loop\`: 170 pass, 0 fail (re-run after rebase onto 5e746c6fb)
- \`bun run typecheck\`: pass
- \`git show --stat\`: 4 files, all ralph-loop (2 impl + 2 tests)

Plan: .omo/plans/ulw-loop-gate-review-only.md (PR-B lane)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `gate-verifier` fallback for ultrawork verification in the ralph-loop hook so verification can proceed when the Oracle agent/model is unavailable.

The verification-agent allowlist now accepts `gate-verifier` alongside `oracle`, and both ultrawork verification prompts instruct spawning a verifier via the category chain `deep` → `unspecified-high` → `unspecified-low` on Oracle spawn failure. The fallback verifier must end its reply with a literal `Agent: gate-verifier` line; omitting it inherits the existing 30-minute stuck-verification timeout, so no new state machine is added.

<sup>Written for commit 8965e85d2b4721312b3930bb3c96a49182a998c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

