### PR TITLE
fix(release): build missing prebuilt inputs in omo-native staging

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,14 @@
+## 2026-09-02 — Build missing prebuilt inputs in the omo-native release staging
+
+The omo-native plugin staging now builds `packages/lsp-daemon/dist` and
+`packages/ast-grep-mcp/dist/cli.js` through the canonical root scripts
+(`build:lsp-daemon`, `build:ast-grep-mcp`) whenever they are absent before
+consuming them. The publish-platform workflow installs dependencies with
+`--ignore-scripts`, so the root prepare build never produced these artifacts
+there and every beta.32 platform build failed with ENOENT on the lsp-daemon
+dist. Prebuilt artifacts are still reused untouched when present, and the
+staged payload checks are unchanged.
+
 ## 2026-09-02 — Give the legacy daemon fixture a cold-Windows readiness budget
 
 The Codex installer test fixture's event-driven readiness wait now allows 30

--- a/script/build-omo-native.test.ts
+++ b/script/build-omo-native.test.ts
@@ -1,0 +1,88 @@
+// Contract tests for the prebuilt-input guarantee of the omo-native plugin build.
+// Regression: publish-platform installs with --ignore-scripts, so beta.32 run
+// 33586966744 hit ENOENT on packages/lsp-daemon/dist in every platform leg.
+
+import { describe, expect, test } from "bun:test"
+import { sep } from "node:path"
+
+import { ensurePrebuiltNativeInputs, type PrebuiltInputDependencies } from "./build-omo-native"
+
+function recordingDependencies(input: {
+  readonly existing: readonly string[]
+  readonly scriptStatus?: number
+  readonly scriptError?: Error
+}): { readonly dependencies: PrebuiltInputDependencies; readonly probed: string[]; readonly built: string[] } {
+  const probed: string[] = []
+  const built: string[] = []
+  const dependencies: PrebuiltInputDependencies = {
+    artifactExists: (absolutePath) => {
+      probed.push(absolutePath)
+      return input.existing.some((suffix) => absolutePath.endsWith(suffix.split("/").join(sep)))
+    },
+    runRootScript: (script) => {
+      built.push(script)
+      return { error: input.scriptError, status: input.scriptStatus ?? 0 }
+    },
+  }
+  return { dependencies, probed, built }
+}
+
+describe("ensurePrebuiltNativeInputs", () => {
+  test("#given both prebuilt artifacts present #when ensuring #then no root build script runs", () => {
+    // given
+    const { dependencies, probed, built } = recordingDependencies({
+      existing: ["packages/lsp-daemon/dist", "packages/ast-grep-mcp/dist/cli.js"],
+    })
+
+    // when
+    ensurePrebuiltNativeInputs(dependencies)
+
+    // then
+    expect(built).toEqual([])
+    expect(probed.some((path) => path.endsWith(["packages", "lsp-daemon", "dist"].join(sep)))).toBe(true)
+    expect(probed.some((path) => path.endsWith(["packages", "ast-grep-mcp", "dist", "cli.js"].join(sep)))).toBe(true)
+  })
+
+  test("#given no prebuilt artifacts #when ensuring #then each input builds via its root script in order", () => {
+    // given
+    const { dependencies, built } = recordingDependencies({ existing: [] })
+
+    // when
+    ensurePrebuiltNativeInputs(dependencies)
+
+    // then
+    expect(built).toEqual(["build:lsp-daemon", "build:ast-grep-mcp"])
+  })
+
+  test("#given only the daemon dist missing #when ensuring #then only build:lsp-daemon runs", () => {
+    // given
+    const { dependencies, built } = recordingDependencies({
+      existing: ["packages/ast-grep-mcp/dist/cli.js"],
+    })
+
+    // when
+    ensurePrebuiltNativeInputs(dependencies)
+
+    // then
+    expect(built).toEqual(["build:lsp-daemon"])
+  })
+
+  test("#given a root build script exits nonzero #when ensuring #then the exit code surfaces", () => {
+    // given
+    const { dependencies } = recordingDependencies({ existing: [], scriptStatus: 7 })
+
+    // when / then
+    expect(() => ensurePrebuiltNativeInputs(dependencies)).toThrow(
+      "build:lsp-daemon failed with exit code 7",
+    )
+  })
+
+  test("#given the spawn itself errors #when ensuring #then the error propagates", () => {
+    // given
+    const spawnError = new Error("spawn bun ENOENT")
+    const { dependencies } = recordingDependencies({ existing: [], scriptError: spawnError })
+
+    // when / then
+    expect(() => ensurePrebuiltNativeInputs(dependencies)).toThrow("spawn bun ENOENT")
+  })
+})

--- a/script/build-omo-native.ts
+++ b/script/build-omo-native.ts
@@ -90,7 +90,42 @@ function parseArgs(argv: readonly string[]): BuildOptions {
   return { outputDir, checkOnly }
 }
 
