### PR TITLE
test(windows): make hook command fixtures shell-portable

### DIFF
--- a/packages/omo-opencode/src/shared/command-executor/execute-hook-command.test.ts
+++ b/packages/omo-opencode/src/shared/command-executor/execute-hook-command.test.ts
@@ -1,13 +1,15 @@
 const { afterEach, beforeEach, describe, expect, test } = require("bun:test")
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 
 const { executeHookCommand } = await import("./execute-hook-command")
 const timeoutAssertionMs = process.platform === "win32" ? 5_000 : 1_000
 
-function nodeCommand(script: string): string {
-  return `"${process.execPath}" -e ${JSON.stringify(script)}`
+function nodeCommand(directory: string, script: string, args: string[] = []): string {
+  const scriptPath = join(directory, "hook-fixture.js")
+  writeFileSync(scriptPath, script)
+  return [`"${process.execPath}"`, `"${scriptPath}"`, ...args.map(arg => `"${arg}"`)].join(" ")
 }
 
 describe("executeHookCommand", () => {
@@ -28,7 +30,7 @@ describe("executeHookCommand", () => {
 
     // when
     const result = await executeHookCommand(
-      nodeCommand("console.log(process.env.__OMO_TEST_ALLOWED_VAR || '', process.env.__OMO_TEST_SECRET_VAR || '')"),
+      nodeCommand(tempDirectory, "console.log(process.env.__OMO_TEST_ALLOWED_VAR || '', process.env.__OMO_TEST_SECRET_VAR || '')"),
       "",
       tempDirectory,
       { allowedEnvVars: ["__OMO_TEST_ALLOWED_VAR"] },
@@ -50,7 +52,7 @@ describe("executeHookCommand", () => {
 
     // when
     const result = await executeHookCommand(
-      nodeCommand("console.log(process.env.__OMO_TEST_FULL_ENV_VAR || '')"),
+      nodeCommand(tempDirectory, "console.log(process.env.__OMO_TEST_FULL_ENV_VAR || '')"),
       "",
       tempDirectory,
     )
@@ -65,7 +67,7 @@ describe("executeHookCommand", () => {
 
   test("#given command ignores normal completion #when timeout expires #then returns timeout instead of hanging", async () => {
     // given
-    const command = nodeCommand("setTimeout(() => {}, 1000)")
+    const command = nodeCommand(tempDirectory, "setTimeout(() => {}, 1000)")
 
     // when
     const startedAt = Date.now()
@@ -87,7 +89,7 @@ describe("executeHookCommand", () => {
   test("#given pluginRoot option #when executing command #then CLAUDE_PLUGIN_ROOT is exported into env", async () => {
     // when
     const result = await executeHookCommand(
-      "echo plugin-root=$CLAUDE_PLUGIN_ROOT",
+      nodeCommand(tempDirectory, "console.log('plugin-root=' + process.env.CLAUDE_PLUGIN_ROOT)"),
       "",
       tempDirectory,
       { pluginRoot: "/tmp/plugin-x" },
@@ -101,7 +103,7 @@ describe("executeHookCommand", () => {
   test("#given pluginRoot option with allowedEnvVars #when executing command #then CLAUDE_PLUGIN_ROOT survives the env scrub", async () => {
     // when
     const result = await executeHookCommand(
-      "echo plugin-root=$CLAUDE_PLUGIN_ROOT",
+      nodeCommand(tempDirectory, "console.log('plugin-root=' + process.env.CLAUDE_PLUGIN_ROOT)"),
       "",
       tempDirectory,
       { pluginRoot: "/tmp/plugin-y", allowedEnvVars: [] },
@@ -119,7 +121,7 @@ describe("executeHookCommand", () => {
     // we substitute earlier so the form works even in commands that disable
     // shell variable expansion downstream.
     const result = await executeHookCommand(
-      'echo "rooted=${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh"',
+      nodeCommand(tempDirectory, "console.log('rooted=' + process.argv[2])", ["${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh"]),
       "",
       tempDirectory,
       { pluginRoot: "/tmp/plugin-z" },

--- a/packages/utils/src/command-executor/execute-hook-command.test.ts
+++ b/packages/utils/src/command-executor/execute-hook-command.test.ts
@@ -1,12 +1,14 @@
 const { afterEach, beforeEach, describe, expect, test } = require("bun:test")
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 
 const { executeHookCommand } = await import("./execute-hook-command")
 
-function nodeCommand(script: string): string {
-  return `"${process.execPath}" -e ${JSON.stringify(script)}`
+function nodeCommand(directory: string, script: string, args: string[] = []): string {
+  const scriptPath = join(directory, "hook-fixture.js")
+  writeFileSync(scriptPath, script)
+  return [`"${process.execPath}"`, `"${scriptPath}"`, ...args.map(arg => `"${arg}"`)].join(" ")
 }
 
 describe("executeHookCommand", () => {
@@ -27,7 +29,7 @@ describe("executeHookCommand", () => {
 
     // when
     const result = await executeHookCommand(
-      nodeCommand("console.log(process.env.__OMO_TEST_ALLOWED_VAR || '', process.env.__OMO_TEST_SECRET_VAR || '')"),
+      nodeCommand(tempDirectory, "console.log(process.env.__OMO_TEST_ALLOWED_VAR || '', process.env.__OMO_TEST_SECRET_VAR || '')"),
       "",
       tempDirectory,
       { allowedEnvVars: ["__OMO_TEST_ALLOWED_VAR"] },
@@ -49,7 +51,7 @@ describe("executeHookCommand", () => {
 
     // when
     const result = await executeHookCommand(
-      nodeCommand("console.log(process.env.__OMO_TEST_FULL_ENV_VAR || '')"),
+      nodeCommand(tempDirectory, "console.log(process.env.__OMO_TEST_FULL_ENV_VAR || '')"),
       "",
       tempDirectory,
     )
@@ -64,7 +66,7 @@ describe("executeHookCommand", () => {
 
   test("#given command ignores normal completion #when timeout expires #then returns timeout instead of hanging", async () => {
     // given
-    const command = nodeCommand("setTimeout(() => {}, 1000)")
+    const command = nodeCommand(tempDirectory, "setTimeout(() => {}, 1000)")
 
     // when
     const startedAt = Date.now()
@@ -86,7 +88,7 @@ describe("executeHookCommand", () => {
   test("#given pluginRoot option #when executing command #then CLAUDE_PLUGIN_ROOT is exported into env", async () => {
     // when
     const result = await executeHookCommand(
-      "echo plugin-root=$CLAUDE_PLUGIN_ROOT",
+      nodeCommand(tempDirectory, "console.log('plugin-root=' + process.env.CLAUDE_PLUGIN_ROOT)"),
       "",
       tempDirectory,
       { pluginRoot: "/tmp/plugin-x" },
@@ -100,7 +102,7 @@ describe("executeHookCommand", () => {
   test("#given pluginRoot option with allowedEnvVars #when executing command #then CLAUDE_PLUGIN_ROOT survives the env scrub", async () => {
     // when
     const result = await executeHookCommand(
-      "echo plugin-root=$CLAUDE_PLUGIN_ROOT",
+      nodeCommand(tempDirectory, "console.log('plugin-root=' + process.env.CLAUDE_PLUGIN_ROOT)"),
       "",
       tempDirectory,
       { pluginRoot: "/tmp/plugin-y", allowedEnvVars: [] },
@@ -118,7 +120,7 @@ describe("executeHookCommand", () => {
     // we substitute earlier so the form works even in commands that disable
     // shell variable expansion downstream.
     const result = await executeHookCommand(
-      'echo "rooted=${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh"',
+      nodeCommand(tempDirectory, "console.log('rooted=' + process.argv[2])", ["${CLAUDE_PLUGIN_ROOT}/scripts/foo.sh"]),
       "",
       tempDirectory,
       { pluginRoot: "/tmp/plugin-z" },


### PR DESCRIPTION
Fixes `executeHookCommand > #given command ignores normal completion #when timeout expires #then returns timeout instead of hanging` (109ms fast-fail, `test (windows-latest, 2/2)`, runs 33547283096 + dev db804d3eb).

## Root cause: shell-sensitive inline fixture, not slowness
The fixture ran `"<execPath>" -e "setTimeout(() => {}, 1000)"` through `spawn(cmd, { shell: true })`. POSIX `/bin/sh` parses that as intended; win32 `cmd.exe` parses the inline `-e` differently, so the child exits IMMEDIATELY with a non-timeout result — the assertion fails in ~109ms without any timeout ever being exercised.

## Fix: portable fixture, identical contract
The helper now writes the Node fixture to a temp `.js` file and invokes `"<execPath>" "<file>"` — no shell-sensitive quoting on any platform, and the fixture stays genuinely uncooperative (`setTimeout(() => {}, 1000)`). The SAME contract is asserted everywhere: command ignores completion, timeout expires, exit code 124, timeout diagnostic, no hang. File-wide audit converted all six tests in BOTH mirrored files (packages/utils + packages/omo-opencode) off POSIX `echo`/`$VAR` expansion to Node-based env/arg assertions, keeping ${CLAUDE_PLUGIN_ROOT} substitution coverage intact.

No production change — win32 process-tree termination via `taskkill /PID .. /T /F` already exists.

## Evidence
Mutation-proven: production timeout result 124→0 fails the test (Expected 124 / Received 0). Affected 12 pass; 20x loop green; package scope 8865 pass / 0 fail; repo typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows test flake where the hook timeout test failed because `cmd.exe` parsed inline `-e` flags differently. Test fixtures now write to temp `.js` files, and all six tests in both mirrored `execute-hook-command` files were converted to Node-based assertions; no production code changed.

<sup>Written for commit 3b313be1fa501260cdd3b32eba11307f339309ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

