### PR TITLE
ci: preserve merged push workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.omo/evidence/20260902-ci-preserve-push-runs/README.md
+++ b/.omo/evidence/20260902-ci-preserve-push-runs/README.md
@@ -45,3 +45,19 @@ policy before the two workflow edits.
 ## Why this is enough
 
 GitHub Actions evaluates `cancel-in-progress` for each run. The predicate is true
+only for pull-request events, so a newer revision still cancels obsolete review
+work. It is false for protected-branch push events, so a later merge can no
+longer cancel validation of an earlier merged commit in the same workflow/ref
+group. The YAML-parsing regression covers both affected workflows, while
+actionlint and the repository workflow tests cover expression syntax and
+surrounding workflow wiring.
+
+The final real-surface proof is performed after this PR merges: the following
+repair PR merges intentionally create adjacent `dev` push runs, and each run
+must reach a terminal non-cancelled result.
+
+## What was omitted
+
+No credentials, environment dumps, auth headers, or secret-bearing logs are
+stored. The evidence keeps only command lines, sanitized test output, and
+GitHub run identifiers needed for review.

--- a/.omo/evidence/20260902-ci-preserve-push-runs/README.md
+++ b/.omo/evidence/20260902-ci-preserve-push-runs/README.md
@@ -1,0 +1,47 @@
+# CI concurrency preservation evidence
+
+## Scope
+
+- Branch: `fix/ci-preserve-merge-push-runs` from `origin/dev@a0dd6cc91`.
+- Incident basis: the supplied repair plan identifies 25 cancelled CI runs and one
+  cancelled Web CI run for merged commits because later pushes cancelled the same
+  workflow/ref concurrency group.
+
+## Change
+
+Both `CI` and `Web CI` now set `cancel-in-progress` to
+`${{ github.event_name == 'pull_request' }}`.
+
+The concurrency group remains `${{ github.workflow }}-${{ github.ref }}`.
+
+## Failing-first contract
+
+Command:
+
+```sh
+bun test script/ci-fast-path.test.ts
+```
+
+Before either workflow changed, the new YAML-parsing contract failed with the
+expected pull-request-only expression and `Received: true`; see
+`red-contract-summary.txt`.
+
+## Validation
+
+- `bun test script/ci-fast-path.test.ts`: 14 pass, 0 fail. The added contract
+  parses both workflows and requires the workflow/ref group plus the
+  pull-request-only cancellation expression. See `green-focused-contract.txt`.
+- `bun test script/ci-fast-path.test.ts script/ci-job-summary-workflow.test.ts`:
+  18 pass, 0 fail. See `green-workflow-tests.txt`.
+- `bun run typecheck:script`: exit 0. See `typecheck-script.txt`.
+- `actionlint` 1.7.10 on both edited workflows: exit 0. See `actionlint.txt`.
+- `actionlint` 1.7.10 using the repository workflow-lint invocation over every
+  workflow: exit 0. See `actionlint-all-workflows.txt`.
+
+Each command was run against the final worktree state on macOS arm64 with Bun
+1.3.14, except the failing-first run, which intentionally used the old workflow
+policy before the two workflow edits.
+
+## Why this is enough
+
+GitHub Actions evaluates `cancel-in-progress` for each run. The predicate is true

--- a/.omo/evidence/20260902-ci-preserve-push-runs/actionlint-all-workflows.txt
+++ b/.omo/evidence/20260902-ci-preserve-push-runs/actionlint-all-workflows.txt
@@ -1,0 +1,14 @@
+Start downloading actionlint v1.7.10 to /var/folders/13/yyrkyfts6qsg303mcwpwzq200000gn/T/tmp.fR8pgMLAcZ
+Detected OS=darwin ext=tar.gz arch=arm64
+Downloading https://github.com/rhysd/actionlint/releases/download/v1.7.10/actionlint_1.7.10_darwin_arm64.tar.gz with curl
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+x actionlint100 2041k  100 2041k    0     0  8300k      0 --:--:-- --:--:-- --:--:-- 8300k
+
+Downloaded and unarchived executable: /var/folders/13/yyrkyfts6qsg303mcwpwzq200000gn/T/tmp.fR8pgMLAcZ/actionlint
+Done: 1.7.10
+installed by downloading from release page
+built with go1.25.5 compiler for darwin/arm64
+
+exit=0

