### PR TITLE
test(lsp-core): make diagnostics freshness deterministic

### DIFF
--- a/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
+++ b/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
@@ -90,6 +90,7 @@ describe("LspClient diagnostics freshness", () => {
 	});
 
 	it("#given stale and future publish versions #when diagnostics target the current version #then neither stale nor future diagnostics satisfy the request", async () => {
+		const staleClock = new ControlledClock();
 		const stale = await harness.makeClient(
 			{
 				publishDiagnostics: [
@@ -101,7 +102,7 @@ describe("LspClient diagnostics freshness", () => {
 					},
 				],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 100, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 100, versionlessPublishQuiescenceMs: 5, timerProvider: staleClock },
 		);
 		await stale.client.openFile(stale.source);
 		const staleDelivery = waitForEventCount(
@@ -113,13 +114,17 @@ describe("LspClient diagnostics freshness", () => {
 		await stale.client.openFile(stale.source);
 		expect(await staleDelivery).toHaveLength(1);
 
-		const staleResult = await stale.client.diagnostics(stale.source);
+		const stalePending = stale.client.diagnostics(stale.source);
+		await staleClock.waitForTimer(100);
+		staleClock.advanceBy(100);
+		const staleResult = await stalePending;
 
 		expect(staleResult.items).toEqual([]);
 		expect(staleResult.transientError?.kind).toBe("freshness_timeout");
 
 		await harness.cleanup();
 
+		const futureClock = new ControlledClock();
 		const future = await harness.makeClient(
 			{
 				publishDiagnostics: [
@@ -131,7 +136,7 @@ describe("LspClient diagnostics freshness", () => {
 					},
 				],
 			},
-			{ diagnosticsFreshnessTimeoutMs: 100, versionlessPublishQuiescenceMs: 5 },
+			{ diagnosticsFreshnessTimeoutMs: 100, versionlessPublishQuiescenceMs: 5, timerProvider: futureClock },
 		);
 		await future.client.openFile(future.source);
 		const futureDelivery = waitForEventCount(
@@ -143,7 +148,10 @@ describe("LspClient diagnostics freshness", () => {
 		await future.client.openFile(future.source);
 		expect(await futureDelivery).toHaveLength(1);
 
-		const futureResult = await future.client.diagnostics(future.source);
+		const futurePending = future.client.diagnostics(future.source);
+		await futureClock.waitForTimer(100);
+		futureClock.advanceBy(100);
+		const futureResult = await futurePending;
 
 		expect(futureResult.items).toEqual([]);
 		expect(futureResult.transientError?.kind).toBe("freshness_timeout");
@@ -155,7 +163,7 @@ describe("LspClient diagnostics freshness", () => {
 				capabilities: { diagnosticProvider: { interFileDependencies: false, workspaceDiagnostics: false } },
 				diagnosticResponses: [
 					{
-						delayMs: 200,
+						releaseOnDidChange: true,
 						report: { kind: "full", resultId: "v1", items: [diagnostic("pull-stale")] },
 					},
 					{

--- a/packages/lsp-core/src/lsp/fixtures/workspace-edit-server.mjs
+++ b/packages/lsp-core/src/lsp/fixtures/workspace-edit-server.mjs
@@ -8,6 +8,7 @@ let nextServerRequestId = 10_000;
 let renameIndex = 0;
 let diagnosticIndex = 0;
 const pendingServerRequests = new Map();
+const releasedDiagnosticResponses = [];
 
 function record(event) {
 	appendFileSync(eventsPath, `${JSON.stringify(event)}\n`, "utf-8");
@@ -146,8 +147,7 @@ function handleRequest(message) {
 			setTimeout(() => process.exit(0), delay);
 			return;
 		}
-		const delay = Number(step?.delayMs ?? 0);
-		setTimeout(() => {
+		const sendDiagnosticResponse = () => {
 			if (step?.error) {
 				record({ type: "serverError", method: "textDocument/diagnostic", error: step.error });
 				sendError(message.id, step.error.code, step.error.message);
@@ -156,7 +156,13 @@ function handleRequest(message) {
 			const result = step?.report ?? { items: scenario.diagnostics ?? [] };
 			record({ type: "serverResponse", method: "textDocument/diagnostic", result });
 			sendResponse(message.id, result);
-		}, delay);
+		};
+		if (step?.releaseOnDidChange === true) {
+			releasedDiagnosticResponses.push(sendDiagnosticResponse);
+		} else {
+			const delay = Number(step?.delayMs ?? 0);
+			setTimeout(sendDiagnosticResponse, delay);
+		}
 		return;
 	}
 	if (message.method === "shutdown") {
@@ -190,6 +196,7 @@ function handleNotification(message) {
 	}
 	if (message.method === "textDocument/didChange") {
 		applyPublishSteps("didChange", message.params.textDocument.uri, message.params.textDocument.version);
+		for (const release of releasedDiagnosticResponses.splice(0)) release();
 	}
 	if (message.method === "exit") process.exit(0);
 }


### PR DESCRIPTION
Fixes `LspClient diagnostics freshness > #given a pull response overtaken by a later local change #when the stale full report returns first #then diagnostics restart within the same request and resolve from the current version` (2929ms, `test (windows-latest, 2/2)`, dev push run 33539615220 — 15 other jobs green, 0 cancelled).

## Why the earlier TimerProvider fix did not cover it
The failing test was never on the client's real clock. Its staleness came from `setTimeout(..., 200)` **inside the spawned fixture process**, while client and test coordinated over real subprocess IO — so injecting a `ControlledClock` into the client could not reach it. Under Windows scheduling the stale response could arrive late enough to interfere with the real freshness deadline. This is the hybrid (controlled-clock × real-subprocess) anti-pattern already rejected in this file, hiding on the SERVER side.

## File-wide audit (all 11 tests)
Three were still time-coupled and are now fixed:
- L92 / L128 (stale & future versioned publishes): now inject separate `ControlledClock`s and advance the exact 100ms freshness timers.
- L160 (this failure): the fixture now HOLDS the stale response with no wall-clock delay and releases it when the later `didChange` arrives; the client then observes it, restarts within the same `diagnostics()` request, sends the second pull, and resolves `pull-fresh`.
Already deterministic: L21, L54, L277 (ControlledClock); L197, L234, L294, L317 (event-driven immediate responses).
Deliberately left on real timing: **L255** (hanging-pull cancellation) — it verifies actual transport timeout and `$/cancelRequest` delivery, not freshness-window scheduling; forcing a controlled clock there would delete the contract under test. L221 likewise tests a real server-close event.

The fixture's normal `delayMs` behavior is unchanged for other tests. **No production change** — `realTimerProvider` and all defaults stay byte-identical.

## Evidence
Mutation-proven twice: swapping the expected fresh diagnostics for stale fails the result assertion; changing the restart request count 2 → 1 fails the restart assertion. Affected file 11 pass / 0 fail; `bun test packages/lsp-core` 162 pass / 0 fail / 1 pre-existing platform skip; 30x loop 30/30 green; package typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `lsp-core` diagnostics freshness integration tests deterministic so they stop flaking under Windows scheduling.

- The two timeout tests now inject `ControlledClock`s and advance the 100ms freshness timer explicitly instead of waiting on real time.
- The fixture now holds a stale diagnostic response and releases it when the later `didChange` arrives, replacing the 200ms `setTimeout`.
- The hanging-pull and server-close tests intentionally stay on real timing because they test actual transport behavior.
- No production code changes; `realTimerProvider` and all defaults are unchanged.

<sup>Written for commit d18877fbf077072140fba8e665650090f028e45e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

