### PR TITLE
test(background-agent): make queue integration deterministic

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.test.ts
@@ -4988,8 +4988,45 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
     test("should handle 10 tasks with limit 5 returning immediately", async () => {
       // given
       const config = { defaultConcurrency: 5 }
+      let releasePromptAsync: () => void = () => {}
+      const promptAsyncReleased = new Promise<void>((resolve) => {
+        releasePromptAsync = resolve
+      })
+      let promptAsyncCalls = 0
+      let promptAsyncCompletions = 0
+      let resolveFivePromptAsyncCalls: (() => void) | undefined
+      const fivePromptAsyncCalls = new Promise<void>((resolve) => {
+        resolveFivePromptAsyncCalls = resolve
+      })
+      let resolveFivePromptAsyncCompletions: (() => void) | undefined
+      const fivePromptAsyncCompletions = new Promise<void>((resolve) => {
+        resolveFivePromptAsyncCompletions = resolve
+      })
+      const gatedClient = {
+        session: {
+          create: async () => ({ data: { id: `ses_${crypto.randomUUID()}` } }),
+          get: async () => ({ data: { directory: "/test/dir" } }),
+          prompt: async () => ({}),
+          promptAsync: async () => {
+            promptAsyncCalls++
+            if (promptAsyncCalls === 5) {
+              resolveFivePromptAsyncCalls?.()
+            }
+            await promptAsyncReleased
+            promptAsyncCompletions++
+            if (promptAsyncCompletions === 5) {
+              resolveFivePromptAsyncCompletions?.()
+            }
+            return {}
+          },
+          messages: async () => ({ data: [] }),
+          todo: async () => ({ data: [] }),
+          status: async () => ({ data: {} }),
+          abort: async () => ({}),
+        },
+      }
       manager.shutdown()
-      manager = new BackgroundManager({ pluginContext: createPluginInput(mockClient), config: config })
+      manager = new BackgroundManager({ pluginContext: createPluginInput(gatedClient), config })
 
       const input = {
         description: "Test task",
@@ -5000,21 +5037,22 @@ describe("BackgroundManager - Non-blocking Queue Integration", () => {
       }
 
       // when
-      const startTime = Date.now()
-      const tasks = await Promise.all(
+      const taskResults = Promise.all(
         Array.from({ length: 10 }, () => manager.launch(input))
       )
-      const endTime = Date.now()
+      const tasks = await taskResults
+      await fivePromptAsyncCalls
 
-      // then
-      expect(endTime - startTime).toBeLessThan(200)
+      // then - all enqueue calls settle while every available prompt is blocked
+      expect(promptAsyncCalls).toBe(5)
       expect(tasks).toHaveLength(10)
       tasks.forEach(task => {
         expect(task.status).toBe("pending")
         expect(task.id).toMatch(/^bg_/)
       })
 
-      await waitUntil(() => tasks.filter(t => manager.getTask(t.id)?.status === "running").length >= 5, 600)
+      releasePromptAsync()
+      await fivePromptAsyncCompletions
 
       const updatedTasks = tasks.map(t => manager.getTask(t.id))
       const runningCount = updatedTasks.filter(t => t?.status === "running").length


### PR DESCRIPTION
Flake fix: `BackgroundManager - Non-blocking Queue Integration > should handle 10 tasks with limit 5 returning immediately` failed at 364ms on macos-latest CI. The test proved "non-blocking" by measuring wall-clock elapsed time (`Date.now()` under 200ms) — scheduler/CI load can blow that threshold while `launch()` is perfectly correct.

Fix: prove the ordering structurally instead of by stopwatch. A controlled `promptAsync` gate starts 10 launches at concurrency limit 5, waits until exactly 5 prompt dispatches have begun, asserts all 10 `launch()` promises already returned while those prompts are still unresolved, then releases the gate and awaits five completions before asserting the 5-running/5-pending state. Test-only, no production change.

Evidence: 30x focused loop green, background-agent scope 743 pass/0 fail, package typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky `BackgroundManager` queue integration test by replacing wall-clock timing with a deterministic structural gate. Old test measured elapsed time, which breaks under scheduler/CI load; new test blocks `promptAsync` calls and verifies all launches return while prompts are pending, then confirms the running and pending counts after release. Test-only change, no production code touched.

<sup>Written for commit 3546a1f4b2f7a1653dc8a58bbddac8058986271f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

