### PR TITLE
test: isolate MCP loader config roots

### DIFF
--- a/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.test.ts
@@ -12,13 +12,15 @@ import { tmpdir } from "os"
 let TEST_DIR = ""
 let TEST_HOME = ""
 
+function loaderOptions(cwd = TEST_DIR) {
+  return { cwd, homeDir: TEST_HOME, claudeConfigDir: join(TEST_HOME, ".claude") }
+}
+
 describe("getSystemMcpServerNames", () => {
   beforeEach(() => {
     TEST_DIR = mkdtempSync(join(tmpdir(), "mcp-loader-test-"))
     TEST_HOME = join(TEST_DIR, "home")
     mkdirSync(TEST_HOME, { recursive: true })
-    process.env.HOME = TEST_HOME
-    process.env.CLAUDE_CONFIG_DIR = join(TEST_HOME, ".claude")
   })
 
   afterEach(() => {
@@ -28,19 +30,17 @@ describe("getSystemMcpServerNames", () => {
 
   it("returns empty set when no .mcp.json files exist", async () => {
     // given
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
 
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names).toBeInstanceOf(Set)
       expect(names.size).toBe(0)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -60,20 +60,17 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names.has("playwright")).toBe(true)
       expect(names.has("sqlite")).toBe(true)
       expect(names.size).toBe(2)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -90,18 +87,15 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".claude", ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names.has("memory")).toBe(true)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -122,19 +116,16 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names.has("playwright")).toBe(false)
       expect(names.has("active")).toBe(true)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -158,18 +149,15 @@ describe("getSystemMcpServerNames", () => {
       },
     }))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names.has("playwright")).toBe(false)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -191,19 +179,16 @@ describe("getSystemMcpServerNames", () => {
      writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(projectMcp))
      writeFileSync(join(TEST_DIR, ".claude", ".mcp.json"), JSON.stringify(localMcp))
 
-     const originalCwd = process.cwd()
-     process.chdir(TEST_DIR)
-
      try {
        // when
        const { getSystemMcpServerNames } = await import("./loader")
-       const names = getSystemMcpServerNames()
+       const names = getSystemMcpServerNames(loaderOptions())
 
        // then
        expect(names.has("playwright")).toBe(true)
        expect(names.has("memory")).toBe(true)
      } finally {
-       process.chdir(originalCwd)
+
      }
    })
 
@@ -220,18 +205,15 @@ describe("getSystemMcpServerNames", () => {
       }
       writeFileSync(userConfigPath, JSON.stringify(userMcpConfig))
 
-      const originalCwd = process.cwd()
-      process.chdir(TEST_DIR)
-
       try {
         // when
         const { getSystemMcpServerNames } = await import("./loader")
-        const names = getSystemMcpServerNames()
+        const names = getSystemMcpServerNames(loaderOptions())
 
         // then
         expect(names.has("user-server")).toBe(true)
       } finally {
-        process.chdir(originalCwd)
+
       }
     })
 
@@ -252,19 +234,16 @@ describe("getSystemMcpServerNames", () => {
         },
       }))
 
-      const originalCwd = process.cwd()
-      process.chdir(TEST_DIR)
-
       try {
         // when
         const { getSystemMcpServerNames } = await import("./loader")
-        const names = getSystemMcpServerNames()
+        const names = getSystemMcpServerNames(loaderOptions())
 
         // then
         expect(names.has("server-from-claude-json")).toBe(true)
         expect(names.has("server-from-mcp-json")).toBe(true)
        } finally {
-         process.chdir(originalCwd)
+
        }
       })
 
@@ -296,20 +275,17 @@ describe("getSystemMcpServerNames", () => {
         },
       }))
 