--- a/.omo/evidence/20260902-ci-preserve-push-runs/actionlint.txt
+++ b/.omo/evidence/20260902-ci-preserve-push-runs/actionlint.txt
@@ -1,0 +1,14 @@
+Start downloading actionlint v1.7.10 to /var/folders/13/yyrkyfts6qsg303mcwpwzq200000gn/T/tmp.jCD1vMZhgf
+Detected OS=darwin ext=tar.gz arch=arm64
+Downloading https://github.com/rhysd/actionlint/releases/download/v1.7.10/actionlint_1.7.10_darwin_arm64.tar.gz with curl
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+x actionlint100 2041k  100 2041k    0     0  3213k      0 --:--:-- --:--:-- --:--:-- 3213k
+
+Downloaded and unarchived executable: /var/folders/13/yyrkyfts6qsg303mcwpwzq200000gn/T/tmp.jCD1vMZhgf/actionlint
+Done: 1.7.10
+installed by downloading from release page
+built with go1.25.5 compiler for darwin/arm64
+
+exit=0

--- a/.omo/evidence/20260902-ci-preserve-push-runs/green-focused-contract.txt
+++ b/.omo/evidence/20260902-ci-preserve-push-runs/green-focused-contract.txt
@@ -1,0 +1,22 @@
+bun test v1.3.14 (0d9b296a)
+
+script/ci-fast-path.test.ts:
+(pass) CI fast-path classifier > ships the classifier consumed by CI [0.51ms]
+(pass) CI fast-path classifier > release-state pull request [30.13ms]
+(pass) CI fast-path classifier > ordinary source push [24.82ms]
+(pass) CI fast-path classifier > generated release merge push [24.98ms]
+(pass) CI fast-path classifier > direct release commit [26.15ms]
+(pass) CI fast-path classifier > web-only pull request [27.14ms]
+(pass) CI fast-path classifier > mixed web and root change [26.56ms]
+(pass) CI fast-path classifier > fails closed when a release-looking push is not a real merge commit [26.98ms]
+(pass) CI fast-path classifier > fails closed when a release-looking merge push has no available diff [26.71ms]
+(pass) CI fast-path classifier > fails closed when the diff is unavailable or empty [50.47ms]
+(pass) CI fast-path workflow wiring > preserves required job identities while gating expensive work [4.99ms]
+(pass) CI fast-path workflow wiring > keeps schema generation on master and skips duplicate draft generation [1.02ms]
+(pass) CI fast-path workflow wiring > keeps the Web CI path contract aligned with classifier inputs [0.33ms]
+(pass) CI fast-path workflow wiring > cancels superseded pull requests without cancelling protected branch pushes [0.85ms]
+
+ 14 pass
+ 0 fail
+ 26 expect() calls
+Ran 14 tests across 1 file. [894.00ms]

--- a/.omo/evidence/20260902-ci-preserve-push-runs/green-workflow-tests.txt
+++ b/.omo/evidence/20260902-ci-preserve-push-runs/green-workflow-tests.txt
@@ -1,0 +1,28 @@
+bun test v1.3.14 (0d9b296a)
+
+script/ci-job-summary-workflow.test.ts:
+(pass) GitHub workflow job summaries > #given a new step-based workflow job #when workflow coverage is checked #then the job is discovered automatically [0.91ms]
+(pass) GitHub workflow job summaries > #given repository workflows #when inspected #then every step-based job writes a concise Markdown summary [6.13ms]
+(pass) GitHub workflow job summaries > #given a privileged publish summary #when it renders dispatch inputs #then raw inputs are passed through env [0.17ms]
+(pass) GitHub workflow job summaries > #given summary inputs #when the shared writer runs #then it emits the Markdown contract GitHub renders [18.75ms]
+
+script/ci-fast-path.test.ts:
+(pass) CI fast-path classifier > ships the classifier consumed by CI [0.14ms]
+(pass) CI fast-path classifier > release-state pull request [32.48ms]
+(pass) CI fast-path classifier > ordinary source push [28.41ms]
+(pass) CI fast-path classifier > generated release merge push [27.09ms]
+(pass) CI fast-path classifier > direct release commit [29.56ms]
+(pass) CI fast-path classifier > web-only pull request [27.89ms]
+(pass) CI fast-path classifier > mixed web and root change [27.71ms]
+(pass) CI fast-path classifier > fails closed when a release-looking push is not a real merge commit [26.69ms]
+(pass) CI fast-path classifier > fails closed when a release-looking merge push has no available diff [23.25ms]
+(pass) CI fast-path classifier > fails closed when the diff is unavailable or empty [51.60ms]
+(pass) CI fast-path workflow wiring > preserves required job identities while gating expensive work [4.59ms]
+(pass) CI fast-path workflow wiring > keeps schema generation on master and skips duplicate draft generation [0.98ms]
+(pass) CI fast-path workflow wiring > keeps the Web CI path contract aligned with classifier inputs [0.32ms]
+(pass) CI fast-path workflow wiring > cancels superseded pull requests without cancelling protected branch pushes [0.86ms]
+
+ 18 pass
+ 0 fail
+ 91 expect() calls
+Ran 18 tests across 2 files. [793.00ms]

