### PR TITLE
Fix #7626: prefer a newer standalone Claude Code over a stale bundled claude-agent-sdk binary

### DIFF
--- a/packages/omo-native/AGENTS.md
+++ b/packages/omo-native/AGENTS.md
@@ -10,6 +10,13 @@ omo-senpi plugin payload produced by `bun run build:omo-native` (gitignored, nev
 - brand: the launcher injects a `SENPI_BRAND` profile (name, `~/.omo/agent` home, `OMO_*` env prefix, wire identity, omo-ai beta update channel) so the pinned engine presents as omo; `--version` and every self-update spelling are answered by the launcher. See `docs/reference/omo-ai-publishing.md`.
 - `bin/lib/` - launcher modules:
   - `launcher.js` — `runLauncher()` dispatch, senpi environment/brand/update routing
+  - `claude-code-executable.js` — `claudeCodeExecutableOverride()`: the engine's claude-sdk-oauth lane
+    runs the native binary bundled with its pinned `@anthropic-ai/claude-agent-sdk`, and a build below
+    `BUNDLED_SDK_FLOOR` does not know the newer Claude model ids the catalog advertises, so those queries
+    fail with `errorMessage: "unknown"` and the retry fallback silently answers from another model. When
+    the bundled build is stale AND a newer standalone Claude Code is installed beside this package, the
+    launcher points `CLAUDE_CODE_EXECUTABLE` at it. An explicit user value always wins, and every
+    resolution failure is fail-open — this never gates the engine spawn.
   - `agent-dir.js` — `canonicalAgentDir()`, `adoptLegacyFlatState()`, legacy flat-dir migration
   - `setup-detect.js` / `setup-import.js` / `setup-models.js` / `setup-report.js` — harness detection, SQLite read-only import, provider mapping, report rendering
   - `setup-detect-cache.js` / `setup-detect-refresh.js` — the interactive launch's setup-suggestion cache: a

--- a/packages/omo-native/bin/lib/claude-code-executable.js
+++ b/packages/omo-native/bin/lib/claude-code-executable.js
@@ -1,0 +1,98 @@
+import { existsSync } from "node:fs"
+import { basename, dirname, join } from "node:path"
+import { packageRoot, readJson } from "./package-paths.js"
+
+// The engine's claude-sdk-oauth lane runs the native `claude` binary bundled with the pinned
+// @anthropic-ai/claude-agent-sdk. Builds below this floor do not carry the newer Claude model ids:
+// 0.3.252 has no `claude-fable-5-1` string, 0.3.257 does. Asking a build for an id it does not know
+// fails the query with `stopReason: "error"`, `errorMessage: "unknown"` and zero tokens, which the
+// retry fallback then hides by answering from a different model - the user reads a normal-looking
+// answer produced by a model they did not select.
+export const BUNDLED_SDK_FLOOR = "0.3.257"
+// Standalone Claude Code ships the same native binary under a lockstep patch number
+// (claude-code 2.1.N carries the claude-agent-sdk 0.3.N build), so this is the same floor.
+export const STANDALONE_CLAUDE_CODE_FLOOR = "2.1.257"
+
+function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(typeof value === "string" ? value : "")
+  return match === null ? undefined : [Number(match[1]), Number(match[2]), Number(match[3])]
+}
+
+function isBelow(version, floor) {
+  const left = parseVersion(version)
+  const right = parseVersion(floor)
+  if (left === undefined || right === undefined) return false
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] < right[index]
+  }
+  return false
+}
+
+function enclosingNodeModules(host) {
+  let current = dirname(host)
+  while (basename(current) !== "node_modules") {
+    const parent = dirname(current)
+    if (parent === current) return undefined
+    current = parent
+  }
+  return current
+}
+
+// Both the nested layout (dependency under the host package) and the hoisted one (host package and
+// dependency as siblings of the same node_modules), which is what a global install produces.
+function packageManifestPaths(host, name) {
+  const segments = [...name.split("/"), "package.json"]
+  const nodeModules = enclosingNodeModules(host)
+  const paths = [join(host, "node_modules", ...segments)]
+  if (nodeModules !== undefined) paths.push(join(nodeModules, ...segments))
+  return paths
+}
+
+function readVersion(paths, exists, readManifest) {
+  for (const path of paths) {
+    if (!exists(path)) continue
+    const version = readManifest(path).version
+    if (typeof version === "string") return { version, path }
+  }
+  return undefined
+}
+
+function binaryFromManifest(manifestPath, manifest, exists) {
+  const bin = manifest.bin
+  const relative = typeof bin === "string" ? bin : typeof bin?.claude === "string" ? bin.claude : undefined
+  const candidates = relative === undefined ? [] : [join(dirname(manifestPath), relative)]
+  for (const name of ["claude.exe", "claude"]) candidates.push(join(dirname(manifestPath), "bin", name))
+  return candidates.find((candidate) => exists(candidate))
+}
+
+/**
+ * The `CLAUDE_CODE_EXECUTABLE` value to hand the engine, or `undefined` to leave it alone.
+ *
+ * Only answers a path when the bundled SDK build is too old to know current Claude model ids AND a
+ * newer standalone Claude Code is already installed beside this package. An explicit user value
+ * always wins, a bundled build at or above the floor is left untouched, and every failure is
+ * fail-open: this is a launcher convenience, never a gate on spawning the engine.
+ */
+export function claudeCodeExecutableOverride(options = {}) {
+  const {
+    env = process.env,
+    senpiRoot,
+    root = packageRoot,
+    exists = existsSync,
+    readManifest = readJson,
+  } = options
+  try {
+    if (typeof env.CLAUDE_CODE_EXECUTABLE === "string" && env.CLAUDE_CODE_EXECUTABLE.length > 0) return undefined
+    if (typeof senpiRoot !== "string") return undefined
+
+    const bundled = readVersion(packageManifestPaths(senpiRoot, "@anthropic-ai/claude-agent-sdk"), exists, readManifest)
+    if (bundled === undefined || !isBelow(bundled.version, BUNDLED_SDK_FLOOR)) return undefined
+
+    const standalone = readVersion(packageManifestPaths(root, "@anthropic-ai/claude-code"), exists, readManifest)
+    if (standalone === undefined || isBelow(standalone.version, STANDALONE_CLAUDE_CODE_FLOOR)) return undefined
+
+    return binaryFromManifest(standalone.path, readManifest(standalone.path), exists)
+  } catch {
+    return undefined
+  }
+}