-      const originalCwd = process.cwd()
-      process.chdir(currentProjectDir)
-
       try {
         //#when
         const { getSystemMcpServerNames } = await import("./loader")
-        const names = getSystemMcpServerNames()
+        const names = getSystemMcpServerNames(loaderOptions(currentProjectDir))
 
         //#then
         expect(names.has("playwright")).toBe(false)
         expect(names.has("sqlite")).toBe(true)
         expect(names.has("memory")).toBe(true)
       } finally {
-        process.chdir(originalCwd)
+
       }
     })
 })
@@ -318,8 +294,6 @@ describe("loadMcpConfigs", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true })
     mkdirSync(TEST_HOME, { recursive: true })
-    process.env.HOME = TEST_HOME
-    process.env.CLAUDE_CONFIG_DIR = join(TEST_HOME, ".claude")
     mock.module("../../shared/logger", () => ({
       log: () => {},
     }))
@@ -341,13 +315,10 @@ describe("loadMcpConfigs", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       //#when
       const { loadMcpConfigs } = await import("./loader")
-      const result = await loadMcpConfigs(["playwright", "sqlite"])
+      const result = await loadMcpConfigs(["playwright", "sqlite"], loaderOptions())
 
       //#then
       expect(result.servers).not.toHaveProperty("playwright")
@@ -357,7 +328,7 @@ describe("loadMcpConfigs", () => {
       expect(result.loadedServers.find((s) => s.name === "sqlite")).toBeUndefined()
       expect(result.loadedServers.find((s) => s.name === "active")).toBeDefined()
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -371,19 +342,16 @@ describe("loadMcpConfigs", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       //#when
       const { loadMcpConfigs } = await import("./loader")
-      const result = await loadMcpConfigs([])
+      const result = await loadMcpConfigs([], loaderOptions())
 
       //#then
       expect(result.servers).toHaveProperty("playwright")
       expect(result.servers).toHaveProperty("active")
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -396,18 +364,15 @@ describe("loadMcpConfigs", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       //#when
       const { loadMcpConfigs } = await import("./loader")
-      const result = await loadMcpConfigs()
+      const result = await loadMcpConfigs([], loaderOptions())
 
       //#then
       expect(result.servers).toHaveProperty("playwright")
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 })

--- a/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.test.ts
@@ -74,6 +74,38 @@ describe("getSystemMcpServerNames", () => {
     }
   })
 
+  it("returns server names from the default ambient paths in an isolated child process", async () => {
+    writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify({
+      mcpServers: {
+        ambient: { command: "npx", args: ["ambient-mcp"] },
+      },
+    }))
+
+    const child = Bun.spawn([
+      process.execPath,
+      "-e",
+      `import { getSystemMcpServerNames } from ${JSON.stringify(join(import.meta.dir, "loader.ts"))}; console.log(JSON.stringify([...getSystemMcpServerNames()]))`,
+    ], {
+      cwd: TEST_DIR,
+      env: {
+        HOME: TEST_HOME,
+        USERPROFILE: TEST_HOME,
+        CLAUDE_CONFIG_DIR: join(TEST_HOME, ".claude"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    expect(child.exitCode).toBeNull()
+    const [output, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      child.exited,
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(JSON.parse(output.trim())).toEqual(["ambient"])
+  })
+
   it("returns server names from .claude/.mcp.json", async () => {
     // given
     mkdirSync(join(TEST_DIR, ".claude"), { recursive: true })

--- a/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.ts
@@ -18,10 +18,16 @@ interface McpConfigPath {
   scope: McpScope
 }
 
-function getMcpConfigPaths(): McpConfigPath[] {
-  const claudeConfigDir = getClaudeConfigDir()
-  const homeDir = getHomeDir()
-  const cwd = process.cwd()
+export interface McpLoaderOptions {
+  cwd?: string
+  homeDir?: string
+  claudeConfigDir?: string
+}
+
+function getMcpConfigPaths(options: McpLoaderOptions = {}): McpConfigPath[] {
+  const claudeConfigDir = options.claudeConfigDir ?? getClaudeConfigDir()
+  const homeDir = options.homeDir ?? getHomeDir()
+  const cwd = options.cwd ?? process.cwd()
 
   return [
     { path: join(homeDir, ".claude.json"), scope: "user" },
@@ -55,10 +61,10 @@ async function loadMcpConfigFile(
   }
 }
 
-export function getSystemMcpServerNames(): Set<string> {
+export function getSystemMcpServerNames(options: McpLoaderOptions = {}): Set<string> {
   const names = new Set<string>()
-  const paths = getMcpConfigPaths()
-  const cwd = process.cwd()
+  const paths = getMcpConfigPaths(options)
+  const cwd = options.cwd ?? process.cwd()
 
   for (const { path } of paths) {
     if (!existsSync(path)) continue
@@ -86,13 +92,14 @@ export function getSystemMcpServerNames(): Set<string> {
 }
 
 export async function loadMcpConfigs(
-  disabledMcps: string[] = []
+  disabledMcps: string[] = [],
+  options: McpLoaderOptions = {}
 ): Promise<McpLoadResult> {
   const servers: McpLoadResult["servers"] = {}
   const loadedServers: LoadedMcpServer[] = []
-  const paths = getMcpConfigPaths()
+  const paths = getMcpConfigPaths(options)
   const disabledSet = new Set(disabledMcps)
-  const cwd = process.cwd()
+  const cwd = options.cwd ?? process.cwd()
 
   for (const { path, scope } of paths) {
     const config = await loadMcpConfigFile(path)

--- a/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/loader.ts
@@ -19,15 +19,31 @@ interface McpConfigPath {
 }
 
 export interface McpLoaderOptions {
-  cwd?: string
-  homeDir?: string
-  claudeConfigDir?: string
+  readonly cwd?: string
+  readonly homeDir?: string
+  readonly claudeConfigDir?: string
 }
 
-function getMcpConfigPaths(options: McpLoaderOptions = {}): McpConfigPath[] {
-  const claudeConfigDir = options.claudeConfigDir ?? getClaudeConfigDir()
-  const homeDir = options.homeDir ?? getHomeDir()
+interface ResolvedMcpLoaderContext {
+  readonly cwd: string
+  readonly homeDir: string
+  readonly claudeConfigDir: string
+}
+
+function resolveMcpLoaderContext(
+  options: McpLoaderOptions = {}
+): ResolvedMcpLoaderContext {
   const cwd = options.cwd ?? process.cwd()
+  const homeDir = options.homeDir ?? getHomeDir()
+  const claudeConfigDir = options.claudeConfigDir ?? (
+    options.homeDir === undefined ? getClaudeConfigDir() : join(homeDir, ".claude")
+  )
+
+  return { cwd, homeDir, claudeConfigDir }
+}
+
+function getMcpConfigPaths(context: ResolvedMcpLoaderContext): McpConfigPath[] {
+  const { claudeConfigDir, homeDir, cwd } = context
 
   return [
     { path: join(homeDir, ".claude.json"), scope: "user" },
@@ -63,8 +79,9 @@ async function loadMcpConfigFile(
 
 export function getSystemMcpServerNames(options: McpLoaderOptions = {}): Set<string> {
   const names = new Set<string>()
-  const paths = getMcpConfigPaths(options)
-  const cwd = options.cwd ?? process.cwd()
+  const context = resolveMcpLoaderContext(options)
+  const paths = getMcpConfigPaths(context)
+  const { cwd } = context
 
   for (const { path } of paths) {
     if (!existsSync(path)) continue
@@ -97,9 +114,10 @@ export async function loadMcpConfigs(
 ): Promise<McpLoadResult> {
   const servers: McpLoadResult["servers"] = {}
   const loadedServers: LoadedMcpServer[] = []
-  const paths = getMcpConfigPaths(options)
+  const context = resolveMcpLoaderContext(options)
+  const paths = getMcpConfigPaths(context)
   const disabledSet = new Set(disabledMcps)
-  const cwd = options.cwd ?? process.cwd()
+  const { cwd } = context
 
   for (const { path, scope } of paths) {
     const config = await loadMcpConfigFile(path)

--- a/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/scope-filtering.test.ts
+++ b/packages/claude-code-compat-core/src/features/claude-code-mcp-loader/scope-filtering.test.ts
@@ -10,18 +10,16 @@ import { shouldLoadMcpServer } from "./scope-filter"
 // blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
 let testDir = ""
 let testHome = ""
-const ORIGINAL_HOME = process.env.HOME
-const ORIGINAL_USERPROFILE = process.env.USERPROFILE
-const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
+
+function loaderOptions(cwd = testDir) {
+  return { cwd, homeDir: testHome, claudeConfigDir: join(testHome, ".claude") }
+}
 
 describe("loadMcpConfigs", () => {
   beforeEach(() => {
     testDir = realpathSync(mkdtempSync(join(tmpdir(), "mcp-scope-filtering-test-")))
     testHome = join(testDir, "home")
     mkdirSync(testHome, { recursive: true })
-    process.env.HOME = testHome
-    process.env.USERPROFILE = testHome
-    process.env.CLAUDE_CONFIG_DIR = join(testHome, ".claude")
     mock.module("../../shared/logger", () => ({
       log: () => {},
     }))
@@ -29,21 +27,6 @@ describe("loadMcpConfigs", () => {
 
   afterEach(() => {
     mock.restore()
-    if (ORIGINAL_HOME === undefined) {
-      delete process.env.HOME
-    } else {
-      process.env.HOME = ORIGINAL_HOME
-    }
-    if (ORIGINAL_USERPROFILE === undefined) {
-      delete process.env.USERPROFILE
-    } else {
-      process.env.USERPROFILE = ORIGINAL_USERPROFILE
-    }
-    if (ORIGINAL_CLAUDE_CONFIG_DIR === undefined) {
-      delete process.env.CLAUDE_CONFIG_DIR
-    } else {
-      process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CLAUDE_CONFIG_DIR
-    }
     rmSync(testDir, { recursive: true, force: true })
   })
 
@@ -128,12 +111,8 @@ describe("loadMcpConfigs", () => {
         })
       )
 
-      const originalCwd = process.cwd()
-      process.chdir(testDir)
-
-      try {
-        const { loadMcpConfigs } = await import("./loader")
-        const result = await loadMcpConfigs()
+      const { loadMcpConfigs } = await import("./loader")
+      const result = await loadMcpConfigs([], loaderOptions())
 
         expect(result.servers).toHaveProperty("globalServer")
         expect(result.servers).toHaveProperty("matchingLocal")
@@ -144,9 +123,6 @@ describe("loadMcpConfigs", () => {
           "globalServer",
           "matchingLocal",
         ])
-      } finally {
-        process.chdir(originalCwd)
-      }
     })
   })
 })

--- a/packages/omo-opencode/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-mcp-loader/loader.test.ts
@@ -12,13 +12,15 @@ import { tmpdir } from "os"
 let TEST_DIR = ""
 let TEST_HOME = ""
 
+function loaderOptions(cwd = TEST_DIR) {
+  return { cwd, homeDir: TEST_HOME, claudeConfigDir: join(TEST_HOME, ".claude") }
+}
+
 describe("getSystemMcpServerNames", () => {
   beforeEach(() => {
     TEST_DIR = mkdtempSync(join(tmpdir(), "mcp-loader-test-"))
     TEST_HOME = join(TEST_DIR, "home")
     mkdirSync(TEST_HOME, { recursive: true })
-    process.env.HOME = TEST_HOME
-    process.env.CLAUDE_CONFIG_DIR = join(TEST_HOME, ".claude")
   })
 
   afterEach(() => {
@@ -28,19 +30,17 @@ describe("getSystemMcpServerNames", () => {
 
   it("returns empty set when no .mcp.json files exist", async () => {
     // given
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
 
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names).toBeInstanceOf(Set)
       expect(names.size).toBe(0)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -60,20 +60,17 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names.has("playwright")).toBe(true)
       expect(names.has("sqlite")).toBe(true)
       expect(names.size).toBe(2)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -90,18 +87,15 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".claude", ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names.has("memory")).toBe(true)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -122,19 +116,16 @@ describe("getSystemMcpServerNames", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names.has("playwright")).toBe(false)
       expect(names.has("active")).toBe(true)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -158,25 +149,22 @@ describe("getSystemMcpServerNames", () => {
       },
     }))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       // when
       const { getSystemMcpServerNames } = await import("./loader")
-      const names = getSystemMcpServerNames()
+      const names = getSystemMcpServerNames(loaderOptions())
 
       // then
       expect(names.has("playwright")).toBe(false)
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
    it("merges server names from multiple .mcp.json files", async () => {
      // given
      mkdirSync(join(TEST_DIR, ".claude"), { recursive: true })
-     
+
      const projectMcp = {
        mcpServers: {
          playwright: { command: "npx", args: ["@playwright/mcp@latest"] },
@@ -187,23 +175,20 @@ describe("getSystemMcpServerNames", () => {
          memory: { command: "npx", args: ["-y", "@anthropic-ai/mcp-server-memory"] },
        },
      }
-     
+
      writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(projectMcp))
      writeFileSync(join(TEST_DIR, ".claude", ".mcp.json"), JSON.stringify(localMcp))
-
-     const originalCwd = process.cwd()
-     process.chdir(TEST_DIR)
 
      try {
        // when
        const { getSystemMcpServerNames } = await import("./loader")
-       const names = getSystemMcpServerNames()
+       const names = getSystemMcpServerNames(loaderOptions())
 
        // then
        expect(names.has("playwright")).toBe(true)
        expect(names.has("memory")).toBe(true)
      } finally {
-       process.chdir(originalCwd)
+
      }
    })
 
@@ -220,18 +205,15 @@ describe("getSystemMcpServerNames", () => {
       }
       writeFileSync(userConfigPath, JSON.stringify(userMcpConfig))
 
-      const originalCwd = process.cwd()
-      process.chdir(TEST_DIR)
-
       try {
         // when
         const { getSystemMcpServerNames } = await import("./loader")
-        const names = getSystemMcpServerNames()
+        const names = getSystemMcpServerNames(loaderOptions())
 
         // then
         expect(names.has("user-server")).toBe(true)
       } finally {
-        process.chdir(originalCwd)
+
       }
     })
 
@@ -252,19 +234,16 @@ describe("getSystemMcpServerNames", () => {
         },
       }))
 
-      const originalCwd = process.cwd()
-      process.chdir(TEST_DIR)
-
       try {
         // when
         const { getSystemMcpServerNames } = await import("./loader")
-        const names = getSystemMcpServerNames()
+        const names = getSystemMcpServerNames(loaderOptions())
 
         // then
         expect(names.has("server-from-claude-json")).toBe(true)
         expect(names.has("server-from-mcp-json")).toBe(true)
        } finally {
-         process.chdir(originalCwd)
+
        }
       })
 
@@ -296,20 +275,17 @@ describe("getSystemMcpServerNames", () => {
         },
       }))
 
-      const originalCwd = process.cwd()
-      process.chdir(currentProjectDir)
-
       try {
         //#when
         const { getSystemMcpServerNames } = await import("./loader")
-        const names = getSystemMcpServerNames()
+        const names = getSystemMcpServerNames(loaderOptions(currentProjectDir))
 
         //#then
         expect(names.has("playwright")).toBe(false)
         expect(names.has("sqlite")).toBe(true)
         expect(names.has("memory")).toBe(true)
       } finally {
-        process.chdir(originalCwd)
+
       }
     })
 })
@@ -318,8 +294,6 @@ describe("loadMcpConfigs", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true })
     mkdirSync(TEST_HOME, { recursive: true })
-    process.env.HOME = TEST_HOME
-    process.env.CLAUDE_CONFIG_DIR = join(TEST_HOME, ".claude")
     mock.module("../../shared/logger", () => ({
       log: () => {},
     }))
@@ -341,13 +315,10 @@ describe("loadMcpConfigs", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       //#when
       const { loadMcpConfigs } = await import("./loader")
-      const result = await loadMcpConfigs(["playwright", "sqlite"])
+      const result = await loadMcpConfigs(["playwright", "sqlite"], loaderOptions())
 
       //#then
       expect(result.servers).not.toHaveProperty("playwright")
@@ -357,7 +328,7 @@ describe("loadMcpConfigs", () => {
       expect(result.loadedServers.find((s) => s.name === "sqlite")).toBeUndefined()
       expect(result.loadedServers.find((s) => s.name === "active")).toBeDefined()
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -371,19 +342,16 @@ describe("loadMcpConfigs", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       //#when
       const { loadMcpConfigs } = await import("./loader")
-      const result = await loadMcpConfigs([])
+      const result = await loadMcpConfigs([], loaderOptions())
 
       //#then
       expect(result.servers).toHaveProperty("playwright")
       expect(result.servers).toHaveProperty("active")
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 
@@ -396,18 +364,15 @@ describe("loadMcpConfigs", () => {
     }
     writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify(mcpConfig))
 
-    const originalCwd = process.cwd()
-    process.chdir(TEST_DIR)
-
     try {
       //#when
       const { loadMcpConfigs } = await import("./loader")
-      const result = await loadMcpConfigs()
+      const result = await loadMcpConfigs([], loaderOptions())
 
       //#then
       expect(result.servers).toHaveProperty("playwright")
     } finally {
-      process.chdir(originalCwd)
+
     }
   })
 })

--- a/packages/omo-opencode/src/features/claude-code-mcp-loader/loader.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-mcp-loader/loader.test.ts
@@ -74,6 +74,38 @@ describe("getSystemMcpServerNames", () => {
     }
   })
 
+  it("returns server names from the default ambient paths in an isolated child process", async () => {
+    writeFileSync(join(TEST_DIR, ".mcp.json"), JSON.stringify({
+      mcpServers: {
+        ambient: { command: "npx", args: ["ambient-mcp"] },
+      },
+    }))
+
+    const child = Bun.spawn([
+      process.execPath,
+      "-e",
+      `import { getSystemMcpServerNames } from ${JSON.stringify(join(import.meta.dir, "loader.ts"))}; console.log(JSON.stringify([...getSystemMcpServerNames()]))`,
+    ], {
+      cwd: TEST_DIR,
+      env: {
+        HOME: TEST_HOME,
+        USERPROFILE: TEST_HOME,
+        CLAUDE_CONFIG_DIR: join(TEST_HOME, ".claude"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    expect(child.exitCode).toBeNull()
+    const [output, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      child.exited,
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(JSON.parse(output.trim())).toEqual(["ambient"])
+  })
+
   it("returns server names from .claude/.mcp.json", async () => {
     // given
     mkdirSync(join(TEST_DIR, ".claude"), { recursive: true })

--- a/packages/omo-opencode/src/features/claude-code-mcp-loader/scope-filtering.test.ts
+++ b/packages/omo-opencode/src/features/claude-code-mcp-loader/scope-filtering.test.ts
@@ -10,18 +10,16 @@ import { shouldLoadMcpServer } from "./scope-filter"
 // blocks until the hook budget expires ("a beforeEach/afterEach hook timed out").
 let testDir = ""
 let testHome = ""
-const ORIGINAL_HOME = process.env.HOME
-const ORIGINAL_USERPROFILE = process.env.USERPROFILE
-const ORIGINAL_CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
+
+function loaderOptions(cwd = testDir) {
+  return { cwd, homeDir: testHome, claudeConfigDir: join(testHome, ".claude") }
+}
 
 describe("loadMcpConfigs", () => {
   beforeEach(() => {
     testDir = realpathSync(mkdtempSync(join(tmpdir(), "mcp-scope-filtering-test-")))
     testHome = join(testDir, "home")
     mkdirSync(testHome, { recursive: true })
-    process.env.HOME = testHome
-    process.env.USERPROFILE = testHome
-    process.env.CLAUDE_CONFIG_DIR = join(testHome, ".claude")
     mock.module("../../shared/logger", () => ({
       log: () => {},
     }))
@@ -29,21 +27,6 @@ describe("loadMcpConfigs", () => {
 
   afterEach(() => {
     mock.restore()
-    if (ORIGINAL_HOME === undefined) {
-      delete process.env.HOME
-    } else {
-      process.env.HOME = ORIGINAL_HOME
-    }
-    if (ORIGINAL_USERPROFILE === undefined) {
-      delete process.env.USERPROFILE
-    } else {
-      process.env.USERPROFILE = ORIGINAL_USERPROFILE
-    }
-    if (ORIGINAL_CLAUDE_CONFIG_DIR === undefined) {
-      delete process.env.CLAUDE_CONFIG_DIR
-    } else {
-      process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CLAUDE_CONFIG_DIR
-    }
     rmSync(testDir, { recursive: true, force: true })
   })
 
@@ -128,12 +111,8 @@ describe("loadMcpConfigs", () => {
         })
       )
 
-      const originalCwd = process.cwd()
-      process.chdir(testDir)
-
-      try {
-        const { loadMcpConfigs } = await import("./loader")
-        const result = await loadMcpConfigs()
+      const { loadMcpConfigs } = await import("./loader")
+      const result = await loadMcpConfigs([], loaderOptions())
 
         expect(result.servers).toHaveProperty("globalServer")
         expect(result.servers).toHaveProperty("matchingLocal")
@@ -144,9 +123,6 @@ describe("loadMcpConfigs", () => {
           "globalServer",
           "matchingLocal",
         ])
-      } finally {
-        process.chdir(originalCwd)
-      }
     })
   })
 })


### PR DESCRIPTION
Flake fix: `getSystemMcpServerNames > returns server names from project .mcp.json` failed at 8438ms on windows-latest CI — an 8s config-parse test is contention, not work.

Root cause: both loader test copies mutated process-global state — `HOME` and `CLAUDE_CONFIG_DIR` reassigned without teardown restore, plus process-wide `process.chdir()` per test. Under parallel shards that lets sibling files contend over cwd/home resolution, and a leaked HOME can walk real user configuration.

Fix: give the loader an explicit context seam and make the tests hermetic.
- `getSystemMcpServerNames()` / `loadMcpConfigs()` accept optional `McpLoaderOptions { cwd, homeDir, claudeConfigDir }`. **Defaults unchanged** — every existing production caller keeps current behavior.
- Both test copies now use isolated `mkdtempSync` roots and pass explicit config roots + cwd; zero `process.chdir()`, zero env mutation.

The `omo-opencode` loader is a re-export, so the real fix lands in `claude-code-compat-core`; both copies were audited.

Evidence: 30x combined loop green (24 pass/0 fail), both loader scopes green, both package typechecks clean, LSP diagnostics clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP loader test flake on Windows CI by removing process-global state mutation from tests. `getSystemMcpServerNames()` and `loadMcpConfigs()` now accept optional `McpLoaderOptions` (`cwd`, `homeDir`, `claudeConfigDir`) with unchanged defaults, and both test copies in `claude-code-compat-core` and `omo-opencode` use isolated temp-dir roots instead of touching environment variables or the process cwd.

- `scope-filtering.test.ts` no longer mutates `HOME`, `USERPROFILE`, or `CLAUDE_CONFIG_DIR`.
- A child-process test verifies default ambient path resolution still works without explicit options.

<sup>Written for commit 6b73ce3b1b6a09415f79dbf56b1c394614d86051. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

