### PR TITLE
fix(native): normalize Terra Fast usability budget

### DIFF
--- a/packages/omo-native/bin/senpi-patch.mjs
+++ b/packages/omo-native/bin/senpi-patch.mjs
@@ -21,6 +21,20 @@ try {
 }
 
 const transforms = {
+  "dist/core/agent-session.js": [
+    [
+      'import { ModelUsabilityBudgetError, projectModelUsabilityBudget, } from "./extensions/builtin/compaction/model-usability-budget.js";',
+      'import { ModelUsabilityBudgetError, projectModelUsabilityBudget, } from "./extensions/builtin/compaction/model-usability-budget.js";\nconst TERRA_FAST_CONTEXT_WINDOW = 650_000;\nfunction normalizeTerraFastModel(model) {\n    if (model?.id !== "gpt-5.6-terra-fast" || model.contextWindow >= TERRA_FAST_CONTEXT_WINDOW)\n        return model;\n    return { ...model, contextWindow: TERRA_FAST_CONTEXT_WINDOW };\n}',
+    ],
+    [
+      "        this.agent = config.agent;",
+      "        this.agent = config.agent;\n        this.agent.state.model = normalizeTerraFastModel(this.agent.state.model);",
+    ],
+    [
+      "    async _switchActiveModel(model, opts) {",
+      "    async _switchActiveModel(model, opts) {\n        model = normalizeTerraFastModel(model);",
+    ],
+  ],
   "dist/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.js": [
     [
       'throw new SessionTurnAttributionError("Claude SDK OAuth result arrived before replay claim");',

--- a/packages/omo-native/test/packed-install.test.ts
+++ b/packages/omo-native/test/packed-install.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createRequire } from "node:module"
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, sep } from "node:path"
 
@@ -20,7 +20,7 @@ describe("omo-ai packed install", () => {
       expect(entries).toContain(join("package", "bin", "senpi-patch.mjs"))
 
       const consumer = join(root, "consumer")
-      Bun.spawnSync(["mkdir", "-p", consumer], { stdout: "ignore", stderr: "ignore" })
+      mkdirSync(consumer)
       writeFileSync(join(consumer, "package.json"), JSON.stringify({ name: "omo-ai-consumer", private: true }))
       const install = Bun.spawnSync(["bun", "add", "--trust", join(root, tarball!)], { cwd: consumer, stdout: "pipe", stderr: "pipe" })
       expect(install.exitCode).toBe(0)
@@ -34,6 +34,10 @@ describe("omo-ai packed install", () => {
       expect(senpiRoot).toBeDefined()
       const sessionRegistryPump = readFileSync(join(senpiRoot!, "dist/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.js"), "utf8")
       expect(sessionRegistryPump).toContain("describeUnclaimedResult")
+      const agentSession = readFileSync(join(senpiRoot!, "dist/core/agent-session.js"), "utf8")
+      expect(agentSession).toContain('const TERRA_FAST_CONTEXT_WINDOW = 650_000;')
+      expect(agentSession).toContain('model = normalizeTerraFastModel(model);')
+      expect(agentSession).toContain("this.agent.state.model = normalizeTerraFastModel(this.agent.state.model);")
     } finally {
       rmSync(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- normalize gpt-5.6-terra-fast to OMO's 650k Terra context window before Senpi's usability-budget projection and model switching
- extend the packed-install regression to verify the production postinstall patch, and make its temp-directory setup work on Windows

## Verification
- bun test packages/omo-native/test/packed-install.test.ts (pass: 1 test, 11 assertions)
- bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json (pass)
- bun run test:senpi was run: 2,502 pass / 14 skip / 12 pre-existing failures in Senpi QA-script and deep-advisor tests; no omo-native failures.
- Live Senpi QA self-test is currently blocked on Windows because drive.mjs writes agent/settings.json before creating its sandbox agent directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes `gpt-5.6-terra-fast`'s context window to 650k before usability-budget projection and model switching, and extends the packed-install regression to verify the production patch and run on Windows.

- Applies normalization when the agent initializes and when switching active models.
- Regression test now asserts the patched `agent-session.js` contains the normalization code.
- Replaces the shell `mkdir -p` with `mkdirSync` so temp-directory setup works on Windows.

<sup>Written for commit caab8f56c950917477b5c95f29b4dc3eb6949a5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

