### PR TITLE
fix(omo-opencode): register kimi-k3-ultrafast with a 256k default context

### DIFF
--- a/packages/omo-opencode/scripts/generate-opengateway-models.test.ts
+++ b/packages/omo-opencode/scripts/generate-opengateway-models.test.ts
@@ -188,6 +188,26 @@ describe("buildOpenGatewayCatalog", () => {
     })
   })
 
+  test("registers kimi-k3-ultrafast with a 256k default context from the override table", () => {
+    // given moonshotai/kimi-k3-ultrafast, absent from models.dev and enriched only by the override table
+    const response: OpenGatewayCatalogResponse = {
+      data: [
+        {
+          id: "moonshotai/kimi-k3-ultrafast",
+          status: "active",
+          endpoints: ["chat_completions"],
+          modalities: { input: ["text", "image"], output: ["text"] },
+        },
+      ],
+    }
+
+    // when the catalog is built with no models.dev metadata for it
+    const catalog = buildOpenGatewayCatalog(response, {})
+
+    // then the override registers the 256k default context alongside the published output limit
+    expect(catalog["moonshotai/kimi-k3-ultrafast"]?.limit).toEqual({ context: 262144, output: 131072 })
+  })
+
   test("excludes a model whose models.dev entry is not tool-capable", () => {
     // given openai/gpt-3.5-turbo with tool_call false
     // when the catalog is built

--- a/packages/omo-opencode/scripts/generate-opengateway-models.ts
+++ b/packages/omo-opencode/scripts/generate-opengateway-models.ts
@@ -111,7 +111,7 @@ const MODEL_OVERRIDES: Readonly<Record<string, OpenGatewayModelOverride>> = {
     name: "Kimi K3 Ultrafast",
     reasoning: true,
     cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 0 },
-    context: 1048576,
+    context: 262144,
     output: 131072,
   },
   "z-ai/glm-5.2-ultrafast": {

--- a/packages/omo-opencode/src/features/opengateway-provider/opengateway-models.json
+++ b/packages/omo-opencode/src/features/opengateway-provider/opengateway-models.json
@@ -640,7 +640,7 @@
       "cache_write": 0
     },
     "limit": {
-      "context": 1048576,
+      "context": 262144,
       "output": 131072
     }
   },


### PR DESCRIPTION
## What

- `packages/omo-opencode/scripts/generate-opengateway-models.ts`: `MODEL_OVERRIDES["moonshotai/kimi-k3-ultrafast"].context` 1048576 → 262144
- `packages/omo-opencode/src/features/opengateway-provider/opengateway-models.json`: shipped catalog entry updated to match — scoped to the ultrafast entry only
- `packages/omo-opencode/scripts/generate-opengateway-models.test.ts`: new test pins the 256k default at the override seam

## Why

The override table registered the serving-tier variant at the base model's full 1M window, so every consumer of the shipped catalog treated 1048576 as its default context. The intended serving default is 256k (262144).

## Scope note

A full `generate-opengateway-models.ts` rerun currently pulls unrelated upstream drift (retires `moonshotai/kimi-k2.5`; adds `qwen/qwen3.8-max`, `x-ai/grok-4.5`, `x-ai/grok-4.6`, `z-ai/glm-5.3`, `z-ai/glm-5.3-flash`). That drift belongs in its own change, so the catalog edit here is scoped to the ultrafast entry; the generator override is the canonical source and keeps 262144 on the next full regeneration.

## Evidence (all test/QA runs executed on mengmotaMac via the bunshin mesh)

- **RED**: test-only scratch branch → `bun test packages/omo-opencode/scripts/generate-opengateway-models.test.ts` → 16 pass / 1 fail; the new pin fails with `expected { context: 262144 }, received { context: 1048576 }`
- **GREEN**: this branch → `bun test packages/omo-opencode/scripts/generate-opengateway-models.test.ts packages/omo-opencode/src/features/opengateway-provider/` → **29 pass / 0 fail** (890 assertions)
- **Regression**: base `moonshotai/kimi-k3` untouched at 1048576 (remote probe `ultrafast=262144 base=1048576`); catalog shape tests (lexicographic keys, entry count) green
- **Real surface**: sandboxed real opencode 1.18.18 (isolated XDG, dummy credential to pass the injection gate) boots clean with the plugin loaded from this branch — server ready, zero error/fail lines in the server log. Note: in opencode 1.18.18 neither `opencode models` nor the server `/config` / `/provider` endpoints surface plugin-injected custom providers (verified identical output on `origin/dev` and this branch), so the 262144 value is proven at the injection seam — the plugin's own `applyOpenGatewayProviderConfig` integration tests run against the real bundled catalog — plus the parsed-artifact probe. A live `opencode run` against the gateway was not possible: no real `OPENGATEWAY_API_KEY` on the QA machine.

## Notes

- The test file already exceeds the 250 pure-LOC guideline (322 before this change, one ~20-line test added); a per-describe split is deliberately left out of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the registered default context for `moonshotai/kimi-k3-ultrafast` from 1M (1048576) to 256k (262144) so catalog consumers no longer treat the serving tier as having a base-model-sized window. Adds a generator test that pins the 256k value at the override seam.

The catalog edit is scoped to the ultrafast entry; a full regeneration would pull unrelated upstream drift (retires `moonshotai/kimi-k2.5`, adds newer models) and is left for a separate change.

<sup>Written for commit 60d36ef53210d615fdd30e9800e5d2d4d90a3f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

