### PR TITLE
test(omo-senpi): await durable DAG overflow before settlement

### DIFF
--- a/packages/omo-senpi/src/components/task/dag-runtime-config.test.ts
+++ b/packages/omo-senpi/src/components/task/dag-runtime-config.test.ts
@@ -102,9 +102,12 @@ describe("assembled DAG runtime configuration", () => {
       },
     })
     await within(runner.started.promise, "node start")
+    // The ring-1 subscriber may drop the task-attached event itself, but its durable overflow is
+    // appended only after that admission burst is journaled. Use the shipped overflow as the
+    // admission barrier before allowing the child to settle.
+    const overflow = await within(overflowDelivered.promise, "configured subscriber overflow")
     runner.outcome.resolve({ status: "completed", finalResponse: "done" })
     await within(runtime.wait(started.snapshot.runId, sessionId), "run completion")
-    const overflow = await within(overflowDelivered.promise, "configured subscriber overflow")
 
     // then
     expect(overflow.droppedCount).toBeGreaterThan(0)


### PR DESCRIPTION
Fixes `assembled DAG runtime configuration > #given subscriber_ring is one ... durable overflow` (7840ms, `senpi-compatibility (windows-latest)`, runs 33547283096 + dev db804d3eb).

## Root cause
The test released the child outcome right after `runner.started` — which only proves `ControlledRunner.start()` returned — then waited for run completion BEFORE the overflow. Terminal settlement and scheduler teardown could race the subscriber drain that journals `dag.stream.overflow` (enqueue → drain → commitOverflow → WAL+checkpoint append → RPC bridge ship).

## Why prior fixes did not cover it
#7607 only removed an artificial 300ms deadline (helper already pass-through). #7614's barrier — `dag.node.task-attached` — CANNOT be used here: with ring size 1 that event may itself be dropped, so waiting on it deadlocks. The correct barrier is the shipped `dag.stream.overflow` event itself, emitted only after the durable append. The test now awaits that before resolving the child outcome. Test-only; no production change.

## Evidence
Mutation-proven: ring 1→100 makes the test hang to the bounded 12s proof (no overflow ⇒ assertions unreachable); reverted. 30x loop green; task scope 501 pass / 0 fail; tsgo clean. File-wide audit: single test, no timers/spawns/platform branches remain.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the durable-overflow flake in the `omo-senpi` DAG runtime config test by awaiting the shipped `dag.stream.overflow` event before settling the child outcome. The old test settled the child right after `runner.started`, letting terminal settlement and scheduler teardown race the subscriber drain that journals the overflow. Test-only change; no production behavior changes.

- `dag.node.task-attached` can't be used as the barrier: with ring size 1 that event may itself be dropped, which deadlocks the wait.
- The overflow event is emitted only after the durable append, making it the correct admission barrier.
- Reproduced the race with a mutation (ring 1→100 hangs to the bounded timeout); the 30x loop passes after the fix.

<sup>Written for commit 227761b7b41920a495cfd893435466838489c00d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

