### PR TITLE
test(omo-opencode): avoid subprocess plugin entry checks

### DIFF
--- a/packages/omo-opencode/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
+++ b/packages/omo-opencode/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
@@ -22,7 +22,7 @@ function normalizePathForAssertion(filePath: string): string {
 function runFindPluginEntry(
   directory: string,
   envOverrides: Record<string, string | undefined> = {},
-): { status: number; stdout: string; stderr: string } {
+): PluginEntryResult {
   const originalEnvironment = new Map<string, string | undefined>()
   for (const [key, value] of Object.entries(envOverrides)) {
     originalEnvironment.set(key, process.env[key])
@@ -34,11 +34,7 @@ function runFindPluginEntry(
   }
 
   try {
-    return {
-      status: 0,
-      stdout: `${JSON.stringify(findPluginEntry(directory))}\n`,
-      stderr: "",
-    }
+    return findPluginEntry(directory)
   } finally {
     for (const [key, value] of originalEnvironment) {
       if (value === undefined) {
@@ -81,14 +77,12 @@ describe("findPluginEntry", () => {
     fs.writeFileSync(configPath, JSON.stringify({ plugin: [PACKAGE_NAME] }))
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(temporaryDirectory)
+    const result = runFindPluginEntry(temporaryDirectory)
 
     // #then entry is not pinned
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo).not.toBeNull()
-    expect(pluginInfo?.isPinned).toBe(false)
-    expect(pluginInfo?.pinnedVersion).toBeNull()
+    expect(result).not.toBeNull()
+    expect(result?.isPinned).toBe(false)
+    expect(result?.pinnedVersion).toBeNull()
   })
 
   test("returns unpinned for latest dist-tag", async () => {
@@ -96,14 +90,12 @@ describe("findPluginEntry", () => {
     fs.writeFileSync(configPath, JSON.stringify({ plugin: [`${PACKAGE_NAME}@latest`] }))
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(temporaryDirectory)
+    const result = runFindPluginEntry(temporaryDirectory)
 
     // #then latest is treated as channel, not pin
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo).not.toBeNull()
-    expect(pluginInfo?.isPinned).toBe(false)
-    expect(pluginInfo?.pinnedVersion).toBe("latest")
+    expect(result).not.toBeNull()
+    expect(result?.isPinned).toBe(false)
+    expect(result?.pinnedVersion).toBe("latest")
   })
 
   test("returns unpinned for beta dist-tag", async () => {
@@ -111,14 +103,12 @@ describe("findPluginEntry", () => {
     fs.writeFileSync(configPath, JSON.stringify({ plugin: [`${PACKAGE_NAME}@beta`] }))
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(temporaryDirectory)
+    const result = runFindPluginEntry(temporaryDirectory)
 
     // #then beta is treated as channel, not pin
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo).not.toBeNull()
-    expect(pluginInfo?.isPinned).toBe(false)
-    expect(pluginInfo?.pinnedVersion).toBe("beta")
+    expect(result).not.toBeNull()
+    expect(result?.isPinned).toBe(false)
+    expect(result?.pinnedVersion).toBe("beta")
   })
 
   test("returns pinned for explicit semver", async () => {
@@ -126,14 +116,12 @@ describe("findPluginEntry", () => {
     fs.writeFileSync(configPath, JSON.stringify({ plugin: [`${PACKAGE_NAME}@3.5.2`] }))
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(temporaryDirectory)
+    const result = runFindPluginEntry(temporaryDirectory)
 
     // #then explicit semver is treated as pin
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo).not.toBeNull()
-    expect(pluginInfo?.isPinned).toBe(true)
-    expect(pluginInfo?.pinnedVersion).toBe("3.5.2")
+    expect(result).not.toBeNull()
+    expect(result?.isPinned).toBe(true)
+    expect(result?.pinnedVersion).toBe("3.5.2")
   })
 
   test("finds preferred plugin entry", async () => {
@@ -141,14 +129,12 @@ describe("findPluginEntry", () => {
     fs.writeFileSync(configPath, JSON.stringify({ plugin: [PLUGIN_NAME] }))
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(temporaryDirectory)
+    const result = runFindPluginEntry(temporaryDirectory)
 
     // #then preferred entry is returned
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo?.entry).toBe(PLUGIN_NAME)
-    expect(pluginInfo?.isPinned).toBe(false)
-    expect(pluginInfo?.pinnedVersion).toBeNull()
+    expect(result?.entry).toBe(PLUGIN_NAME)
+    expect(result?.isPinned).toBe(false)
+    expect(result?.pinnedVersion).toBeNull()
   })
 
   test("finds legacy plugin entry", async () => {
@@ -156,14 +142,12 @@ describe("findPluginEntry", () => {
     fs.writeFileSync(configPath, JSON.stringify({ plugin: [LEGACY_PLUGIN_NAME] }))
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(temporaryDirectory)
+    const result = runFindPluginEntry(temporaryDirectory)
 
     // #then legacy entry is returned
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo?.entry).toBe(LEGACY_PLUGIN_NAME)
-    expect(pluginInfo?.isPinned).toBe(false)
-    expect(pluginInfo?.pinnedVersion).toBeNull()
+    expect(result?.entry).toBe(LEGACY_PLUGIN_NAME)
+    expect(result?.isPinned).toBe(false)
+    expect(result?.pinnedVersion).toBeNull()
   })
 
   test("finds preferred plugin entry with pinned version", async () => {
@@ -171,14 +155,12 @@ describe("findPluginEntry", () => {
     fs.writeFileSync(configPath, JSON.stringify({ plugin: [`${PLUGIN_NAME}@3.15.0`] }))
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(temporaryDirectory)
+    const result = runFindPluginEntry(temporaryDirectory)
 
     // #then preferred versioned entry is returned
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo?.entry).toBe(`${PLUGIN_NAME}@3.15.0`)
-    expect(pluginInfo?.isPinned).toBe(true)
-    expect(pluginInfo?.pinnedVersion).toBe("3.15.0")
+    expect(result?.entry).toBe(`${PLUGIN_NAME}@3.15.0`)
+    expect(result?.isPinned).toBe(true)
+    expect(result?.pinnedVersion).toBe("3.15.0")
   })
 
   test("returns null for unrelated plugin entry", async () => {
@@ -186,12 +168,10 @@ describe("findPluginEntry", () => {
     fs.writeFileSync(configPath, JSON.stringify({ plugin: ["some-other-plugin"] }))
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(temporaryDirectory)
+    const result = runFindPluginEntry(temporaryDirectory)
 
     // #then no matching entry is returned
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo).toBeNull()
+    expect(result).toBeNull()
   })
 
   test("reads user config from profile dir even when OPENCODE_CONFIG_DIR changes after import", async () => {
@@ -204,17 +184,15 @@ describe("findPluginEntry", () => {
     )
 
     // #when plugin entry is detected
-    const execution = runFindPluginEntry(path.join(temporaryDirectory, "workspace"), {
+    const result = runFindPluginEntry(path.join(temporaryDirectory, "workspace"), {
       OPENCODE_CONFIG_DIR: profileConfigDir,
     })
 
     // #then profile dir is respected
-    expect(execution.status).toBe(0)
-    const pluginInfo = JSON.parse(execution.stdout.trim()) as PluginEntryResult
-    expect(pluginInfo).not.toBeNull()
-    expect(normalizePathForAssertion(pluginInfo?.configPath ?? "")).toBe(
+    expect(result).not.toBeNull()
+    expect(normalizePathForAssertion(result?.configPath ?? "")).toBe(
       normalizePathForAssertion(path.join(profileConfigDir, "opencode.json")),
     )
-    expect(pluginInfo?.pinnedVersion).toBe("beta")
+    expect(result?.pinnedVersion).toBe("beta")
   })
 })

--- a/packages/omo-opencode/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
+++ b/packages/omo-opencode/src/hooks/auto-update-checker/checker/plugin-entry.test.ts
@@ -1,11 +1,11 @@
 /// <reference types="bun-types" />
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
-import { spawnSync } from "node:child_process"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
 import { PACKAGE_NAME } from "../constants"
+import { findPluginEntry } from "./plugin-entry"
 import { LEGACY_PLUGIN_NAME, PLUGIN_NAME } from "../../../shared/plugin-identity"
 
 type PluginEntryResult = {
@@ -22,26 +22,31 @@ function normalizePathForAssertion(filePath: string): string {
 function runFindPluginEntry(
   directory: string,
   envOverrides: Record<string, string | undefined> = {},
-): { status: number | null; stdout: string; stderr: string } {
-  const command = [
-    `import { findPluginEntry } from ${JSON.stringify("./packages/omo-opencode/src/hooks/auto-update-checker/checker/plugin-entry")};`,
-    `const result = findPluginEntry(${JSON.stringify(directory)});`,
-    "console.log(JSON.stringify(result));",
-  ].join("")
+): { status: number; stdout: string; stderr: string } {
+  const originalEnvironment = new Map<string, string | undefined>()
+  for (const [key, value] of Object.entries(envOverrides)) {
+    originalEnvironment.set(key, process.env[key])
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
 
-  const execution = spawnSync(process.execPath, ["-e", command], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      ...envOverrides,
-    },
-    encoding: "utf-8",
-  })
-
-  return {
-    status: execution.status,
-    stdout: execution.stdout,
-    stderr: execution.stderr,
+  try {
+    return {
+      status: 0,
+      stdout: `${JSON.stringify(findPluginEntry(directory))}\n`,
+      stderr: "",
+    }
+  } finally {
+    for (const [key, value] of originalEnvironment) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fixes `findPluginEntry > returns unpinned for bare package name`, which failed at 5123ms on `test (windows-latest, 1/2)` (dev push run on head 560790f87 — 16 other jobs green, 0 cancelled, so genuine).

## Root cause: a real subprocess per test
`plugin-entry.test.ts:17-46` ran `spawnSync(process.execPath, ["-e", ...])` for **every one of its 9 tests**, launching a fresh Node process synchronously with inherited repo cwd and environment. That is the entire ~5s cost on a slow Windows runner.

Production was audited and is NOT at fault: `plugin-entry.ts:18-42` only checks a bounded list of config paths via `existsSync`/`readFileSync` — no package-tree resolution, no registry/network access, no upward filesystem walk. **No production change.**

## Fix: call the real function in-process
Replaced the subprocess harness with direct in-process calls to the real `findPluginEntry` — genuinely exercising production, not a spy (the call-shape-only trap that review caught on #7610). All assertions preserved: the full bare-name unpinned check, every parsing/selection assertion, and the profile-specific `OPENCODE_CONFIG_DIR` behavior.

Env isolation is retained deliberately, since the subprocess had been providing it: a save/restore helper with `try/finally`, `mkdtempSync` per test, and `OPENCODE_CONFIG_DIR` restored on teardown — so this does not reintroduce the ambient-leak class fixed three times in this campaign (#7598, #7604, #7606). Verified: zero `spawnSync`/`execPath` references remain.

## File-wide audit
The subprocess harness was the only real-process boundary in the file. Temp dirs already used `mkdtempSync` per test (no `Date.now()` collision like #7609), fixtures contain only the required config files (no bulk like #7608), and no HOME/XDG/cwd dependency pulls in real user state.

## Evidence
Mutation-proven: flipping the bare-name assertion to `isPinned: true` fails deterministically (8 pass / 1 fail); restored before commit. Focused file 9 pass / 0 fail; auto-update-checker scope 81 pass / 0 fail; 20x loop all green; package typecheck and LSP diagnostics clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky `plugin-entry.test.ts` by replacing subprocess spawning with in-process calls to `findPluginEntry`, so the test no longer times out on Windows CI. No production code changes; environment isolation is preserved via save/restore.

<sup>Written for commit 846eda2bcc2cbe11df8ec128362250702657efce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

