### PR TITLE
ci: capture Windows root-test telemetry

### DIFF
--- a/.github/scripts/windows-ci-telemetry.ps1
+++ b/.github/scripts/windows-ci-telemetry.ps1
@@ -1,0 +1,187 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string]$ArtifactDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern("^[a-z0-9-]+$")]
+  [string]$Invocation,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
+  [string[]]$TestArguments
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$telemetryErrors = [System.Collections.Generic.List[object]]::new()
+
+function Add-TelemetryError {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Stage,
+
+    [Parameter(Mandatory = $true)]
+    [System.Exception]$Exception
+  )
+
+  $telemetryErrors.Add([ordered]@{
+      stage = $Stage
+      errorType = $Exception.GetType().FullName
+    })
+  Write-Warning "Windows CI telemetry capture failed during $Stage; test execution continues."
+}
+
+function ConvertTo-ProcessRecord {
+  param(
+    [Parameter(Mandatory = $true)]
+    [Microsoft.Management.Infrastructure.CimInstance]$Process
+  )
+
+  $creationTimeUtc = if ($null -eq $Process.CreationDate) {
+    $null
+  } else {
+    $Process.CreationDate.ToUniversalTime().ToString("o")
+  }
+
+  return [ordered]@{
+    name = [string]$Process.Name
+    pid = [uint32]$Process.ProcessId
+    parentPid = [uint32]$Process.ParentProcessId
+    creationTimeUtc = $creationTimeUtc
+  }
+}
+
+function Get-ProcessRecord {
+  param(
+    [Parameter(Mandatory = $true)]
+    [uint32]$ProcessId
+  )
+
+  $process = Get-CimInstance `
+    -ClassName Win32_Process `
+    -Filter "ProcessId = $ProcessId" `
+    -OperationTimeoutSec 5
+  if ($null -eq $process) {
+    return $null
+  }
+  return ConvertTo-ProcessRecord -Process $process
+}
+
+function Get-SurvivingDescendants {
+  param(
+    [Parameter(Mandatory = $true)]
+    [uint32]$RootProcessId
+  )
+
+  $processes = @(Get-CimInstance -ClassName Win32_Process -OperationTimeoutSec 5)
+  $descendantIds = [System.Collections.Generic.HashSet[uint32]]::new()
+  $pendingParents = [System.Collections.Generic.Queue[uint32]]::new()
+  $pendingParents.Enqueue($RootProcessId)
+
+  while ($pendingParents.Count -gt 0) {
+    $parentProcessId = $pendingParents.Dequeue()
+    foreach ($process in $processes) {
+      if ([uint32]$process.ParentProcessId -ne $parentProcessId) {
+        continue
+      }
+      $processId = [uint32]$process.ProcessId
+      if ($descendantIds.Add($processId)) {
+        $pendingParents.Enqueue($processId)
+      }
+    }
+  }
+
+  return @(
+    $processes |
+      Where-Object { $descendantIds.Contains([uint32]$_.ProcessId) } |
+      ForEach-Object { ConvertTo-ProcessRecord -Process $_ }
+  )
+}
+
+$preTestUtc = [DateTime]::UtcNow.ToString("o")
+$preTestStopwatchTimestamp = [System.Diagnostics.Stopwatch]::GetTimestamp()
+$telemetryProcess = $null
+try {
+  $telemetryProcess = Get-ProcessRecord -ProcessId ([uint32]$PID)
+} catch {
+  Add-TelemetryError -Stage "pre-test process capture" -Exception $_.Exception
+}
+
+$testExitCode = 1
+$testProcess = $null
+$testProcessRecord = $null
+$testLaunchErrorType = $null
+try {
+  $testProcess = Start-Process `
+    -FilePath "bun" `
+    -ArgumentList $TestArguments `
+    -NoNewWindow `
+    -PassThru
+  try {
+    $testProcessRecord = Get-ProcessRecord -ProcessId ([uint32]$testProcess.Id)
+  } catch {
+    Add-TelemetryError -Stage "test process capture" -Exception $_.Exception
+  }
+  $testProcess.WaitForExit()
+  $testExitCode = $testProcess.ExitCode
+} catch {
+  $testLaunchErrorType = $_.Exception.GetType().FullName
+  Write-Error "Windows root-test process failed to start or wait." -ErrorAction Continue
+}
+
+$postTestUtc = [DateTime]::UtcNow.ToString("o")
+$postTestStopwatchTimestamp = [System.Diagnostics.Stopwatch]::GetTimestamp()
+$survivingDescendants = @()
+if ($null -ne $testProcess) {
+  try {
+    $survivingDescendants = @(Get-SurvivingDescendants -RootProcessId ([uint32]$testProcess.Id))
+  } catch {
+    Add-TelemetryError -Stage "post-test descendant capture" -Exception $_.Exception
+  }
+}
+
+$payload = [ordered]@{
+  schemaVersion = 1
+  correlation = [ordered]@{
+    runId = $env:GITHUB_RUN_ID
+    runAttempt = $env:GITHUB_RUN_ATTEMPT
+    job = $env:GITHUB_JOB
+    shard = $env:WINDOWS_TEST_SHARD
+    invocation = $Invocation
+  }
+  timing = [ordered]@{
+    stopwatchFrequency = [string][System.Diagnostics.Stopwatch]::Frequency
+    preTest = [ordered]@{
+      utc = $preTestUtc
+      stopwatchTimestamp = [string]$preTestStopwatchTimestamp
+    }
+    postTest = [ordered]@{
+      utc = $postTestUtc
+      stopwatchTimestamp = [string]$postTestStopwatchTimestamp
+    }
+  }
+  temporaryPaths = [ordered]@{
+    runnerTemp = $env:RUNNER_TEMP
+    processTemp = [System.IO.Path]::GetTempPath()
+    temp = $env:TEMP
+    tmp = $env:TMP
+  }
+  telemetryProcess = $telemetryProcess
+  testProcess = $testProcessRecord
+  testExitCode = $testExitCode
+  testLaunchErrorType = $testLaunchErrorType
+  survivingDescendants = $survivingDescendants
+  telemetryErrors = @($telemetryErrors)
+}
+
+try {
+  New-Item -ItemType Directory -Path $ArtifactDirectory -Force | Out-Null
+  $artifactPath = Join-Path $ArtifactDirectory "$Invocation.json"
+  $payload | ConvertTo-Json -Depth 8 | Set-Content -Path $artifactPath -Encoding utf8NoBOM
+} catch {
+  Add-TelemetryError -Stage "artifact write" -Exception $_.Exception
+}
+
+exit $testExitCode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,7 @@ jobs:
           node packages/omo-senpi/plugin/scripts/build-extension.mjs --check
 
       - name: Run Senpi compatibility tests
-        if: needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
+        if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         shell: bash
         run: |
           set -euo pipefail
@@ -464,6 +464,41 @@ jobs:
           bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json
           bun test ./.agents/skills/senpi-qa/scripts/resolve-evidence-dir.test.mjs
           bun test packages/omo-senpi
+
+      - name: Run Senpi compatibility tests with Windows telemetry
+        if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os == 'Windows' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
+        shell: pwsh
+        env:
+          WINDOWS_TEST_SHARD: senpi-compatibility
+        run: |
+          bun run build:senpi-plugin
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $packDirectory = Join-Path $env:RUNNER_TEMP "omo-senpi-pack"
+          New-Item -ItemType Directory -Path $packDirectory -Force | Out-Null
+          npm pack --pack-destination $packDirectory packages/omo-senpi/plugin
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          npm --prefix packages/lsp-daemon test -- test/daemon-roundtrip.test.ts
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          bun test ./.agents/skills/senpi-qa/scripts/resolve-evidence-dir.test.mjs
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $telemetryDirectory = Join-Path $env:RUNNER_TEMP "windows-senpi-compatibility-telemetry"
+          & .github/scripts/windows-ci-telemetry.ps1 `
+            -ArtifactDirectory $telemetryDirectory `
+            -Invocation "senpi-compatibility" `
+            -TestArguments @("test", "packages/omo-senpi")
+          exit $LASTEXITCODE
+
+      - name: Upload Windows Senpi telemetry
+        if: always() && runner.os == 'Windows' && needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-senpi-compatibility-telemetry-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/windows-senpi-compatibility-telemetry/*.json
+          if-no-files-found: warn
+          overwrite: false
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,20 @@ jobs:
       # preload per file and OOM-kills the 7 GB runners, and --no-isolate leaks
       # module state between files. Job-level sharding is the parallelism.
       - name: Run tests
-        if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '1/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
+        if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows' && matrix.shard == '1/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         run: bun test packages/omo-opencode packages/memory-core
+
+      - name: Run tests with Windows telemetry
+        if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os == 'Windows' && matrix.shard == '1/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
+        shell: pwsh
+        env:
+          WINDOWS_TEST_SHARD: ${{ matrix.shard }}
+        run: |
+          $telemetryDirectory = Join-Path $env:RUNNER_TEMP "windows-root-test-telemetry"
+          & .github/scripts/windows-ci-telemetry.ps1 `
+            -ArtifactDirectory $telemetryDirectory `
+            -Invocation "shard-1" `
+            -TestArguments @("test", "packages/omo-opencode", "packages/memory-core")
 
       - name: Run tests
         if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows' && matrix.shard == '2/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
@@ -221,10 +233,30 @@ jobs:
       - name: Run tests
         if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os == 'Windows' && matrix.shard == '2/2' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
         shell: pwsh
+        env:
+          WINDOWS_TEST_SHARD: ${{ matrix.shard }}
         run: |
-          bun test packages/senpi-task/src/runners/rpc-process.windows.test.ts packages/senpi-task/src/__adversarial__/chaos-bench.test.ts packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts script/codex-installer-version.test.ts packages/shared-skills/provenance-gate.test.ts packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts packages/senpi-task/src/dag/scheduler.test.ts packages/omo-native/test/payload.test.ts script/build-omo-binary.test.ts
+          $telemetryDirectory = Join-Path $env:RUNNER_TEMP "windows-root-test-telemetry"
+          & .github/scripts/windows-ci-telemetry.ps1 `
+            -ArtifactDirectory $telemetryDirectory `
+            -Invocation "shard-2-quarantine" `
+            -TestArguments @("test", "packages/senpi-task/src/runners/rpc-process.windows.test.ts", "packages/senpi-task/src/__adversarial__/chaos-bench.test.ts", "packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts", "script/codex-installer-version.test.ts", "packages/shared-skills/provenance-gate.test.ts", "packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts", "packages/senpi-task/src/dag/scheduler.test.ts", "packages/omo-native/test/payload.test.ts", "script/build-omo-binary.test.ts")
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          bun --config=bunfig.win2.parallel.toml test --parallel
+          & .github/scripts/windows-ci-telemetry.ps1 `
+            -ArtifactDirectory $telemetryDirectory `
+            -Invocation "shard-2-remainder" `
+            -TestArguments @("--config=bunfig.win2.parallel.toml", "test", "--parallel")
+          exit $LASTEXITCODE
+
+      - name: Upload Windows post-test telemetry
+        if: always() && runner.os == 'Windows' && needs.ci-mode.outputs.run_heavy == 'true' && (matrix.os == 'ubuntu-latest' || needs.ci-mode.outputs.full_matrix == 'true')
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-root-test-telemetry-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.shard == '1/2' && 'shard-1' || 'shard-2' }}
+          path: ${{ runner.temp }}/windows-root-test-telemetry/*.json
+          if-no-files-found: warn
+          overwrite: false
 
       - name: Write job summary
         if: always()

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/README.md
@@ -1,0 +1,56 @@
+# Windows CI Telemetry Evidence
+
+## What was tested
+
+- TDD RED:
+  `bun test script/ci-root-test-partition.test.ts` against the contract before
+  telemetry implementation.
+- Contract GREEN:
+  `bun test script/ci-root-test-partition.test.ts`.
+- Required local gate:
+  `bun test script/ci-root-test-partition.test.ts script/ci-fast-path.full-matrix.test.ts`.
+- Workflow validation:
+  `actionlint -shellcheck= .github/workflows/ci.yml`. The repository's workflow
+  lint configuration disables shellcheck and validates the Actions/YAML
+  contract.
+- TypeScript review:
+  LSP diagnostics and the programming skill's
+  `check-no-excuse-rules.ts` against `script/ci-root-test-partition.test.ts`.
+- Senpi QA:
+  `node packages/omo-senpi/scripts/qa/drive.mjs --self-test`,
+  `node packages/omo-senpi/scripts/qa/drive.mjs`,
+  `tsgo --noEmit -p packages/omo-senpi/tsconfig.json`, and
+  `bun run test:senpi`.
+
+## What was observed
+
+- RED failed for the intended reason with the exact diagnostic:
+  `windows telemetry contract: missing post-test capture`.
+- The focused GREEN run passed 15 tests with 81 expectations.
+- The final required two-file run passed 36 tests with 139 expectations.
+- `actionlint -shellcheck=` exited 0 with no output.
+- The strict TypeScript audit reported no violations.
+- The Senpi driver self-test reported `SELF-TEST OK`.
+- The live Senpi driver reported `PASS`, proved ultrawork injection and comment
+  checking, used an isolated temporary agent directory, and reported both the
+  real `~/.senpi/agent` and `~/.omo/agent` untouched.
+- The Senpi package gate passed 2,537 tests with one declared skip and zero
+  failures, then passed all 10 evidence-resolver tests.
+
+## Why it is enough
+
+The contract tests pin the machine-consumed workflow and collector invariants:
+all three Windows Bun invocations use the telemetry wrapper, the wrapper records
+pre/post QPC and UTC timing plus allowlisted process and temporary-path data,
+the Bun exit code remains authoritative, and a uniquely named artifact uploads
+from an `always()` step with telemetry failures marked non-gating. The live
+Senpi run proves the CI-facing Senpi surface still loads through the real
+harness in isolation. Native Windows artifact evidence will be added after the
+draft PR's required Windows matrix run.
+
+## What was omitted
+
+Raw environment dumps, command lines, credentials, tokens, cookies, and full
+host logs were not captured. The evidence records only allowlisted process
+metadata, temporary paths, exit status, selected isolation fields, and
+reviewer-relevant command summaries.

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/README.md
@@ -14,6 +14,9 @@
 - TDD RED:
   `bun test script/ci-root-test-partition.test.ts` against the contract before
   telemetry implementation.
+- Senpi coverage TDD RED:
+  `bun test script/ci-root-test-partition.test.ts` after adding the Windows
+  Senpi telemetry contract and before changing `.github/workflows/ci.yml`.
 - Contract GREEN:
   `bun test script/ci-root-test-partition.test.ts`.
 - Required local gate:
@@ -51,6 +54,25 @@
   returned exit code `0`, and the full CI run remained green.
 - RED failed for the intended reason with the exact diagnostic:
   `windows telemetry contract: missing post-test capture`.
+- Six of nine observed `windows-latest` failures occurred in
+  `senpi-compatibility`, while only three occurred in the instrumented root
+  test shards. The Senpi failures included `memory run supervisor > released
+  child`, `reflection and dream run reconciliation`, `ordered delivery
+  mailbox`, and three `assembled DAG runtime` cases.
+- Run
+  [33703009335](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33703009335)
+  failed in `senpi-compatibility (windows-latest)` on `assembled DAG runtime >
+  #given an unknown node skill` and produced no Senpi telemetry because that
+  job was not instrumented.
+- The Senpi coverage RED failed with
+  `Windows Senpi compatibility tests must be telemetry-wrapped`, received
+  workflow step index `-1`, and exited `1`. The full RED and GREEN outputs are
+  appended to `tdd-red.txt`.
+- After the workflow change, the focused GREEN passed 16 tests with 93
+  expectations and exited `0`.
+- The coverage-extension two-file gate passed 37 tests with 151 expectations,
+  and `actionlint -shellcheck= .github/workflows/ci.yml` exited `0` with no
+  output.
 - The focused GREEN run passed 15 tests with 81 expectations.
 - The final required two-file run passed 36 tests with 139 expectations.
 - `actionlint -shellcheck=` exited 0 with no output.
@@ -75,6 +97,14 @@ captured the expected fields for all three real Windows Bun invocations while
 all 18 jobs passed. Together, the contract tests, isolated live Senpi run, and
 downloaded Windows artifacts cover both the collector contract and its
 observable behavior in the required CI environment.
+
+The coverage extension applies that same collector to the flaky
+`bun test packages/omo-senpi` invocation on Windows only. It leaves the
+Linux/macOS Bash step unchanged, preserves the preceding Windows build, pack,
+daemon test, typecheck, and evidence-resolver order, exits with the wrapped
+test's real status, and uploads `senpi-compatibility.json` from a separate
+non-gating `if: always()` artifact step. This closes the larger uncovered
+surface represented by six of the nine observed Windows failures.
 
 ## What was omitted
 

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/README.md
@@ -2,6 +2,15 @@
 
 ## What was tested
 
+- Native Windows CI run
+  [33701704942](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33701704942)
+  at commit `f57a652e3` exercised the complete 18-job matrix, including
+  `senpi-compatibility (windows-latest)`, `test (windows-latest, 1/2)`, and
+  `test (windows-latest, 2/2)`.
+- The two Windows root-test telemetry artifacts from that run were downloaded
+  and inspected:
+  `windows-root-test-telemetry-33701704942-1-shard-1` and
+  `windows-root-test-telemetry-33701704942-1-shard-2`.
 - TDD RED:
   `bun test script/ci-root-test-partition.test.ts` against the contract before
   telemetry implementation.
@@ -24,6 +33,22 @@
 
 ## What was observed
 
+- CI run `33701704942` completed successfully with all 18 jobs green.
+- GitHub reported exactly two artifacts:
+  `windows-root-test-telemetry-33701704942-1-shard-1` (601 bytes) and
+  `windows-root-test-telemetry-33701704942-1-shard-2` (1,246 bytes).
+- The shard 1 artifact contains `shard-1.json`. The shard 2 artifact contains
+  `shard-2-quarantine.json` and `shard-2-remainder.json`.
+- Every telemetry JSON records both `timing.preTest` and `timing.postTest`.
+  Each post-test UTC timestamp and stopwatch timestamp is greater than its
+  matching pre-test value, so both clocks are monotonic across each test
+  invocation.
+- Every telemetry JSON records `testExitCode: 0`, plus named
+  `telemetryProcess` and `testProcess` records with `pid`, `parentPid`, and
+  `creationTimeUtc`. No surviving descendants or telemetry errors were
+  reported.
+- Telemetry did not alter any test outcome: each wrapped Bun invocation
+  returned exit code `0`, and the full CI run remained green.
 - RED failed for the intended reason with the exact diagnostic:
   `windows telemetry contract: missing post-test capture`.
 - The focused GREEN run passed 15 tests with 81 expectations.
@@ -45,12 +70,17 @@ pre/post QPC and UTC timing plus allowlisted process and temporary-path data,
 the Bun exit code remains authoritative, and a uniquely named artifact uploads
 from an `always()` step with telemetry failures marked non-gating. The live
 Senpi run proves the CI-facing Senpi surface still loads through the real
-harness in isolation. Native Windows artifact evidence will be added after the
-draft PR's required Windows matrix run.
+harness in isolation. Native Windows run `33701704942` proves the wrapper
+captured the expected fields for all three real Windows Bun invocations while
+all 18 jobs passed. Together, the contract tests, isolated live Senpi run, and
+downloaded Windows artifacts cover both the collector contract and its
+observable behavior in the required CI environment.
 
 ## What was omitted
 
 Raw environment dumps, command lines, credentials, tokens, cookies, and full
 host logs were not captured. The evidence records only allowlisted process
 metadata, temporary paths, exit status, selected isolation fields, and
-reviewer-relevant command summaries.
+reviewer-relevant command summaries. The downloaded artifacts omit test stdout
+and stderr because those remain available in the linked CI run and are not
+needed to establish the telemetry schema or process lineage.

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/local-gates.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/local-gates.txt
@@ -1,0 +1,54 @@
+Contract GREEN
+==============
+Command:
+bun test script/ci-root-test-partition.test.ts
+
+Result:
+15 pass
+0 fail
+81 expect() calls
+
+Required combined gate after telemetry hardening
+================================================
+Command:
+bun test script/ci-root-test-partition.test.ts script/ci-fast-path.full-matrix.test.ts
+
+Result:
+36 pass
+0 fail
+139 expect() calls
+
+Workflow lint
+=============
+Command:
+actionlint -shellcheck= .github/workflows/ci.yml
+
+Result:
+exit 0, no diagnostics
+
+TypeScript checks
+=================
+LSP diagnostics before the final two assertion-only lines:
+No diagnostics found.
+
+Programming no-excuse audit:
+No violations in 1 file(s).
+
+Senpi package gate
+==================
+Commands:
+tsgo --noEmit -p packages/omo-senpi/tsconfig.json
+bun run test:senpi
+
+Result:
+Typecheck exited 0.
+2537 pass
+1 skip
+0 fail
+8094 expect() calls
+Ran 2538 tests across 334 files.
+
+Evidence resolver tests:
+10 pass
+0 fail
+31 expect() calls

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/senpi-live.json
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/senpi-live.json
@@ -1,0 +1,15 @@
+{
+  "result": "PASS",
+  "ultraworkInjected": true,
+  "commentChecker": "PASS",
+  "realSenpiUntouched": true,
+  "realSenpiChangedPaths": [],
+  "realSenpiProtectedChangedPaths": [],
+  "realSenpiCredentialDigestUntouched": true,
+  "realOmoUntouched": true,
+  "realOmoChangedPaths": [],
+  "realOmoProtectedChangedPaths": [],
+  "providedSenpiCodingAgentDir": "unset",
+  "sandboxAgentDir": "/private/var/folders/13/yyrkyfts6qsg303mcwpwzq200000gn/T/omo-senpi-qa-JjfxST/agent",
+  "sandboxCwd": "/private/var/folders/13/yyrkyfts6qsg303mcwpwzq200000gn/T/omo-senpi-qa-JjfxST/project"
+}

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/tdd-red.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/tdd-red.txt
@@ -1,0 +1,15 @@
+Command:
+bun test script/ci-root-test-partition.test.ts
+
+Observed:
+error: windows telemetry contract: missing post-test capture
+(fail) root test CI partition > #given Windows root-test telemetry #when the matrix is rendered #then post-test state is captured
+
+Result:
+10 pass
+1 fail
+42 expect() calls
+
+This is the required failing-first contract signal. An earlier bootstrap
+attempt stopped before test execution because the fresh worktree had no
+dependencies; it is not counted as RED evidence.

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/tdd-red.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/tdd-red.txt
@@ -13,3 +13,59 @@ Result:
 This is the required failing-first contract signal. An earlier bootstrap
 attempt stopped before test execution because the fresh worktree had no
 dependencies; it is not counted as RED evidence.
+
+---
+
+Senpi coverage extension RED
+
+Command:
+bun test script/ci-root-test-partition.test.ts
+
+Observed:
+217 |     const windowsStepStart = job.indexOf(windowsStepName)
+218 |
+219 |     expect(
+220 |       windowsStepStart,
+221 |       "Windows Senpi compatibility tests must be telemetry-wrapped",
+222 |     ).toBeGreaterThanOrEqual(0)
+            ^
+error: Windows Senpi compatibility tests must be telemetry-wrapped
+
+Expected: >= 0
+Received: -1
+
+      at <anonymous> (/Users/sungsoopark/Documents/GitHub/oh-my-openagent/.local-ignore/pr-worktrees/windows-ci-telemetry/script/ci-root-test-partition.test.ts:222:7)
+(fail) root test CI partition > #given Windows Senpi compatibility tests #when the package gate runs #then telemetry wraps the flaky test invocation [0.22ms]
+
+15 pass
+1 fail
+84 expect() calls
+Ran 16 tests across 1 file. [616.00ms]
+
+Command exited with code 1.
+
+This is the required failing-first signal: the new workflow contract found no
+Windows-specific Senpi telemetry step before `.github/workflows/ci.yml` was
+changed.
+
+---
+
+Senpi coverage extension GREEN
+
+Command:
+bun test script/ci-root-test-partition.test.ts
+
+Observed:
+bun test v1.3.14 (0d9b296a)
+
+16 pass
+0 fail
+93 expect() calls
+Ran 16 tests across 1 file. [519.00ms]
+
+Command exited with code 0.
+
+The same focused contract now proves the Windows Senpi package gate uses the
+existing telemetry harness with invocation `senpi-compatibility`, preserves the
+wrapped Bun test exit code, and uploads telemetry from a non-gating
+`if: always()` step.

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/windows-root-test-telemetry-33701704942-1-shard-1/shard-1.json
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/windows-root-test-telemetry-33701704942-1-shard-1/shard-1.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "correlation": {
+    "runId": "33701704942",
+    "runAttempt": "1",
+    "job": "test",
+    "shard": "1/2",
+    "invocation": "shard-1"
+  },
+  "timing": {
+    "stopwatchFrequency": "10000000",
+    "preTest": {
+      "utc": "2026-09-03T01:01:53.1747611Z",
+      "stopwatchTimestamp": "3117118519"
+    },
+    "postTest": {
+      "utc": "2026-09-03T01:08:43.4090591Z",
+      "stopwatchTimestamp": "7219387143"
+    }
+  },
+  "temporaryPaths": {
+    "runnerTemp": "D:\\a\\_temp",
+    "processTemp": "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\",
+    "temp": "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp",
+    "tmp": "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp"
+  },
+  "telemetryProcess": {
+    "name": "pwsh.exe",
+    "pid": 2148,
+    "parentPid": 8120,
+    "creationTimeUtc": "2026-09-03T01:01:52.8329730Z"
+  },
+  "testProcess": {
+    "name": "bun.exe",
+    "pid": 856,
+    "parentPid": 2148,
+    "creationTimeUtc": "2026-09-03T01:01:53.2711680Z"
+  },
+  "testExitCode": 0,
+  "testLaunchErrorType": null,
+  "survivingDescendants": [],
+  "telemetryErrors": []
+}

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/windows-root-test-telemetry-33701704942-1-shard-2/shard-2-quarantine.json
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/windows-root-test-telemetry-33701704942-1-shard-2/shard-2-quarantine.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "correlation": {
+    "runId": "33701704942",
+    "runAttempt": "1",
+    "job": "test",
+    "shard": "2/2",
+    "invocation": "shard-2-quarantine"
+  },
+  "timing": {
+    "stopwatchFrequency": "10000000",
+    "preTest": {
+      "utc": "2026-09-03T01:01:41.2761579Z",
+      "stopwatchTimestamp": "4222155690"
+    },
+    "postTest": {
+      "utc": "2026-09-03T01:03:47.5875293Z",
+      "stopwatchTimestamp": "5485221707"
+    }
+  },
+  "temporaryPaths": {
+    "runnerTemp": "D:\\a\\_temp",
+    "processTemp": "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\",
+    "temp": "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp",
+    "tmp": "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp"
+  },
+  "telemetryProcess": {
+    "name": "pwsh.exe",
+    "pid": 7712,
+    "parentPid": 1264,
+    "creationTimeUtc": "2026-09-03T01:01:40.9516360Z"
+  },
+  "testProcess": {
+    "name": "bun.exe",
+    "pid": 6396,
+    "parentPid": 7712,
+    "creationTimeUtc": "2026-09-03T01:01:41.3672260Z"
+  },
+  "testExitCode": 0,
+  "testLaunchErrorType": null,
+  "survivingDescendants": [],
+  "telemetryErrors": []
+}

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/windows-root-test-telemetry-33701704942-1-shard-2/shard-2-remainder.json
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/windows-root-test-telemetry-33701704942-1-shard-2/shard-2-remainder.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "correlation": {
+    "runId": "33701704942",
+    "runAttempt": "1",
+    "job": "test",
+    "shard": "2/2",
+    "invocation": "shard-2-remainder"
+  },
+  "timing": {
+    "stopwatchFrequency": "10000000",
+    "preTest": {
+      "utc": "2026-09-03T01:03:47.7388428Z",
+      "stopwatchTimestamp": "5486733310"
+    },
+    "postTest": {
+      "utc": "2026-09-03T01:09:33.9855110Z",
+      "stopwatchTimestamp": "8949224749"
+    }
+  },
+  "temporaryPaths": {
+    "runnerTemp": "D:\\a\\_temp",
+    "processTemp": "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\",
+    "temp": "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp",
+    "tmp": "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp"
+  },
+  "telemetryProcess": {
+    "name": "pwsh.exe",
+    "pid": 7712,
+    "parentPid": 1264,
+    "creationTimeUtc": "2026-09-03T01:01:40.9516360Z"
+  },
+  "testProcess": {
+    "name": "bun.exe",
+    "pid": 7308,
+    "parentPid": 7712,
+    "creationTimeUtc": "2026-09-03T01:03:47.7593720Z"
+  },
+  "testExitCode": 0,
+  "testLaunchErrorType": null,
+  "survivingDescendants": [],
+  "telemetryErrors": []
+}

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -6,6 +6,10 @@ import {
 } from "./root-test-serial-quarantine.ts"
 
 const workflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8")
+const windowsTelemetryScript = readFileSync(
+  new URL("../.github/scripts/windows-ci-telemetry.ps1", import.meta.url),
+  "utf8",
+)
 const rootConfig = readFileSync(new URL("../bunfig.root.toml", import.meta.url), "utf8")
 const win2ConfigPath = new URL("../bunfig.win2.toml", import.meta.url)
 const win2ParallelConfigPath = new URL("../bunfig.win2.parallel.toml", import.meta.url)
@@ -29,6 +33,16 @@ function quotedPatterns(config: string): readonly string[] {
   return [...config.matchAll(/"([^"]+\/\*\*)"/g)].map((match) => match[1] ?? "")
 }
 
+function assertWindowsTelemetryContract(script: string): void {
+  if (
+    !script.includes("$postTestUtc") ||
+    !script.includes("$postTestStopwatchTimestamp") ||
+    !script.includes("postTest =")
+  ) {
+    throw new Error("windows telemetry contract: missing post-test capture")
+  }
+}
+
 describe("root test CI partition", () => {
   test("#given required status check names #when the root matrix is declared #then only os and shard appear", () => {
     const job = rootTestJob()
@@ -49,7 +63,9 @@ describe("root test CI partition", () => {
     const job = rootTestJob()
 
     expect(job).toContain("bun test packages/omo-opencode packages/memory-core")
-    expect(job).toContain("bun --config=bunfig.win2.parallel.toml test --parallel")
+    expect(job).toContain(
+      '-TestArguments @("--config=bunfig.win2.parallel.toml", "test", "--parallel")',
+    )
     expect(existsSync(win2ConfigPath)).toBe(true)
     expect(existsSync(win2ParallelConfigPath)).toBe(true)
     expect(quotedPatterns(readFileSync(win2ConfigPath, "utf8"))).toContain("packages/omo-opencode/**")
@@ -61,9 +77,10 @@ describe("root test CI partition", () => {
     const serialCommand = serialQuarantineCommand()
 
     expect(ROOT_TEST_SERIAL_QUARANTINE_PATHS.length).toBeGreaterThan(0)
-    // Both parallel legs (POSIX and Windows shard 2) run the same serial list,
-    // so a file added to or dropped from the module must move both legs.
-    expect([...job.matchAll(new RegExp(escapeForRegExp(serialCommand), "g"))]).toHaveLength(2)
+    expect([...job.matchAll(new RegExp(escapeForRegExp(serialCommand), "g"))]).toHaveLength(1)
+    for (const testPath of ROOT_TEST_SERIAL_QUARANTINE_PATHS) {
+      expect([...job.matchAll(new RegExp(escapeForRegExp(testPath), "g"))]).toHaveLength(2)
+    }
   })
 
   test("#given the shared quarantine module #when the shard-2 bunfig is read #then it ignores exactly the quarantined files", () => {
@@ -125,11 +142,81 @@ describe("root test CI partition", () => {
     const job = rootTestJob()
     const runBlock = job.slice(job.indexOf("      - name: Run tests"))
 
-    expect(runBlock).toContain("if: needs.ci-mode.outputs.run_heavy == 'true' && matrix.shard == '1/2'")
+    expect(runBlock).toContain(
+      "if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows' && matrix.shard == '1/2'",
+    )
+    expect(runBlock).toContain(
+      "if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os == 'Windows' && matrix.shard == '1/2'",
+    )
     expect(runBlock).toContain("if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os != 'Windows' && matrix.shard == '2/2'")
     expect(runBlock).toContain("if: needs.ci-mode.outputs.run_heavy == 'true' && runner.os == 'Windows' && matrix.shard == '2/2'")
     expect(runBlock).not.toContain("shell: bash\n        run: |")
     expect(job).toContain("timeout-minutes: ${{ matrix.os == 'windows-latest' && 60 || 30 }}")
+  })
+
+  test("#given a telemetry fixture without post-test state #when the contract is checked #then the diagnostic is stable", () => {
+    const missingPostTestCapture = `
+      $preTestUtc = [DateTime]::UtcNow.ToString("o")
+      $preTestStopwatchTimestamp = [System.Diagnostics.Stopwatch]::GetTimestamp()
+      exit $testExitCode
+    `
+
+    expect(() => assertWindowsTelemetryContract(missingPostTestCapture)).toThrow(
+      "windows telemetry contract: missing post-test capture",
+    )
+  })
+
+  test("#given Windows root-test telemetry #when the collector runs #then timing and process state avoid secrets", () => {
+    assertWindowsTelemetryContract(windowsTelemetryScript)
+    expect(windowsTelemetryScript).toContain("$preTestUtc")
+    expect(windowsTelemetryScript).toContain("$preTestStopwatchTimestamp")
+    expect(windowsTelemetryScript).toContain("stopwatchFrequency")
+    expect(windowsTelemetryScript).toContain("-OperationTimeoutSec 5")
+    expect(windowsTelemetryScript).toContain("[string]$postTestStopwatchTimestamp")
+    expect(windowsTelemetryScript).toContain("name =")
+    expect(windowsTelemetryScript).toContain("pid =")
+    expect(windowsTelemetryScript).toContain("parentPid =")
+    expect(windowsTelemetryScript).toContain("creationTimeUtc =")
+    expect(windowsTelemetryScript).toContain("temporaryPaths =")
+    expect(windowsTelemetryScript).toContain("testExitCode = $testExitCode")
+    expect(windowsTelemetryScript).toContain("survivingDescendants =")
+    expect(windowsTelemetryScript).not.toContain("CommandLine")
+    expect(windowsTelemetryScript).not.toContain("ExecutablePath")
+    expect(windowsTelemetryScript).not.toContain("Get-ChildItem Env:")
+  })
+
+  test("#given Windows test failures #when telemetry completes #then the Bun exit code remains authoritative", () => {
+    expect(windowsTelemetryScript).toContain("$testExitCode = $testProcess.ExitCode")
+    expect(windowsTelemetryScript).toContain("exit $testExitCode")
+    expect(windowsTelemetryScript).toContain("Write-Warning")
+    expect(windowsTelemetryScript).not.toContain("exit 0")
+  })
+
+  test("#given both Windows shards #when root tests run #then telemetry wraps every Bun invocation", () => {
+    const job = rootTestJob()
+
+    expect([
+      ...job.matchAll(/& \.github\/scripts\/windows-ci-telemetry\.ps1/g),
+    ]).toHaveLength(3)
+    expect(job).toContain('-Invocation "shard-1"')
+    expect(job).toContain('-Invocation "shard-2-quarantine"')
+    expect(job).toContain('-Invocation "shard-2-remainder"')
+    expect(job).toContain("WINDOWS_TEST_SHARD: ${{ matrix.shard }}")
+  })
+
+  test("#given Windows telemetry files #when a matrix leg finishes #then immutable artifacts always upload without gating", () => {
+    const job = rootTestJob()
+    const uploadStep = job.slice(
+      job.indexOf("      - name: Upload Windows post-test telemetry"),
+      job.indexOf("      - name: Write job summary"),
+    )
+
+    expect(uploadStep).toContain("if: always() && runner.os == 'Windows'")
+    expect(uploadStep).toContain("continue-on-error: true")
+    expect(uploadStep).toContain("uses: actions/upload-artifact@v6")
+    expect(uploadStep).toContain("${{ github.run_id }}-${{ github.run_attempt }}")
+    expect(uploadStep).toContain("if-no-files-found: warn")
+    expect(uploadStep).toContain("overwrite: false")
   })
 
   test("#given Windows cache restore costs more than install #when the root matrix runs #then only non-Windows jobs restore Bun cache", () => {

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -29,6 +29,13 @@ function rootTestJob(): string {
   return workflow.slice(start, end)
 }
 
+function senpiCompatibilityJob(): string {
+  const start = workflow.indexOf("  senpi-compatibility:\n")
+  const end = workflow.indexOf("\n  lazycodex-published-smoke:", start)
+  if (start < 0 || end < 0) throw new Error("Senpi compatibility job not found")
+  return workflow.slice(start, end)
+}
+
 function quotedPatterns(config: string): readonly string[] {
   return [...config.matchAll(/"([^"]+\/\*\*)"/g)].map((match) => match[1] ?? "")
 }
@@ -202,6 +209,36 @@ describe("root test CI partition", () => {
     expect(job).toContain('-Invocation "shard-2-quarantine"')
     expect(job).toContain('-Invocation "shard-2-remainder"')
     expect(job).toContain("WINDOWS_TEST_SHARD: ${{ matrix.shard }}")
+  })
+
+  test("#given Windows Senpi compatibility tests #when the package gate runs #then telemetry wraps the flaky test invocation", () => {
+    const job = senpiCompatibilityJob()
+    const windowsStepName = "      - name: Run Senpi compatibility tests with Windows telemetry"
+    const windowsStepStart = job.indexOf(windowsStepName)
+
+    expect(
+      windowsStepStart,
+      "Windows Senpi compatibility tests must be telemetry-wrapped",
+    ).toBeGreaterThanOrEqual(0)
+
+    const windowsStep = job.slice(
+      windowsStepStart,
+      job.indexOf("      - name: Upload Windows Senpi telemetry", windowsStepStart),
+    )
+    const uploadStep = job.slice(
+      job.indexOf("      - name: Upload Windows Senpi telemetry"),
+      job.indexOf("      - name: Write job summary"),
+    )
+
+    expect(windowsStep).toContain("runner.os == 'Windows'")
+    expect(windowsStep).toContain("shell: pwsh")
+    expect(windowsStep).toContain("& .github/scripts/windows-ci-telemetry.ps1")
+    expect(windowsStep).toContain('-Invocation "senpi-compatibility"')
+    expect(windowsStep).toContain('-TestArguments @("test", "packages/omo-senpi")')
+    expect(windowsStep).toContain("exit $LASTEXITCODE")
+    expect(uploadStep).toContain("if: always() && runner.os == 'Windows'")
+    expect(uploadStep).toContain("continue-on-error: true")
+    expect(uploadStep).toContain("uses: actions/upload-artifact@v6")
   })
 
   test("#given Windows telemetry files #when a matrix leg finishes #then immutable artifacts always upload without gating", () => {


### PR DESCRIPTION
Adds non-gating Windows process, timing, filesystem, and exit telemetry with always-uploaded artifacts. Telemetry does not alter test status.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds non-gating telemetry for Windows CI tests that captures process, timing, filesystem, and exit data without affecting test results.

- All four Windows Bun invocations now run through `.github/scripts/windows-ci-telemetry.ps1`, including the previously uncovered `senpi-compatibility` job.
- Telemetry artifacts are always uploaded with `continue-on-error` and `if-no-files-found: warn`, so collection failures never gate the pipeline.
- The Bun exit code remains authoritative; the wrapper only exits with the test's exit code.
- Expands `script/ci-root-test-partition.test.ts` to pin the telemetry contract and adds evidence under `.omo/evidence/omo-senpi-adapter/20260903-windows-ci-telemetry/` from a green Windows CI run plus local RED/GREEN, lint, and Senpi QA gates.

<sup>Written for commit 27ea6b9880b6b90af7e7c2311e6f1f6fb106ba69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

