### PR TITLE
test(omo-senpi): remove DAG runtime deadline races

### DIFF
--- a/packages/omo-senpi/src/components/task/dag-runtime-config.test.ts
+++ b/packages/omo-senpi/src/components/task/dag-runtime-config.test.ts
@@ -23,20 +23,8 @@ function deferred<T>() {
   return { promise, resolve }
 }
 
-function within<T>(promise: Promise<T>, label: string, ms = 300): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
-    void promise.then(
-      (value) => {
-        clearTimeout(timeout)
-        resolve(value)
-      },
-      (error: unknown) => {
-        clearTimeout(timeout)
-        reject(error)
-      },
-    )
-  })
+function within<T>(promise: Promise<T>, _label: string, _ms = 300): Promise<T> {
+  return promise
 }
 
 class ControlledRunner implements ManagedRunner {

--- a/packages/omo-senpi/src/components/task/dag-runtime.test.ts
+++ b/packages/omo-senpi/src/components/task/dag-runtime.test.ts
@@ -39,20 +39,8 @@ function deferred<T>() {
   return { promise, resolve }
 }
 
-function within<T>(promise: Promise<T>, ms = 300): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms)
-    void promise.then(
-      (value) => {
-        clearTimeout(timeout)
-        resolve(value)
-      },
-      (error: unknown) => {
-        clearTimeout(timeout)
-        reject(error)
-      },
-    )
-  })
+function within<T>(promise: Promise<T>, _ms = 300): Promise<T> {
+  return promise
 }
 
 class ScriptedRunner implements ManagedRunner {
@@ -951,7 +939,9 @@ describe("assembled DAG runtime control verbs", () => {
         nodeWaiters.add(waiter)
       })
     }
-    const whenAttached = (nodeId: string) => whenNode(nodeId, (event) => event.type === "dag.node.task-attached")
+    const whenAttached = (nodeId: string, occurrence = 1) =>
+      whenNode(nodeId, (event) => event.type === "dag.node.task-attached" &&
+        nodeEvents.filter((candidate) => candidate.nodeId === nodeId && candidate.type === "dag.node.task-attached").length >= occurrence)
     const whenState = (nodeId: string, state: string) =>
       whenNode(nodeId, (event) => event.type === "dag.node.transitioned" && event.to === state)
     const sessionId = `session-${name}`
@@ -1057,8 +1047,9 @@ describe("assembled DAG runtime control verbs", () => {
     await within(runner.whenStarted(1))
     runner.handles[0]?.fail("solo blew up")
     await within(runtime.wait(runId, sessionId), 5_000)
+    const retryAttached = whenAttached("solo", 2)
     const resumed = await within(runtime.retry(runId), 5_000)
-    await within(whenAttached("solo"), 5_000)
+    await within(retryAttached, 5_000)
     const childrenAfterRetry = runner.handles.length
 
     // when the resumed run passes back through the schedulable-status gate


### PR DESCRIPTION
Fixes the ONLY remaining failure on dev: `senpi-compatibility (windows-latest)` on run 33525950049 (head dff4a156a, 16 jobs green, 0 cancelled) failed three tests together:

- `assembled DAG runtime > ... no unhandled rejection escapes and a later run still completes` (7019ms)
- `assembled DAG runtime > ... detach switches sessions ... old scheduler terminates without resolving ownership` (5953ms)
- `assembled DAG runtime configuration > subscriber_ring is one ... durable overflow` (7202ms)

## One shared seam, not three bugs
`dag-runtime.test.ts:42` defined `within(promise, ms = 300)` rejecting on a REAL-CLOCK `setTimeout`, used ~50 times in that file — and `dag-runtime-config.test.ts:26` carried a second copy of the same pattern. The enclosing tests declare `{ timeout: 15_000 }`, so the outer budget was generous while every inner await stayed hard-bounded at 300ms; on a loaded Windows runner the three tests ran 20x+ that budget and rejected with `timed out after 300ms`.

This is also why #7601 did not hold: it correctly replaced a `setImmediate` tick-guess with an explicit `disposed` deferred, but the wait itself remained `await within(disposed)` under the same racy bound. (`error: subscriber exploded` is a deliberate fixture throw for the overflow test, not a fault.)

## Fix — remove the false constraint, do not inflate it
These tests assert ORDERING and OUTCOME, never latency, so a wall-clock bound encoded machine speed as contract. Both `within()` implementations become pass-throughs to promises that are already event-driven, leaving bun's own per-test `timeout` as the only bound. **No timeout inflation** (raising 300 to a larger number was explicitly rejected), no sleeps, no retries, no `.skip`/`.only`, no platform conditionals. Net −21 lines, test-only, **no production change**.

## Latent bug found in the same pass
The shared harness's `whenAttached("solo")` searched historical events and could match the FIRST attachment rather than the retry's second. Added occurrence-aware `whenAttached(nodeId, occurrence)` and pre-armed the second-attachment promise before `runtime.retry()`.

## Mutation proofs
- drop `{ abort: "skip" }` from production cancellation -> abort-boundary contract fails (disposal count wrong)
- `subscriber_ring: 1` -> `100` -> durable-overflow promise times out
- force the new pass-through to reject -> **13 of 17** runtime/config tests fail, proving it was the common deadline seam
- revert the occurrence-aware wait -> retry assertion fails (`Expected length: 1, Received length: 2`)

Evidence: 30x loop green (16 pass/0 fail); `bun test packages/omo-senpi/src/components/task` 501 pass/0 fail; `tsgo --noEmit` clean; `git diff --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the hard-coded 300ms deadline in the DAG runtime test helpers that was causing flaky failures on loaded CI runners; tests now rely on bun's per-test timeout only. No production code changes.

**Bug Fixes**
- `within()` in `dag-runtime.test.ts` and `dag-runtime-config.test.ts` is now a pass-through to the promise; the wall-clock deadline encoded machine speed as contract and failed on loaded runners when the three affected tests ran 20x+ over budget.
- `whenAttached("solo")` could match the first attachment instead of the retry's second; it now accepts an occurrence argument, and the second-attachment promise is pre-armed before `runtime.retry()`.

<sup>Written for commit 29c788afee5f040017e9721d57df398b2d2ed8ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

