### PR TITLE
fix(runtime-fallback): recover silent requests and fallback retries

### DIFF
--- a/assets/oh-my-opencode.schema.json
+++ b/assets/oh-my-opencode.schema.json
@@ -9190,6 +9190,11 @@
               "type": "number",
               "minimum": 0
             },
+            "first_prompt_watchdog_seconds": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 9007199254740991
+            },
             "notify_on_fallback": {
               "type": "boolean"
             },

--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -11065,6 +11065,11 @@
                   "type": "number",
                   "minimum": 0
                 },
+                "first_prompt_watchdog_seconds": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 9007199254740991
+                },
                 "notify_on_fallback": {
                   "type": "boolean"
                 },
@@ -25857,6 +25862,11 @@
                       "timeout_seconds": {
                         "type": "number",
                         "minimum": 0
+                      },
+                      "first_prompt_watchdog_seconds": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 9007199254740991
                       },
                       "notify_on_fallback": {
                         "type": "boolean"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -868,6 +868,7 @@ Auto-switches to backup models on API errors.
     "max_fallback_attempts": 3,
     "cooldown_seconds": 60,
     "timeout_seconds": 30,
+    "first_prompt_watchdog_seconds": 90,
     "notify_on_fallback": true
   }
 }
@@ -880,6 +881,7 @@ Auto-switches to backup models on API errors.
 | `max_fallback_attempts` | `3`                 | Max fallback attempts per session (1–20)                                                                                       |
 | `cooldown_seconds`      | `60`                | Seconds before retrying a failed model                                                                                         |
 | `timeout_seconds`       | `30`                | Seconds before forcing next fallback. **Set to `0` to disable timeout-based escalation and `message.updated` provider retry signal detection.** Structured `session.status` retry events can still trigger fallback. |
+| `first_prompt_watchdog_seconds` | `90` | Seconds to wait for first assistant progress before dispatching a configured fallback. |
 | `notify_on_fallback`    | `true`              | Toast notification on model switch                                                                                             |
 | `restore_primary_after_cooldown` | `false` | Return to the primary model after its cooldown expires                                                                       |
 

--- a/packages/omo-opencode/src/config/schema/oh-my-opencode-config.test.ts
+++ b/packages/omo-opencode/src/config/schema/oh-my-opencode-config.test.ts
@@ -39,6 +39,44 @@ describe("OhMyOpenCodeConfigSchema team_mode", () => {
   })
 })
 
