### PR TITLE
fix(codex-installer): materialize prompts-core directive into the plugin cache

### DIFF
--- a/.omo/evidence/20260902-codex-cache-prompt-layout/QA.md
+++ b/.omo/evidence/20260902-codex-cache-prompt-layout/QA.md
@@ -1,0 +1,35 @@
+# QA — Codex plugin cache: materialize prompts-core ultrawork directive (beta.33 LazyCodex smoke fix)
+
+Date: 2026-09-02 · base: origin/dev 38a46e6013ecd1b1d68c3c0fde7964f927184732 · compute: bunshin mengmotaMac (darwin-arm64, bun 1.4.0, node 26.7.0) + gorky (linux-x86_64, bun 1.4.0, node 24.4.1). Nothing ran on the session host.
+
+## Defect
+publish run 33596952745 (v5.0.0-beta.33) `post-publish-verify / Smoke test published lazycodex-ai` failed: the installer copies only `packages/omo-codex/plugin` into `<CODEX_HOME>/plugins/cache/sisyphuslabs/omo/<version>` and re-runs `npm run sync:skills` there; `sync-skills.mjs` resolved the canonical prompt as `<plugin>/../../../packages/prompts-core/prompts/ultrawork/codex.md` = `plugins/cache/packages/...` -> ENOENT. beta.32's fix (#7630) put the file in the tarball but the flattened cache never sees it.
+
+## Fix
+- `src/install/codex-cache-install.ts`: `copyCanonicalPromptSources()` (same pattern as `copyRootRuntimeDists`) materializes `<repoRoot>/packages/prompts-core/prompts/ultrawork/codex.md` at `<pluginRoot>/packages/prompts-core/prompts/ultrawork/codex.md` in the cache.
+- `plugin/scripts/canonical-ultrawork-directive.mjs`: `resolveCanonicalUltraworkDirectivePath(pluginRoot, repoRoot)` -> checkout path when present, else plugin-internal copy; `sync-skills.mjs` uses it.
+- `scripts/install-dist/install-local.mjs` regenerated (`bun run build:codex-install`); sha256 a3651b8b677d2f064fd825b290b90d8ecad77d72566733ce0f50621441dedcf3, byte-identical on mengmotaMac and gorky; marker `4c2cf806...:774951d3...`.
+
+## C1 installer test (packages/omo-codex/scripts/install-cache-copy.test.mjs)
+- RED (tests patch only, committed bundle): `node --test install-cache-copy.test.mjs` -> tests 7 / pass 6 / fail 1 = "#given packaged prompts-core directive ... materialized into the plugin cache" (both machines).
+- GREEN (fix + rebuilt bundle): full `node --test packages/omo-codex/scripts/*.test.mjs` after CI-parity prebuilds (build:git-bash-mcp, build:lsp-tools-mcp, build:lsp-daemon): mengmotaMac tests 172 / pass 172 / fail 0. gorky 169/172: the 3 "bun absent everywhere ... omo runtime wrapper" cases fail there before and after the change (host PATH shape), not related.
+
+## C2 resolver test (packages/omo-codex/plugin/test/canonical-ultrawork-directive.test.mjs)
+- RED: `ERR_MODULE_NOT_FOUND .../plugin/scripts/canonical-ultrawork-directive.mjs` (module absent on dev).
+- GREEN: 2/2 pass (checkout wins; flattened cache falls back to plugin-internal copy).
+
+## C3 real surface — the failing smoke, replayed against the published beta.33 tarball (mengmotaMac, isolated HOME/CODEX_HOME/CODEX_LOCAL_BIN_DIR under /tmp/omo-beta34-c3-mengmotaMac)
+- RED (tarball untouched): `node packages/omo-codex/scripts/install-local.mjs install --no-tui --codex-autonomous` -> exit 1
+  `Error: ENOENT: no such file or directory, open '.../codex/plugins/cache/packages/prompts-core/prompts/ultrawork/codex.md'` at `sync-skills.mjs:278` (identical to the CI smoke failure).
+- GREEN (only install-dist bundle + sync-skills.mjs + canonical-ultrawork-directive.mjs overlaid): exit 0, `Installed 1 plugin(s) from sisyphuslabs.`
+  cache 5.0.0-beta.33: `packages/prompts-core/prompts/ultrawork/codex.md` present; `skills/ultrawork/SKILL.md` present and CONTAINS the canonical body byte-for-byte (27374 B inside 27724 B); 26 skills; `omo-agent-toolkit` bin linked.
+
+## C4 adjacent regression (both machines)
+- `bun test script/codex-install-bundle-freshness.test.ts script/lazycodex-prompts-core-payload.test.ts`: 3 pass / 0 fail (bundle staged in the index).
+- `bun --cwd packages/omo-codex run typecheck`: exit 0.
+- `bun test packages/omo-codex/src/install/codex-cache-install.test.ts`: 8 pass / 0 fail.
+- plugin `npm ci && bun run build && npm test`: tests 337 / pass 335 / fail 2 — both CodeGraph MCP entry tests (`component-codegraph-mcp-smoke`); reproduced on pristine dev 38a46e6 on gorky (PRISTINE_CG_RC=1), so pre-existing/environmental, not touched by this change.
+- publish.yml is unchanged (the earlier CI-side `cp` staging idea was dropped: untestable and duplicated the prompt in the tarball).
+
+## Real ~/.codex untouched
+All C3 runs used `CODEX_HOME=/tmp/omo-beta34-c3-mengmotaMac/codex`; no path under the real home was written.

