### PR TITLE
test(worktree-sweep): make the age fixture deterministic

### DIFF
--- a/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
@@ -307,21 +307,47 @@ describe("sweepWorktrees --older-than", () => {
     const old = path.join(base, "wt-old")
     const oldDirty = path.join(base, "wt-old-dirty")
 
-    await addUnmergedWorktree(repo, "young-branch", young)
-    await addUnmergedWorktree(repo, "old-branch", old)
-    await addUnmergedWorktree(repo, "old-dirty-branch", oldDirty)
-    // The untracked file first (writing it would touch the directory mtime), then age the directory.
+    // All three branches can share one unmerged commit. Creating that commit once
+    // avoids repeating checkout/commit cycles, which made this test exceed Bun's
+    // default timeout on slower Windows runners.
+    git(repo, ["worktree", "add", "-b", "young-branch", young, "main"])
+    await commit(young, "unmerged commit")
+    git(repo, ["worktree", "add", "-b", "old-branch", old, "young-branch"])
+    git(repo, ["worktree", "add", "-b", "old-dirty-branch", oldDirty, "young-branch"])
+
+    // Set both sides of the cutoff explicitly so filesystem timestamp granularity
+    // and fixture setup duration cannot change the age classification.
     await fs.writeFile(path.join(oldDirty, "scratch.txt"), "local change\n")
+    const youngTime = new Date(Date.now() + DAY_MS)
     const staleTime = new Date(Date.now() - 10 * DAY_MS)
-    await fs.utimes(old, staleTime, staleTime)
-    await fs.utimes(oldDirty, staleTime, staleTime)
+    await Promise.all([
+      fs.utimes(young, youngTime, youngTime),
+      fs.utimes(old, staleTime, staleTime),
+      fs.utimes(oldDirty, staleTime, staleTime),
+    ])
 
     const result = await sweepWorktrees({ repos: [repo], olderThanDays: 7 })
 
     const report = result.repos[0]!
-    expect(decisionFor(report, young).reason).toBe("unmerged")
-    expect(decisionFor(report, old).decision).toBe("SWEEP")
-    expect(decisionFor(report, oldDirty).reason).toBe("dirty")
+    expect(decisionFor(report, young)).toEqual({
+      path: young,
+      ref: "young-branch",
+      decision: "KEEP",
+      reason: "unmerged",
+    })
+    expect(decisionFor(report, old)).toEqual({
+      path: old,
+      ref: "old-branch",
+      decision: "SWEEP",
+    })
+    expect(decisionFor(report, oldDirty)).toEqual({
+      path: oldDirty,
+      ref: "old-dirty-branch",
+      decision: "KEEP",
+      reason: "dirty",
+    })
+    expect(result.sweepCount).toBe(1)
+    expect(result.keepCount).toBe(2)
   })
 
   test("olderThanDays 0 never sweeps unmerged worktrees regardless of age", async () => {


### PR DESCRIPTION
Flake fix: `sweepWorktrees --older-than` failed at 5002ms on windows-latest CI. The fixture ran three separate checkout/commit/worktree sequences (risking Bun's 5s default timeout on slow runners) and derived the stale mtime from a live `Date.now()` taken AFTER setup, so age classification depended on setup speed and FS timestamp precision.

Fix: one reused unmerged commit for all three linked worktrees, explicit mtimes (young = future, stale = fixed relative past), plus exact classification + aggregate count assertions so the test cannot pass vacuously. Test-only, no production change. 30x loop green; worktree-sweep scope 20/0; typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky `sweepWorktrees --older-than` test that timed out on Windows by making the age fixture deterministic.

- Reuses one unmerged commit for all three worktrees instead of separate checkout/commit cycles, avoiding Bun's 5s timeout on slow runners.
- Sets explicit mtimes (future for the young worktree, fixed past for stale ones) so classification no longer depends on setup speed or filesystem timestamp precision.
- Asserts exact decision objects plus sweep/keep counts so the test cannot pass vacuously.

Test-only change; no production impact.

<sup>Written for commit 47acf21004d25d20c24931dc381f59dc02cc5f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