+describe("OhMyOpenCodeConfigSchema runtime_fallback", () => {
+  it("accepts a positive integer first-prompt watchdog window", () => {
+    // given
+    const rawConfig = {
+      runtime_fallback: {
+        first_prompt_watchdog_seconds: 120,
+      },
+    }
+
+    // when
+    const result = OhMyOpenCodeConfigSchema.safeParse(rawConfig)
+
+    // then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.runtime_fallback).toMatchObject({
+        first_prompt_watchdog_seconds: 120,
+      })
+    }
+  })
+
+  it("rejects a non-positive or fractional first-prompt watchdog window", () => {
+    // given
+    const invalidConfigs = [
+      { first_prompt_watchdog_seconds: 0 },
+      { first_prompt_watchdog_seconds: -1 },
+      { first_prompt_watchdog_seconds: 1.5 },
+    ]
+
+    // when
+    const results = invalidConfigs.map((runtimeFallback) =>
+      OhMyOpenCodeConfigSchema.safeParse({ runtime_fallback: runtimeFallback }))
+
+    // then
+    expect(results.every((result) => !result.success)).toBe(true)
+  })
+})
+
 describe("OhMyOpenCodeConfigSchema telemetry", () => {
   it("allows telemetry omission", () => {
     // given

--- a/packages/omo-opencode/src/config/schema/runtime-fallback.ts
+++ b/packages/omo-opencode/src/config/schema/runtime-fallback.ts
@@ -11,6 +11,8 @@ export const RuntimeFallbackConfigSchema = z.object({
   cooldown_seconds: z.number().min(0).optional(),
   /** Session-level timeout in seconds to advance fallback when provider hangs (default: 30). Set to 0 to disable timeout escalation and message.updated auto-retry signal detection. */
   timeout_seconds: z.number().min(0).optional(),
+  /** First-prompt watchdog window in seconds (default: 90). */
+  first_prompt_watchdog_seconds: z.number().int().min(1).optional(),
   /** Show toast notification when switching to fallback model (default: true) */
   notify_on_fallback: z.boolean().optional(),
   restore_primary_after_cooldown: z.boolean().optional(),

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.test.ts
@@ -114,4 +114,17 @@ describe("createAbortSessionRequest reservation release", () => {
     // then
     expect(getPromptReservation(sessionID)?.source).toBe("user-prompt")
   })
+
+  test("#given the first-prompt watchdog aborts a silent session #when the abort request completes #then the abort is marked as OMO-internal", async () => {
+    // given
+    const deps = createDeps()
+    const sessionID = "session-first-prompt-watchdog-abort"
+    const abortSessionRequest = createAbortSessionRequest(deps)
+
+    // when
+    await abortSessionRequest(sessionID, "first-prompt-watchdog")
+
+    // then
+    expect(deps.internallyAbortedSessions.has(sessionID)).toBe(true)
+  })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/auto-retry-abort.ts
@@ -11,7 +11,8 @@ export function createAbortSessionRequest(deps: HookDeps) {
       source === "session.status.retry-signal" ||
       source === "message.updated.retry-signal" ||
       source === "message.updated.quota-fallback" ||
-      source === "session.timeout"
+      source === "session.timeout" ||
+      source === "first-prompt-watchdog"
     ) {
       deps.internallyAbortedSessions.add(sessionID)
       deps.sessionLastAccess.set(sessionID, Date.now())

--- a/packages/omo-opencode/src/hooks/runtime-fallback/constants.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_CONFIG: Required<RuntimeFallbackConfig> = {
   max_fallback_attempts: 3,
   cooldown_seconds: 60,
   timeout_seconds: 30,
+  first_prompt_watchdog_seconds: 90,
   notify_on_fallback: true,
   restore_primary_after_cooldown: false,
 }
@@ -40,4 +41,4 @@ export const HOOK_NAME = "runtime-fallback"
  * practice) yet much shorter than the 30-minute outer poll timeout that
  * would otherwise be the only safety net.
  */
-export const DEFAULT_FIRST_PROMPT_WATCHDOG_MS = 90_000
+export const DEFAULT_FIRST_PROMPT_WATCHDOG_MS = DEFAULT_CONFIG.first_prompt_watchdog_seconds * 1000

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.test.ts
@@ -90,4 +90,41 @@ describe("dispatchFallbackRetry", () => {
     expect(state.pendingFallbackModel).toBe(undefined)
     expect(state.failedModels.size).toBe(0)
   })
+
+  test("#given fallback dispatch is accepted #when fallback retry runs #then the watchdog acceptance callback receives the fallback generation", async () => {
+    // given
+    const toastMessages: string[] = []
+    const deps = createDeps(toastMessages)
+    const acceptedFallbacks: Array<{ sessionID: string; model: string; agent: string | undefined }> = []
+    deps.onFallbackAccepted = (sessionID, model, agent) => {
+      acceptedFallbacks.push({ sessionID, model, agent })
+    }
+    const sessionID = "session-accepted-fallback-watchdog"
+    const state = createFallbackState("openai/gpt-5.4")
+    deps.sessionStates.set(sessionID, state)
+    const helpers: AutoRetryHelpers = {
+      abortSessionRequest: async () => {},
+      clearSessionFallbackTimeout: () => {},
+      scheduleSessionFallbackTimeout: () => {},
+      autoRetryWithFallback: async () => ({ accepted: true, status: "dispatched" }),
+      resolveAgentForSessionFromContext: async () => undefined,
+      cleanupStaleSessions: () => {},
+    }
+
+    // when
+    await dispatchFallbackRetry(deps, helpers, {
+      sessionID,
+      state,
+      fallbackModels: ["litellm/openai.eu.gpt-5.5"],
+      resolvedAgent: "sisyphus-junior",
+      source: "session.error",
+    })
+
+    // then
+    expect(acceptedFallbacks).toEqual([{
+      sessionID,
+      model: "litellm/openai.eu.gpt-5.5",
+      agent: "sisyphus-junior",
+    }])
+  })
 })

--- a/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/fallback-retry-dispatcher.ts
@@ -60,6 +60,7 @@ export async function dispatchFallbackRetry(
       })
       return
     }
+    deps.onFallbackAccepted?.(options.sessionID, result.newModel, options.resolvedAgent)
     if (deps.config.notify_on_fallback) {
       await deps.ctx.client.tui
         .showToast({

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog-progress-events.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog-progress-events.test.ts
@@ -15,6 +15,7 @@ function createRecordingWatchdog(calls: RecordedWatchdogCalls): FirstPromptWatch
     onUserMessage(sessionID) {
       calls.user.push(sessionID)
     },
+    onFallbackAccepted() {},
     onAssistantProgress(sessionID) {
       calls.progress.push(sessionID)
     },

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -3,6 +3,7 @@ import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { subagentSessions } from "../../features/claude-code-session-state"
 import { createFirstPromptWatchdog, observeEventForWatchdog, type FirstPromptWatchdog } from "./first-prompt-watchdog"
+import { createFallbackState } from "./fallback-state"
 
 const WATCHDOG_MS = 100
 const SAFE_WAIT_BEFORE_FIRE_MS = 40
@@ -196,6 +197,30 @@ describe("first-prompt-watchdog", () => {
     watchdog.dispose()
   })
 
+  it("#given a parent session stays silent past the threshold and has a fallback configured #when the watchdog fires #then it aborts the in-flight request and dispatches the fallback model", async () => {
+    // given
+    const sessionID = "session-silent-parent"
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+
+    // when
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await getFakeTimers().advanceBy(SAFE_WAIT_AFTER_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toEqual([{
+      sessionID,
+      newModel: FALLBACK_MODEL,
+      resolvedAgent: AGENT,
+      source: "first-prompt-watchdog",
+    }])
+
+    watchdog.dispose()
+  })
+
   it("#given a subagent produces assistant text before the threshold #when progress is observed #then the watchdog is cancelled and no fallback is dispatched", async () => {
     // given
     const sessionID = "session-makes-progress"
@@ -214,6 +239,34 @@ describe("first-prompt-watchdog", () => {
     // then
     expect(calls.abort).toEqual([])
     expect(calls.autoRetry).toEqual([])
+
+    watchdog.dispose()
+  })
+
+  it("#given a fallback prompt is accepted after the original user event #when the watchdog is re-armed #then the fallback generation receives a fresh silence window", async () => {
+    // given
+    const sessionID = "session-fallback-watchdog-rearm"
+    subagentSessions.add(sessionID)
+    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const calls: RecordedCalls = { abort: [], autoRetry: [] }
+    const helpers = createHelpers(calls, AGENT)
+    const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
+    deps.sessionStates.set(sessionID, createFallbackState(PRIMARY_MODEL))
+
+    watchdog.onUserMessage(sessionID, PRIMARY_MODEL, AGENT)
+    await getFakeTimers().advanceBy(SAFE_WAIT_BEFORE_FIRE_MS)
+
+    // when
+    watchdog.onFallbackAccepted(sessionID, FALLBACK_MODEL, AGENT)
+    await getFakeTimers().advanceBy(SAFE_WAIT_BEFORE_FIRE_MS)
+
+    // then
+    expect(calls.abort).toEqual([])
+    expect(calls.autoRetry).toEqual([])
+
+    await getFakeTimers().advanceBy(SAFE_WAIT_BEFORE_FIRE_MS * 2)
+    expect(calls.abort).toEqual([{ sessionID, source: "first-prompt-watchdog" }])
+    expect(calls.autoRetry).toHaveLength(1)
 
     watchdog.dispose()
   })
@@ -282,11 +335,11 @@ describe("first-prompt-watchdog", () => {
     watchdog.dispose()
   })
 
-  it("#given the session is not a subagent #when a user message is observed #then the watchdog never arms and nothing fires", async () => {
+  it("#given a parent session has no fallback configured #when a user message is observed #then the watchdog does not abort or dispatch", async () => {
     // given
     const sessionID = "session-not-a-subagent"
     // NOT added to subagentSessions
-    const deps = createDeps(PLUGIN_CONFIG_WITH_FALLBACK)
+    const deps = createDeps()
     const calls: RecordedCalls = { abort: [], autoRetry: [] }
     const helpers = createHelpers(calls, AGENT)
     const watchdog = createFirstPromptWatchdog(deps, helpers, WATCHDOG_MS)
@@ -356,6 +409,7 @@ function createRecordingWatchdog(calls: RecordedWatchdogCalls): FirstPromptWatch
     onUserMessage(sessionID, model, agent) {
       calls.user.push({ sessionID, model, agent })
     },
+    onFallbackAccepted() {},
     onAssistantProgress(sessionID) {
       calls.progress.push(sessionID)
     },

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.ts
@@ -2,7 +2,6 @@ import type { HookDeps, RuntimeFallbackTimeout } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { HOOK_NAME, DEFAULT_FIRST_PROMPT_WATCHDOG_MS } from "./constants"
 import { log } from "../../shared/logger"
-import { subagentSessions } from "../../features/claude-code-session-state"
 import { resolveMessageEventSessionID, resolveSessionEventID } from "../../shared/event-session-id"
 import { isRecord } from "../../shared/record-type-guard"
 import { normalizeModelToCanonicalString } from "./normalize-model"
@@ -19,6 +18,7 @@ declare function clearTimeout(timeout: RuntimeFallbackTimeout): void
 
 export interface FirstPromptWatchdog {
   onUserMessage(sessionID: string, model?: string, agent?: string): void
+  onFallbackAccepted(sessionID: string, model: string, agent?: string): void
   onAssistantProgress(sessionID: string): void
   onSessionTerminal(sessionID: string): void
   dispose(): void
@@ -133,20 +133,26 @@ export function createFirstPromptWatchdog(
     armed.delete(sessionID)
   }
 
+  const arm = (sessionID: string, model: string | undefined, agent: string | undefined, reason: string): void => {
+    cancel(sessionID)
+    armed.add(sessionID)
+    const timer = setTimeout(async () => {
+      await fire(sessionID, model, agent)
+    }, watchdogMs)
+    timers.set(sessionID, timer)
+
+    log(`[${HOOK_NAME}] ${SOURCE}: armed (${reason})`, { sessionID, model, agent, watchdogMs })
+  }
+
   const fire = async (sessionID: string, model: string | undefined, agent: string | undefined): Promise<void> => {
     timers.delete(sessionID)
     armed.delete(sessionID)
-
-    if (!subagentSessions.has(sessionID)) {
-      log(`[${HOOK_NAME}] ${SOURCE}: session no longer a subagent at fire time, skipping`, { sessionID })
-      return
-    }
 
     const resolvedAgent = await helpers.resolveAgentForSessionFromContext(sessionID, agent)
     const fallbackModels = getFallbackModelsForSession(sessionID, resolvedAgent, deps.pluginConfig)
 
     if (fallbackModels.length === 0) {
-      log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms with no fallback configured`, {
+      log(`[${HOOK_NAME}] ${SOURCE}: session silent past ${watchdogMs}ms with no fallback configured`, {
         sessionID,
         model,
         agent: resolvedAgent,
@@ -172,7 +178,7 @@ export function createFirstPromptWatchdog(
       deps.sessionLastAccess.set(sessionID, Date.now())
     }
 
-    log(`[${HOOK_NAME}] ${SOURCE}: subagent silent past ${watchdogMs}ms, dispatching fallback`, {
+    log(`[${HOOK_NAME}] ${SOURCE}: session silent past ${watchdogMs}ms, dispatching fallback`, {
       sessionID,
       model: state.currentModel,
       fallbackCount: fallbackModels.length,
@@ -196,16 +202,12 @@ export function createFirstPromptWatchdog(
   return {
     onUserMessage(sessionID, model, agent) {
       if (!sessionID) return
-      if (!subagentSessions.has(sessionID)) return
       if (armed.has(sessionID)) return
-
-      armed.add(sessionID)
-      const timer = setTimeout(async () => {
-        await fire(sessionID, model, agent)
-      }, watchdogMs)
-      timers.set(sessionID, timer)
-
-      log(`[${HOOK_NAME}] ${SOURCE}: armed for subagent`, { sessionID, model, agent, watchdogMs })
+      arm(sessionID, model, agent, "user message")
+    },
+    onFallbackAccepted(sessionID, model, agent) {
+      if (!sessionID || !model) return
+      arm(sessionID, model, agent, "accepted fallback")
     },
     onAssistantProgress(sessionID) {
       if (!sessionID || !armed.has(sessionID)) return

--- a/packages/omo-opencode/src/hooks/runtime-fallback/hook.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/hook.ts
@@ -41,6 +41,7 @@ export function createRuntimeFallbackHook(
     max_fallback_attempts: options?.config?.max_fallback_attempts ?? DEFAULT_CONFIG.max_fallback_attempts,
     cooldown_seconds: options?.config?.cooldown_seconds ?? DEFAULT_CONFIG.cooldown_seconds,
     timeout_seconds: options?.config?.timeout_seconds ?? DEFAULT_CONFIG.timeout_seconds,
+    first_prompt_watchdog_seconds: options?.config?.first_prompt_watchdog_seconds ?? DEFAULT_CONFIG.first_prompt_watchdog_seconds,
     notify_on_fallback: options?.config?.notify_on_fallback ?? DEFAULT_CONFIG.notify_on_fallback,
     restore_primary_after_cooldown: options?.config?.restore_primary_after_cooldown ?? DEFAULT_CONFIG.restore_primary_after_cooldown,
   }
@@ -63,7 +64,14 @@ export function createRuntimeFallbackHook(
   const baseEventHandler = factories.createEventHandler(deps, helpers)
   const messageUpdateHandler = factories.createMessageUpdateHandler(deps, helpers)
   const chatMessageHandler = factories.createChatMessageHandler(deps)
-  const firstPromptWatchdog = factories.createFirstPromptWatchdog(deps, helpers)
+  const firstPromptWatchdog = factories.createFirstPromptWatchdog(
+    deps,
+    helpers,
+    config.first_prompt_watchdog_seconds * 1000,
+  )
+  deps.onFallbackAccepted = (sessionID, model, agent) => {
+    firstPromptWatchdog.onFallbackAccepted(sessionID, model, agent)
+  }
 
   let cleanupInterval: RuntimeFallbackInterval | null = null
   let intervalStarted = false
@@ -113,6 +121,7 @@ export function createRuntimeFallbackHook(
     deps.sessionFallbackTimeouts.clear()
     deps.sessionStatusRetryKeys.clear()
     deps.internallyAbortedSessions.clear()
+    deps.onFallbackAccepted = undefined
   }
 
   return {

--- a/packages/omo-opencode/src/hooks/runtime-fallback/types.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/types.ts
@@ -96,4 +96,5 @@ export interface HookDeps {
    * loop (every cycle started over at attempt:1). See issue #4006.
    */
   internallyAbortedSessions: Set<string>
+  onFallbackAccepted?: (sessionID: string, model: string, agent?: string) => void
 }


### PR DESCRIPTION
## Summary

- Arm the first-prompt watchdog for any session with a configured fallback, including parent sessions.
- Mark watchdog-owned aborts as OMO-internal so the resulting abort event cannot reset fallback attempt state.
- Re-arm the watchdog after an accepted fallback dispatch so a silent fallback generation receives its own bounded recovery window.
- Add validated `first_prompt_watchdog_seconds` configuration with a documented 90-second default.
- Add regression coverage for the parent-session gap, abort ownership, accepted-fallback re-arm, dispatcher wiring, and schema validation.

## Why

The existing watchdog only covered tracked subagents. A silent parent request could therefore remain pending without reaching a provider error, so OpenCode never entered its fallback chain. Separately, a watchdog abort could be mistaken for a user abort and reset retry state; an accepted fallback could then remain silent without another watchdog window.

Related context: https://github.com/code-yeongyu/oh-my-openagent/issues/5982 and https://github.com/code-yeongyu/oh-my-openagent/issues/6637

## Verification

- RED captured before the fix: 37 pass, 3 expected regression failures.
- `bun test packages/omo-opencode/src/hooks/runtime-fallback` — 290 pass, 0 fail.
- Schema tests — 12 pass, 0 fail.
- `bun run typecheck` — passed.
- OpenCode-only bundles — passed.
- Isolated OpenCode serve/SSE QA — passed with temporary state, explicit request bounds, and no intentional live-database mutation.
- `git diff --check` — passed.
- The repository-wide `bun test` was stopped after unrelated Codex/Senpi native-build baseline failures; no runtime-fallback failure was reported.

No LiteLLM, model-chain, Codex, Senpi, or local deployment configuration changes are included.