--- a/.omo/evidence/20260902-codex-cache-prompt-layout/c3-green-beta33-tarball-overlay.log
+++ b/.omo/evidence/20260902-codex-cache-prompt-layout/c3-green-beta33-tarball-overlay.log
@@ -1,0 +1,11 @@
+
+added 18 packages in 17s
+npm warn install-scripts 1 package has install scripts not yet covered by allowScripts:
+npm warn install-scripts   @code-yeongyu/comment-checker@0.8.0 (postinstall: node postinstall.js)
+npm warn install-scripts
+npm warn install-scripts Run `npm install-scripts ls` to review, or `npm install-scripts approve <pkg>` to allow.
+
+> @sisyphuslabs/omo-codex-plugin@5.0.0-beta.33 sync:skills
+> node scripts/sync-skills.mjs
+
+Installed 1 plugin(s) from sisyphuslabs.

--- a/.omo/evidence/20260902-codex-cache-prompt-layout/c3-red-beta33-tarball.log
+++ b/.omo/evidence/20260902-codex-cache-prompt-layout/c3-red-beta33-tarball.log
@@ -1,0 +1,27 @@
+
+added 18 packages in 26s
+npm warn install-scripts 1 package has install scripts not yet covered by allowScripts:
+npm warn install-scripts   @code-yeongyu/comment-checker@0.8.0 (postinstall: node postinstall.js)
+npm warn install-scripts
+npm warn install-scripts Run `npm install-scripts ls` to review, or `npm install-scripts approve <pkg>` to allow.
+
+> @sisyphuslabs/omo-codex-plugin@5.0.0-beta.33 sync:skills
+> node scripts/sync-skills.mjs
+
+node:internal/fs/promises:1360
+  return new FileHandle(await PromisePrototypeThen(
+                        ^
+
+Error: ENOENT: no such file or directory, open '/private/tmp/omo-beta34-c3-mengmotaMac/codex/plugins/cache/packages/prompts-core/prompts/ultrawork/codex.md'
+    at async open (node:internal/fs/promises:1360:25)
+    at async readFile (node:internal/fs/promises:2149:14)
+    at async syncSkills (file:///private/tmp/omo-beta34-c3-mengmotaMac/codex/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.33-65289-1788331890909/scripts/sync-skills.mjs:278:38)
+    at async file:///private/tmp/omo-beta34-c3-mengmotaMac/codex/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.33-65289-1788331890909/scripts/sync-skills.mjs:303:2 {
+  errno: -2,
+  code: 'ENOENT',
+  syscall: 'open',
+  path: '/private/tmp/omo-beta34-c3-mengmotaMac/codex/plugins/cache/packages/prompts-core/prompts/ultrawork/codex.md'
+}
+
+Node.js v26.7.0
+npm run sync:skills failed in /tmp/omo-beta34-c3-mengmotaMac/codex/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.33-65289-1788331890909 with exit code 1

--- a/packages/omo-codex/plugin/scripts/canonical-ultrawork-directive.mjs
+++ b/packages/omo-codex/plugin/scripts/canonical-ultrawork-directive.mjs
@@ -1,0 +1,17 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+// Relative to BOTH the repo root and the plugin root. In a repo checkout the directive lives at
+// <repo>/packages/prompts-core/prompts/ultrawork/codex.md. The Codex installer flattens the plugin
+// directory into <CODEX_HOME>/plugins/cache/<marketplace>/<name>/<version>, where the repo-relative
+// path dangles (it would resolve to plugins/cache/packages/...), so the installer materializes the
+// same file at <pluginRoot>/packages/prompts-core/prompts/ultrawork/codex.md and sync-skills reads
+// that copy instead. Keep the two segments lists in lockstep with
+// packages/omo-codex/src/install/codex-cache-install.ts (copyCanonicalPromptSources).
+export const canonicalUltraworkDirectiveRelativePath = join("packages", "prompts-core", "prompts", "ultrawork", "codex.md");
+
+export function resolveCanonicalUltraworkDirectivePath(pluginRoot, repoRoot) {
+	const checkoutPath = join(repoRoot, canonicalUltraworkDirectiveRelativePath);
+	if (existsSync(checkoutPath)) return checkoutPath;
+	return join(pluginRoot, canonicalUltraworkDirectiveRelativePath);
+}

--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -3,6 +3,7 @@ import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { resolveCanonicalUltraworkDirectivePath } from "./canonical-ultrawork-directive.mjs";
 import { isCliEntry } from "./entry-guard.mjs";
 import { sharedSkillsRootPath } from "@oh-my-opencode/shared-skills";
 
@@ -14,14 +15,7 @@ const skillsRoot = join(root, "skills");
 // from a component-local copy: sync-skills runs before build-components (see plugin/package.json
 // build chain), so consuming components/ultrawork/scripts/sync-directive.mjs output would break a
 // clean checkout.
-const canonicalUltraworkDirectivePath = join(
-	repoRoot,
-	"packages",
-	"prompts-core",
-	"prompts",
-	"ultrawork",
-	"codex.md",
-);
+const canonicalUltraworkDirectivePath = resolveCanonicalUltraworkDirectivePath(root, repoRoot);
 const ultraworkSkillFrontmatter = `---
 name: ultrawork
 description: Binding ultrawork mode directive for omo on Codex. When a prompt contains ultrawork or ulw, the omo UserPromptSubmit hook injects a short bootstrap that points at this file. Read the whole file and follow every rule in it for the rest of the task.

--- a/packages/omo-codex/plugin/test/canonical-ultrawork-directive.test.mjs
+++ b/packages/omo-codex/plugin/test/canonical-ultrawork-directive.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	canonicalUltraworkDirectiveRelativePath,
+	resolveCanonicalUltraworkDirectivePath,
+} from "../scripts/canonical-ultrawork-directive.mjs";
+
+test("#given a repo checkout #when resolving the ultrawork directive #then the checkout copy wins over a plugin-internal copy", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-canonical-prompt-"));
+	const pluginRoot = join(root, "plugin");
+	const repoRoot = join(root, "checkout");
+	const checkoutPrompt = join(repoRoot, canonicalUltraworkDirectiveRelativePath);
+	const pluginPrompt = join(pluginRoot, canonicalUltraworkDirectiveRelativePath);
+	await mkdir(join(checkoutPrompt, ".."), { recursive: true });
+	await mkdir(join(pluginPrompt, ".."), { recursive: true });
+	await writeFile(checkoutPrompt, "checkout");
+	await writeFile(pluginPrompt, "staged");
+
+	try {
+		// when
+		const resolved = resolveCanonicalUltraworkDirectivePath(pluginRoot, repoRoot);
+
+		// then
+		assert.equal(resolved, checkoutPrompt);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test("#given the flattened plugin cache #when the repo-relative directive is absent #then the plugin-internal copy is resolved", async () => {
+	// given
+	const root = await mkdtemp(join(tmpdir(), "omo-canonical-prompt-"));
+	const pluginRoot = join(root, "plugins", "cache", "sisyphuslabs", "omo", "0.1.0");
+	const repoRoot = join(pluginRoot, "..", "..", "..");
+	const pluginPrompt = join(pluginRoot, canonicalUltraworkDirectiveRelativePath);
+	await mkdir(join(pluginPrompt, ".."), { recursive: true });
+	await writeFile(pluginPrompt, "staged");
+
+	try {
+		// when
+		const resolved = resolveCanonicalUltraworkDirectivePath(pluginRoot, repoRoot);
+
+		// then
+		assert.equal(resolved, pluginPrompt);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});

--- a/packages/omo-codex/scripts/install-cache-copy.test.mjs
+++ b/packages/omo-codex/scripts/install-cache-copy.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { realpathSync } from "node:fs";
 import { mkdir, readdir, readFile, rename, stat, writeFile } from "node:fs/promises";
-import { basename, join, relative, sep } from "node:path";
+import { basename, dirname, join, relative, sep } from "node:path";
 import test from "node:test";
 
 import { installCachedPlugin } from "./install-dist/install-local.mjs";
@@ -164,6 +164,32 @@ test("#given packaged root CLI runtimes #when caching omo plugin #then root dist
 	// then
 	assert.equal(await readFile(join(installed.path, "dist", "cli", "index.js"), "utf8"), "console.log('omo')\n");
 	assert.equal(await readFile(join(installed.path, "dist", "cli-node", "index.js"), "utf8"), "console.log('omo node')\n");
+});
+
+test("#given packaged prompts-core directive #when caching omo plugin #then the ultrawork directive is materialized into the plugin cache", async () => {
+	// given
+	const root = await makeTempDir();
+	const repoRoot = join(root, "repo");
+	const codexHome = join(root, "codex-home");
+	const sourceRoot = join(repoRoot, "packages", "omo-codex", "plugin");
+	const directiveRelativePath = join("packages", "prompts-core", "prompts", "ultrawork", "codex.md");
+	await mkdir(sourceRoot, { recursive: true });
+	await mkdir(dirname(join(repoRoot, directiveRelativePath)), { recursive: true });
+	await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }));
+	await writeFile(join(repoRoot, directiveRelativePath), "# ultrawork directive\n");
+
+	// when
+	const installed = await installCachedPlugin({
+		codexHome,
+		marketplaceName: "sisyphuslabs",
+		name: "omo",
+		sourcePath: sourceRoot,
+		version: "0.1.0",
+		runCommand: async () => {},
+	});
+
+	// then
+	assert.equal(await readFile(join(installed.path, directiveRelativePath), "utf8"), "# ultrawork directive\n");
 });
 
 test("#given existing cache #when npm install fails #then previous active cache is preserved", async () => {

--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// omo-codex-install:205bedf47724fa71954f05ae72d7770ef1df26ce392216cb7e5ef72300f7c2be:2c6b840fadcd993447fd3e4c1b3e0965718c343ab68ad16a4972970dd0b828e7
+// omo-codex-install:4c2cf806f738afdb6669160f1b4a630e65da013dc297be7cc36b361192403a21:774951d3a77a5a46d7112112b453669c1f67fe41e80b2cc5c8850c6c325e1abc
 var __defProp = Object.defineProperty;
 var __returnValue = (v) => v;
 function __exportSetter(name, newValue) {
@@ -7977,7 +7977,7 @@ var package_default;
 var init_package = __esm(() => {
   package_default = {
     name: "@oh-my-opencode/omo-codex",
-    version: "5.0.0-beta.31",
+    version: "5.0.0-beta.33",
     type: "module",
     private: true,
     description: "Codex harness adapter for oh-my-openagent. Vendored Codex plugin namespace (omo) + TypeScript installer + telemetry.",
@@ -9652,6 +9652,7 @@ async function installCachedPlugin(input) {
     const rewroteLocalFileDependencies = await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath);
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath });
     await copyRootRuntimeDists({ pluginRoot: tempPath, sourcePath: input.sourcePath });
+    await copyCanonicalPromptSources({ pluginRoot: tempPath, sourcePath: input.sourcePath });
     const installArgs = rewroteLocalFileDependencies ? ["install", "--omit=dev", "--no-audit", "--no-fund"] : ["ci", "--omit=dev"];
     await maybeRunNpmInstall(tempPath, input.runCommand, npmInstallEnv, installArgs);
     await removeCachedManagedNpmBinShims(tempPath);
@@ -9806,6 +9807,20 @@ async function copyRootRuntimeDists(input) {
       continue;
     await mkdir3(dirname5(join12(input.pluginRoot, runtimePath)), { recursive: true });
     await cp2(sourcePath, join12(input.pluginRoot, runtimePath), { recursive: true });
+  }
+}
+var canonicalPromptRelativePaths = [join12("packages", "prompts-core", "prompts", "ultrawork", "codex.md")];
+async function copyCanonicalPromptSources(input) {
+  const repoRoot = repoRootForCodexPluginSource(input.sourcePath);
+  if (repoRoot === null)
+    return;
+  for (const relativePath of canonicalPromptRelativePaths) {
+    const sourceFile = join12(repoRoot, relativePath);
+    if (!await fileExistsStrict(sourceFile))
+      continue;
+    const targetFile = join12(input.pluginRoot, relativePath);
+    await mkdir3(dirname5(targetFile), { recursive: true });
+    await cp2(sourceFile, targetFile);
   }
 }
 function repoRootForCodexPluginSource(sourcePath) {

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -36,6 +36,7 @@ export async function installCachedPlugin(input: {
     const rewroteLocalFileDependencies = await rewriteCachedPackageLocalFileDependencies(tempPath, input.sourcePath)
     await copyBundledMcpRuntimeDists({ pluginRoot: tempPath, sourceRoot: input.sourcePath })
     await copyRootRuntimeDists({ pluginRoot: tempPath, sourcePath: input.sourcePath })
+    await copyCanonicalPromptSources({ pluginRoot: tempPath, sourcePath: input.sourcePath })
     // Rewriting local file: dependencies desyncs package.json from package-lock.json, and npm ci
     // aborts with EUSAGE on that drift (lazycodex#137; approach credited to the community fix in
     // oh-my-openagent#6202). The temp cache dir is throwaway, so let npm install reconcile the lock
@@ -201,6 +202,25 @@ async function copyRootRuntimeDists(input: { readonly pluginRoot: string; readon
     if (!(await fileExistsStrict(join(sourcePath, "index.js")))) continue
     await mkdir(dirname(join(input.pluginRoot, runtimePath)), { recursive: true })
     await cp(sourcePath, join(input.pluginRoot, runtimePath), { recursive: true })
+  }
+}
+
+// sync-skills.mjs runs again inside the flattened cache (maybeRunNpmSyncSkills) and composes the
+// ultrawork skill from the canonical prompts-core directive. In the repo layout it resolves
+// <plugin>/../../../packages/prompts-core/...; in the cache that path dangles under plugins/cache/,
+// so the directive is materialized inside the plugin root and sync-skills falls back to that copy
+// (plugin/scripts/canonical-ultrawork-directive.mjs). Keep both path lists in lockstep.
+const canonicalPromptRelativePaths = [join("packages", "prompts-core", "prompts", "ultrawork", "codex.md")] as const
+
+async function copyCanonicalPromptSources(input: { readonly pluginRoot: string; readonly sourcePath: string }): Promise<void> {
+  const repoRoot = repoRootForCodexPluginSource(input.sourcePath)
+  if (repoRoot === null) return
+  for (const relativePath of canonicalPromptRelativePaths) {
+    const sourceFile = join(repoRoot, relativePath)
+    if (!(await fileExistsStrict(sourceFile))) continue
+    const targetFile = join(input.pluginRoot, relativePath)
+    await mkdir(dirname(targetFile), { recursive: true })
+    await cp(sourceFile, targetFile)
   }
 }
 


### PR DESCRIPTION
## Why

Every `lazycodex-ai` install of beta.32 / beta.33 fails in `npm run sync:skills` with
`ENOENT .../plugins/cache/packages/prompts-core/prompts/ultrawork/codex.md` (publish run 33596952745, `post-publish-verify / Smoke test published lazycodex-ai`).
The installer copies only `packages/omo-codex/plugin` into `<CODEX_HOME>/plugins/cache/sisyphuslabs/omo/<version>` and re-runs `sync:skills` there; `sync-skills.mjs` resolved the canonical ultrawork prompt relative to the repo (`<plugin>/../../../packages/prompts-core/...`), which in the flattened cache points at `plugins/cache/packages/...`. Shipping the file in the tarball (#7630) could not fix that because the cache never sees the tarball root.

## What

- `codex-cache-install.ts`: `copyCanonicalPromptSources()` materializes `packages/prompts-core/prompts/ultrawork/codex.md` inside the cached plugin root — same mechanism the installer already uses for repo-level inputs (`copyRootRuntimeDists`, bundled MCP dists).
- `plugin/scripts/canonical-ultrawork-directive.mjs`: `resolveCanonicalUltraworkDirectivePath(pluginRoot, repoRoot)` — checkout path first, plugin-internal copy second; `sync-skills.mjs` uses it.
- `install-dist/install-local.mjs` regenerated via `bun run build:codex-install` (sha256 `a3651b8b…`, byte-identical on darwin-arm64 and linux-x64). `publish.yml` untouched.

## Proof (all on the bunshin fleet: mengmotaMac + gorky; details in `.omo/evidence/20260902-codex-cache-prompt-layout/QA.md`)

| criterion | RED | GREEN |
|---|---|---|
| installer test `install-cache-copy.test.mjs` | 7 tests / 1 fail (new case) on the committed bundle | `packages/omo-codex/scripts/*.test.mjs` 172/172 (mengmotaMac) |
| resolver test `plugin/test/canonical-ultrawork-directive.test.mjs` | `ERR_MODULE_NOT_FOUND` | 2/2 |
| **real smoke replay**: published beta.33 tarball, isolated `CODEX_HOME`, `install-local.mjs install --no-tui --codex-autonomous` | exit 1, the exact CI ENOENT at `sync-skills.mjs:278` | exit 0 with only the bundle + sync-skills + resolver overlaid; cached `skills/ultrawork/SKILL.md` contains the canonical body byte-for-byte, 26 skills, toolkit bin linked |
| regression | — | `codex-install-bundle-freshness` + `lazycodex-prompts-core-payload` 3/3, `omo-codex` typecheck 0, `codex-cache-install.test.ts` 8/8, plugin `npm test` 335/337 (the 2 CodeGraph MCP entry failures reproduce on pristine `dev` 38a46e6 — pre-existing, untouched here) |

Real `~/.codex` was never written; every install used a throwaway `CODEX_HOME`.

Unblocks the beta.34 publish (post-publish LazyCodex smoke).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LazyCodex installer failing with `ENOENT` during `sync:skills` because the canonical ultrawork prompt wasn't present in the flattened plugin cache. The installer now copies the prompt file into the cache, and `sync-skills` falls back to that copy when the repo checkout path isn't available.

**Bug Fixes**
- `codex-cache-install.ts` materializes `packages/prompts-core/prompts/ultrawork/codex.md` inside the cached plugin root.
- `sync-skills.mjs` uses a new resolver that prefers the repo checkout path and falls back to the plugin-internal copy.
- Added tests covering the installer copy and resolver behavior.

<sup>Written for commit 96f891e82b5f4342056f24d81e9150b482b811e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

