### PR TITLE
ci: add allowlisted Windows flake soak workflow

### DIFF
--- a/.github/workflows/windows-flake-soak.yml
+++ b/.github/workflows/windows-flake-soak.yml
@@ -1,0 +1,165 @@
+name: Windows flake soak
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Focused Windows test target to repeat
+        required: true
+        type: choice
+        options:
+          - reconciliation
+          - hooks-state
+          - mailbox
+          - team-message
+          - memory-supervisor
+          - facts-lock
+          - reply-listener
+          - dag-race
+          - memfs-restore
+          - senpi-overflow
+          - full-shard-2
+      iterations:
+        description: Number of identical iterations to run
+        required: true
+        default: 10
+        type: number
+
+permissions:
+  contents: read
+
+jobs:
+  soak:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run allowlisted target repeatedly
+        shell: pwsh
+        env:
+          SOAK_TARGET: ${{ inputs.target }}
+          SOAK_ITERATIONS: ${{ inputs.iterations }}
+          WINDOWS_TEST_SHARD: flake-soak
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+
+          $targets = @{
+            "reconciliation" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "packages/omo-senpi/src/components/memory/worker/run-reconciliation.test.ts")
+              }
+            )
+            "hooks-state" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "script/senpi-hooks-state.test.ts")
+              }
+            )
+            "mailbox" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "packages/omo-senpi/src/components/thread/mailbox.test.ts")
+              }
+            )
+            "team-message" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts")
+              }
+            )
+            "memory-supervisor" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.integration.test.ts")
+              }
+            )
+            "facts-lock" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "packages/memory-core/src/locks", "packages/omo-senpi/src/components/memory/commands/facts.test.ts")
+              }
+            )
+            "reply-listener" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "packages/openclaw-core/src/__tests__/reply-listener-startup.test.ts")
+              }
+            )
+            "dag-race" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "packages/senpi-task/src/dag")
+              }
+            )
+            "memfs-restore" = @(
+              [ordered]@{
+                Phase = "test"
+                Arguments = [string[]]@("test", "packages/omo-senpi/src/components/memory/commands/memfs-extra.test.ts")
+              }
+            )
+            "senpi-overflow" = @()
+            "full-shard-2" = @(
+              [ordered]@{
+                Phase = "quarantine"
+                Arguments = [string[]]@("test", "packages/senpi-task/src/runners/rpc-process.windows.test.ts", "packages/senpi-task/src/__adversarial__/chaos-bench.test.ts", "packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts", "script/codex-installer-version.test.ts", "packages/shared-skills/provenance-gate.test.ts", "packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts", "packages/senpi-task/src/dag/scheduler.test.ts", "packages/omo-native/test/payload.test.ts", "script/build-omo-binary.test.ts")
+              }
+              [ordered]@{
+                Phase = "remainder"
+                Arguments = [string[]]@("--config=bunfig.win2.parallel.toml", "test", "--parallel")
+              }
+            )
+          }
+
+          $target = $env:SOAK_TARGET
+          if (-not $targets.ContainsKey($target)) {
+            Write-Error "windows soak target is not allowlisted"
+            exit 1
+          }
+
+          $iterationCount = 0
+          if (
+            -not [int]::TryParse($env:SOAK_ITERATIONS, [ref]$iterationCount) -or
+            $iterationCount -lt 1 -or $iterationCount -gt 50
+          ) {
+            Write-Error "windows soak iterations must be an integer from 1 to 50"
+            exit 1
+          }
+
+          if ($target -eq "senpi-overflow") {
+            Write-Error "target not yet implemented: senpi-overflow"
+            exit 1
+          }
+
+          $telemetryDirectory = Join-Path $env:RUNNER_TEMP "windows-flake-soak-telemetry"
+          $phases = @($targets[$target])
+          for ($iteration = 1; $iteration -le $iterationCount; $iteration++) {
+            foreach ($phase in $phases) {
+              $invocation = "$target-iteration-$iteration-$($phase.Phase)"
+              & .github/scripts/windows-ci-telemetry.ps1 `
+                -ArtifactDirectory $telemetryDirectory `
+                -Invocation $invocation `
+                -TestArguments $phase.Arguments
+              $iterationExitCode = $LASTEXITCODE
+              if ($iterationExitCode -ne 0) {
+                Write-Error "Windows soak target '$target' failed at iteration $iteration (phase '$($phase.Phase)')."
+                exit $iterationExitCode
+              }
+            }
+          }
+
+      - name: Upload Windows soak telemetry
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-flake-soak-${{ inputs.target }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/windows-flake-soak-telemetry/*.json
+          if-no-files-found: warn

--- a/.github/workflows/windows-flake-soak.yml
+++ b/.github/workflows/windows-flake-soak.yml
@@ -31,6 +31,9 @@ permissions:
 jobs:
   soak:
     runs-on: windows-latest
+    env:
+      SOAK_ITERATIONS_RAN: "0"
+      SOAK_FAILED_ITERATION: none
     steps:
       - uses: actions/checkout@v7
 
@@ -142,6 +145,7 @@ jobs:
           $telemetryDirectory = Join-Path $env:RUNNER_TEMP "windows-flake-soak-telemetry"
           $phases = @($targets[$target])
           for ($iteration = 1; $iteration -le $iterationCount; $iteration++) {
+            "SOAK_ITERATIONS_RAN=$iteration" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
             foreach ($phase in $phases) {
               $invocation = "$target-iteration-$iteration-$($phase.Phase)"
               & .github/scripts/windows-ci-telemetry.ps1 `
@@ -150,6 +154,7 @@ jobs:
                 -TestArguments $phase.Arguments
               $iterationExitCode = $LASTEXITCODE
               if ($iterationExitCode -ne 0) {
+                "SOAK_FAILED_ITERATION=$iteration" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
                 Write-Error "Windows soak target '$target' failed at iteration $iteration (phase '$($phase.Phase)')."
                 exit $iterationExitCode
               }
@@ -163,3 +168,18 @@ jobs:
           name: windows-flake-soak-${{ inputs.target }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/windows-flake-soak-telemetry/*.json
           if-no-files-found: warn
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        env:
+          JOB_SUMMARY_TITLE: Windows flake soak (${{ inputs.target }})
+          JOB_SUMMARY_STATUS: ${{ job.status }}
+          JOB_SUMMARY_DETAILS: |
+            - Selected target: `${{ inputs.target }}`.
+            - Requested iterations: `${{ inputs.iterations }}`.
+            - Iterations actually run: `${{ env.SOAK_ITERATIONS_RAN }}`.
+            - Failed iteration: `${{ env.SOAK_FAILED_ITERATION }}`.
+            - Telemetry artifact: `windows-flake-soak-${{ inputs.target }}-${{ github.run_id }}-${{ github.run_attempt }}` in this workflow run's **Artifacts** section.
+          JOB_SUMMARY_NEXT: Download the telemetry artifact from this workflow run and inspect the JSON for the failed iteration.
+        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -56,6 +56,7 @@ const workflowExpectations = [
   { path: ".github/workflows/stats.yml", jobs: ["stats"] },
   { path: ".github/workflows/web-ci.yml", jobs: ["format-lint-typecheck-build"] },
   { path: ".github/workflows/web-deploy.yml", jobs: ["deploy"] },
+  { path: ".github/workflows/windows-flake-soak.yml", jobs: ["soak"] },
 ] as const satisfies readonly WorkflowExpectation[]
 
 function discoverWorkflowPaths(): readonly string[] {

--- a/script/windows-flake-soak-workflow.test.ts
+++ b/script/windows-flake-soak-workflow.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+
+const workflowPath = new URL("../.github/workflows/windows-flake-soak.yml", import.meta.url)
+const workflow = existsSync(workflowPath) ? readFileSync(workflowPath, "utf8") : ""
+const unsupportedTargetFixture = "bun-test-from-user-input"
+
+const expectedTargets = [
+  {
+    name: "reconciliation",
+    arguments: [
+      '@("test", "packages/omo-senpi/src/components/memory/worker/run-reconciliation.test.ts")',
+    ],
+  },
+  {
+    name: "hooks-state",
+    arguments: ['@("test", "script/senpi-hooks-state.test.ts")'],
+  },
+  {
+    name: "mailbox",
+    arguments: ['@("test", "packages/omo-senpi/src/components/thread/mailbox.test.ts")'],
+  },
+  {
+    name: "team-message",
+    arguments: [
+      '@("test", "packages/omo-opencode/src/features/team-mode/tools/messaging.test.ts")',
+    ],
+  },
+  {
+    name: "memory-supervisor",
+    arguments: [
+      '@("test", "packages/omo-senpi/src/components/memory/worker/memory-run-supervisor.integration.test.ts")',
+    ],
+  },
+  {
+    name: "facts-lock",
+    arguments: [
+      '@("test", "packages/memory-core/src/locks", "packages/omo-senpi/src/components/memory/commands/facts.test.ts")',
+    ],
+  },
+  {
+    name: "reply-listener",
+    arguments: [
+      '@("test", "packages/openclaw-core/src/__tests__/reply-listener-startup.test.ts")',
+    ],
+  },
+  {
+    name: "dag-race",
+    arguments: ['@("test", "packages/senpi-task/src/dag")'],
+  },
+  {
+    name: "memfs-restore",
+    arguments: [
+      '@("test", "packages/omo-senpi/src/components/memory/commands/memfs-extra.test.ts")',
+    ],
+  },
+  {
+    name: "senpi-overflow",
+    arguments: [] as readonly string[],
+  },
+  {
+    name: "full-shard-2",
+    arguments: [
+      '@("test", "packages/senpi-task/src/runners/rpc-process.windows.test.ts", "packages/senpi-task/src/__adversarial__/chaos-bench.test.ts", "packages/omo-codex/src/install/install-codex-legacy-agent-purge.test.ts", "script/codex-installer-version.test.ts", "packages/shared-skills/provenance-gate.test.ts", "packages/omo-codex/src/install/install-codex-mcp-manifest.test.ts", "packages/senpi-task/src/dag/scheduler.test.ts", "packages/omo-native/test/payload.test.ts", "script/build-omo-binary.test.ts")',
+      '@("--config=bunfig.win2.parallel.toml", "test", "--parallel")',
+    ],
+  },
+] as const
+
+function assertTargetAllowlisted(source: string, target: string): void {
+  if (!source.includes(`        - ${target}`) || !source.includes(`"${target}" = @(`)) {
+    throw new Error("windows soak target is not allowlisted")
+  }
+}
+
+function soakStep(source: string): string {
+  const start = source.indexOf("      - name: Run allowlisted target repeatedly")
+  const end = source.indexOf("      - name: Upload Windows soak telemetry", start)
+  if (start < 0 || end < 0) throw new Error("windows soak step not found")
+  const step = source.slice(start, end)
+  const runStart = step.indexOf("        run: |\n")
+  if (runStart < 0) throw new Error("windows soak run block not found")
+  return step.slice(runStart)
+}
+
+describe("Windows flake soak workflow", () => {
+  test("#given an unsupported target fixture #when the allowlist is checked #then the target is rejected", () => {
+    expect(() => assertTargetAllowlisted(workflow, unsupportedTargetFixture)).toThrow(
+      "windows soak target is not allowlisted",
+    )
+  })
+
+  test("#given intended flaky surfaces #when the allowlist is checked #then every target is predeclared", () => {
+    for (const target of expectedTargets) {
+      assertTargetAllowlisted(workflow, target.name)
+    }
+  })
+
+  test("#given a manually dispatched soak #when triggers are inspected #then no automatic event is registered", () => {
+    const triggerStart = workflow.indexOf("on:\n")
+    const triggerEnd = workflow.indexOf("\npermissions:", triggerStart)
+    const trigger = workflow.slice(triggerStart, triggerEnd)
+
+    expect(trigger).toContain("workflow_dispatch:")
+    expect(trigger).not.toContain("push:")
+    expect(trigger).not.toContain("pull_request:")
+  })
+
+  test("#given target and iteration inputs #when the job starts #then both boundaries are validated", () => {
+    const step = soakStep(workflow)
+
+    expect(workflow).toContain("runs-on: windows-latest")
+    expect(workflow).toContain("type: choice")
+    expect(workflow).toContain("type: number")
+    expect(step).toContain("$targets.ContainsKey($target)")
+    expect(step).toContain('Write-Error "windows soak target is not allowlisted"')
+    expect(step).toContain("[int]::TryParse($env:SOAK_ITERATIONS, [ref]$iterationCount)")
+    expect(step).toContain("$iterationCount -lt 1 -or $iterationCount -gt 50")
+  })
+
+  test("#given an allowlisted target #when commands are resolved #then only fixed Bun arguments are selected", () => {
+    const step = soakStep(workflow)
+
+    for (const target of expectedTargets) {
+      for (const args of target.arguments) {
+        expect(step).toContain(args)
+      }
+    }
+    expect(step).toContain('$target -eq "senpi-overflow"')
+    expect(step).toContain("target not yet implemented: senpi-overflow")
+    expect(step).toContain("-TestArguments $phase.Arguments")
+    expect(step).not.toContain("${{ inputs.target }}")
+    expect(step).not.toContain("Invoke-Expression")
+    expect(step).not.toContain("cmd /c")
+    expect(step).not.toContain("powershell -Command")
+  })
+
+  test("#given multiple iterations #when a selected command runs #then arguments stay unchanged and the first failure stops", () => {
+    const step = soakStep(workflow)
+
+    expect(step).toContain("$phases = @($targets[$target])")
+    expect(step).toContain(
+      "for ($iteration = 1; $iteration -le $iterationCount; $iteration++)",
+    )
+    expect(step).toContain("& .github/scripts/windows-ci-telemetry.ps1")
+    expect(step).toContain("failed at iteration $iteration")
+    expect(step).toContain("exit $iterationExitCode")
+    expect(step).not.toContain("timeout")
+    expect(step).not.toContain("$phase.Arguments +")
+  })
+
+  test("#given any job outcome #when the soak finishes #then telemetry artifacts always upload", () => {
+    const uploadStart = workflow.indexOf("      - name: Upload Windows soak telemetry")
+    const upload = workflow.slice(uploadStart)
+
+    expect(upload).toContain("if: always()")
+    expect(upload).toContain("uses: actions/upload-artifact@v4")
+    expect(upload).toContain("${{ github.run_id }}-${{ github.run_attempt }}")
+    expect(upload).toContain("if-no-files-found: warn")
+  })
+})


### PR DESCRIPTION
Adds a workflow_dispatch-only native Windows workflow that repeats an allowlisted focused test target N times with the existing per-iteration telemetry, stops on the first failure, and always uploads artifacts. No arbitrary commands, no timeout overrides, no changes to normal CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual-only Windows workflow that soaks a selected flaky test target by repeating it up to 50 times with the existing per-iteration telemetry, stopping at the first failure, always uploading artifacts, and writing a job summary with run details. Normal CI is untouched.

**New Features**
- Both inputs are validated: the target must be on an 11-entry allowlist and iterations must be 1–50.
- Each target maps to hardcoded test arguments, so the dispatch input never reaches the shell; `senpi-overflow` is a placeholder that errors until implemented.
- `script/windows-flake-soak-workflow.test.ts` guards the allowlist, the manual-only trigger, and the fixed-arguments constraint.

<sup>Written for commit c15f4266e2ee2a8a2abebe0d5ca7be03cec2a25d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

