### PR TITLE
test(windows): widen legacy daemon fixture readiness budget

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,12 @@
+## 2026-09-02 — Give the legacy daemon fixture a cold-Windows readiness budget
+
+The Codex installer test fixture's event-driven readiness wait now allows 30
+seconds on Windows, matching the platform-specific execution budgets the
+installer integration tests already use. Assertions and event-driven behavior
+remain unchanged; only the fixture's failure deadline is widened past the flat
+5-second bound that a cold Windows runner exceeded while spawning the fixture
+daemon.
+
 ## 2026-09-01 — Defer bind-time reflection reconciliation on scheduler contention
 
 Session-start reflection reconciliation now uses a zero-wait scheduler lock and defers when a sibling session is already scheduling the same memory identity. Normal reflection reservation and completion paths retain their existing serialized wait budget.

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// omo-codex-install:819e258f7485f9ccdcbb64a54ac0097bf81cd8e2980d7f907017f224b1f99b98:2c6b840fadcd993447fd3e4c1b3e0965718c343ab68ad16a4972970dd0b828e7
+// omo-codex-install:205bedf47724fa71954f05ae72d7770ef1df26ce392216cb7e5ef72300f7c2be:2c6b840fadcd993447fd3e4c1b3e0965718c343ab68ad16a4972970dd0b828e7
 var __defProp = Object.defineProperty;
 var __returnValue = (v) => v;
 function __exportSetter(name, newValue) {

--- a/packages/omo-codex/src/install/lsp-daemon-reaper.test-support.ts
+++ b/packages/omo-codex/src/install/lsp-daemon-reaper.test-support.ts
@@ -21,6 +21,10 @@ export type SpawnedChild = ChildProcessByStdio<null, Readable, Readable>
 type LegacyEndpointKind = "natural" | "hashed" | "windowsPipe"
 
 const NODE_BINARY_LOOKUP_TIMEOUT_MS = 5_000
+// Event-driven readiness wait: the deadline only bounds failure, so widening it never
+// slows a passing run. Windows CI spawned the fixture daemon in 5.9s (run 33582797101),
+// past the previous flat 5s bound, while the enclosing win32 test budgets allow 120s.
+const CHILD_READY_TIMEOUT_MS = platform() === "win32" ? 30_000 : 5_000
 
 function nodeBinary(): string {
   if (process.env.NODE_BINARY) return process.env.NODE_BINARY
@@ -197,7 +201,7 @@ export function startIdleNodeProcess(): SpawnedChild {
 
 export async function waitForChildReady(child: SpawnedChild): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("legacy daemon fixture did not report ready")), 5_000)
+    const timeout = setTimeout(() => reject(new Error("legacy daemon fixture did not report ready")), CHILD_READY_TIMEOUT_MS)
     const onData = (chunk: Buffer): void => {
       if (!chunk.toString("utf8").includes("ready")) return
       clearTimeout(timeout)


### PR DESCRIPTION
## What

`waitForChildReady` in `packages/omo-codex/src/install/lsp-daemon-reaper.test-support.ts` kept a flat 5-second readiness deadline while the enclosing Windows installer-integration budgets were already widened to 120s (8897ead88). A cold `windows-latest` runner spawned the real legacy-daemon fixture in 5886.80ms, so the only failure in CI run [33582797101](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33582797101) attempt 1, `test (windows-latest, 2/2)`, was:

```
(fail) install-codex > #given a live unverifiable legacy daemon dir #when installing omo
       #then it warns and does not copy legacy IPC state into the OMO home [5886.80ms]
error: legacy daemon fixture did not report ready   (lsp-daemon-reaper.test-support.ts:200)
```

The wait is event-driven (subscribes to the child's stdout `ready` line before resolving), so the deadline only bounds *failure*: widening it cannot slow a passing run. Windows now gets `30_000`; other platforms keep `5_000`. No assertion changed, no test skipped.

The committed installer bundle marker (`scripts/install-dist/install-local.mjs`) is restamped because `script/codex-install-bundle-freshness.test.ts` includes test-support sources in its source digest (verified empirically: the gate goes red without the restamp). The bundle **body digest is unchanged** (`2c6b840f…`), i.e. the shipped installer bytes are identical — this PR cannot change runtime behavior.

## Why not fix failures-store here

The shard 1/2 reds (`facts failure store persistence` x3) were independent timing flakes: all three timed out just past bun's 5s default (5.2-6.3s) doing real lock+fsync IO, and every other annotation (ENOENT rename, EPERM link, parked-vs-backoff) originates inside those same timed-out test bodies racing `afterEach` cleanup after the timeout — no production stack proves a regression. Attempt 2 of the same run turned both windows shards green (run 33582797101, `conclusion=success`, attempt 2), and the same pin/lockfile delta passed all windows jobs on branch runs 33582345364 / 33582374741. Recorded as flake; intentionally not patched in this PR.

## QA (mengmotaHost, Bun only)

- Baseline: `bun test packages/omo-codex/src/install/install-codex.test.ts packages/omo-codex/src/install/lsp-daemon-reaper-live.test.ts` -> 15 pass / 1 skip / 0 fail.
- Typecheck: `bun --cwd packages/omo-codex run typecheck` green; memory-core typecheck green.
- Mutation proof (regression evidence for the budget wiring): deadline -> 1ms reproduces the exact CI failure (`legacy daemon fixture did not report ready`, 4 fail / 0 pass on reaper-live); restore -> green (5 tests, 7.52s).
- `bun test script/codex-install-bundle-freshness.test.ts` -> 2 pass with the restamp staged, 1 fail without it.
- Evidence: `.omo/evidence/20260902-daemon-fixture-ready-budget/` (validation.log + summary.md) in the working tree.

## Residual risk

None expected: test-support only + byte-identical bundle body. Windows readiness failures now surface at 30s with the same error message.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky Windows CI failure in the Codex installer tests by widening the legacy daemon fixture's readiness timeout from 5s to 30s on Windows. The wait is event-driven, so only the failure deadline changes; assertions and passing-run speed are unaffected.

- Windows now allows 30s for the fixture to report ready; other platforms keep 5s.
- Restamps the installer bundle marker because the freshness gate covers test-support sources; the bundle body digest is unchanged, so runtime behavior is identical.

<sup>Written for commit 8887260e996f16d0c7e3c690233848437578294b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