--- a/packages/omo-native/bin/lib/launcher.js
+++ b/packages/omo-native/bin/lib/launcher.js
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs"
 import { delimiter, join } from "node:path"
 import { spawnNode } from "./child-process.js"
+import { claudeCodeExecutableOverride } from "./claude-code-executable.js"
 import { runDoctor } from "./doctor.js"
 import { migrateLegacyBunGlobalManifest } from "./legacy-bun-global-migration.js"
 import { adoptLegacyFlatState, canonicalAgentDir } from "./agent-dir.js"
@@ -83,6 +84,13 @@ function senpiEnvironment(senpiRoot) {
     const shim = join(binDir, process.platform === "win32" ? "senpi.cmd" : "senpi")
     if (existsSync(shim)) env.SENPI_BIN = shim
   }
+  // The engine's claude-sdk-oauth lane runs the native binary bundled with its pinned
+  // claude-agent-sdk, and a bundled build older than the Claude model ids the catalog advertises
+  // fails those queries with `errorMessage: "unknown"` - which the retry fallback then hides by
+  // answering from a different model. When a newer standalone Claude Code is already installed
+  // beside this package, hand the engine that binary instead; an explicit user value always wins.
+  const claudeCodeExecutable = claudeCodeExecutableOverride({ env, senpiRoot })
+  if (claudeCodeExecutable !== undefined) env.CLAUDE_CODE_EXECUTABLE = claudeCodeExecutable
   // Anything resolving the product by name must re-enter through this launcher, otherwise it
   // would reach the engine directly and lose the brand.
   env.OMO_BIN = join(packageRoot, "bin", "omo.js")

