### PR TITLE
fix(omo-native): survive deleted Linux exec paths and forward signals on re-exec

### DIFF
--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -14,6 +14,7 @@ import {
   type EmbeddedFile,
   type EmbeddedManifest,
 } from "./compile-runtime"
+import { propagateResult, runChild } from "./bin/lib/child-process.js"
 import { migrateLegacyBunGlobalManifest } from "./bin/lib/legacy-bun-global-migration.js"
 import { adoptLegacyFlatState, canonicalAgentDir } from "./bin/lib/agent-dir.js"
 import { nearestNodeBin, readJson } from "./bin/lib/package-paths.js"
@@ -201,8 +202,8 @@ async function main(): Promise<void> {
   if (answerCompiledFastPath(process.argv.slice(2), manifest)) return
   if (needsProvisioning) {
     if (shouldReexecAfterProvisioning()) {
-      const child = spawn(expected, process.argv.slice(2), { env: process.env, stdio: "inherit" })
-      await new Promise<void>((resolvePromise) => child.on("close", (code) => { process.exitCode = code ?? 1; resolvePromise() }))
+      const result = await runChild(expected, process.argv.slice(2), { env: process.env })
+      propagateResult(result)
       return
     }
     execDir = dirname(expected)

--- a/packages/omo-native/compile-runtime.ts
+++ b/packages/omo-native/compile-runtime.ts
@@ -55,6 +55,13 @@ export function materializeProvisionedExecutable(
     return
   }
   if (provisionedExecutableMatches(sourcePath, destinationPath)) return
+  if (existsSync(destinationPath)) {
+    try {
+      statSync(sourcePath)
+    } catch {
+      return
+    }
+  }
   const temporaryPath = `${destinationPath}.tmp-${process.pid}`
   try {
     rmSync(temporaryPath, { force: true })
@@ -66,11 +73,16 @@ export function materializeProvisionedExecutable(
   }
 }
 
+export function stripDeletedExecSuffix(execPath: string): string {
+  return execPath.endsWith(" (deleted)") ? execPath.slice(0, -" (deleted)".length) : execPath
+}
+
 export function runningExecutablePath(
   argv0 = process.argv[0],
   execPath = process.execPath,
   platform = process.platform,
 ): string {
+  if (platform === "linux") return stripDeletedExecSuffix(execPath)
   return platform === "win32" && argv0.toLowerCase().endsWith(".exe") ? argv0 : execPath
 }
 

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -60,6 +60,22 @@ describe("compiled omo entry launcher parity", () => {
     expect(shouldReexecAfterProvisioning("darwin")).toBe(true)
   })
 
+  test("strips Linux procfs deleted suffix but preserves it on other platforms", () => {
+    const deletedPath = "/runtime/omo (deleted)"
+    expect(runningExecutablePath("/runtime/omo", deletedPath, "linux")).toBe("/runtime/omo")
+    // Only Linux procfs produces this exact suffix; other platforms leave it untouched.
+    expect(runningExecutablePath("/runtime/omo", deletedPath, "darwin")).toBe(deletedPath)
+    expect(runningExecutablePath("/runtime/omo", deletedPath, "win32")).toBe(deletedPath)
+  })
+
+  test("recognizes a deleted Linux executable as the provisioned path", () => {
+    const root = temp()
+    const expected = join(root, "omo")
+    writeFileSync(expected, "binary")
+
+    expect(isProvisionedExecutable(runningExecutablePath(expected, `${expected} (deleted)`, "linux"), expected)).toBe(true)
+  })
+
   test("pins the engine package dir to the provisioned root", () => {
     // Defence in depth alongside the re-exec: PACKAGE_DIR is consulted by
     // getPackageDir() ahead of dirname(process.execPath), so the engine stays
@@ -240,6 +256,26 @@ describe("embedded runtime provisioning", () => {
 
     expect(readFileSync(destination, "utf8")).toBe("compiled binary")
     expect(existsSync(`${destination}.tmp-${process.pid}`)).toBe(false)
+  })
+
+  test("keeps an existing destination when the deleted Linux source cannot be read", () => {
+    const root = temp()
+    const source = join(root, "missing-source (deleted)")
+    const destination = join(root, "runtime", "omo")
+    mkdirSync(join(root, "runtime"), { recursive: true })
+    writeFileSync(destination, "already-provisioned")
+
+    expect(() => materializeProvisionedExecutable(source, destination, "linux")).not.toThrow()
+    expect(readFileSync(destination, "utf8")).toBe("already-provisioned")
+  })
+
+  test("still throws when the deleted Linux source and destination are both absent", () => {
+    const root = temp()
+    const source = join(root, "missing-source (deleted)")
+    const destination = join(root, "runtime", "omo")
+    mkdirSync(join(root, "runtime"), { recursive: true })
+
+    expect(() => materializeProvisionedExecutable(source, destination, "linux")).toThrow()
   })
 
   test("selects the omo manifest when senpi also embeds an unrelated manifest", async () => {

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -76,6 +76,12 @@ describe("compiled omo entry launcher parity", () => {
     expect(isProvisionedExecutable(runningExecutablePath(expected, `${expected} (deleted)`, "linux"), expected)).toBe(true)
   })
 
+  test("re-exec source contract uses signal-aware child execution", () => {
+    const source = readFileSync(new URL("../compile-entry.ts", import.meta.url), "utf8")
+    expect(source).toContain('import { propagateResult, runChild } from "./bin/lib/child-process.js"')
+    expect(source).not.toContain("spawn(expected")
+  })
+
   test("pins the engine package dir to the provisioned root", () => {
     // Defence in depth alongside the re-exec: PACKAGE_DIR is consulted by
     // getPackageDir() ahead of dirname(process.execPath), so the engine stays


### PR DESCRIPTION
## Summary

- The compiled `omo` binary could die at startup on Linux with `ENOENT ... copyfile '.../binary-runtime/<ver>/omo (deleted)'`. When a sibling launch renamed a fresh copy over the provisioned executable while a re-exec'd child was starting, Linux `/proc/self/exe` reported the running image as `... (deleted)`; `isProvisionedExecutable` then failed, provisioning re-ran, and `copyFileSync` of the deleted path threw. `runningExecutablePath` now strips the exact procfs ` (deleted)` suffix on Linux, and `materializeProvisionedExecutable` keeps an existing destination when the source cannot be read instead of throwing.
- The post-provisioning re-exec used a bare `spawn(expected, argv, { stdio: "inherit" })`. A `SIGTERM` to the visible parent killed it instantly and left the engine child reparented to init. The re-exec now goes through the launcher's existing `runChild`/`propagateResult` (SIGTERM/SIGHUP forwarding, bounded grace, signal-faithful exit), the same contract the node launcher adopted in #7372.

## Changes

- `packages/omo-native/compile-runtime.ts`: `stripDeletedExecSuffix` + Linux branch in `runningExecutablePath`; existing-destination guard in `materializeProvisionedExecutable` (copy failures with an absent destination still throw).
- `packages/omo-native/compile-entry.ts`: re-exec via `runChild(expected, argv, { env })` + `propagateResult(result)`.
- `packages/omo-native/test/compile-entry.test.ts`: 5 new tests (suffix strip per platform, deleted path recognized as provisioned, materialize guard both ways, re-exec source contract).

## QA & Evidence

- **What was tested:** `bun test packages/omo-native/test/compile-entry.test.ts` on gorky (Linux x86_64) at HEAD, then with `compile-runtime.ts`/`compile-entry.ts` swapped back to `origin/dev` (mutation), then restored.
  **Observed result:** HEAD 32 pass / 0 fail; mutation 28 pass / 4 fail (exactly the 4 new behavioral/contract tests); `origin/dev` full package suite 222 pass; fix branch full suite 227 pass / 0 fail; `bunx tsc -p packages/omo-native/tsconfig.json --noEmit` clean.
  **Artifact:** gorky `/tmp/omo-resume-repro-20260902/verify.log` (sanitized excerpt in the PR discussion).
  **Why sufficient:** every new assertion is proven to fail against the unfixed code and pass with it.
- **What was tested:** real-surface, beta.33 release binary `omo-linux-x64` on gorky: (C1) fresh `~/.omo/binary-runtime/<ver>` + two concurrent `omo --resume` launches driven over a pty; (C2) `kill -TERM <parent pid>` of the running launcher; (C3) `--version` provisioning.
  **Observed result (before):** C1 one launch rc=1 with the ENOENT/`(deleted)` stack, sibling resumed; C2 parent rc=-15, engine child reparented to init and still alive 3s later; C3 provisioned.
  **Observed result (after, linux-x64 binary rebuilt from this branch via `bun run script/build-omo-binary.ts --target linux-x64`, 132,015,304 bytes):** C1 both concurrent `--resume` launches alive with the planted session resumed (`alive=true` for both drivers); C2 parent exited 0 within 0.9s of `SIGTERM`, `ps` shows no `binary-runtime/<ver>/omo` survivor; C3 `omo --version` prints `omo 5.0.0-0.beta.34 (engine: senpi 2026.9.2)` and provisions `~/.omo/binary-runtime/5.0.0-0.beta.34/omo`.
  **Artifact:** gorky `/tmp/omo-resume-repro-20260902/{beta33,fixed}-race*.json`, `build.log`.
  **Why sufficient:** the exact crash and the exact orphan are exercised on the compiled artifact, not only the TS helpers.

## Risks & Residuals

- `propagateResult` re-raises a child's signal death on the parent (parent dies by the same signal) — intended parity with the node launcher; mitigated by the existing `child-process-signal.test.ts` contract.
- The source-contract test pins the import line; a future refactor that keeps `runChild` but renames the module path must update it — accepted.
- Windows path unchanged (no re-exec, no procfs) — not applicable.

## Automated Checks

```bash
bun test packages/omo-native/test
bunx tsc -p packages/omo-native/tsconfig.json --noEmit
```

## Related Issues

Follow-up to #7372 (launcher signal forwarding). Surfaced while investigating a Linux "resume silently dies" report.