--- a/.omo/evidence/20260902-ci-preserve-push-runs/red-contract-summary.txt
+++ b/.omo/evidence/20260902-ci-preserve-push-runs/red-contract-summary.txt
@@ -1,0 +1,9 @@
+Command:
+  bun test script/ci-fast-path.test.ts
+
+Result before the workflow edits: exit 1.
+Expected: ${{ github.event_name == 'pull_request' }}
+Received: true
+
+The contract parses both CI workflow paths. The old unconditional policy fails
+when it reaches the first workflow because `true` is not the event predicate.

--- a/.omo/evidence/20260902-ci-preserve-push-runs/typecheck-script.txt
+++ b/.omo/evidence/20260902-ci-preserve-push-runs/typecheck-script.txt
@@ -1,0 +1,3 @@
+$ tsgo --noEmit -p script/tsconfig.json
+
+exit=0

--- a/script/ci-fast-path.test.ts
+++ b/script/ci-fast-path.test.ts
@@ -194,4 +194,15 @@ describe("CI fast-path workflow wiring", () => {
       ".github/workflows/web-ci.yml",
     ])
   })
+
+  test("cancels superseded pull requests without cancelling protected branch pushes", () => {
+    for (const workflowPath of [ciWorkflowPath, webWorkflowPath]) {
+      const workflow = parseWorkflow(workflowPath)
+      const concurrency = workflow["concurrency"]
+      if (!isRecord(concurrency)) throw new Error(`${workflowPath.pathname} must define concurrency`)
+
+      expect(concurrency["group"]).toBe("${{ github.workflow }}-${{ github.ref }}")
+      expect(concurrency["cancel-in-progress"]).toBe("${{ github.event_name == 'pull_request' }}")
+    }
+  })
 })


### PR DESCRIPTION
## Summary

Merged `push` runs on `dev` and `master` now retain their workflow/ref concurrency group without cancelling earlier merged commits. Superseded pull-request runs still cancel to avoid duplicate PR work. The same policy is enforced for both CI and Web CI.

## Changes

- Added a YAML-parsing workflow contract that reads both shipped workflows and requires the pull-request-only cancellation predicate.
- Changed only the two `cancel-in-progress` values; triggers, concurrency groups, jobs, and package versions remain unchanged.

## QA and evidence

- Failing-first contract: `.omo/evidence/20260902-ci-preserve-push-runs/red-contract-summary.txt`
- Focused contract: 14 pass, 0 fail in `.omo/evidence/20260902-ci-preserve-push-runs/green-focused-contract.txt`
- Related workflow tests: 18 pass, 0 fail in `.omo/evidence/20260902-ci-preserve-push-runs/green-workflow-tests.txt`
- Script typecheck: exit 0 in `.omo/evidence/20260902-ci-preserve-push-runs/typecheck-script.txt`
- actionlint 1.7.10 on the edited workflows and all workflows: exit 0 in `.omo/evidence/20260902-ci-preserve-push-runs/actionlint.txt` and `.omo/evidence/20260902-ci-preserve-push-runs/actionlint-all-workflows.txt`

## Risks and residuals

The event predicate is evaluated by GitHub Actions: only `pull_request` runs may cancel. Push runs on the protected branches are therefore preserved. The regression test parses the committed YAML for both workflows, and actionlint validates the expression. No merge has been requested; this PR is intentionally left for the lead to merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops CI runs for pushes merged to `dev` and `master` from being cancelled by later pushes to the same branch. `cancel-in-progress` in `.github/workflows/ci.yml` and `.github/workflows/web-ci.yml` is now `${{ github.event_name == 'pull_request' }}`, so superseded pull-request runs still cancel while merged push runs are preserved.

**Validation**
- Adds a regression test in `script/ci-fast-path.test.ts` that parses both workflows and requires the workflow/ref concurrency group plus the pull-request-only cancellation predicate.
- Adds an evidence README and logs under `.omo/evidence/20260902-ci-preserve-push-runs/` covering focused tests, related workflow tests, script typecheck, and actionlint.

<sup>Written for commit 9ca06453ddfa4e79f5ef870e69f68ed3efffe0e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

