### PR TITLE
test(lsp-core): drive diagnostics freshness through a controlled clock

### DIFF
--- a/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
+++ b/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
@@ -2,6 +2,8 @@ import { writeFileSync } from "node:fs";
 
 import { afterEach, describe, expect, it } from "bun:test";
 
+import { ControlledClock } from "./controlled-clock-test-support.js";
+
 import {
 	createWorkspaceEditTestHarness,
 	diagnostic,
@@ -17,6 +19,7 @@ afterEach(async () => {
 
 describe("LspClient diagnostics freshness", () => {
 	it("#given a versionless publish that arrives after the current change #when no newer eligible publish arrives before quiescence #then diagnostics wait for that quiescence window and return the versionless payload", async () => {
+		const clock = new ControlledClock();
 		const context = await harness.makeClient(
 			{
 				publishDiagnostics: [
@@ -27,7 +30,7 @@ describe("LspClient diagnostics freshness", () => {
 					},
 				],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 80, versionlessPublishQuiescenceMs: 20 },
+			{ diagnosticsFreshnessTimeoutMs: 80, versionlessPublishQuiescenceMs: 20, timerProvider: clock },
 		);
 		await context.client.openFile(context.source);
 		const versionlessDelivery = waitForEventCount(
@@ -35,36 +38,52 @@ describe("LspClient diagnostics freshness", () => {
 			(event) => event.type === "clientResponse" && event.method === "workspace/configuration",
 			1,
 		);
-		const startedAt = Date.now();
 		writeFileSync(context.source, "const after = 1;\n", "utf-8");
 		await context.client.openFile(context.source);
 		expect(await versionlessDelivery).toHaveLength(1);
 
-		const result = await context.client.diagnostics(context.source);
-		const elapsedMs = Date.now() - startedAt;
+		const pending = context.client.diagnostics(context.source);
+		await clock.waitForTimer(20);
+		expect(clock.scheduledDelays.at(-1)).toBe(20);
+		clock.advanceBy(20);
+		const result = await pending;
 
 		expect(result.items).toEqual([diagnostic("post-generation-versionless")]);
-		expect(elapsedMs).toBeGreaterThanOrEqual(15);
 	});
 
 	it("#given only a pre-generation versionless publish #when a newer local version asks for diagnostics #then the stale versionless publish is ignored and the request does not resolve clean", async () => {
+		const clock = new ControlledClock();
 		const context = await harness.makeClient(
 			{
 				publishDiagnostics: [
 					{
 						trigger: "didOpen",
 						diagnostics: [diagnostic("pre-generation-versionless")],
+						awaitClientDelivery: true,
 					},
 				],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 300, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 300, versionlessPublishQuiescenceMs: 5, timerProvider: clock },
 		);
 		await context.client.openFile(context.source);
-		expect((await context.client.diagnostics(context.source)).items).toEqual([diagnostic("pre-generation-versionless")]);
+		await waitForEventCount(
+			context.events,
+			(event) => event.type === "clientResponse" && event.method === "workspace/configuration",
+			1,
+		);
+		const initial = context.client.diagnostics(context.source);
+		await clock.waitForTimer(5);
+		expect(clock.scheduledDelays.at(-1)).toBe(5);
+		clock.advanceBy(5);
+		expect((await initial).items).toEqual([diagnostic("pre-generation-versionless")]);
 		writeFileSync(context.source, "const after = 1;\n", "utf-8");
 		await context.client.openFile(context.source);
 
-		const result = await context.client.diagnostics(context.source);
+		const pending = context.client.diagnostics(context.source);
+		await clock.waitForTimer(300);
+		expect(clock.scheduledDelays.at(-1)).toBe(300);
+		clock.advanceBy(300);
+		const result = await pending;
 
 		expect(result.items).toEqual([]);
 		expect(result.transientError?.kind).toBe("freshness_timeout");
@@ -248,19 +267,20 @@ describe("LspClient diagnostics freshness", () => {
 	});
 
 	it("#given a server without pull support that never publishes diagnostics #when diagnostics run on a clean file #then the request resolves clean after the freshness window instead of reporting a timeout", async () => {
+		const clock = new ControlledClock();
 		const context = await harness.makeClient(
 			{},
-			{ diagnosticsFreshnessTimeoutMs: 60, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 60, versionlessPublishQuiescenceMs: 5, timerProvider: clock },
 		);
 
-		const startedAt = Date.now();
-		const result = await context.client.diagnostics(context.source);
-		const elapsedMs = Date.now() - startedAt;
+		const pending = context.client.diagnostics(context.source);
+		await clock.waitForTimer(60);
+		expect(clock.scheduledDelays.at(-1)).toBe(60);
+		clock.advanceBy(60);
+		const result = await pending;
 
 		expect(result.transientError).toBeUndefined();
 		expect(result.items).toEqual([]);
-		// The full freshness window is still honored so a slow publisher can win.
-		expect(elapsedMs).toBeGreaterThanOrEqual(45);
 	});
 
 	it("#given a pull-supported server that cached diagnostics for an older document version #when the file changes and a later pull is rejected as unsupported without any publish #then the fallback resolves empty instead of returning the stale cached diagnostics", async () => {

--- a/packages/lsp-core/src/lsp/client-diagnostics-pull-timeout.test.ts
+++ b/packages/lsp-core/src/lsp/client-diagnostics-pull-timeout.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { ControlledClock } from "./controlled-clock-test-support.js";
+import { LspClient } from "./client.js";
+import { LspRequestTimeoutError } from "./errors.js";
+import type { ResolvedServer } from "./types.js";
+
+const fakeServer: ResolvedServer = {
+	id: "pull-timeout-fake",
+	command: ["pull-timeout-fake"],
+	extensions: [".ts"],
+	priority: 0,
+};
+
+class HangingPullClient extends LspClient {
+	readonly grantedPullTimeouts: number[] = [];
+
+	constructor(root: string, private readonly clock: ControlledClock) {
+		super(root, fakeServer, { diagnosticsFreshnessTimeoutMs: 50, versionlessPublishQuiescenceMs: 5, timerProvider: clock });
+		this.setDiagnosticPullSupported(true);
+	}
+
+	protected override async sendNotification(): Promise<void> {}
+
+	protected override async sendRequest<T>(
+		method: string,
+		...args: [] | [unknown] | [unknown, { timeoutMs?: number; signal?: AbortSignal }]
+	): Promise<T> {
+		if (method !== "textDocument/diagnostic") {
+			throw new Error(`unexpected request in hanging-pull fixture: ${method}`);
+		}
+		const timeoutMs = args[1]?.timeoutMs ?? 0;
+		this.grantedPullTimeouts.push(timeoutMs);
+		this.clock.advanceBy(timeoutMs);
+		throw new LspRequestTimeoutError(method);
+	}
+}
+
+describe("LspClient diagnostics pull timeout conversion", () => {
+	let root: string | null = null;
+
+	afterEach(() => {
+		if (root !== null) rmSync(root, { recursive: true, force: true });
+		root = null;
+	});
+
+	it("#given a pull that exhausts the freshness window #when diagnostics settle #then the timeout converts to freshness_timeout instead of rejecting", async () => {
+		root = mkdtempSync(join(tmpdir(), "lsp-pull-timeout-"));
+		const source = join(root, "sample.ts");
+		writeFileSync(source, "const value = 1;\n", "utf-8");
+		const clock = new ControlledClock();
+		const client = new HangingPullClient(root, clock);
+
+		const result = await client.diagnostics(source);
+
+		expect(client.grantedPullTimeouts).toEqual([50]);
+		expect(result.items).toEqual([]);
+		expect(result.transientError?.kind).toBe("freshness_timeout");
+	});
+});

--- a/packages/lsp-core/src/lsp/client.ts
+++ b/packages/lsp-core/src/lsp/client.ts
@@ -19,6 +19,7 @@ import type {
 } from "./types.js";
 import { LspRequestTimeoutError } from "./errors.js";
 import { WorkspaceDocumentState } from "./workspace-document-state.js";
+import type { TimerProvider } from "./timer-provider.js";
 import type { LspRenameResult, WorkspaceEditCommitIo } from "./workspace-edit-types.js";
 import { WorkspaceMutationController } from "./workspace-mutation-controller.js";
 
@@ -36,6 +37,7 @@ export interface LspDiagnosticsResult {
 export interface LspClientOptions extends LspClientTimeoutOptions {
 	readonly diagnosticsFreshnessTimeoutMs?: number;
 	readonly versionlessPublishQuiescenceMs?: number;
+	readonly timerProvider?: TimerProvider;
 }
 
 export class LspClient extends LspClientConnection {
@@ -52,6 +54,7 @@ export class LspClient extends LspClientConnection {
 			(method, params) => this.sendNotification(method, params),
 			(uri) => this.diagnosticsStore.delete(uri),
 			{
+				timerProvider: this.timerProvider,
 				versionlessPublishQuiescenceMs:
 					options.versionlessPublishQuiescenceMs ?? VERSIONLESS_PUBLISH_QUIESCENCE_MS,
 			},
@@ -207,7 +210,7 @@ export class LspClient extends LspClientConnection {
 		const absPath = this.resolveWorkspacePath(filePath);
 		const uri = pathToFileURL(absPath).href;
 		await this.openFile(absPath);
-		const deadlineAt = Date.now() + this.diagnosticsFreshnessTimeoutMs;
+		const deadlineAt = this.timerProvider.now() + this.diagnosticsFreshnessTimeoutMs;
 
 		for (;;) {
 			signal?.throwIfAborted();
@@ -220,7 +223,7 @@ export class LspClient extends LspClientConnection {
 			if (!pushFallbackOnly) {
 				const cached = this.documents.getPullCache(snapshot);
 				try {
-					const remainingMs = deadlineAt - Date.now();
+					const remainingMs = deadlineAt - this.timerProvider.now();
 					if (remainingMs <= 0) return this.freshnessTimeout(absPath);
 					const result = await this.sendRequest<{ items?: Diagnostic[]; kind?: string; resultId?: string }>(
 						"textDocument/diagnostic",
@@ -262,7 +265,7 @@ export class LspClient extends LspClientConnection {
 
 			if (!pushFallbackOnly) continue;
 
-			const remainingMs = deadlineAt - Date.now();
+			const remainingMs = deadlineAt - this.timerProvider.now();
 			if (remainingMs <= 0) {
 				// A server that never advertised pull diagnostics (or rejected the pull
 				// method) and has never published for this document stays silent for a

--- a/packages/lsp-core/src/lsp/controlled-clock-test-support.ts
+++ b/packages/lsp-core/src/lsp/controlled-clock-test-support.ts
@@ -1,0 +1,61 @@
+import type { TimerProvider } from "./timer-provider.js";
+
+interface ControlledTimer {
+	readonly at: number;
+	readonly callback: () => void;
+	cancelled: boolean;
+}
+
+interface TimerWaiter {
+	readonly delayMs: number | undefined;
+	readonly resolve: () => void;
+}
+
+/**
+ * Deterministic TimerProvider for tests: timers fire only through advanceBy(),
+ * and waitForTimer(delayMs) resolves once a timer with exactly that delay is
+ * scheduled, so tests order themselves behind the timer they intend to fire.
+ */
+export class ControlledClock implements TimerProvider {
+	private readonly timers: ControlledTimer[] = [];
+	private currentTime = 0;
+	private readonly timerWaiters = new Set<TimerWaiter>();
+	readonly scheduledDelays: number[] = [];
+
+	readonly now = (): number => this.currentTime;
+	readonly setTimeout = (callback: () => void, delayMs: number): ReturnType<typeof setTimeout> => {
+		const timer: ControlledTimer = { at: this.currentTime + delayMs, callback, cancelled: false };
+		this.scheduledDelays.push(delayMs);
+		this.timers.push(timer);
+		for (const waiter of this.timerWaiters) {
+			if (waiter.delayMs === undefined || waiter.delayMs === delayMs) {
+				this.timerWaiters.delete(waiter);
+				waiter.resolve();
+			}
+		}
+		return timer as unknown as ReturnType<typeof setTimeout>;
+	};
+	readonly clearTimeout = (handle: ReturnType<typeof setTimeout>): void => {
+		(handle as unknown as { cancelled: boolean }).cancelled = true;
+	};
+
+	waitForTimer(delayMs?: number): Promise<void> {
+		const hasTimer = this.timers.some(
+			(timer) => !timer.cancelled && (delayMs === undefined || timer.at === this.currentTime + delayMs),
+		);
+		if (hasTimer) return Promise.resolve();
+		return new Promise((resolve) => {
+			this.timerWaiters.add({ delayMs, resolve });
+		});
+	}
+
+	advanceBy(delayMs: number): void {
+		this.currentTime += delayMs;
+		for (;;) {
+			const index = this.timers.findIndex((timer) => timer.at <= this.currentTime);
+			if (index < 0) return;
+			const timer = this.timers.splice(index, 1)[0];
+			if (timer && !timer.cancelled) timer.callback();
+		}
+	}
+}

--- a/packages/lsp-core/src/lsp/timer-provider.ts
+++ b/packages/lsp-core/src/lsp/timer-provider.ts
@@ -1,0 +1,13 @@
+export type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface TimerProvider {
+	readonly now: () => number;
+	readonly setTimeout: (callback: () => void, delayMs: number) => TimerHandle;
+	readonly clearTimeout: (handle: TimerHandle) => void;
+}
+
+export const realTimerProvider: TimerProvider = {
+	now: () => Date.now(),
+	setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+	clearTimeout: (handle) => clearTimeout(handle),
+};

--- a/packages/lsp-core/src/lsp/transport-request-timeout.test.ts
+++ b/packages/lsp-core/src/lsp/transport-request-timeout.test.ts
@@ -1,0 +1,73 @@
+import { PassThrough } from "node:stream";
+
+import { describe, expect, it } from "bun:test";
+
+import { ControlledClock } from "./controlled-clock-test-support.js";
+import { LspRequestTimeoutError } from "./errors.js";
+import { JsonRpcConnection } from "./json-rpc-connection.js";
+import { LspClientTransport } from "./transport.js";
+import type { LspClientTimeoutOptions } from "./transport.js";
+import type { ResolvedServer } from "./types.js";
+
+const fakeServer: ResolvedServer = {
+	id: "controlled-clock-fake",
+	command: ["controlled-clock-fake"],
+	extensions: [".ts"],
+	priority: 0,
+};
+
+class WiredTransport extends LspClientTransport {
+	constructor(timeouts: LspClientTimeoutOptions, connection: JsonRpcConnection) {
+		super("/tmp", fakeServer, timeouts);
+		this.connection = connection;
+	}
+
+	request<T>(method: string, params: unknown, options: { timeoutMs?: number }): Promise<T> {
+		return this.sendRequest<T>(method, params, options);
+	}
+}
+
+function encodeMessage(message: Record<string, unknown>): string {
+	const body = JSON.stringify(message);
+	return `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`;
+}
+
+function makeWiredTransport(clock: ControlledClock): { transport: WiredTransport; serverToClient: PassThrough } {
+	const serverToClient = new PassThrough();
+	const clientToServer = new PassThrough();
+	const connection = new JsonRpcConnection(serverToClient, clientToServer);
+	connection.listen();
+	return { transport: new WiredTransport({ timerProvider: clock }, connection), serverToClient };
+}
+
+describe("LspClientTransport request timeout via TimerProvider", () => {
+	it("#given a request the server never answers #when the injected clock passes the timeout #then the request rejects with LspRequestTimeoutError", async () => {
+		const clock = new ControlledClock();
+		const { transport } = makeWiredTransport(clock);
+
+		const pending = transport.request("textDocument/diagnostic", { textDocument: { uri: "file:///a.ts" } }, {
+			timeoutMs: 50,
+		});
+		await clock.waitForTimer(50);
+		expect(clock.scheduledDelays.at(-1)).toBe(50);
+		clock.advanceBy(50);
+
+		await expect(pending).rejects.toBeInstanceOf(LspRequestTimeoutError);
+	});
+
+	it("#given a request answered before the deadline #when the injected clock later passes the timeout #then the settled result stands", async () => {
+		const clock = new ControlledClock();
+		const { transport, serverToClient } = makeWiredTransport(clock);
+
+		const pending = transport.request<{ items: unknown[] }>(
+			"textDocument/diagnostic",
+			{ textDocument: { uri: "file:///a.ts" } },
+			{ timeoutMs: 50 },
+		);
+		await clock.waitForTimer(50);
+		serverToClient.write(encodeMessage({ jsonrpc: "2.0", id: 1, result: { items: [] } }));
+
+		await expect(pending).resolves.toEqual({ items: [] });
+		clock.advanceBy(50);
+	});
+});

--- a/packages/lsp-core/src/lsp/transport.ts
+++ b/packages/lsp-core/src/lsp/transport.ts
@@ -1,4 +1,6 @@
 import { reportBestEffortCleanupError } from "./cleanup-errors.js";
+import { realTimerProvider } from "./timer-provider.js";
+import type { TimerProvider } from "./timer-provider.js";
 import { INIT_TIMEOUT_MS, REQUEST_TIMEOUT_MS, STOP_HARD_KILL_TIMEOUT_MS, STOP_SIGKILL_GRACE_MS } from "./constants.js";
 import { LspConnectionClosedError, LspProcessExitedError, LspRequestTimeoutError } from "./errors.js";
 import { JsonRpcConnection } from "./json-rpc-connection.js";
@@ -12,6 +14,7 @@ export { createLspSpawnEnv } from "./transport-protocol.js";
 export interface LspClientTimeoutOptions {
 	requestTimeoutMs?: number;
 	initializeTimeoutMs?: number;
+	timerProvider?: TimerProvider;
 }
 
 type WorkspaceApplyEditHandler = (params: unknown) => Promise<WorkspaceApplyEditResponse>;
@@ -35,6 +38,7 @@ export class LspClientTransport {
 	protected readonly diagnosticsStore = new Map<string, Diagnostic[]>();
 	protected readonly requestTimeoutMs: number;
 	protected readonly initializeTimeoutMs: number;
+	protected readonly timerProvider: TimerProvider;
 	private workspaceApplyEditHandler: WorkspaceApplyEditHandler | null = null;
 	private diagnosticPullSupported = false;
 	private documentFormattingSupported = false;
@@ -46,6 +50,7 @@ export class LspClientTransport {
 	) {
 		this.requestTimeoutMs = timeouts.requestTimeoutMs ?? REQUEST_TIMEOUT_MS;
 		this.initializeTimeoutMs = timeouts.initializeTimeoutMs ?? INIT_TIMEOUT_MS;
+		this.timerProvider = timeouts.timerProvider ?? realTimerProvider;
 	}
 
 	pid(): number | undefined {
@@ -187,7 +192,7 @@ export class LspClientTransport {
 		const options = args[1];
 		const timeoutMs = options?.timeoutMs ?? this.requestTimeoutMs;
 		const timeoutController = new AbortController();
-		const timeoutHandle = setTimeout(() => {
+		const timeoutHandle = this.timerProvider.setTimeout(() => {
 			const stderrTail = this.stderrBuffer.slice(-5).join("\n");
 			timeoutController.abort(new LspRequestTimeoutError(method, stderrTail || undefined));
 		}, timeoutMs);
@@ -213,7 +218,7 @@ export class LspClientTransport {
 			}
 			throw error;
 		} finally {
-			clearTimeout(timeoutHandle);
+			this.timerProvider.clearTimeout(timeoutHandle);
 			combinedSignal.dispose();
 		}
 	}

--- a/packages/lsp-core/src/lsp/workspace-document-state.ts
+++ b/packages/lsp-core/src/lsp/workspace-document-state.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { effectiveExtension } from "./effective-extension.js";
 import { getLanguageId } from "./language-mappings.js";
 import type { Diagnostic } from "./types.js";
+import type { TimerProvider } from "./timer-provider.js";
 import type { PlannedWorkspaceOperation, WorkspaceMutation, WorkspaceMutationDelta } from "./workspace-edit-types.js";
 
 const WATCHED_FILE_BATCH_SIZE = 128;
@@ -76,6 +77,7 @@ export type PushDiagnosticsResolution =
 
 export interface WorkspaceDocumentStateOptions {
 	readonly now?: () => number;
+	readonly timerProvider?: TimerProvider;
 	readonly versionlessPublishQuiescenceMs?: number;
 }
 
@@ -114,6 +116,7 @@ export class WorkspaceDocumentState {
 	private readonly openByUri = new Map<string, OpenDocumentState>();
 	private readonly openPromises = new Map<string, Promise<void>>();
 	private readonly now: () => number;
+	private readonly timerProvider: TimerProvider;
 	private readonly versionlessPublishQuiescenceMs: number;
 
 	constructor(
@@ -121,7 +124,12 @@ export class WorkspaceDocumentState {
 		private readonly clearDiagnostics: (uri: string) => void,
 		options: WorkspaceDocumentStateOptions = {},
 	) {
-		this.now = options.now ?? (() => Date.now());
+		this.timerProvider = options.timerProvider ?? {
+			now: options.now ?? (() => Date.now()),
+			setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+			clearTimeout: (handle) => clearTimeout(handle),
+		};
+		this.now = () => this.timerProvider.now();
 		this.versionlessPublishQuiescenceMs =
 			options.versionlessPublishQuiescenceMs ?? DEFAULT_VERSIONLESS_PUBLISH_QUIESCENCE_MS;
 	}
@@ -232,11 +240,11 @@ export class WorkspaceDocumentState {
 			const finish = () => {
 				if (settled) return;
 				settled = true;
-				clearTimeout(timer);
+				this.timerProvider.clearTimeout(timer);
 				state.waiters.delete(finish);
 				resolveActivity();
 			};
-			const timer = setTimeout(finish, timeoutMs);
+			const timer = this.timerProvider.setTimeout(finish, timeoutMs);
 			if (typeof timer.unref === "function") timer.unref();
 			state.waiters.add(finish);
 		});


### PR DESCRIPTION
## Problem

`test (windows-latest, 2/2)` flaked on PR #7586's first full-matrix run: two tests in `packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts` raced real-clock micro-windows (80ms freshness timeout, 20ms/5ms versionless-publish quiescence) against a real spawned fake LSP server. Loaded Windows runners blow those windows (observed 4s/2.9s timing failures on run 33491586661); wall-clock assertions like `elapsedMs >= 15` pass or fail by scheduler luck.

## Fix (no timeout inflation, no retries, no platform conditionals)

- New `TimerProvider` seam (`timer-provider.ts`): `now`/`setTimeout`/`clearTimeout`, default `realTimerProvider` = native timers, so production behavior is unchanged.
- Threaded through `LspClient` (freshness deadline), `WorkspaceDocumentState` (versionless-publish quiescence), and `LspClientTransport.sendRequest()` request expiry — every timing decision on the diagnostics freshness path shares one provider.
- Flaky tests rewritten to drive a hand-rolled `ControlledClock` (`waitForTimer`/`advanceBy`): same semantic contracts (versionless publish honored after quiescence; stale pre-generation publish ignored with `freshness_timeout`; never-publishing server resolves clean after the window), zero wall-clock dependence. Scheduled-delay assertions (20/300/60/50 ms) pin the configured windows.
- New regression: pull-supported server hanging on `textDocument/diagnostic` — controlled clock expires the pull deterministically (RED captured against native-timer transport: bounded run exit 124, never settles).

## Evidence

- Determinism loop: 20/20 green runs of the integration file.
- Package suite: 161 pass / 0 fail / 1 pre-existing skip; tsgo typecheck pass.
- Ultrabrain strict review: REQUEST_CHANGES round 1 (transport timeout seam blocker) -> fixed -> **VERDICT: APPROVE** (notes only).
- `ci:full-matrix` label applied so windows-latest runs on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes diagnostics freshness tests deterministic by replacing real-clock timing with an injectable `TimerProvider` clock, so flaky tests no longer depend on wall-clock windows on loaded CI runners.

- Adds a `TimerProvider` seam (`now`, `setTimeout`, `clearTimeout`) with a production default that keeps runtime behavior unchanged.
- Threads the provider through `LspClient`, `WorkspaceDocumentState`, and `LspClientTransport` so all freshness and request-expiry decisions share one clock.
- Rewrites the flaky integration tests to drive a `ControlledClock`, removing dependence on real 20/50/60/80 ms windows.
- Adds regression tests covering the freshness timeout for a pull-supported server that hangs on the diagnostic request, and request-expiry behavior driven through the injected clock.

<sup>Written for commit b680e29bc4e6bad7919b528c768ca96aad25b17d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

