### PR TITLE
test(senpi): pin memfs backup collision and stub the rpc catalog probe

### DIFF
--- a/packages/omo-senpi/src/components/memory/commands/memfs-extra.test.ts
+++ b/packages/omo-senpi/src/components/memory/commands/memfs-extra.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { existsSync } from "node:fs"
-import { readFile, readdir, rm, writeFile } from "node:fs/promises"
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { MemoryFakeExtensionAPI } from "../memory.test-support"
@@ -13,6 +12,7 @@ import {
   type FakeCommandContext,
   type FakeDeps,
 } from "./commands.test-support"
+import { backupTimestamp } from "./backup"
 import { registerMemfsCommand } from "./memfs"
 
 const tempDirs: string[] = []
@@ -75,16 +75,21 @@ describe("/memfs backup", () => {
 
   test("#given a backup already exists for the same clock #when backup runs again #then the existing backup is not clobbered", async () => {
     // given
-    const { identityRoot, pi, ctx } = await harness()
-    await invoke(pi, "memfs", "backup", ctx)
+    const { identityRoot, pi, ctx, deps } = await harness()
+    const stamp = backupTimestamp(deps.now?.() ?? 0)
+    const existingName = `memory-backup-${stamp}`
+    const existingPersona = join(identityRoot, existingName, "system", "persona.md")
+    await mkdir(join(identityRoot, existingName, "system"), { recursive: true })
+    await writeFile(existingPersona, "existing backup sentinel\n")
 
     // when
     await invoke(pi, "memfs", "backup", ctx)
 
     // then
-    const backups = await backupNames(identityRoot)
-    expect(backups).toHaveLength(2)
-    expect(new Set(backups).size).toBe(2)
+    expect(await backupNames(identityRoot)).toEqual([existingName, `${existingName}-2`])
+    expect(await readFile(existingPersona, "utf8")).toBe("existing backup sentinel\n")
+    expect(await readFile(join(identityRoot, `${existingName}-2`, "system", "persona.md"), "utf8"))
+      .toContain("seeded persona")
   })
 })
 

--- a/packages/omo-senpi/src/components/task/task-rpc-launch-parity.test.ts
+++ b/packages/omo-senpi/src/components/task/task-rpc-launch-parity.test.ts
@@ -6,18 +6,8 @@ import { fileURLToPath } from "node:url"
 import { afterEach, describe, expect, test } from "bun:test"
 
 import type { RpcRunnerSpec } from "@oh-my-opencode/senpi-task"
-import { createRpcModelAdmission, PROBE_TIMEOUT_MS } from "@oh-my-opencode/senpi-task/rpc-model-admission"
+import { createRpcModelAdmission } from "@oh-my-opencode/senpi-task/rpc-model-admission"
 import { buildRpcModelCatalogSpawn, type RpcSpawnDescriptor } from "@oh-my-opencode/senpi-task/rpc-spawn"
-
-/**
- * Admission can spend three full catalog probes worst case: a timed-out probe is re-probed once
- * (a timeout is inconclusive, not absence), and a first exit-0 listing that omits the requested
- * model. Keep the test deadline derived from the production budget, with 20s for termination and
- * runner overhead. The confirming probe deliberately keeps the full probe budget: it decides a
- * rejection, so starving it would time out on exactly the slow-but-complete listings this path must
- * admit.
- */
-const ADMISSION_TEST_TIMEOUT_MS = PROBE_TIMEOUT_MS * 3 + 20_000
 
 const agentDirs: string[] = []
 const mockProviderExtension = fileURLToPath(
@@ -38,7 +28,9 @@ function buildPinnedCatalogSpawn(spec: RpcRunnerSpec, parentEnv: NodeJS.ProcessE
   })
 }
 
