### PR TITLE
test(omo-opencode): budget and diagnose worktree-sweep classification on Windows

### DIFF
--- a/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
@@ -14,6 +14,7 @@ import { worktreeSweep } from "./worktree-sweep"
 import type { WorktreeSweepRepoReport } from "./types"
 
 const DAY_MS = 24 * 60 * 60 * 1000
+const GIT_COMMAND_TIMEOUT_MS = 10_000
 const temporaryDirectories: string[] = []
 
 afterAll(async () => {
@@ -29,16 +30,62 @@ const GIT_ENV = {
   GIT_TERMINAL_PROMPT: "0",
 }
 
-function git(cwd: string, args: readonly string[]): string {
-  const result = spawnSync("git", ["-C", cwd, ...args], {
-    encoding: "utf8",
-    env: GIT_ENV,
-  })
+interface GitCommandResult {
+  readonly status: number | null
+  readonly stdout: string
+  readonly stderr: string
+  readonly error?: Error
+}
+
+interface GitInvocationOptions {
+  readonly phase?: string
+  readonly run?: () => GitCommandResult
+  readonly now?: () => number
+}
+
+function git(cwd: string, args: readonly string[], options: GitInvocationOptions = {}): string {
+  const now = options.now ?? (() => performance.now())
+  const startedAt = now()
+  const result: GitCommandResult =
+    options.run?.() ??
+    spawnSync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      env: GIT_ENV,
+      timeout: GIT_COMMAND_TIMEOUT_MS,
+    })
+  const elapsedMs = Math.max(0, Math.round(now() - startedAt))
   if (result.status !== 0) {
-    throw new Error(`git ${args.join(" ")} failed in ${cwd}: ${result.stderr}`)
+    const phase = options.phase ?? `running git ${args.join(" ")}`
+    const detail = result.error?.message || result.stderr.trim() || "no error output"
+    throw new Error(
+      `git setup phase "${phase}" failed after ${elapsedMs}ms: ${detail} (git ${args.join(" ")} in ${cwd})`,
+    )
   }
   return result.stdout
 }
+
+describe("git fixture helper", () => {
+  test("reports the setup phase and elapsed time when a git command times out", () => {
+    let nowMs = 100
+
+    expect(() =>
+      git("/repo", ["worktree", "add"], {
+        phase: "creating external worktree",
+        run: () => ({
+          status: null,
+          stdout: "",
+          stderr: "",
+          error: new Error("timed out"),
+        }),
+        now: () => {
+          const current = nowMs
+          nowMs = 137
+          return current
+        },
+      }),
+    ).toThrow('git setup phase "creating external worktree" failed after 37ms: timed out')
+  })
+})
 
 async function commit(repo: string, message: string): Promise<void> {
   git(repo, [
@@ -85,7 +132,9 @@ async function createFixture(prefix = "wt-sweep-"): Promise<Fixture> {
 async function addMergedWorktree(repo: string, name: string, worktreePath: string): Promise<void> {
   git(repo, ["branch", name])
   git(repo, ["merge", "--ff-only", name])
-  git(repo, ["worktree", "add", worktreePath, name])
+  git(repo, ["worktree", "add", worktreePath, name], {
+    phase: `creating ${name.replace(/-branch$/, "")} worktree`,
+  })
 }
 
 /** Same as addMergedWorktree but leaves the branch unmerged. */
@@ -93,7 +142,9 @@ async function addUnmergedWorktree(repo: string, name: string, worktreePath: str
   git(repo, ["checkout", "-b", name])
   await commit(repo, `${name} commit`)
   git(repo, ["checkout", "main"])
-  git(repo, ["worktree", "add", worktreePath, name])
+  git(repo, ["worktree", "add", worktreePath, name], {
+    phase: `creating ${name.replace(/-branch$/, "")} worktree`,
+  })
 }
 
 function decisionFor(report: WorktreeSweepRepoReport, worktreePath: string) {
@@ -214,7 +265,9 @@ describe("sweepWorktrees classification", () => {
     await addMergedWorktree(repo, "missing-branch", missing)
     await fs.rm(missing, { recursive: true, force: true })
     const mergedTip = git(repo, ["rev-parse", "merged-branch"]).trim()
-    git(repo, ["worktree", "add", "--detach", detached, mergedTip])
+    git(repo, ["worktree", "add", "--detach", detached, mergedTip], {
+      phase: "creating detached worktree",
+    })
 
     const result = await sweepWorktrees({
       repos: [repo],
@@ -257,7 +310,7 @@ describe("sweepWorktrees classification", () => {
     // Dry-run removed nothing.
     expect(await fs.stat(merged)).toBeTruthy()
     expect(git(repo, ["worktree", "list", "--porcelain"])).toContain(toPosix(missing))
-  })
+  }, { timeout: 30_000 })
 
   test("detects the default branch through origin/HEAD when present", async () => {
     const base = await newTmpDir("wt-sweep-origin-")


### PR DESCRIPTION
The heaviest worktree-sweep test creates seven worktrees but was the only one left on Bun's 5000ms default, so it timed out mid git worktree add on the slower Windows runner (CI run 33704571922). Adds the Windows-aware budget its siblings already use and makes git setup failures name the stalled phase and elapsed time. No global timeout change, no skip, no retry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives the heaviest worktree-sweep test a Windows-aware timeout budget and makes git setup failures report the stalled phase and elapsed time. The test previously timed out mid `git worktree add` on slower Windows runners; it now runs under the same 30s budget as its sibling tests. No global timeout change, no skip, no retry.

- Git setup errors now include the phase label and elapsed time, e.g. `creating external worktree failed after 37ms`.
- Adds a unit test for the new error message using an injected command runner and clock.

<sup>Written for commit ba323d22784c55ea1d9170063a9f6c194b42adc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

