### PR TITLE
ci(review-claims): name summary steps per job-summary contract

### DIFF
--- a/.github/workflows/review-claims.yml
+++ b/.github/workflows/review-claims.yml
@@ -41,7 +41,7 @@ jobs:
             } else {
               core.info('No active review claim labels. Gate is green.');
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -91,7 +91,7 @@ jobs:
             }
             await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [claimer] });
             core.info(`Requested review from claimer ${claimer}.`);
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -152,7 +152,7 @@ jobs:
                 core.info(`Kept ${name}: claimed by ${latestLabeler[name] ?? 'unknown'}, review came from ${reviewer}.`);
               }
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -222,7 +222,7 @@ jobs:
                 core.info(`PR #${pr.number}: applied ${STALE}.`);
               }
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |


### PR DESCRIPTION
## Problem
dev is red: script/ci-job-summary-workflow.test.ts fails with '.github/workflows/review-claims.yml gate must write a job summary'. The contract requires the step name 'Write job summary' + GITHUB_STEP_SUMMARY; review-claims.yml named its four summary steps 'Workflow summary'. This also blocks unrelated PRs (7578, 7580).

## Evidence
- RED on pure dev (no changes): 1 fail, 'gate must write a job summary' — remote bun test on mengmotaMac via bunshin.
- GREEN after rename: 4/4 pass, same harness.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the four summary steps in `review-claims.yml` to `Write job summary` so the workflow matches the job-summary contract and the CI gate passes. This fixes the red `dev` branch and unblocks unrelated PRs.

<sup>Written for commit 3616665d9c796524584ec46850ff4d1937d4b931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