-function createAdmission() {
+function createAdmission(options: {
+  readonly onProbe?: (descriptor: RpcSpawnDescriptor) => void
+} = {}) {
   const agentDir = mkdtempSync(join(tmpdir(), "omo-task-rpc-model-profile-"))
   agentDirs.push(agentDir)
   const parentEnv = {
@@ -57,6 +49,16 @@ function createAdmission() {
   }
   return createRpcModelAdmission({
     buildSpawn: (spec) => buildPinnedCatalogSpawn(spec, parentEnv),
+    probe: async (descriptor) => {
+      options.onProbe?.(descriptor)
+      const hasProviderExtension = descriptor.args.includes(mockProviderExtension)
+      return {
+        code: 0,
+        stdout: hasProviderExtension ? "provider model\nomo-mock mock-1\n" : "provider model\n",
+        stderr: "",
+        timedOut: false,
+      }
+    },
   })
 }
 
@@ -95,14 +97,19 @@ describe("task RPC launch profile parity", () => {
 
   test("#given an explicit provider extension #when process model admission runs #then its model is visible without credentials", async () => {
     // given
-    const admit = createAdmission()
+    let observed: RpcSpawnDescriptor | undefined
+    const admit = createAdmission({ onProbe: (descriptor) => { observed = descriptor } })
 
     // when
     const admission = admit(makeSpec([mockProviderExtension]))
 
     // then
-    expect(await admission).toBeUndefined()
-  }, { timeout: ADMISSION_TEST_TIMEOUT_MS })
+    return admission.then(() => {
+      expect(observed?.args).toContain("--extension")
+      expect(observed?.args).toContain(mockProviderExtension)
+      expect(observed?.env.HOME).toBe(agentDirs.at(-1))
+    })
+  })
 
   test("#given a model known only through parent resources #when its provider extension is not forwarded #then admission rejects before launch", async () => {
     // given
@@ -112,11 +119,16 @@ describe("task RPC launch profile parity", () => {
     const admission = admit(makeSpec([]))
 
     // then
-    await expect(admission).rejects.toMatchObject({
-      failure: {
-        kind: "model_unavailable",
-        message: expect.stringMatching(/omo-mock\/mock-1.*probed catalog has/),
+    return admission.then(
+      () => { throw new Error("expected model admission to reject") },
+      (error: unknown) => {
+        expect(error).toMatchObject({
+          failure: {
+            kind: "model_unavailable",
+            message: expect.stringMatching(/omo-mock\/mock-1.*probed catalog has/),
+          },
+        })
       },
-    })
-  }, { timeout: ADMISSION_TEST_TIMEOUT_MS })
+    )
+  })
 })


### PR DESCRIPTION
Two senpi-compatibility flakes seen failing on windows CI, both fixed through EXISTING injected seams — no production change, no timeout inflation.

### 1. `/memfs backup > ... the existing backup is not clobbered` (5012ms)
`memfs-extra.test.ts:76` relied on two real-time backup calls landing inside the same wall-clock second to construct the collision it asserts. Cross a second boundary and the collision never happens, so the test proved nothing (and could fail).

Fix: drive the existing `deps.now` seam — pre-create the exact `memory-backup-<timestamp>` directory, drop a sentinel file in it, then assert the sentinel survives and the new backup lands on the deterministic `-2` suffix. The collision is now constructed, not raced.

### 2. `task RPC launch profile parity > ... model is visible without credentials` (60709ms = the test deadline)
`task-rpc-launch-parity.test.ts:101` reached `probeModelCatalog`, which launches the REAL senpi CLI; the test was waiting on a child-process startup + catalog handshake and hit the 60s deadline on loaded Windows runners.

Fix: inject the catalog-probe boundary through `createRpcModelAdmission`. The stub returns the model only when the explicit provider extension is present, and the assertions check the generated descriptor carries that extension and uses the isolated child profile; the negative case rejects immediately through the same stub.

Evidence: focused tests 14 pass / 0 fail, 30x per-file loop green, `tsgo --noEmit` clean, LSP diagnostics clean on both changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two senpi-compatibility test flakes on Windows CI by using existing injection seams instead of relying on real timing or child-process startup. No production code changes.

- The memfs backup collision test now pre-creates the exact `memory-backup-<timestamp>` directory with a sentinel file, asserting the sentinel survives and the new backup lands on the deterministic `-2` suffix instead of racing the wall clock.
- The task RPC launch parity test now stubs the catalog probe through `createRpcModelAdmission`, returning the model only when the explicit provider extension is present, and checking the generated descriptor carries that extension and uses the isolated child profile.

<sup>Written for commit 3a9ec75699aec797b64fa811363b752ab371f11d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

