### PR TITLE
fix(delegate-task): preserve long child completion handoff

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.status-fallback.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.status-fallback.test.ts
@@ -48,4 +48,55 @@ describe("pollSyncSession status fallback", () => {
     // then
     expect(result).toBeNull()
   })
+
+  test("#given a long newest-first transcript and missing status #when polling #then the terminal child is handed back", async () => {
+    // given: the original user turn is just outside the old fixed 100-message page
+    __setTimingConfig({
+      POLL_INTERVAL_MS: 1,
+      MAX_POLL_TIME_MS: 50,
+    })
+    const messages = [
+      {
+        info: { id: "msg_000", role: "user", time: { created: 1_000 } },
+      },
+      ...Array.from({ length: 100 }, (_, index) => ({
+        info: {
+          id: `msg_${String(index + 1).padStart(3, "0")}`,
+          role: "assistant",
+          time: { created: 2_000 + index },
+          finish: "tool-calls",
+        },
+        parts: [{ type: "tool-call", text: `tool call ${index + 1}` }],
+      })),
+      {
+        info: { id: "msg_101", role: "assistant", time: { created: 3_000 }, finish: "stop" },
+        parts: [{ type: "text", text: "Long child complete" }],
+      },
+    ]
+    const newestFirst = [...messages].reverse()
+    const messageQueries: Array<{ limit?: number } | undefined> = []
+    const client = unsafeTestValue<OpencodeClient>({
+      session: {
+        messages: async (request: { query?: { limit?: number } }) => {
+          const limit = request.query?.limit
+          messageQueries.push(request.query)
+          return { data: limit === undefined ? newestFirst : newestFirst.slice(0, limit) }
+        },
+        status: async () => ({ data: {} }),
+        abort: async () => ({ data: {} }),
+      },
+    })
+
+    // when
+    const result = await pollSyncSession(toolContext, client, {
+      sessionID: "ses_long_missing_status",
+      agentToUse: "sisyphus",
+      toastManager: null,
+      taskId: undefined,
+    }, 50)
+
+    // then
+    expect(result).toBeNull()
+    expect(messageQueries[0]).toBeUndefined()
+  })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
@@ -47,9 +47,20 @@ async function fetchSessionMessages(
   client: OpencodeClient,
   sessionID: string
 ): Promise<SessionMessage[]> {
-  const messagesResult = await client.session.messages({ path: { id: sessionID }, query: { limit: 100 } })
-  const rawData = (messagesResult as { data?: unknown })?.data ?? messagesResult
-  return Array.isArray(rawData) ? (rawData as SessionMessage[]) : []
+  const messagesResult = await client.session.messages({ path: { id: sessionID } })
+  const messages = normalizeSDKResponse(messagesResult, [] as SessionMessage[])
+
+  return messages
+    .map((message, index) => ({ message, index }))
+    .sort((a, b) => {
+      const aCreated = a.message.info?.time?.created
+      const bCreated = b.message.info?.time?.created
+      if (aCreated !== undefined && bCreated !== undefined && aCreated !== bCreated) {
+        return aCreated - bCreated
+      }
+      return a.index - b.index
+    })
+    .map(({ message }) => message)
 }
 
 const DEFAULT_MAX_ASSISTANT_TURNS = 300


### PR DESCRIPTION
## Summary

- Remove the sync child poller's hard-coded 100-message page.
- Normalize and chronologically order the complete transcript before completion detection.
- Add a regression test for a newest-first transcript with 100 in-progress turns before the terminal assistant response.

## Why

A long-running delegated child can have its original user turn or terminal response outside the fixed page. The poller then cannot prove completion and eventually reports inactivity even though the child finished, which leaves the parent without the result.

## Verification

- `bun test packages/omo-opencode/src/tools/delegate-task` — 489 pass, 0 fail.
- `bun run typecheck` — passed.
- OpenCode isolated serve/SSE smoke — passed with temporary XDG/HOME state and explicit request bounds; live database session count unchanged.
- `git diff --check` — passed.
- The repository-wide `bun test` was bounded during QA and did not complete within the host's 300-second safety bound; the scoped suite above is green.

No Codex, Senpi, LiteLLM, model, or local configuration files are included.
