### PR TITLE
ci(review-claims): name summary steps per the job-summary contract

### DIFF
--- a/.github/workflows/review-claims.yml
+++ b/.github/workflows/review-claims.yml
@@ -42,7 +42,7 @@ jobs:
             } else {
               core.info('No active review claim labels. Gate is green.');
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -92,7 +92,7 @@ jobs:
             }
             await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [claimer] });
             core.info(`Requested review from claimer ${claimer}.`);
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -170,7 +170,7 @@ jobs:
                 }
               }
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |
@@ -253,7 +253,7 @@ jobs:
                 }
               }
             }
-      - name: Workflow summary
+      - name: Write job summary
         if: always()
         shell: bash
         run: |


### PR DESCRIPTION
## What
Renames the \`Workflow summary\` steps in review-claims.yml to the contract-mandated literal \`Write job summary\` (4 jobs).

## Why
dev is currently RED on \`script/ci-job-summary-workflow.test.ts\`: the contract requires each registered job's summary step to be literally named \`Write job summary\` + reference GITHUB_STEP_SUMMARY; the gate job (registered in the contract by 2636aa1f7) writes the summary but under the name \`Workflow summary\` since the #7584 refresh. Reproduced on pristine origin/dev (a1be34a0): 3 pass / 1 fail -> with this rename: all pass. Name-only change; step bodies untouched.

## QA
- \`bun test script/ci-job-summary-workflow.test.ts\`: 4/4 pass on this branch (was 3/4 on dev)
- \`bunx actionlint .github/workflows/review-claims.yml\`: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the `Workflow summary` steps in `review-claims.yml` to `Write job summary` so the job-summary contract test passes on `dev`.

- The four summary steps now use the contract-required literal name.
- Step bodies are unchanged; this is a name-only fix.

<sup>Written for commit 5a7cefdb72d642e16631c83cd15efd6e5ced105d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

