### PR TITLE
test(team-mode): budget Windows fallback wake case

### DIFF
--- a/.omo/evidence/20260902-team-message-windows-budget/README.md
+++ b/.omo/evidence/20260902-team-message-windows-budget/README.md
@@ -1,0 +1,43 @@
+# Team-message Windows test budget QA
+
+## What was tested
+
+- Failing-first evidence: GitHub Actions run `33602178990`, job
+  `test (windows-latest, 1/2)`.
+- Focused fallback wake:
+  `bun test ./packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts --test-name-pattern "generic fallback wakes cover two messages"`.
+- Complete messaging suite:
+  `bun test ./packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts`.
+- Adapter typecheck:
+  `./node_modules/.bin/tsgo --noEmit -p packages/omo-opencode/tsconfig.json`.
+- Isolated OpenCode TUI:
+  `bash .agents/skills/opencode-qa/scripts/tui-smoke.sh --self-test`.
+
+## What was observed
+
+The Windows CI case reached Bun's 5 second test default after 5.094 seconds.
+The test already uses a separate 3 second event timeout to fail when the second
+fallback wake does not dispatch. The repair keeps that event deadline and gives
+only the outer integration case a 15 second budget on Windows for fixture,
+mailbox filesystem, and prompt-queue work. Other platforms keep 5 seconds.
+
+The focused test passed with 1 test, 6 expectations, and 0 failures. The full
+messaging file passed with 41 tests, 138 expectations, and 0 failures. Adapter
+typecheck exited 0 without diagnostics.
+
+The real OpenCode TUI rendered under tmux, accepted a key into the composer,
+removed the tmux session, and left the real database unchanged at 8046 sessions.
+
+## Why this is enough
+
+The unchanged 3 second event timeout still detects the behavioral regression;
+only unrelated outer setup time receives a Windows allowance. The full file
+covers adjacent live-delivery, mailbox, and prompt-gate behavior. Typecheck and
+the isolated TUI smoke cover the consuming OpenCode adapter and real harness.
+Required PR CI supplies the authoritative Windows rerun.
+
+## What was omitted
+
+No credentials, auth headers, environment dumps, database rows, or raw terminal
+capture are stored. The evidence keeps commands, deterministic summaries, and
+the isolation proof.

--- a/.omo/evidence/20260902-team-message-windows-budget/focused-test.txt
+++ b/.omo/evidence/20260902-team-message-windows-budget/focused-test.txt
@@ -1,0 +1,10 @@
+Command:
+bun test ./packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts --test-name-pattern "generic fallback wakes cover two messages"
+
+Observed:
+(pass) createTeamSendMessageTool > #given generic fallback wakes cover two messages #when the first is acknowledged #then the second message still wakes [2489.34ms]
+1 pass
+40 filtered out
+0 fail
+6 expect() calls
+Ran 1 test across 1 file. [5.61s]

--- a/.omo/evidence/20260902-team-message-windows-budget/messaging-tests.txt
+++ b/.omo/evidence/20260902-team-message-windows-budget/messaging-tests.txt
@@ -1,0 +1,8 @@
+Command:
+bun test ./packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts
+
+Observed:
+41 pass
+0 fail
+138 expect() calls
+Ran 41 tests across 1 file. [22.80s]

--- a/.omo/evidence/20260902-team-message-windows-budget/tui-smoke.txt
+++ b/.omo/evidence/20260902-team-message-windows-budget/tui-smoke.txt
@@ -1,0 +1,9 @@
+Command:
+bash .agents/skills/opencode-qa/scripts/tui-smoke.sh --self-test
+
+Observed:
+PASS: TUI rendered under tmux (marker found; version 1.18.26)
+PASS: send-keys reached the TUI composer (sentinel echoed)
+PASS: tmux session torn down (has-session false)
+PASS: real DB untouched (session count 8046 unchanged)
+PASS: tui-smoke

--- a/.omo/evidence/20260902-team-message-windows-budget/typecheck.txt
+++ b/.omo/evidence/20260902-team-message-windows-budget/typecheck.txt
@@ -1,0 +1,5 @@
+Command:
+./node_modules/.bin/tsgo --noEmit -p packages/omo-opencode/tsconfig.json
+
+Observed:
+Exit code 0 with no diagnostics.

--- a/.omo/plans/20260902-team-message-windows-budget.md
+++ b/.omo/plans/20260902-team-message-windows-budget.md
@@ -1,0 +1,23 @@
+# Team-message Windows test budget
+
+## Failure
+
+CI run `33602178990` timed out the generic fallback second-message test after
+5.094 seconds on `windows-latest`.
+
+## Change
+
+- Preserve the test's 3 second event timeout, which detects a missing fallback
+  wake.
+- Give only this integration case a 15 second outer timeout on Windows for
+  fixture, mailbox filesystem, and prompt-queue work.
+- Keep Bun's 5 second default on other platforms.
+- Add no sleep, polling, retry, skip, or weakened assertion.
+
+## Verification
+
+- Run the focused fallback test.
+- Run the complete messaging test file.
+- Typecheck the OpenCode adapter.
+- Run isolated OpenCode real-harness QA and record evidence.
+- Require green PR CI and Cubic before merge.

--- a/packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts
@@ -108,6 +108,8 @@ type Deferred<T> = {
 
 const temporaryDirectories: string[] = []
 const TEST_EVENT_TIMEOUT_MS = 3_000
+// The inner event timeout still fails a missing wake; this outer budget covers fixture I/O on loaded Windows runners.
+const FALLBACK_WAKE_TEST_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 5_000
 const realSetTimeout = globalThis.setTimeout
 const realClearTimeout = globalThis.clearTimeout
 
@@ -828,7 +830,7 @@ describe("createTeamSendMessageTool", () => {
     expect(promptTexts).toHaveLength(2)
     expect(secondInjection.injected).toBe(true)
     expect(secondInjection.content).toContain("second fallback")
-  })
+  }, FALLBACK_WAKE_TEST_TIMEOUT_MS)
 
   test("#given a queued fallback recipient shut down #when the prompt gate clears #then the obsolete wake is cancelled", async () => {
     // given


### PR DESCRIPTION
## Summary

Windows shard 1 in CI run 33602178990 timed out the generic fallback second-message integration case at the Bun 5 second outer test limit after 5.094 seconds.

The behavioral event wait remains bounded at 3 seconds, so a missing second wake still fails quickly. Only the outer integration budget becomes 15 seconds on Windows for fixture, mailbox filesystem, and prompt-queue work; other platforms keep 5 seconds. No sleeps, polling, retries, skips, or assertions changed.

## Verification

- Focused fallback wake: 1 pass, 0 fail, 6 expectations.
- Complete messaging file: 41 pass, 0 fail, 138 expectations.
- OpenCode adapter typecheck: pass with no diagnostics.
- Isolated OpenCode TUI smoke: rendered, accepted input, cleaned up, real DB count unchanged.

## Evidence

.omo/evidence/20260902-team-message-windows-budget/README.md

## Risk

Test-only Windows outer timeout configuration. Required Windows PR CI is the authoritative rerun.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows CI timeout for the generic fallback second-message test by giving that test a 15-second outer budget on Windows only; the inner 3-second event timeout still detects missing wake-ups, and other platforms keep 5 seconds.

<sup>Written for commit d6a868fabaab74e56961f2202df265c797190de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

