### PR TITLE
ci(review-claims): hourly sweep release backstop for restricted-token contexts

### DIFF
--- a/.github/workflows/review-claims.yml
+++ b/.github/workflows/review-claims.yml
@@ -12,7 +12,7 @@ on:
   pull_request_review:
     types: [submitted]
   schedule:
-    - cron: "23 */6 * * *"
+    - cron: "23 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -41,7 +41,7 @@ jobs:
             } else {
               core.info('No active review claim labels. Gate is green.');
             }
-      - name: Write job summary
+      - name: Workflow summary
         if: always()
         shell: bash
         run: |
@@ -91,7 +91,7 @@ jobs:
             }
             await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [claimer] });
             core.info(`Requested review from claimer ${claimer}.`);
-      - name: Write job summary
+      - name: Workflow summary
         if: always()
         shell: bash
         run: |
@@ -138,13 +138,21 @@ jobs:
             }
             for (const name of present) {
               if (latestLabeler[name] === reviewer) {
-                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
-                core.info(`Removed ${name}: claimer ${reviewer} submitted their review.`);
+                try {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+                  core.info(`Removed ${name}: claimer ${reviewer} submitted their review.`);
+                } catch (e) {
+                  if (e.status === 403) {
+                    core.warning(`Token is read-only in this PR context; the hourly sweep will release ${name} instead.`);
+                  } else {
+                    throw e;
+                  }
+                }
               } else {
                 core.info(`Kept ${name}: claimed by ${latestLabeler[name] ?? 'unknown'}, review came from ${reviewer}.`);
               }
             }
-      - name: Write job summary
+      - name: Workflow summary
         if: always()
         shell: bash
         run: |
@@ -192,12 +200,18 @@ jobs:
               let removedAny = false;
               for (const name of present) {
                 const info = latest[name];
-                if (!info || now - info.at < MAX_AGE_MS) continue;
+                if (!info) continue;
                 const reviewedSince = reviews.some((r) =>
                   r.user && r.user.login === info.actor &&
                   Date.parse(r.submitted_at) > info.at &&
                   (r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED'));
-                if (reviewedSince) continue;
+                if (reviewedSince) {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name })
+                    .catch((e) => core.info(`PR #${pr.number}: ${name} release skipped: ${e.message}`));
+                  core.info(`PR #${pr.number}: released ${name} — claimer ${info.actor} already reviewed (backstop for restricted-token contexts).`);
+                  continue;
+                }
+                if (now - info.at < MAX_AGE_MS) continue;
                 await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name })
                   .catch((e) => core.info(`PR #${pr.number}: ${name} removal skipped: ${e.message}`));
                 removedAny = true;
@@ -208,7 +222,7 @@ jobs:
                 core.info(`PR #${pr.number}: applied ${STALE}.`);
               }
             }
-      - name: Write job summary
+      - name: Workflow summary
         if: always()
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
Follow-up to the review-claims system: live E2E surfaced that `pull_request_review`-triggered runs get a READ-ONLY token on fork PRs (`Resource not accessible by integration`, 403 on removeLabel), so the claimer's review could not release the claim label on fork PRs.

## Changes
- **Hourly sweep** (was 6-hourly): faster self-healing.
- **Sweep release backstop**: when the claimer has submitted an approve/request-changes review after claiming, the sweep now releases the claim label regardless of age (runs in a trusted schedule context with a full-power token).
- **Graceful 403 in release-claim**: fork-PR contexts log a warning instead of failing the job; the sweep handles the release.

3-day staleness semantics unchanged.

## QA
Root-caused on senpi PR #1250 (fork): claim phase verified live (gate red, reviewer auto-request, stale-review auto-clear); release via review event 403'd; this backstop closes that gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sweep backstop so claim labels are released on fork PRs where the review event's token is read-only and 403s on label removal. The 3-day staleness behavior is unchanged.

**Changes**
- Sweep now runs hourly instead of every 6 hours for faster self-healing.
- When the claimer has already submitted an approve or request-changes review, the sweep releases the label regardless of age using its full-token schedule context.
- The review-event job logs a warning instead of failing when label removal is 403 in fork-PR contexts; the sweep handles the release.

<sup>Written for commit 355ba420853261bf17125b63a8a3c3c1a82ffb45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

