### PR TITLE
test(openclaw-core): make reply-listener restart readiness deterministic

### DIFF
--- a/.omo/evidence/20260902-openclaw-restart-test-determinism/qa-summary.md
+++ b/.omo/evidence/20260902-openclaw-restart-test-determinism/qa-summary.md
@@ -1,0 +1,97 @@
+# OpenClaw restart test determinism QA
+
+## Scope
+
+The only code change is in `packages/openclaw-core/src/__tests__/reply-listener-restart-persisted-config.test.ts`. The test now transforms the pending daemon state into its ready state synchronously inside the spawn mock. `startReplyListener()` writes that pending state synchronously before calling the mock, so the mock observes its real production boundary. No production file changed.
+
+## Failing-first evidence
+
+GitHub Actions run [33580607971](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33580607971), `dev` push `e719373053473d29ae0513b7b54159fede377395`, failed in `test (windows-latest, 2/2)`.
+
+Observed failing test output:
+
+```text
+(fail) startReplyListener > restarts an already running daemon when persisted reply-listener config is stale [1283.41ms]
+```
+
+The original mock started readiness with `setTimeout(..., 5)` and recursively scheduled another timer while the pending state file was absent. The production path creates and writes that file before the synchronous spawn call, so the timer is unnecessary and made the test depend on scheduler timing.
+
+## Automated verification
+
+### Focused regression
+
+**What was tested:**
+
+```text
+bun test packages/openclaw-core/src/__tests__/reply-listener-restart-persisted-config.test.ts
+```
+
+**Observed:** exit 0.
+
+```text
+1 pass
+0 fail
+6 expect() calls
+Ran 1 test across 1 file. [3.16s]
+```
+
+The restart test passed in 12.73 ms. Its existing assertions remain intact: restart success, exactly one spawn, SIGTERM of the prior daemon, and the three persisted-config checks.
+
+### Package suite
+
+**What was tested:**
+
+```text
+bun test packages/openclaw-core
+```
+
+**Observed:** exit 0.
+
+```text
+68 pass
+0 fail
+156 expect() calls
+Ran 68 tests across 15 files. [5.78s]
+```
+
+The changed stale persisted-config test passed in 1.58 ms. The related runtime-signature restart, startup, timeout, state, daemon-resolution, and daemon-process tests also passed.
+
+### Scoped typecheck
+
+**What was tested:**
+
+```text
+bunx --no-install tsgo --noEmit -p packages/openclaw-core/tsconfig.json
+```
+
+**Observed:** exit 0 with no diagnostics.
+
+### Isolated OpenCode real-harness smoke
+
+**What was tested:**
+
+```text
+bash .agents/skills/opencode-qa/scripts/tui-smoke.sh --self-test
+```
+
+**Observed:** exit 0.
+
+```text
+PASS: TUI rendered under tmux (marker found; version 1.18.26)
+PASS: send-keys reached the TUI composer (sentinel echoed)
+PASS: tmux session torn down (has-session false)
+PASS: real DB untouched (session count 8046 unchanged)
+PASS: tui-smoke
+```
+
+This drives the installed OpenCode TUI through tmux. The skill creates an isolated XDG sandbox and proved the real OpenCode database session count was unchanged before and after the smoke.
+
+## Why this is sufficient
+
+The focused test now drives readiness at the exact synchronous state-write/spawn boundary that production guarantees. It retains every restart and persistence assertion. The complete core-package suite covers adjacent reply-listener behavior, scoped typecheck covers the changed TypeScript package, and the isolated real-harness smoke confirms the consuming OpenCode surface boots, accepts input, cleans up, and preserves the host database.
+
+## Environment notes and omissions
+
+The worktree initially had no `node_modules`; the first focused and package commands could not resolve `@oh-my-opencode/rules-engine`, and `tsgo` was absent from `PATH`. `bun install --frozen-lockfile` materialized the workspace dependencies but its lifecycle build stopped when inherited local submodule URLs were blocked by Git file-transport policy. No tracked source or lockfile changed. The final test and typecheck commands above used the installed workspace dependencies and passed.
+
+No credential, token, auth-header, environment-variable, or raw database content was recorded.