--- a/packages/omo-native/test/claude-code-executable.test.ts
+++ b/packages/omo-native/test/claude-code-executable.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import {
+  BUNDLED_SDK_FLOOR,
+  claudeCodeExecutableOverride,
+  STANDALONE_CLAUDE_CODE_FLOOR,
+} from "../bin/lib/claude-code-executable.js"
+
+const roots: string[] = []
+
+type Fixture = { senpiRoot: string; root: string; standaloneBinary: string }
+
+function writeJson(path: string, value: unknown) {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(value))
+}
+
+function createFixture(options: { bundled?: string; standalone?: string } = {}): Fixture {
+  const { bundled = "0.3.241", standalone } = options
+  const home = mkdtempSync(join(tmpdir(), "omo-claude-executable-"))
+  roots.push(home)
+  const nodeModules = join(home, "node_modules")
+  const senpiRoot = join(nodeModules, "@code-yeongyu", "senpi")
+  const root = join(nodeModules, "omo-ai")
+  writeJson(join(senpiRoot, "package.json"), { name: "@code-yeongyu/senpi", version: "2026.9.2-4" })
+  writeJson(join(root, "package.json"), { name: "omo-ai", version: "5.0.0-0.beta.35" })
+  if (bundled !== "") {
+    writeJson(join(nodeModules, "@anthropic-ai", "claude-agent-sdk", "package.json"), {
+      name: "@anthropic-ai/claude-agent-sdk",
+      version: bundled,
+    })
+  }
+  const standaloneRoot = join(nodeModules, "@anthropic-ai", "claude-code")
+  const standaloneBinary = join(standaloneRoot, "bin", "claude.exe")
+  if (standalone !== undefined) {
+    writeJson(join(standaloneRoot, "package.json"), {
+      name: "@anthropic-ai/claude-code",
+      version: standalone,
+      bin: { claude: "bin/claude.exe" },
+    })
+    mkdirSync(dirname(standaloneBinary), { recursive: true })
+    writeFileSync(standaloneBinary, "")
+  }
+  return { senpiRoot, root, standaloneBinary }
+}
+
+function override(fixture: Fixture, env: Record<string, string> = {}) {
+  return claudeCodeExecutableOverride({ env, senpiRoot: fixture.senpiRoot, root: fixture.root })
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("claudeCodeExecutableOverride", () => {
+  describe("#given a bundled claude-agent-sdk below the floor and a newer standalone Claude Code", () => {
+    describe("#when the launcher composes the engine environment", () => {
+      test("#then the standalone binary is handed to the engine", () => {
+        const fixture = createFixture({ bundled: "0.3.241", standalone: "2.1.259" })
+        expect(override(fixture)).toBe(fixture.standaloneBinary)
+      })
+    })
+  })
+
+  describe("#given the user already set CLAUDE_CODE_EXECUTABLE", () => {
+    describe("#when the bundled build is stale and a newer standalone exists", () => {
+      test("#then the explicit value is left untouched", () => {
+        const fixture = createFixture({ bundled: "0.3.241", standalone: "2.1.259" })
+        expect(override(fixture, { CLAUDE_CODE_EXECUTABLE: "/custom/claude" })).toBeUndefined()
+      })
+    })
+  })
+
+  describe("#given a bundled claude-agent-sdk at the floor", () => {
+    describe("#when a newer standalone Claude Code is installed", () => {
+      test("#then the bundled binary keeps serving the lane", () => {
+        const fixture = createFixture({ bundled: BUNDLED_SDK_FLOOR, standalone: "2.1.259" })
+        expect(override(fixture)).toBeUndefined()
+      })
+    })
+  })
+
+  describe("#given a stale bundled claude-agent-sdk", () => {
+    describe("#when no standalone Claude Code is installed", () => {
+      test("#then nothing is injected", () => {
+        const fixture = createFixture({ bundled: "0.3.241" })
+        expect(override(fixture)).toBeUndefined()
+      })
+    })
+
+    describe("#when the installed standalone Claude Code is itself below the floor", () => {
+      test("#then nothing is injected, because it carries the same stale binary", () => {
+        const fixture = createFixture({ bundled: "0.3.241", standalone: "2.1.251" })
+        expect(override(fixture)).toBeUndefined()
+      })
+    })
+
+    describe("#when the standalone Claude Code is exactly at the floor", () => {
+      test("#then that binary is handed to the engine", () => {
+        const fixture = createFixture({ bundled: "0.3.241", standalone: STANDALONE_CLAUDE_CODE_FLOOR })
+        expect(override(fixture)).toBe(fixture.standaloneBinary)
+      })
+    })
+  })
+
+  describe("#given the bundled claude-agent-sdk cannot be inspected", () => {
+    describe("#when the launcher composes the engine environment", () => {
+      test("#then resolution fails open and the engine spawns unchanged", () => {
+        const fixture = createFixture({ bundled: "", standalone: "2.1.259" })
+        expect(override(fixture)).toBeUndefined()
+      })
+    })
+  })
+
+  describe("#given a standalone manifest that cannot be parsed", () => {
+    describe("#when the launcher composes the engine environment", () => {
+      test("#then the thrown parse error never reaches the spawn path", () => {
+        const fixture = createFixture({ bundled: "0.3.241", standalone: "2.1.259" })
+        writeFileSync(join(dirname(dirname(fixture.standaloneBinary)), "package.json"), "{ not json")
+        expect(override(fixture)).toBeUndefined()
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes the root cause of #7626 for the `omo-ai` distribution: a `claude-sdk-oauth` model id that the **bundled** `@anthropic-ai/claude-agent-sdk` native binary does not know fails the query with `stopReason: "error"` / `errorMessage: "unknown"` / zero tokens, and the retry fallback then answers from a *different* model with nothing on screen saying so.

## Why the launcher is the right seam

`omo-ai` pins `@code-yeongyu/senpi`, which pins `@anthropic-ai/claude-agent-sdk` **exactly** (`0.3.241`, with per-platform native binaries as pinned optional deps). A dependency-side `overrides` block is ignored by npm for a non-root package, so this package cannot pull a newer SDK build — but it *can* stop handing the engine a binary that is too old for the ids the model catalog advertises. `resolveClaudeCodeExecutable` already reads `CLAUDE_CODE_EXECUTABLE` before the bundled candidates; this change makes the launcher answer that variable when, and only when, it is safe to.

This is the same shape as the existing `claudeCodeVersionFloor` in `bin/senpi-patch.mjs` (the #7650 fix): a version floor that no-ops the moment the pinned engine ships a build at or above it.

## What changed

New `bin/lib/claude-code-executable.js`, wired into `senpiEnvironment()` in `bin/lib/launcher.js`. It returns a path only when **all** of these hold:

1. the user has not set `CLAUDE_CODE_EXECUTABLE` (an explicit value always wins);
2. the engine's bundled `@anthropic-ai/claude-agent-sdk` is **below `0.3.257`**;
3. a standalone `@anthropic-ai/claude-code` is installed beside this package at **`2.1.257` or newer**;
4. its `bin.claude` binary actually exists on disk.

Anything else — unreadable manifest, missing package, malformed JSON, absent binary — returns `undefined` and the engine spawns exactly as before. Resolution is fail-open by contract; it never gates the spawn.

## How the floor was pinned

Not guessed — string-scanned from the published win32-x64 native binaries:

```text
@anthropic-ai/claude-agent-sdk-win32-x64@0.3.252  ->  claude-fable-5-1 ABSENT
@anthropic-ai/claude-agent-sdk-win32-x64@0.3.257  ->  claude-fable-5-1 present
```

`0.3.253`–`0.3.256` were never published, so `0.3.257` is the exact first build carrying the id. Standalone Claude Code ships the same binary under a lockstep patch number (`claude-code 2.1.N` ↔ `claude-agent-sdk 0.3.N`; locally `claude-code@2.1.259/bin/claude.exe` is 219,715,232 bytes against `claude-agent-sdk-win32-x64@0.3.259`'s 219,715,808-byte unpacked size), which is why the standalone floor is `2.1.257`.

The bundled `0.3.241` binary does know `claude-opus-5`, `claude-sonnet-5` and `claude-mythos-5` — the gap is specific to ids published after that build.

## Verification

`bun test packages/omo-native/test/claude-code-executable.test.ts` — 8 pass, covering: stale bundled + newer standalone → path returned; explicit env value → untouched; bundled at floor → untouched; standalone missing → untouched; standalone below floor → untouched; standalone exactly at floor → returned; unreadable bundled manifest → fail-open; malformed standalone manifest → fail-open.

Real-surface check against a live global install (Windows 10.0.26200, node v24.13.0, `omo-ai@5.0.0-0.beta.35`, engine `senpi@2026.9.2-4`, bundled SDK `0.3.241`, standalone `claude-code@2.1.259`):

```text
claudeCodeExecutableOverride({ env: {}, senpiRoot, root })
  -> C:\Users\lg\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe
claudeCodeExecutableOverride({ env: { CLAUDE_CODE_EXECUTABLE: "/x" }, ... })
  -> undefined
```

That resolved path is exactly the binary this behavior was measured against on the same box:

| model | executable | fallback | rc | secs | outcome |
|---|---|---|---|---|---|
| `claude-fable-5-1` | bundled 0.3.241 | off | 124 | 152 | `stopReason: error`, 0 tokens, then the process hangs past `agent_end` |
| `claude-fable-5-1` | standalone 2.1.259 | off | 0 | 116 | `stopReason: stop`, 19387 tokens, correct answer |
| `claude-fable-5-1` | bundled 0.3.241 | on | 0 | 118 | normal-looking answer — silently produced by another model |
| `claude-fable-5` | bundled 0.3.241 | on | 0 | 42 | ok (control) |
| `claude-opus-5` | bundled 0.3.241 | on | 0 | 45 | ok (control) |

Full diagnostic capture is in [this comment on #7626](https://github.com/code-yeongyu/oh-my-openagent/issues/7626#issuecomment-5519204488).

`bun test packages/omo-native/test` on this branch: 168 pass / 34 skip / 8 fail — the 8 failures are identical on pristine `dev` in the same worktree (they need an installed workspace and a staged `plugin/` payload, neither of which this change touches).

## Scope / what this does not fix

- Silent fallback substitution is still invisible when no standalone is installed. Suggestions 1 and 2 in the issue body (surface the substitution; map `query_failed` to an actionable message naming `CLAUDE_CODE_EXECUTABLE`) live in the engine and are untouched here.
- On Windows the failed query also leaves the process alive after `agent_end`; that hang is an engine-side issue and is not addressed by this PR.
- Users with a stale bundled SDK and no standalone Claude Code see no behavior change at all.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7626: queries for Claude model ids the bundled `@anthropic-ai/claude-agent-sdk` binary does not know fail with `errorMessage: "unknown"` and the retry fallback silently answers from a different model. The launcher now points `CLAUDE_CODE_EXECUTABLE` at a newer standalone `@anthropic-ai/claude-code` when one is installed, so the selected model actually answers.

**Behavior**
- Sets `CLAUDE_CODE_EXECUTABLE` only when the bundled SDK is below `0.3.257` and a standalone `@anthropic-ai/claude-code` at `2.1.257` or newer is installed with its `bin.claude` binary present.
- An explicit user-set value always wins, and every resolution failure is fail-open, so the engine spawns exactly as before.

<sup>Written for commit 3b03315fa0c43c92bb660c2592aa658d866617d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

