### PR TITLE
test(omo-senpi): await DAG task attachment

### DIFF
--- a/packages/omo-senpi/src/components/task/dag-runtime.test.ts
+++ b/packages/omo-senpi/src/components/task/dag-runtime.test.ts
@@ -531,7 +531,16 @@ describe("assembled DAG runtime", () => {
     cleanupRoots.push(cwd)
     const abortError = new DOMException("This operation was aborted", "AbortError")
     const runner = new ScriptedRunner(abortError)
-    const pi = new FakeExtensionAPI()
+    const taskAttached = deferred<void>()
+    const pi = Object.assign(new FakeExtensionAPI(), {
+      rpc: {
+        emit: (name: string, data: unknown) => {
+          if (name !== "omo.dag.event" || typeof data !== "object" || data === null) return
+          if ("type" in data && data.type === "dag.node.task-attached") taskAttached.resolve()
+        },
+        handle: () => undefined,
+      },
+    })
     const engine = composeTaskEngine({
       pi,
       omoConfig: loadOmoConfig({ cwd }).config,
@@ -553,6 +562,7 @@ describe("assembled DAG runtime", () => {
       },
     })
     await within(runner.whenStarted(1))
+    await within(taskAttached.promise)
     const unhandled: unknown[] = []
     const onUnhandled = (reason: unknown): void => { unhandled.push(reason) }
     process.on("unhandledRejection", onUnhandled)


### PR DESCRIPTION
Fixes the RESIDUAL `assembled DAG runtime > #given a live-shaped in-process child whose abort rejects ... no unhandled rejection escapes and a later run still completes` failure (5959ms, `senpi-compatibility (windows-latest)`, run 33545443039).

## Why the two previous fixes did not cover it
- #7601 replaced a `setImmediate` tick-guess with an explicit `disposed` deferred — fixed disposal OBSERVATION.
- #7607 made `within()` a pass-through — removed the artificial 300ms deadline (verified present on dev).
Neither synchronized the actual **admission** transition, which is where the residual coupling lived.

## Root cause
`runner.whenStarted(1)` fires as soon as `ScriptedRunner.start()` returns. It does NOT prove the scheduler completed admission or journaled `dag.node.task-attached`. Cancellation then enters `scheduler.cancel() → performCancellation() → whenAdmissionIdle() → taskManager.cancelTask(..., { abort: "skip" })` (packages/senpi-task/src/dag/scheduler.ts). On Windows the test could reach cancellation while admission was still completing, so the cancellation path waited on the admission boundary — the multi-second lifecycle coupling.

Note `runtime.attach()` is NOT the culprit: for a fresh run with no paused records it sets the session, resumes paused runs, re-schedules pending work, attaches the RPC bridge and syncs subscriptions — it neither spawns a process nor polls an OS lifecycle event.

## Fix
Subscribe to the exact durable transition `dag.node.task-attached` after `whenStarted(1)` and before cancellation, guaranteeing the child is attached, the scheduler has recorded the attachment, and cancellation cannot race admission. **Test-only; no production change**, and `build-extension.mjs --check` confirms bundled output stays current.

## File-wide audit
All 16 tests inventoried. The shared cancellation seam is used by the two-node integration cancellation test, this abort-boundary test, detach handling, recovery pause/resume, and the control-verb tests. The fix was applied to the race-specific synchronization rather than altering shared production behavior.

## Evidence
Mutation-proven: dropping `{ abort: "skip" }` from production cancellation surfaces the simulated `AbortError` and drives `runner.abortCalls` 0 → 2, failing the contract; restored unchanged. 30x loop all green (16 tests, 0 fail, ~1.2s per run); `packages/omo-senpi/src/components/task` 501 pass / 0 fail; `tsgo --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the residual flaky `assembled DAG runtime` abort test on Windows by awaiting the `dag.node.task-attached` transition before cancellation.

- The test previously canceled as soon as `runner.whenStarted(1)` resolved, which doesn't guarantee the scheduler completed admission.
- Waiting on the deferred event ensures the child is attached and recorded, so cancellation can't race admission.
- Test-only change; no production behavior modified.

<sup>Written for commit fb6faae0dce18d11a18caf4e7d0eafbeec39419e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

