### PR TITLE
test(omo-native): isolate credential import roots

### DIFF
--- a/packages/omo-native/test/setup-import.test.ts
+++ b/packages/omo-native/test/setup-import.test.ts
@@ -81,10 +81,12 @@ function fixture(): Fixture {
 
 function run(item: Fixture, args: string[], ttyInput?: string) {
   const before = sourceSnapshot(item)
-  const env = {
+  const env: NodeJS.ProcessEnv = {
     ...process.env, HOME: item.home, USERPROFILE: item.home, SENPI_CODING_AGENT_DIR: item.agentDir,
     XDG_DATA_HOME: item.xdg,
   }
+  delete env.OMO_CODING_AGENT_DIR
+  delete env.PI_CODING_AGENT_DIR
   // spawnSync only returns after the child exited and was reaped, so teardown never races a live
   // child; a surfaced spawn error must fail here instead of being read as empty output.
   const result = ttyInput === undefined


### PR DESCRIPTION
Fixes `omo setup credential inheritance > #given pinned omp and gjc databases #when accepted #then allow-listed rows import and unknown schema is noticed`, a GENUINE failure on dev push run 33522199491 (head 185a90b30, ubuntu 2/2, 16 jobs green, zero cancelled).

Root cause (`packages/omo-native/test/setup-import.test.ts:76-90`) — an ambient ENV LEAK, not slowness: the spawned child inherited all of `process.env`, and `canonicalAgentDir()` prioritizes `OMO_CODING_AGENT_DIR` over `SENPI_CODING_AGENT_DIR`. On a polluted runner an ambient `OMO_CODING_AGENT_DIR` redirected setup to unrelated real/sibling state, so the test observed pre-existing `google`/`openai` credentials and got `imported: 0` — and it could contend with sibling setup tests.

Fix: explicitly strip `OMO_CODING_AGENT_DIR` and `PI_CODING_AGENT_DIR` from the isolated test environment. **No production change** — production already supports explicit `home`/`env` roots and resolves the canonical directory correctly; the defect was purely the test inheriting ambient state. SQLite fixtures were already minimal for the contract (two allow-listed stores + one unknown-schema fixture) and are unchanged.

Both halves of the contract stay mutation-proven:
- allow-list: expecting an unexpected imported row fails with the exact `toEqual` mismatch (the unknown row is not imported).
- unknown schema: asserting the notice is ABSENT fails, because `auth schema version 99 is unknown` is emitted.

Runtime: ~5.8s on CI (12.08s locally under polluted ambient state) -> **~0.25s**.

Evidence: 20x loop 20/20 green; affected file 9 pass/0 fail; `typecheck:packages` clean; LSP clean. The 4 remaining `doctor.test.ts` failures in that package scope are the known pre-existing setup-import/doctor artifact family, untouched here.

This is the third instance of the same ambient/fixture class in this sweep (after #7604 sibling-detection and #7598 MCP loader), all now hermetic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `omo setup` credential import test to avoid flakiness by stripping `OMO_CODING_AGENT_DIR` and `PI_CODING_AGENT_DIR` from the child process env. No production code changed.

<sup>Written for commit 4ef2e5983d2efff7eae85301bde374a84ce279ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

