### PR TITLE
fix(model-core): cap grok output reserve when output limit equals context window (fixes #7541)

### DIFF
--- a/packages/model-core/src/model-capabilities-bundled-snapshot.test.ts
+++ b/packages/model-core/src/model-capabilities-bundled-snapshot.test.ts
@@ -4,6 +4,32 @@ import { getBundledModelCapabilitiesSnapshot, getModelCapabilities } from "./mod
 import bundledModelCapabilitiesSnapshotJson from "../../../packages/omo-opencode/src/generated/model-capabilities.generated.json"
 
 describe("bundled model capabilities snapshot", () => {
+  describe("#given xAI grok models where maxTokens equals contextWindow", () => {
+    test("#when resolving maxOutputTokens #then it is capped to a practical limit well below contextWindow", () => {
+      // given
+      const bundledSnapshot = getBundledModelCapabilitiesSnapshot(bundledModelCapabilitiesSnapshotJson)
+      const affectedModels = [
+        { providerID: "xai", modelID: "xai/grok-4.5", contextWindow: 500_000 },
+        { providerID: "xai", modelID: "xai/grok-4.6", contextWindow: 500_000 },
+        { providerID: "xai", modelID: "xai/grok-build-0.1", contextWindow: 256_000 },
+      ]
+
+      // when
+      const results = affectedModels.map(({ providerID, modelID, contextWindow }) => ({
+        modelID,
+        contextWindow,
+        caps: getModelCapabilities({ providerID, modelID, bundledSnapshot }),
+      }))
+
+      // then — maxOutputTokens must be strictly less than half the context window
+      // so OpenCode's getPromptContextWindow does not reserve half the window for output
+      for (const { modelID, contextWindow, caps } of results) {
+        expect(caps.maxOutputTokens).toBeDefined()
+        expect(caps.maxOutputTokens!).toBeLessThan(contextWindow * 0.5)
+      }
+    })
+  })
+
   test("keeps GPT-4.1 OpenAI variants marked as supporting tool calls", () => {
     // given
     const bundledSnapshot = getBundledModelCapabilitiesSnapshot(bundledModelCapabilitiesSnapshotJson)

--- a/packages/model-core/src/model-capabilities/supplemental-entries.ts
+++ b/packages/model-core/src/model-capabilities/supplemental-entries.ts
@@ -111,4 +111,109 @@ export const SUPPLEMENTAL_MODEL_CAPABILITIES: Record<string, ModelCapabilitiesSn
 			output: 128000,
 		},
 	},
+	"grok-4.5": {
+		id: "grok-4.5",
+		family: "grok",
+		reasoning: false,
+		temperature: true,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 500000,
+			output: 32768,
+		},
+	},
+	"xai/grok-4.5": {
+		id: "xai/grok-4.5",
+		family: "grok",
+		reasoning: false,
+		temperature: true,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 500000,
+			output: 32768,
+		},
+	},
+	"x-ai/grok-4.5": {
+		id: "x-ai/grok-4.5",
+		family: "grok",
+		reasoning: false,
+		temperature: true,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 500000,
+			output: 32768,
+		},
+	},
+	"grok-4.6": {
+		id: "grok-4.6",
+		family: "grok",
+		reasoning: false,
+		temperature: true,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 500000,
+			output: 32768,
+		},
+	},
+	"xai/grok-4.6": {
+		id: "xai/grok-4.6",
+		family: "grok",
+		reasoning: false,
+		temperature: true,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 500000,
+			output: 32768,
+		},
+	},
+	"xai/grok-build-0.1": {
+		id: "xai/grok-build-0.1",
+		family: "grok",
+		reasoning: false,
+		temperature: true,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 256000,
+			output: 32768,
+		},
+	},
+	"x-ai/grok-build-0.1": {
+		id: "x-ai/grok-build-0.1",
+		family: "grok",
+		reasoning: false,
+		temperature: true,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 256000,
+			output: 32768,
+		},
+	},
 }


### PR DESCRIPTION
## What changed

Added supplemental model capability entries for xAI grok models where the bundled snapshot reports `output: contextWindow` (i.e. the output limit equals the full context window). The supplemental entries override those values with `output: 32768`, which is a realistic maximum generation limit for these models.

**Affected models:**
- `grok-4.5`, `xai/grok-4.5`, `x-ai/grok-4.5` (context: 500 000 → output capped at 32 768)
- `grok-4.6`, `xai/grok-4.6` (context: 500 000 → output capped at 32 768)
- `xai/grok-build-0.1`, `x-ai/grok-build-0.1` (context: 256 000 → output capped at 32 768)

## Why

OpenCode's `getPromptContextWindow` computes the usable prompt budget as `contextWindow - min(maxOutputTokens, contextWindow / 2)`. When `maxOutputTokens` equals `contextWindow` (as the bundled snapshot reports for these models), the formula reserves exactly half the context window for output — 250 000 tokens for a 500 000-token model — leaving only 250 000 tokens for the prompt. This matches the symptom reported in #7541.

`grok-4.3` is unaffected because its snapshot entry already has `maxTokens: 30000`.

The fix is entirely plugin-side: `SUPPLEMENTAL_MODEL_CAPABILITIES` entries win over the bundled snapshot via `getBundledModelCapabilitiesSnapshot()`, so no changes to the generated JSON or the OpenCode runtime are needed.

## Observed behavior

Before fix: `getModelCapabilities({ providerID: 'xai', modelID: 'xai/grok-4.6' }).maxOutputTokens === 500000`
After fix: `maxOutputTokens === 32768` (< 250 000, so the output reserve drops from 250 000 to 32 768 tokens)

## QA / evidence

- RED test added to `packages/model-core/src/model-capabilities-bundled-snapshot.test.ts` asserting `maxOutputTokens < contextWindow * 0.5` for all affected model IDs — confirmed failing before the fix.
- GREEN after adding supplemental entries: `2 pass, 0 fail`.
- Full `packages/model-core/` regression: `364 pass, 0 fail`.
- Typecheck (`bun run typecheck`): clean, no errors.

## Residual risk

The `output: 32768` value is based on xAI's documented generation limit for these models. If xAI raises the actual output limit in future, the supplemental entry can be updated or removed once the bundled snapshot reflects the correct value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7541 by adding supplemental capability entries that cap the output limit for xAI `grok` models whose bundled snapshot reports `output` equal to the context window. Previously `getModelCapabilities` returned `maxOutputTokens` as the full context window, so `getPromptContextWindow` reserved half the context for output and left only half for the prompt.

**Affected models**

- `grok-4.5`, `xai/grok-4.5`, `x-ai/grok-4.5`, `grok-4.6`, `xai/grok-4.6`, `xai/grok-build-0.1`, and `x-ai/grok-build-0.1` now have `output` capped at 32,768.

<sup>Written for commit b5a757323b8287903c733d389c3ef1eb55ff06f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

