### PR TITLE
fix(mcp-client-core): make env filtering hermetic on Windows

### DIFF
--- a/packages/mcp-client-core/src/skill-mcp-manager/core-behavior.test.ts
+++ b/packages/mcp-client-core/src/skill-mcp-manager/core-behavior.test.ts
@@ -18,23 +18,15 @@ describe("skill MCP core behavior", () => {
 
   it("#given ambient secrets and declared MCP env #when cleaning env #then only ambient secrets are stripped", () => {
     // given
-    const originalToken = process.env["OPENAI_API_KEY"]
-    process.env["OPENAI_API_KEY"] = "ambient-secret"
+    // when
+    const cleaned = createCleanMcpEnvironment(
+      { OPENAI_API_KEY: "declared-secret", SAFE_FLAG: "1" },
+      { OPENAI_API_KEY: "ambient-secret" },
+    )
 
-    try {
-      // when
-      const cleaned = createCleanMcpEnvironment({ OPENAI_API_KEY: "declared-secret", SAFE_FLAG: "1" })
-
-      // then
-      expect(cleaned["OPENAI_API_KEY"]).toBe("declared-secret")
-      expect(cleaned["SAFE_FLAG"]).toBe("1")
-    } finally {
-      if (originalToken === undefined) {
-        delete process.env["OPENAI_API_KEY"]
-      } else {
-        process.env["OPENAI_API_KEY"] = originalToken
-      }
-    }
+    // then
+    expect(cleaned["OPENAI_API_KEY"]).toBe("declared-secret")
+    expect(cleaned["SAFE_FLAG"]).toBe("1")
   })
 
   it("#given token-bearing text #when redacting #then secret values are removed", () => {

--- a/packages/mcp-client-core/src/skill-mcp-manager/env-cleaner.ts
+++ b/packages/mcp-client-core/src/skill-mcp-manager/env-cleaner.ts
@@ -1,12 +1,11 @@
 // Filters npm/pnpm/yarn config env vars that break MCP servers in pnpm projects (#456)
 // Also filters secret-containing env vars to prevent exposure to malicious stdio MCP servers (#B-02)
 export const EXCLUDED_ENV_PATTERNS: RegExp[] = [
-  // npm/pnpm/yarn config patterns (original)
+  // npm/pnpm/yarn config patterns
   /^NPM_CONFIG_/i,
-  /^npm_config_/,
-  /^YARN_/,
-  /^PNPM_/,
-  /^NO_UPDATE_NOTIFIER$/,
+  /^YARN_/i,
+  /^PNPM_/i,
+  /^NO_UPDATE_NOTIFIER$/i,
 
   // Specific high-risk secret env vars (explicit blocks)
   /^ANTHROPIC_API_KEY$/i,

--- a/packages/omo-opencode/src/features/skill-mcp-manager/env-cleaner.test.ts
+++ b/packages/omo-opencode/src/features/skill-mcp-manager/env-cleaner.test.ts
@@ -1,36 +1,17 @@
 /// <reference types="bun-types" />
 
-import { describe, it, expect, afterEach } from "bun:test"
+import { describe, it, expect } from "bun:test"
 import { createCleanMcpEnvironment, EXCLUDED_ENV_PATTERNS } from "./env-cleaner"
 
 describe("createCleanMcpEnvironment", () => {
-  // Store original env to restore after tests
-  const originalEnv = { ...process.env }
-
-  afterEach(() => {
-    // Restore original environment
-    for (const key of Object.keys(process.env)) {
-      if (!(key in originalEnv)) {
-        delete process.env[key]
-      }
-    }
-    for (const [key, value] of Object.entries(originalEnv)) {
-      process.env[key] = value
-    }
-  })
-
   describe("NPM_CONFIG_* filtering", () => {
     it("filters out uppercase NPM_CONFIG_* variables", () => {
-      // given
-      process.env.NPM_CONFIG_REGISTRY = "https://private.registry.com"
-      process.env.NPM_CONFIG_CACHE = "/some/cache/path"
-      process.env.NPM_CONFIG_PREFIX = "/some/prefix"
-      process.env.PATH = "/usr/bin"
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment()
-
-      // then
+      const cleanEnv = createCleanMcpEnvironment({}, {
+        NPM_CONFIG_REGISTRY: "https://private.registry.com",
+        NPM_CONFIG_CACHE: "/some/cache/path",
+        NPM_CONFIG_PREFIX: "/some/prefix",
+        PATH: "/usr/bin",
+      })
       expect(cleanEnv.NPM_CONFIG_REGISTRY).toBeUndefined()
       expect(cleanEnv.NPM_CONFIG_CACHE).toBeUndefined()
       expect(cleanEnv.NPM_CONFIG_PREFIX).toBeUndefined()
@@ -38,17 +19,13 @@ describe("createCleanMcpEnvironment", () => {
     })
 
     it("filters out lowercase npm_config_* variables", () => {
-      // given
-      process.env.npm_config_registry = "https://private.registry.com"
-      process.env.npm_config_cache = "/some/cache/path"
-      process.env.npm_config_https_proxy = "http://proxy:8080"
-      process.env.npm_config_proxy = "http://proxy:8080"
-      process.env.HOME = "/home/user"
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment()
-
-      // then
+      const cleanEnv = createCleanMcpEnvironment({}, {
+        npm_config_registry: "https://private.registry.com",
+        npm_config_cache: "/some/cache/path",
+        npm_config_https_proxy: "http://proxy:8080",
+        npm_config_proxy: "http://proxy:8080",
+        HOME: "/home/user",
+      })
       expect(cleanEnv.npm_config_registry).toBeUndefined()
       expect(cleanEnv.npm_config_cache).toBeUndefined()
       expect(cleanEnv.npm_config_https_proxy).toBeUndefined()
@@ -59,16 +36,12 @@ describe("createCleanMcpEnvironment", () => {
 
   describe("YARN_* filtering", () => {
     it("filters out YARN_* variables", () => {
-      // given
-      process.env.YARN_CACHE_FOLDER = "/yarn/cache"
-      process.env.YARN_ENABLE_IMMUTABLE_INSTALLS = "true"
-      process.env.YARN_REGISTRY = "https://yarn.registry.com"
-      process.env.NODE_ENV = "production"
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment()
-
-      // then
+      const cleanEnv = createCleanMcpEnvironment({}, {
+        YARN_CACHE_FOLDER: "/yarn/cache",
+        YARN_ENABLE_IMMUTABLE_INSTALLS: "true",
+        YARN_REGISTRY: "https://yarn.registry.com",
+        NODE_ENV: "production",
+      })
       expect(cleanEnv.YARN_CACHE_FOLDER).toBeUndefined()
       expect(cleanEnv.YARN_ENABLE_IMMUTABLE_INSTALLS).toBeUndefined()
       expect(cleanEnv.YARN_REGISTRY).toBeUndefined()
@@ -78,15 +51,11 @@ describe("createCleanMcpEnvironment", () => {
 
   describe("PNPM_* filtering", () => {
     it("filters out PNPM_* variables", () => {
-      // given
-      process.env.PNPM_HOME = "/pnpm/home"
-      process.env.PNPM_STORE_DIR = "/pnpm/store"
-      process.env.USER = "testuser"
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment()
-
-      // then
+      const cleanEnv = createCleanMcpEnvironment({}, {
+        PNPM_HOME: "/pnpm/home",
+        PNPM_STORE_DIR: "/pnpm/store",
+        USER: "testuser",
+      })
       expect(cleanEnv.PNPM_HOME).toBeUndefined()
       expect(cleanEnv.PNPM_STORE_DIR).toBeUndefined()
       expect(cleanEnv.USER).toBe("testuser")
@@ -95,67 +64,35 @@ describe("createCleanMcpEnvironment", () => {
 
   describe("NO_UPDATE_NOTIFIER filtering", () => {
     it("filters out NO_UPDATE_NOTIFIER variable", () => {
-      // given
-      process.env.NO_UPDATE_NOTIFIER = "1"
-      process.env.SHELL = "/bin/bash"
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment()
-
-      // then
+      const cleanEnv = createCleanMcpEnvironment({}, { NO_UPDATE_NOTIFIER: "1", SHELL: "/bin/bash" })
       expect(cleanEnv.NO_UPDATE_NOTIFIER).toBeUndefined()
       expect(cleanEnv.SHELL).toBe("/bin/bash")
     })
   })
 
   describe("custom environment overlay", () => {
-    it("merges custom env on top of clean process.env", () => {
-      // given
-      process.env.PATH = "/usr/bin"
-      process.env.NPM_CONFIG_REGISTRY = "https://private.registry.com"
-      const customEnv = {
+    it("merges custom env on top of clean ambient env", () => {
+      const cleanEnv = createCleanMcpEnvironment({
         SAFE_CUSTOM_VAR: "custom-value",
         ANOTHER_SAFE_VAR: "another-value",
-      }
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment(customEnv)
-
-      // then
+      }, { PATH: "/usr/bin", NPM_CONFIG_REGISTRY: "https://private.registry.com" })
       expect(cleanEnv.PATH).toBe("/usr/bin")
       expect(cleanEnv.NPM_CONFIG_REGISTRY).toBeUndefined()
       expect(cleanEnv.SAFE_CUSTOM_VAR).toBe("custom-value")
       expect(cleanEnv.ANOTHER_SAFE_VAR).toBe("another-value")
     })
 
-    it("custom env can override process.env values", () => {
-      // given
-      process.env.NODE_ENV = "development"
-      const customEnv = {
-        NODE_ENV: "production",
-      }
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment(customEnv)
-
-      // then
+    it("custom env can override ambient env values", () => {
+      const cleanEnv = createCleanMcpEnvironment({ NODE_ENV: "production" }, { NODE_ENV: "development" })
       expect(cleanEnv.NODE_ENV).toBe("production")
     })
 
     it("passes through secret-named keys from customEnv without filtering", () => {
-      // given - custom env values are explicitly declared in skill config
-      process.env.PATH = "/usr/bin"
-      process.env.MCP_API_KEY = "ambient-secret-from-process-env"
-      const customEnv = {
+      const cleanEnv = createCleanMcpEnvironment({
         MCP_API_KEY: "skill-declared-api-key",
         TELEGRAM_BOT_TOKEN: "skill-configured-bot-token",
         SAFE_VAR: "safe-value",
-      }
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment(customEnv)
-
-      // then - custom env overrides ambient values and is not filtered
+      }, { PATH: "/usr/bin", MCP_API_KEY: "ambient-secret-from-process-env" })
       expect(cleanEnv.MCP_API_KEY).toBe("skill-declared-api-key")
       expect(cleanEnv.TELEGRAM_BOT_TOKEN).toBe("skill-configured-bot-token")
       expect(cleanEnv.SAFE_VAR).toBe("safe-value")
@@ -163,31 +100,17 @@ describe("createCleanMcpEnvironment", () => {
     })
 
     it("passes TELEGRAM_BOT_TOKEN through when declared in skill env (issue #3995)", () => {
-      // given - TELEGRAM_BOT_TOKEN matches /_TOKEN$/i but is explicitly declared
-      process.env.TELEGRAM_BOT_TOKEN = "ambient-bot-token"
-      const customEnv = {
-        TELEGRAM_BOT_TOKEN: "skill-bot-token",
-      }
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment(customEnv)
-
-      // then
+      const cleanEnv = createCleanMcpEnvironment({ TELEGRAM_BOT_TOKEN: "skill-bot-token" }, {
+        TELEGRAM_BOT_TOKEN: "ambient-bot-token",
+      })
       expect(cleanEnv.TELEGRAM_BOT_TOKEN).toBe("skill-bot-token")
     })
 
-    it("still filters secret-named vars from process.env when customEnv is provided", () => {
-      // given
-      process.env.AMBIENT_API_KEY = "ambient-secret"
-      process.env.PATH = "/usr/bin"
-      const customEnv = {
-        SAFE_CUSTOM_VAR: "custom-value",
-      }
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment(customEnv)
-
-      // then
+    it("still filters secret-named vars from ambient env when customEnv is provided", () => {
+      const cleanEnv = createCleanMcpEnvironment({ SAFE_CUSTOM_VAR: "custom-value" }, {
+        AMBIENT_API_KEY: "ambient-secret",
+        PATH: "/usr/bin",
+      })
       expect(cleanEnv.AMBIENT_API_KEY).toBeUndefined()
       expect(cleanEnv.PATH).toBe("/usr/bin")
       expect(cleanEnv.SAFE_CUSTOM_VAR).toBe("custom-value")
@@ -195,14 +118,8 @@ describe("createCleanMcpEnvironment", () => {
   })
 
   describe("undefined value handling", () => {
-    it("skips undefined values from process.env", () => {
-      // given - process.env can have undefined values in TypeScript
-      const envWithUndefined = { UNDEFINED_VAR: undefined }
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment({}, envWithUndefined)
-
-      // then - should not throw and should not include undefined values
+    it("skips undefined values from ambient env", () => {
+      const cleanEnv = createCleanMcpEnvironment({}, { UNDEFINED_VAR: undefined })
       expect(cleanEnv.UNDEFINED_VAR).toBeUndefined()
       expect(Object.values(cleanEnv).every((v) => v !== undefined)).toBe(true)
     })
@@ -210,346 +127,154 @@ describe("createCleanMcpEnvironment", () => {
 
   describe("mixed case handling", () => {
     it("filters both uppercase and lowercase npm config variants", () => {
-      // given - pnpm/yarn can set both cases simultaneously
-      process.env.NPM_CONFIG_CACHE = "/uppercase/cache"
-      process.env.npm_config_cache = "/lowercase/cache"
-      process.env.NPM_CONFIG_REGISTRY = "https://uppercase.registry.com"
-      process.env.npm_config_registry = "https://lowercase.registry.com"
-
-      // when
-      const cleanEnv = createCleanMcpEnvironment()
-
-      // then
+      const cleanEnv = createCleanMcpEnvironment({}, {
+        NPM_CONFIG_CACHE: "/uppercase/cache",
+        npm_config_cache: "/lowercase/cache",
+        NPM_CONFIG_REGISTRY: "https://uppercase.registry.com",
+        npm_config_registry: "https://lowercase.registry.com",
+      })
       expect(cleanEnv.NPM_CONFIG_CACHE).toBeUndefined()
       expect(cleanEnv.npm_config_cache).toBeUndefined()
       expect(cleanEnv.NPM_CONFIG_REGISTRY).toBeUndefined()
       expect(cleanEnv.npm_config_registry).toBeUndefined()
     })
   })
+
+  describe("default ambient environment", () => {
+    it("reads the live process environment by default without mutating it", () => {
+      const cleanEnv = createCleanMcpEnvironment()
+      for (const [key, value] of Object.entries(process.env)) {
+        if (value === undefined) continue
+        if (EXCLUDED_ENV_PATTERNS.some((pattern) => pattern.test(key))) {
+          expect(cleanEnv[key]).toBeUndefined()
+        } else {
+          expect(cleanEnv[key]).toBe(value)
+        }
+      }
+    })
+  })
+
+  describe("Windows environment casing", () => {
+    it("preserves ambient Path under its own key casing", () => {
+      const cleanEnv = createCleanMcpEnvironment({}, { Path: "C:\\Windows\\system32" })
+      expect(cleanEnv.Path).toBe("C:\\Windows\\system32")
+    })
+
+    it("filters Windows-cased npm config variables", () => {
+      const cleanEnv = createCleanMcpEnvironment({}, { Npm_Config_Registry: "https://private.registry.com" })
+      expect(cleanEnv.Npm_Config_Registry).toBeUndefined()
+    })
+
+    it("filters mixed-case Yarn_ variables", () => {
+      const cleanEnv = createCleanMcpEnvironment({}, { Yarn_Cache_Folder: "C:\\yarn\\cache" })
+      expect(cleanEnv.Yarn_Cache_Folder).toBeUndefined()
+    })
+
+    it("filters mixed-case Pnpm_ variables", () => {
+      const cleanEnv = createCleanMcpEnvironment({}, { Pnpm_Home: "C:\\pnpm" })
+      expect(cleanEnv.Pnpm_Home).toBeUndefined()
+    })
+  })
 })
 
 describe("EXCLUDED_ENV_PATTERNS", () => {
   it("contains patterns for npm, yarn, and pnpm configs", () => {
-    // given / #when / #then
     expect(EXCLUDED_ENV_PATTERNS.length).toBeGreaterThanOrEqual(4)
-
-    // Test that patterns match expected strings
     const testCases = [
-      { pattern: "NPM_CONFIG_REGISTRY", shouldMatch: true },
-      { pattern: "npm_config_registry", shouldMatch: true },
-      { pattern: "YARN_CACHE_FOLDER", shouldMatch: true },
-      { pattern: "PNPM_HOME", shouldMatch: true },
-      { pattern: "NO_UPDATE_NOTIFIER", shouldMatch: true },
-      { pattern: "GOOGLE_APPLICATION_CREDENTIALS", shouldMatch: true },
-      { pattern: "GOOGLE_CLOUD_PROJECT", shouldMatch: true },
-      { pattern: "AZURE_CLIENT_ID", shouldMatch: true },
-      { pattern: "GCP_SERVICE_ACCOUNT", shouldMatch: true },
-      { pattern: "FIREBASE_CONFIG", shouldMatch: true },
-      { pattern: "HEROKU_API_KEY", shouldMatch: true },
-      { pattern: "DOCKER_AUTH_CONFIG", shouldMatch: true },
-      { pattern: "KUBECONFIG", shouldMatch: true },
-      { pattern: "VAULT_TOKEN", shouldMatch: true },
-      { pattern: "APP_CREDENTIALS", shouldMatch: true },
-      { pattern: "PATH", shouldMatch: false },
-      { pattern: "HOME", shouldMatch: false },
-      { pattern: "NODE_ENV", shouldMatch: false },
-    ]
+      ["NPM_CONFIG_REGISTRY", true], ["npm_config_registry", true], ["YARN_CACHE_FOLDER", true],
+      ["PNPM_HOME", true], ["NO_UPDATE_NOTIFIER", true], ["GOOGLE_APPLICATION_CREDENTIALS", true],
+      ["GOOGLE_CLOUD_PROJECT", true], ["AZURE_CLIENT_ID", true], ["GCP_SERVICE_ACCOUNT", true],
+      ["FIREBASE_CONFIG", true], ["HEROKU_API_KEY", true], ["DOCKER_AUTH_CONFIG", true],
+      ["KUBECONFIG", true], ["VAULT_TOKEN", true], ["APP_CREDENTIALS", true],
+      ["PATH", false], ["HOME", false], ["NODE_ENV", false],
+    ] as const
+    for (const [pattern, shouldMatch] of testCases) {
+      expect(EXCLUDED_ENV_PATTERNS.some((regex) => regex.test(pattern))).toBe(shouldMatch)
+    }
+  })
 
-    for (const { pattern, shouldMatch } of testCases) {
-      const matches = EXCLUDED_ENV_PATTERNS.some((regex: RegExp) => regex.test(pattern))
-      expect(matches).toBe(shouldMatch)
+  it("uses case-insensitive matching for every excluded environment pattern", () => {
+    for (const pattern of EXCLUDED_ENV_PATTERNS) {
+      expect(pattern.flags.includes("i")).toBe(true)
     }
   })
 })
+
 describe("secret env var filtering", () => {
   it("filters out ANTHROPIC_API_KEY", () => {
-    // given
-    process.env.ANTHROPIC_API_KEY = "sk-ant-api03-secret"
-    process.env.PATH = "/usr/bin"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.ANTHROPIC_API_KEY).toBeUndefined()
-    expect(cleanEnv.PATH).toBe("/usr/bin")
+    const cleanEnv = createCleanMcpEnvironment({}, { ANTHROPIC_API_KEY: "sk-ant-api03-secret", PATH: "/usr/bin" })
+    expect(cleanEnv.ANTHROPIC_API_KEY).toBeUndefined(); expect(cleanEnv.PATH).toBe("/usr/bin")
   })
-
   it("filters out AWS_SECRET_ACCESS_KEY", () => {
-    // given
-    process.env.AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-    process.env.AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
-    process.env.HOME = "/home/user"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.AWS_SECRET_ACCESS_KEY).toBeUndefined()
-    expect(cleanEnv.AWS_ACCESS_KEY_ID).toBeUndefined()
-    expect(cleanEnv.HOME).toBe("/home/user")
+    const cleanEnv = createCleanMcpEnvironment({}, { AWS_SECRET_ACCESS_KEY: "secret", AWS_ACCESS_KEY_ID: "key", HOME: "/home/user" })
+    expect(cleanEnv.AWS_SECRET_ACCESS_KEY).toBeUndefined(); expect(cleanEnv.AWS_ACCESS_KEY_ID).toBeUndefined(); expect(cleanEnv.HOME).toBe("/home/user")
   })
-
   it("filters out GITHUB_TOKEN", () => {
-    // given
-    process.env.GITHUB_TOKEN = "ghp_secrettoken123456789"
-    process.env.GITHUB_API_TOKEN = "another_secret_token"
-    process.env.SHELL = "/bin/bash"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.GITHUB_TOKEN).toBeUndefined()
-    expect(cleanEnv.GITHUB_API_TOKEN).toBeUndefined()
-    expect(cleanEnv.SHELL).toBe("/bin/bash")
+    const cleanEnv = createCleanMcpEnvironment({}, { GITHUB_TOKEN: "secret", GITHUB_API_TOKEN: "secret", SHELL: "/bin/bash" })
+    expect(cleanEnv.GITHUB_TOKEN).toBeUndefined(); expect(cleanEnv.GITHUB_API_TOKEN).toBeUndefined(); expect(cleanEnv.SHELL).toBe("/bin/bash")
   })
-
   it("filters out OPENAI_API_KEY", () => {
-    // given
-    process.env.OPENAI_API_KEY = "sk-secret123456789"
-    process.env.LANG = "en_US.UTF-8"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.OPENAI_API_KEY).toBeUndefined()
-    expect(cleanEnv.LANG).toBe("en_US.UTF-8")
+    const cleanEnv = createCleanMcpEnvironment({}, { OPENAI_API_KEY: "secret", LANG: "en_US.UTF-8" })
+    expect(cleanEnv.OPENAI_API_KEY).toBeUndefined(); expect(cleanEnv.LANG).toBe("en_US.UTF-8")
   })
-
   it("filters out DATABASE_URL with credentials", () => {
-    // given
-    process.env.DATABASE_URL = "postgresql://user:password@localhost:5432/db"
-    process.env.DB_PASSWORD = "supersecretpassword"
-    process.env.TERM = "xterm-256color"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.DATABASE_URL).toBeUndefined()
-    expect(cleanEnv.DB_PASSWORD).toBeUndefined()
-    expect(cleanEnv.TERM).toBe("xterm-256color")
+    const cleanEnv = createCleanMcpEnvironment({}, { DATABASE_URL: "postgresql://user:password@localhost:5432/db", DB_PASSWORD: "secret", TERM: "xterm-256color" })
+    expect(cleanEnv.DATABASE_URL).toBeUndefined(); expect(cleanEnv.DB_PASSWORD).toBeUndefined(); expect(cleanEnv.TERM).toBe("xterm-256color")
   })
-
   it("filters out exact cloud credential env vars", () => {
-    // given
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = "/tmp/gcp-service-account.json"
-    process.env.GOOGLE_CLOUD_PROJECT = "demo-project"
-    process.env.PATH = "/usr/bin"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.GOOGLE_APPLICATION_CREDENTIALS).toBeUndefined()
-    expect(cleanEnv.GOOGLE_CLOUD_PROJECT).toBeUndefined()
-    expect(cleanEnv.PATH).toBe("/usr/bin")
+    const cleanEnv = createCleanMcpEnvironment({}, { GOOGLE_APPLICATION_CREDENTIALS: "/tmp/file", GOOGLE_CLOUD_PROJECT: "demo", PATH: "/usr/bin" })
+    expect(cleanEnv.GOOGLE_APPLICATION_CREDENTIALS).toBeUndefined(); expect(cleanEnv.GOOGLE_CLOUD_PROJECT).toBeUndefined(); expect(cleanEnv.PATH).toBe("/usr/bin")
   })
 })
 
 describe("suffix-based secret filtering", () => {
   it("filters variables ending with _KEY", () => {
-    // given
-    process.env.MY_API_KEY = "secret-value"
-    process.env.SOME_KEY = "another-secret"
-    process.env.TMPDIR = "/tmp"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.MY_API_KEY).toBeUndefined()
-    expect(cleanEnv.SOME_KEY).toBeUndefined()
-    expect(cleanEnv.TMPDIR).toBe("/tmp")
+    const cleanEnv = createCleanMcpEnvironment({}, { MY_API_KEY: "secret", SOME_KEY: "secret", TMPDIR: "/tmp" })
+    expect(cleanEnv.MY_API_KEY).toBeUndefined(); expect(cleanEnv.SOME_KEY).toBeUndefined(); expect(cleanEnv.TMPDIR).toBe("/tmp")
   })
-
   it("filters variables ending with _SECRET", () => {
-    // given
-    process.env.AWS_SECRET = "secret-value"
-    process.env.JWT_SECRET = "jwt-secret-token"
-    process.env.USER = "testuser"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.AWS_SECRET).toBeUndefined()
-    expect(cleanEnv.JWT_SECRET).toBeUndefined()
-    expect(cleanEnv.USER).toBe("testuser")
+    const cleanEnv = createCleanMcpEnvironment({}, { AWS_SECRET: "secret", JWT_SECRET: "secret", USER: "testuser" })
+    expect(cleanEnv.AWS_SECRET).toBeUndefined(); expect(cleanEnv.JWT_SECRET).toBeUndefined(); expect(cleanEnv.USER).toBe("testuser")
   })
-
   it("filters variables ending with _TOKEN", () => {
-    // given
-    process.env.ACCESS_TOKEN = "token-value"
-    process.env.BEARER_TOKEN = "bearer-token"
-    process.env.HOME = "/home/user"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.ACCESS_TOKEN).toBeUndefined()
-    expect(cleanEnv.BEARER_TOKEN).toBeUndefined()
-    expect(cleanEnv.HOME).toBe("/home/user")
+    const cleanEnv = createCleanMcpEnvironment({}, { ACCESS_TOKEN: "token", BEARER_TOKEN: "token", HOME: "/home/user" })
+    expect(cleanEnv.ACCESS_TOKEN).toBeUndefined(); expect(cleanEnv.BEARER_TOKEN).toBeUndefined(); expect(cleanEnv.HOME).toBe("/home/user")
   })
-
   it("filters variables ending with _PASSWORD", () => {
-    // given
-    process.env.DB_PASSWORD = "db-password"
-    process.env.APP_PASSWORD = "app-secret"
-    process.env.NODE_ENV = "production"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.DB_PASSWORD).toBeUndefined()
-    expect(cleanEnv.APP_PASSWORD).toBeUndefined()
-    expect(cleanEnv.NODE_ENV).toBe("production")
+    const cleanEnv = createCleanMcpEnvironment({}, { DB_PASSWORD: "secret", APP_PASSWORD: "secret", NODE_ENV: "production" })
+    expect(cleanEnv.DB_PASSWORD).toBeUndefined(); expect(cleanEnv.APP_PASSWORD).toBeUndefined(); expect(cleanEnv.NODE_ENV).toBe("production")
   })
-
   it("filters variables ending with _CREDENTIAL", () => {
-    // given
-    process.env.GCP_CREDENTIAL = "json-credential"
-    process.env.AZURE_CREDENTIAL = "azure-creds"
-    process.env.PWD = "/current/dir"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.GCP_CREDENTIAL).toBeUndefined()
-    expect(cleanEnv.AZURE_CREDENTIAL).toBeUndefined()
-    expect(cleanEnv.PWD).toBe("/current/dir")
+    const cleanEnv = createCleanMcpEnvironment({}, { GCP_CREDENTIAL: "secret", AZURE_CREDENTIAL: "secret", PWD: "/current/dir" })
+    expect(cleanEnv.GCP_CREDENTIAL).toBeUndefined(); expect(cleanEnv.AZURE_CREDENTIAL).toBeUndefined(); expect(cleanEnv.PWD).toBe("/current/dir")
   })
-
   it("filters variables ending with _API_KEY", () => {
-    // given
-    // given
-    process.env.STRIPE_API_KEY = "sk_live_secret"
-    process.env.SENDGRID_API_KEY = "SG.secret"
-    process.env.SHELL = "/bin/zsh"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.STRIPE_API_KEY).toBeUndefined()
-    expect(cleanEnv.SENDGRID_API_KEY).toBeUndefined()
-    expect(cleanEnv.SHELL).toBe("/bin/zsh")
+    const cleanEnv = createCleanMcpEnvironment({}, { STRIPE_API_KEY: "secret", SENDGRID_API_KEY: "secret", SHELL: "/bin/zsh" })
+    expect(cleanEnv.STRIPE_API_KEY).toBeUndefined(); expect(cleanEnv.SENDGRID_API_KEY).toBeUndefined(); expect(cleanEnv.SHELL).toBe("/bin/zsh")
   })
-
   it("filters variables ending with _CREDENTIALS", () => {
-    // given
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = "/tmp/gcp-service-account.json"
-    process.env.APP_CREDENTIALS = "service-account"
-    process.env.HOME = "/home/user"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.GOOGLE_APPLICATION_CREDENTIALS).toBeUndefined()
-    expect(cleanEnv.APP_CREDENTIALS).toBeUndefined()
-    expect(cleanEnv.HOME).toBe("/home/user")
+    const cleanEnv = createCleanMcpEnvironment({}, { GOOGLE_APPLICATION_CREDENTIALS: "/tmp/file", APP_CREDENTIALS: "secret", HOME: "/home/user" })
+    expect(cleanEnv.GOOGLE_APPLICATION_CREDENTIALS).toBeUndefined(); expect(cleanEnv.APP_CREDENTIALS).toBeUndefined(); expect(cleanEnv.HOME).toBe("/home/user")
   })
 })
 
 describe("cloud provider env filtering", () => {
   it("filters cloud provider and infrastructure prefixes without breaking safe vars", () => {
-    // given
-    process.env.AZURE_CLIENT_ID = "azure-client"
-    process.env.GCP_SERVICE_ACCOUNT = "gcp-account"
-    process.env.FIREBASE_CONFIG = "firebase-config"
-    process.env.HEROKU_API_KEY = "heroku-key"
-    process.env.DOCKER_AUTH_CONFIG = '{"auths":{}}'
-    process.env.KUBECONFIG = "/tmp/kubeconfig"
-    process.env.VAULT_TOKEN_HELPER = "vault-helper"
-    process.env.PATH = "/usr/bin"
-    process.env.USER = "testuser"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.AZURE_CLIENT_ID).toBeUndefined()
-    expect(cleanEnv.GCP_SERVICE_ACCOUNT).toBeUndefined()
-    expect(cleanEnv.FIREBASE_CONFIG).toBeUndefined()
-    expect(cleanEnv.HEROKU_API_KEY).toBeUndefined()
-    expect(cleanEnv.DOCKER_AUTH_CONFIG).toBeUndefined()
-    expect(cleanEnv.KUBECONFIG).toBeUndefined()
-    expect(cleanEnv.VAULT_TOKEN_HELPER).toBeUndefined()
-    expect(cleanEnv.PATH).toBe("/usr/bin")
-    expect(cleanEnv.USER).toBe("testuser")
+    const cleanEnv = createCleanMcpEnvironment({}, {
+      AZURE_CLIENT_ID: "secret", GCP_SERVICE_ACCOUNT: "secret", FIREBASE_CONFIG: "secret", HEROKU_API_KEY: "secret",
+      DOCKER_AUTH_CONFIG: "secret", KUBECONFIG: "/tmp/kubeconfig", VAULT_TOKEN_HELPER: "secret", PATH: "/usr/bin", USER: "testuser",
+    })
+    expect(cleanEnv.AZURE_CLIENT_ID).toBeUndefined(); expect(cleanEnv.GCP_SERVICE_ACCOUNT).toBeUndefined(); expect(cleanEnv.FIREBASE_CONFIG).toBeUndefined()
+    expect(cleanEnv.HEROKU_API_KEY).toBeUndefined(); expect(cleanEnv.DOCKER_AUTH_CONFIG).toBeUndefined(); expect(cleanEnv.KUBECONFIG).toBeUndefined()
+    expect(cleanEnv.VAULT_TOKEN_HELPER).toBeUndefined(); expect(cleanEnv.PATH).toBe("/usr/bin"); expect(cleanEnv.USER).toBe("testuser")
   })
 })
 
 describe("safe environment variables preserved", () => {
-  it("preserves PATH", () => {
-    // given
-    process.env.PATH = "/usr/bin:/usr/local/bin"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.PATH).toBe("/usr/bin:/usr/local/bin")
-  })
-
-  it("preserves HOME", () => {
-    // given
-    process.env.HOME = "/home/testuser"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.HOME).toBe("/home/testuser")
-  })
-
-  it("preserves SHELL", () => {
-    // given
-    process.env.SHELL = "/bin/bash"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.SHELL).toBe("/bin/bash")
-  })
-
-  it("preserves LANG", () => {
-    // given
-    process.env.LANG = "en_US.UTF-8"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.LANG).toBe("en_US.UTF-8")
-  })
-
-  it("preserves TERM", () => {
-    // given
-    process.env.TERM = "xterm-256color"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.TERM).toBe("xterm-256color")
-  })
-
-  it("preserves TMPDIR", () => {
-    // given
-    process.env.TMPDIR = "/tmp"
-
-    // when
-    const cleanEnv = createCleanMcpEnvironment()
-
-    // then
-    expect(cleanEnv.TMPDIR).toBe("/tmp")
-})
+  for (const [name, value] of [["PATH", "/usr/bin:/usr/local/bin"], ["HOME", "/home/testuser"], ["SHELL", "/bin/bash"], ["LANG", "en_US.UTF-8"], ["TERM", "xterm-256color"], ["TMPDIR", "/tmp"]] as const) {
+    it(`preserves ${name}`, () => {
+      const cleanEnv = createCleanMcpEnvironment({}, { [name]: value })
+      expect(cleanEnv[name]).toBe(value)
+    })
+  }
 })


### PR DESCRIPTION
## Problem

`test (windows-latest, 1/2)` on dev fails in `packages/omo-opencode/src/features/skill-mcp-manager/env-cleaner.test.ts` (8 tests), e.g.:

```
expect(cleanEnv.PATH).toBe("/usr/bin")  // Expected: "/usr/bin", Received: undefined
```

Root cause: the tests mutated `process.env` and asserted case-exact keys on the plain object returned by `createCleanMcpEnvironment()`. On win32, env keys are case-aliased — setting `PATH` updates the canonical `Path` entry, and `Object.entries(process.env)` enumerates `Path`, so the copied plain object never has a `PATH` key. The suite was platform-dependent and parallel-unsafe by construction.

## Fix (no workarounds, no platform conditionals)

- **Hermetic tests**: every test now passes an explicit ambient env object through the existing `ambientEnv` parameter — zero `process.env` mutation, no snapshot/restore. Same coverage preserved.
- **Windows-shaped regressions**: ambient `{ Path: "C:\\Windows\\system32" }` preserved under its own casing; `Npm_Config_Registry` / `Yarn_Cache_Folder` / `Pnpm_Home` filtered.
- **Production**: `EXCLUDED_ENV_PATTERNS` made uniformly case-insensitive (`/^YARN_/i`, `/^PNPM_/i`, `/^NO_UPDATE_NOTIFIER$/i`; redundant lowercase `/^npm_config_/` collapsed into `/^NPM_CONFIG_/i`) so Windows-cased config vars cannot leak into stdio MCP spawns.
- **Recurrence guard**: contract test asserting every excluded pattern carries the `i` flag.
- **Default-wiring coverage**: read-only test proving the default `ambientEnv = process.env` path without mutating the environment.
- `core-behavior.test.ts` ambient-secret test rewritten to the explicit seam as well.

## Evidence

- RED first: mixed-case Yarn_/Pnpm_ filtering + flag guard failed on old code (3 fails / 35 pass), then GREEN after the regex change.
- Mutation proofs (remote, mengmotaMac): filter disabled -> 26 tests RED; `/i` dropped from `YARN_` -> exactly the guard + Yarn mixed-case RED; restored -> 43/43 GREEN.
- Package suites (`packages/mcp-client-core` + `packages/omo-opencode`): 8367 pass / 0 fail in the worktree.
- `ci:full-matrix` label applied so windows-latest runs on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the MCP environment cleaner hermetic on Windows so test assertions no longer fail on win32, and keeps Windows-cased npm/yarn/pnpm config vars from leaking into stdio MCP spawns.

**Bug Fixes**
- Windows env keys are case-aliased, so mutating `process.env` in tests caused case-exact assertions to fail on win32.
- Tests now pass explicit ambient env objects through `ambientEnv`, removing all `process.env` mutation.
- All `EXCLUDED_ENV_PATTERNS` match case-insensitively, including the previously lowercase-only `/^npm_config_/` pattern.
- Added a guard test asserting every excluded pattern carries the `i` flag.

<sup>Written for commit ace706ec54d6d87e8b415a4fe4712e01111000ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