+// The native staging chain (build:senpi-plugin:native) consumes prebuilt package
+// artifacts instead of rebuilding them, unlike build:senpi-plugin which always
+// runs build:lsp-daemon and build:ast-grep-mcp first. Callers such as the
+// publish-platform workflow install with --ignore-scripts, so the root prepare
+// build never produced these inputs there; build any missing one through the
+// same root scripts the full chain uses.
+const PREBUILT_NATIVE_INPUTS = [
+  { artifactPath: join("packages", "lsp-daemon", "dist"), buildScript: "build:lsp-daemon" },
+  { artifactPath: join("packages", "ast-grep-mcp", "dist", "cli.js"), buildScript: "build:ast-grep-mcp" },
+] as const
+
+export interface PrebuiltInputDependencies {
+  readonly artifactExists: (absolutePath: string) => boolean
+  readonly runRootScript: (script: string) => { readonly error?: Error | undefined; readonly status: number | null }
+}
+
+const defaultPrebuiltInputDependencies: PrebuiltInputDependencies = {
+  artifactExists: existsSync,
+  runRootScript: (script) => spawnSync("bun", ["run", script], { cwd: repoRoot, stdio: "inherit" }),
+}
+
+export function ensurePrebuiltNativeInputs(
+  dependencies: PrebuiltInputDependencies = defaultPrebuiltInputDependencies,
+): void {
+  for (const input of PREBUILT_NATIVE_INPUTS) {
+    if (dependencies.artifactExists(join(repoRoot, input.artifactPath))) continue
+    const result = dependencies.runRootScript(input.buildScript)
+    if (result.error !== undefined) throw result.error
+    if (result.status !== 0) {
+      throw new Error(`${input.buildScript} failed with exit code ${result.status ?? 1}`)
+    }
+  }
+}
+
 function runSenpiPluginBuild(outputDir: string): void {
+  ensurePrebuiltNativeInputs()
   const buildRoot = mkdtempSync(join(tmpdir(), "omo-native-build-"))
   const lspSource = join(buildRoot, "lsp-daemon", "dist")
   const astSource = join(buildRoot, "ast-grep-mcp", "cli.js")
@@ -195,7 +230,9 @@ function main(argv: readonly string[]): number {
 }
 
 try {
+  if (import.meta.main) {
   process.exit(main(process.argv.slice(2)))
+}
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error))
   process.exit(1)


### PR DESCRIPTION
## What

Every `publish-platform` leg of the beta.32 retry (run [33586966744](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33586966744)) died with the same fatal before staging began:

```
ENOENT: no such file or directory, lstat '...\packages\lsp-daemon\dist'
bun run script/build-omo-native.ts --output ...\omo-plugin-stage-...\plugin failed with exit code 1
```

Root cause: `publish-platform.yml` installs with `bun install --frozen-lockfile --ignore-scripts` (line 67), so the root `prepare` build never runs there. beta.31's release path tolerated that because `build-omo-native` invoked the self-contained `build:senpi-plugin` chain, which always runs `build:lsp-daemon` and `build:ast-grep-mcp` first. The post-beta.31 rework (`a63cc0357`/`d2dcb49f3` isolation lane) switched to `build:senpi-plugin:native`, which **consumes** prebuilt `packages/lsp-daemon/dist` and `packages/ast-grep-mcp/dist/cli.js` via `cpSync` without anything producing them — the ast-grep entry was the guaranteed next fatal after the daemon dist.

## Fix (pipeline contract, not dist patching)

`runSenpiPluginBuild()` now calls `ensurePrebuiltNativeInputs()` first: any missing input is built through the **same canonical root scripts** the full chain uses (`build:lsp-daemon`, `build:ast-grep-mcp`); present artifacts keep being reused untouched. `main()` gained the `import.meta.main` guard (same precedent as `build-omo-binary.ts:717`) so the new contract tests can import the seam without executing a build. `findMissingArtifact` payload checks are unchanged — nothing skipped, nothing weakened. This fixes every caller (publish workflow, fresh checkouts running `bun run build:omo-native`), not just this workflow.

## Proof (mengmotaHost, Bun only)

- **RED**: publish-identical worktree (`bun install --frozen-lockfile --ignore-scripts`, both prebuilt inputs absent) reproduces the exact release fatal: `ENOENT ... lstat '.../packages/lsp-daemon/dist'`, exit 1.
- **GREEN** (same env, fixed script):
  - new `script/build-omo-native.test.ts` — 5/5 (missing→builds in order, present→no-op, nonzero exit surfaces, spawn error propagates)
  - `bun run typecheck:script` green
  - `bun run script/build-omo-native.ts --output <tmp>` → exit 0, `omo-native payload complete (36 required artifacts present)`
  - **release-platform mirror**: `bun run script/build-omo-binary.ts --target darwin-arm64 --omo-version 5.0.0-beta.32 --omo-ai-version 5.0.0-0.beta.32` → exit 0, `omo-darwin-arm64` (107MB) + SHA256SUMS
- **Pre-existing failure isolated**: `script/build-omo-binary.test.ts` shows `sidecar parity set` failing 1/23 in this worktree — a pristine `origin/dev` worktree with the identical `--ignore-scripts` install fails that SAME test **plus** `plugin staging isolation guard` (2 fails; the guard fails with this very ENOENT). With the fix: 20 pass → 21 pass; the parity fail is environmental to ignore-scripts installs and green on full-install CI.
- Evidence: `.omo/evidence/20260902-publish-prebuilt-inputs/` (red/green logs + summary).

## Residual risk

Publish legs additionally exercise `npm --prefix packages/lsp-daemon ci` on each platform runner (network + platform npm). That is the same step every full CI install already runs via the root prepare build, now simply reachable from the release path again — identical to the beta.31 contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `omo-native` release staging so `publish-platform` no longer fails with ENOENT when prebuilt native inputs are missing. The beta.32 publish legs died before staging because the workflow installs with `--ignore-scripts` and the native staging chain consumed `packages/lsp-daemon/dist` and `packages/ast-grep-mcp/dist/cli.js` without building them. Staging now builds missing inputs through the canonical `build:lsp-daemon` and `build:ast-grep-mcp` scripts and reuses existing artifacts untouched.

**Bug Fixes**
- Adds contract tests for the new prebuilt-input guarantee, covering missing, present, and failing script cases.
- Guards `main()` with `import.meta.main` so tests can import the build module without running a build.

<sup>Written for commit daa6a0e5f1026f7bc5390f3a685a97c04b11ad7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

