### PR TITLE
test(omo-senpi): await DAG child disposal explicitly

### DIFF
--- a/packages/omo-senpi/src/components/task/dag-runtime.test.ts
+++ b/packages/omo-senpi/src/components/task/dag-runtime.test.ts
@@ -61,6 +61,7 @@ class ScriptedRunner implements ManagedRunner {
     readonly emit: (event: ManagedChildEvent) => void
     readonly listenerCount: () => number
     readonly settle: (output: string) => void
+    readonly disposed: Promise<void>
     readonly fail: (message: string) => void
   }> = []
   readonly #signals = new Map<number, ReturnType<typeof deferred<void>>>()
@@ -74,6 +75,7 @@ class ScriptedRunner implements ManagedRunner {
 
   start(spec: ManagedStartSpec): Promise<ManagedChildHandle> {
     const outcome = deferred<RunnerOutcome>()
+    const disposed = deferred<void>()
     const listeners = new Set<(event: ManagedChildEvent) => void>()
     const handle: ManagedChildHandle = {
       task_id: spec.taskId,
@@ -95,6 +97,7 @@ class ScriptedRunner implements ManagedRunner {
       lastAssistantText: () => undefined,
       dispose: () => {
         this.disposeCalls += 1
+        disposed.resolve()
         return Promise.resolve()
       },
     }
@@ -105,6 +108,7 @@ class ScriptedRunner implements ManagedRunner {
       },
       listenerCount: () => listeners.size,
       settle: (output) => outcome.resolve({ status: "completed", finalResponse: output }),
+      disposed: disposed.promise,
       fail: (message) => outcome.resolve({ status: "error", failure: { kind: "child-turn-failed", message } }),
     })
     this.#signals.get(this.handles.length)?.resolve()
@@ -581,7 +585,6 @@ describe("assembled DAG runtime", () => {
       await within(runner.whenStarted(2))
       runner.handles[1]?.settle("runtime survived")
       const survived = await within(runtime.wait(survivor.snapshot.runId, sessionId))
-      await new Promise<void>((resolve) => setImmediate(resolve))
 
       // then
       expect(cancelled.status).toBe("cancelled")
@@ -591,7 +594,9 @@ describe("assembled DAG runtime", () => {
       expect(survived.nodes.survivor).toEqual(expect.objectContaining({ output: "runtime survived" }))
       expect(unhandled).toEqual([])
       runner.handles[0]?.settle("cancelled child reached its natural boundary")
-      await new Promise<void>((resolve) => setImmediate(resolve))
+      const disposed = runner.handles[0]?.disposed
+      if (disposed === undefined) throw new Error("cancelled child handle was not retained")
+      await within(disposed)
       expect(runner.disposeCalls).toBe(1)
     } finally {
       process.off("unhandledRejection", onUnhandled)


### PR DESCRIPTION
Flake fix for a test that only became visible once the permanent senpi-compat red was cleared by #7594.

`assembled DAG runtime > #given a live-shaped in-process child whose abort rejects #when the assembled runtime cancels #then no unhandled rejection escapes and a later run still completes` failed at 8359ms on senpi-compatibility (windows-latest), CI run 33508665211.

Root cause (`packages/omo-senpi/src/components/task/dag-runtime.test.ts:596-600`): the test used `setImmediate` to INFER that deferred child disposal had finished. That tick ordering is not guaranteed relative to the runtime's cancellation bookkeeping, so on Windows the test could observe the wrong state or stall for seconds.

Fix: subscribe to the exact transition instead of guessing a tick — `ScriptedRunner` now exposes an explicit `disposed` deferred, and the test awaits that through the existing bounded `within()` helper. Test-only; **no production change**.

Production behavior confirmed correct as-is: DAG cancellation deliberately calls `cancelTask(..., { abort: "skip" })` for in-process children, and lifecycle disposal is deferred until `waitForOutcome()` settles, which is what keeps the injected abort rejection from escaping.

Mutation proof: removing `{ abort: "skip" }` from production cancellation makes the test fail exactly as designed (`abortCalls` 0 -> 2, AbortError unhandled rejections captured); restoring it returns green.

Evidence: 30x loop green (~33-37ms per run), omo-senpi scope 2527 pass / 0 fail / 1 pre-existing platform skip, both tsgo typechecks pass, LSP clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky DAG runtime test by awaiting the child's explicit `disposed` deferred instead of inferring completion with `setImmediate`, so the test no longer stalls or fails on Windows. Test-only; no production behavior changes.

<sup>Written for commit 32aa4aca7924ad4ce29256cb29f2b0a0d333b18e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

