### PR TITLE
test(senpi): slim memfs backup fixture

### DIFF
--- a/packages/omo-senpi/src/components/memory/commands/memfs-extra.test.ts
+++ b/packages/omo-senpi/src/components/memory/commands/memfs-extra.test.ts
@@ -38,6 +38,9 @@ async function harness(options: { readonly hasUI?: boolean } = {}): Promise<Harn
   const { root, identity } = await tempIdentity()
   tempDirs.push(root)
   await seededRepo(identity, SEEDS)
+  // Hooks are generated-fixture implementation detail, not part of the backup contract. Keeping
+  // them out of this recursive-copy fixture avoids copying dozens of irrelevant files on win32.
+  await rm(join(identity.identityPaths.repo, ".git", "hooks"), { recursive: true, force: true })
   const deps = fakeDeps(identity)
   const pi = new MemoryFakeExtensionAPI()
   registerMemfsCommand(pi, deps)


### PR DESCRIPTION
Fixes `/memfs backup > #given a repository #when backup runs #then a sibling memory-backup dir holds a copy`, which failed at 5027ms on `senpi-compatibility (windows-latest)` (run 33531028709).

This is a SIBLING of the collision test fixed in #7600 — the fourth time in this campaign a per-test fix left neighbours on the same machinery — so this lane audited the whole file instead.

## Root cause: fixture bulk, not timing
`createRepoBackup()` performs a real recursive copy of the repository INCLUDING `.git`. The seeded fixture is only ~132 KB, but generated `.git/hooks` adds ~76 KB spread across many small files. That per-file overhead is negligible on macOS and crosses the ~5s Windows boundary.

Fix: drop the generated hooks directory from the shared harness after `git init`:
```ts
await rm(join(identity.identityPaths.repo, ".git", "hooks"), { recursive: true, force: true })
```
It remains a real Git repository and the contract is unchanged — the test still proves a sibling backup directory holds a copy of the seeded content. **No production change.**

## File-wide audit (the point of this PR)
Every other timing/ambient exposure in `memfs-extra.test.ts` was checked and is already clean: `fakeDeps()` injects a fixed `now` so all backup-producing tests build timestamps deterministically; the collision test additionally pre-creates the same-second directory + sentinel (#7600); no `Date.now()`, sleeps, polling, `setImmediate` or timing guesses remain; temp roots use `mkdtemp` with no shared fixed root or real-memory-repo contention; assertions use `path.join()` and semantic content checks, with no POSIX-mode, case, or separator sensitivity.

## Evidence
Mutation-proven (no-op the backup call -> RED, zero backups where one is required; restore -> green). Focused file 11 pass/0 fail; target test ~1.03s -> ~0.62s, whole file ~8.4s -> ~7.1s locally; 20x loop 20/20 green; commands suite 138 pass/0 fail; `tsgo --noEmit` clean; LSP clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky memfs backup test on Windows by removing the generated `.git/hooks` directory from the test fixture, cutting execution time below the ~5s boundary.

- The fixture still remains a real Git repository; the backup contract is unchanged.
- Audited the whole test file for other timing or ambient exposures; none remain.

<sup>Written for commit 28f6c61194839367d065632361d63a9cfdcb811b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

