### PR TITLE
refactor(model-core): drop the ulw reviewer agent fallback chains

### DIFF
--- a/packages/model-core/AGENTS.md
+++ b/packages/model-core/AGENTS.md
@@ -14,7 +14,7 @@ Harness-neutral model resolution core (`@oh-my-opencode/model-core`). Resolves w
 | `model-resolution-pipeline.ts` | `resolveModelPipeline()` - 6-step resolution with logging hooks for testing |
 | `provider-cache.ts` | `ProviderCache` DI interface: `readConnectedProvidersCache()`, `findProviderModelMetadata()` |
 | `model-availability.ts` | `fuzzyMatchModel()` - exact, then exact model-ID, then shortest **substring** match against `availableModels` (not prefix) |
-| `agent-model-requirements.ts` | Hardcoded `AGENT_MODEL_REQUIREMENTS` fallback chains (14 agents) |
+| `agent-model-requirements.ts` | Hardcoded `AGENT_MODEL_REQUIREMENTS` fallback chains (11 agents) |
 | `category-model-requirements.ts` | Hardcoded `CATEGORY_MODEL_REQUIREMENTS` fallback chains (8 categories) |
 | `provider-model-id-transform.ts` | Provider-specific ID transforms (Vercel sub-provider inference, Claude version dots, Gemini preview suffixes) |
 | `model-capabilities/index.ts` | `getModelCapabilities()` - 4-source priority: runtime metadata -> runtime snapshot -> bundled snapshot -> heuristic family; alias canonicalization, suffix/prefix-tolerant lookup candidates, `resolutionMode` diagnostics |

--- a/packages/model-core/src/agent-model-requirements.ts
+++ b/packages/model-core/src/agent-model-requirements.ts
@@ -129,33 +129,6 @@ export const AGENT_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["opencode-go"], model: "glm-5.2" }
     ],
   },
-  "omo-senpi-code-reviewer": {
-    fallbackChain: [
-      { providers: ["openai", "openai-codex"], model: "gpt-5.6-terra", variant: "medium" },
-      { providers: ["github-copilot"], model: "gpt-5.6-terra", variant: "medium" },
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
-      { providers: ["opencode-go"], model: "glm-5.2" },
-      { providers: ["kimi-for-coding"], model: "kimi-k3" }
-    ],
-  },
-  "omo-senpi-qa-executor": {
-    fallbackChain: [
-      { providers: ["openai", "openai-codex"], model: "gpt-5.6-luna", variant: "high" },
-      { providers: ["github-copilot"], model: "gpt-5.6-luna", variant: "high" },
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-4-6" },
-      { providers: ["opencode-go"], model: "glm-5.2" },
-      { providers: ["kimi-for-coding"], model: "kimi-k3" }
-    ],
-  },
-  "omo-senpi-gate-reviewer": {
-    fallbackChain: [
-      { providers: ["openai", "openai-codex"], model: "gpt-5.6-sol", variant: "low" },
-      { providers: ["github-copilot"], model: "gpt-5.6-sol", variant: "low" },
-      { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-opus-5", variant: "max" },
-      { providers: ["opencode-go"], model: "glm-5.2" },
-      { providers: ["kimi-for-coding"], model: "kimi-k3" }
-    ],
-  },
   atlas: {
     fallbackChain: [
       { providers: ["anthropic", "github-copilot", "opencode"], model: "claude-sonnet-5" },

--- a/packages/model-core/src/model-requirements-invariants.test.ts
+++ b/packages/model-core/src/model-requirements-invariants.test.ts
@@ -13,9 +13,6 @@ const expectedAgents = [
   "momus",
   "atlas",
   "sisyphus-junior",
-  "omo-senpi-code-reviewer",
-  "omo-senpi-qa-executor",
-  "omo-senpi-gate-reviewer",
 ] as const
 
 const expectedCategories = [


### PR DESCRIPTION
## Summary

Drops the three `omo-senpi-*` ulw reviewer agents (`omo-senpi-code-reviewer`, `omo-senpi-qa-executor`, `omo-senpi-gate-reviewer`) from `AGENT_MODEL_REQUIREMENTS` in `packages/model-core`.

These entries were dead on this surface: nothing in `packages/omo-opencode` (the only consumer of `AGENT_MODEL_REQUIREMENTS` besides model-core's own tests) references the reviewer trio. They existed only as a hand-mirrored "source of truth" for the senpi-task copy, and that copy is being replaced by category-based resolution (companion PR: `feat/reviewer-agents-category-model-routing`), so there is nothing left to mirror.

## Changes

- `packages/model-core/src/agent-model-requirements.ts`: remove the three reviewer entries; every other agent and every category entry is byte-identical.
- `packages/model-core/src/model-requirements-invariants.test.ts`: `expectedAgents` re-pinned to the 11 remaining agents (RED at 14 vs 11, then GREEN).
- `packages/model-core/AGENTS.md`: "14 agents" -> "11 agents".

## Verification

- `bun test packages/model-core/src/model-requirements-*.test.ts` green (RED->GREEN transcripts captured).
- `bunx tsgo --noEmit -p packages/model-core/tsconfig.json` exit 0.
- `rg 'omo-senpi-' packages/model-core` prints nothing.
- Full `bun test packages/model-core` + typecheck run remotely on a clean clone (see checks).

Independent of the companion PR; mergeable on its own.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the three unused `omo-senpi-*` reviewer agent fallback chains from `AGENT_MODEL_REQUIREMENTS` in `packages/model-core`.

These entries were dead: the only consumer of the requirements, `omo-opencode`, never references them, and they merely mirrored the senpi-task copy that's being replaced by category-based resolution.

Also updates the invariant test's expected agent list and the agent count in `AGENTS.md` from 14 to 11.

<sup>Written for commit 2546845e11d10d37e4c05b03f642d38c905f1613. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