--- a/packages/openclaw-core/src/__tests__/reply-listener-restart-persisted-config.test.ts
+++ b/packages/openclaw-core/src/__tests__/reply-listener-restart-persisted-config.test.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../../../bun-test.d.ts" />
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { dirname, join } from "path"
 import { fileURLToPath, pathToFileURL } from "url"
@@ -167,30 +167,21 @@ describe("startReplyListener", () => {
       livePids.add(nextPid)
       daemonPids.add(nextPid)
 
-      const markReady = (): void => {
-        if (!existsSync(stateFilePath)) {
-          setTimeout(markReady, 5)
-          return
-        }
-
-        const pendingState = JSON.parse(readFileSync(stateFilePath, "utf-8")) as Record<string, unknown>
-        writeFileSync(
-          stateFilePath,
-          JSON.stringify(
-            {
-              ...pendingState,
-              isRunning: true,
-              pid: nextPid,
-              lastPollAt: "2026-04-07T00:00:00.000Z",
-              messagesSeen: 2,
-            },
-            null,
-            2,
-          ),
-        )
-      }
-
-      setTimeout(markReady, 5)
+      const pendingState = JSON.parse(readFileSync(stateFilePath, "utf-8")) as Record<string, unknown>
+      writeFileSync(
+        stateFilePath,
+        JSON.stringify(
+          {
+            ...pendingState,
+            isRunning: true,
+            pid: nextPid,
+            lastPollAt: "2026-04-07T00:00:00.000Z",
+            messagesSeen: 2,
+          },
+          null,
+          2,
+        ),
+      )
 
       return {
         pid: nextPid,


### PR DESCRIPTION
## Summary

Replaces the stale persisted-config restart test's timer-driven readiness poll with a synchronous ready-state write inside the spawn mock. Production already persists the pending state immediately before invoking that mock, so the test now models the real spawn/state boundary without scheduler timing luck.

## Changes

- The restart mock reads the already-persisted pending state and writes the expected ready state during its synchronous spawn call.
- Removes the unused file-existence check and every test-only timer while retaining all six existing assertions.
- Adds reviewer-readable QA evidence for the failing Windows CI run, focused regression, package suite, scoped typecheck, and isolated OpenCode harness smoke.

## QA & Evidence

- **What was tested:** Focused stale persisted-config restart regression.
  **Observed result:** 1 pass, 0 fail, 6 expectations.
- **What was tested:** `bun test packages/openclaw-core`.
  **Observed result:** 68 pass, 0 fail, 156 expectations.
- **What was tested:** `bunx --no-install tsgo --noEmit -p packages/openclaw-core/tsconfig.json`.
  **Observed result:** exit 0 with no diagnostics.
- **What was tested:** Isolated real OpenCode TUI smoke through `opencode-qa`.
  **Observed result:** rendered under tmux, accepted input, cleaned up, and preserved the real OpenCode DB session count.
- **Artifact:** [`.omo/evidence/20260902-openclaw-restart-test-determinism/qa-summary.md`](https://github.com/code-yeongyu/oh-my-openagent/blob/test/openclaw-restart-determinism/.omo/evidence/20260902-openclaw-restart-test-determinism/qa-summary.md)

## Risks & Residuals

The change is test-only. The focused test preserves all prior restart and persisted-config assertions while removing its timer dependency. No production behavior changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the timer-driven readiness poll in the stale persisted-config restart test with a synchronous ready-state write inside the spawn mock, so the test no longer depends on scheduler timing and stops flaking on Windows CI. The mock now mirrors the real spawn boundary; no production code changes.

- The mock reads the already-persisted pending state and writes the expected ready state during its synchronous spawn call.
- Removes the unused file-existence check and all test-only timers while keeping all six existing assertions.
- Adds a QA evidence file covering the failing Windows run, focused regression, package suite, scoped typecheck, and isolated OpenCode TUI smoke.

<sup>Written for commit 57e2ef0f6f557940a1679fee6fc7abf3e3517eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

