### PR TITLE
ci: temporarily serialize Windows shard 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
           & .github/scripts/windows-ci-telemetry.ps1 `
             -ArtifactDirectory $telemetryDirectory `
             -Invocation "shard-2-remainder" `
-            -TestArguments @("--config=bunfig.win2.parallel.toml", "test", "--parallel")
+            -TestArguments @("--config=bunfig.win2.parallel.toml", "test")
           exit $LASTEXITCODE
 
       - name: Upload Windows post-test telemetry

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/README.md
@@ -53,6 +53,28 @@ The commands were run from the isolated
   inheritance failure was an intermittent flake, not a regression caused by
   serialization. Serializing Windows shard 2 is safe.
 
+## Post-Rebase Root-Cause Update
+
+- PR #7678 failed CI twice before this rebase. Both failures occurred only in
+  `test (windows-latest, 2/2)` on
+  `omo setup credential inheritance > #given pinned omp and gjc databases #when accepted #then allow-listed rows import and unknown schema is noticed`.
+  In both runs, two `win32 EBUSY` teardown-failure lines preceded a
+  `beforeEach`/`afterEach` teardown hook timeout.
+- The failures were root-caused to leaked setup-import SQLite database
+  handles. The fix landed on `origin/dev` as commit `e54c7c18c` in PR #7681,
+  closing those handles deterministically through the existing
+  `withDatabase` helper.
+- `ci/windows-shard2-serial` was rebased cleanly onto the `origin/dev` tip at
+  `e54c7c18c`. The rebased workflow still removes only `--parallel` from the
+  telemetry-wrapped Windows shard-2 remainder invocation.
+- The required post-rebase regression command passed with `28 pass`,
+  `0 fail`, and `203 expect() calls`:
+  `bun test script/ci-root-test-partition.test.ts script/ci-job-summary-workflow.test.ts script/windows-flake-soak-workflow.test.ts`.
+- This rebase is the decisive serial-plus-fix validation configuration:
+  Windows shard 2 now runs serially while also containing the deterministic
+  setup-import database-handle fix. Per instruction, this update is pushed
+  without waiting for the resulting CI run.
+
 ## Known Defect
 
 The `.github/workflows/windows-flake-soak.yml` job summary reported

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/README.md
@@ -1,0 +1,65 @@
+# Windows Shard 2 Serial QA Evidence
+
+## What Was Tested
+
+1. Failing-first contract:
+   `bun test script/ci-root-test-partition.test.ts`
+2. Green contract after the workflow change:
+   `bun test script/ci-root-test-partition.test.ts`
+3. Required workflow regression set:
+   `bun test script/ci-root-test-partition.test.ts script/ci-job-summary-workflow.test.ts script/windows-flake-soak-workflow.test.ts`
+4. Repository-equivalent workflow lint:
+   `actionlint -shellcheck="" .github/workflows/ci.yml`
+5. Diff review of the Windows shard-2 remainder, its telemetry wrapper, the
+   serial quarantine command, and the workflow-summary invariant.
+
+The commands were run from the isolated
+`ci/windows-shard2-serial` worktree.
+
+## What Was Observed
+
+- RED failed for the intended reason with the exact diagnostic:
+  `windows shard 2 must remain serial while five-gate repairs are pending`.
+  The full output is in `red.txt`.
+- GREEN passed with `17 pass`, `0 fail`, and `96 expect() calls`.
+  The full output is in `green.txt`.
+- The required three-file regression set passed with `28 pass`, `0 fail`,
+  and `203 expect() calls`. The full output is in `verification.txt`.
+- Repository-equivalent actionlint exited 0 with no output. The command and
+  result are in `actionlint.txt`.
+- A plain actionlint run with shellcheck enabled reported the existing
+  `SC2129` finding at the CI classifier block and `SC2016` finding at the
+  draft-release block. Neither finding is in the changed Windows invocation.
+  The repository's `lint-workflows` gate disables shellcheck, so the
+  repository-equivalent actionlint command above is the relevant clean gate.
+
+## Why It Is Enough
+
+The failing-first contract proves that the previous telemetry-wrapped Windows
+shard-2 remainder is rejected specifically for carrying `--parallel`. The
+same contract then proves that the remainder keeps the telemetry invocation
+and uses the unchanged `bunfig.win2.parallel.toml` without the parallel flag.
+
+The combined regression run also proves that:
+
+- the serial quarantine and root-test partition remain intact;
+- every step-based job still writes its required Markdown job summary; and
+- `.github/workflows/windows-flake-soak.yml` remains unchanged and satisfies
+  its contract.
+
+Actionlint provides the closest local execution surface for validating that
+the edited GitHub Actions workflow remains structurally valid.
+
+## What Was Omitted
+
+This change only removes `--parallel` from the Windows shard-2 remainder. It
+does not affect the separate `senpi-compatibility` job and does not affect
+shard 1. It is expected to help only shard-2 flakes, such as the OpenClaw
+reply-listener startup test and the
+`script/senpi-hooks-state.test.ts` legacy-boundary test. This evidence does not
+claim that the change fixes `senpi-compatibility` flakes.
+
+No test was skipped, retried, or given a longer timeout. The serial quarantine
+command was preserved. `bunfig.win2.parallel.toml` and
+`.github/workflows/windows-flake-soak.yml` were not edited. CI was not awaited
+because the requested stop point is immediately after PR creation.

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/README.md
@@ -12,6 +12,9 @@
    `actionlint -shellcheck="" .github/workflows/ci.yml`
 5. Diff review of the Windows shard-2 remainder, its telemetry wrapper, the
    serial quarantine command, and the workflow-summary invariant.
+6. Windows flake soak workflow run `33713505691`, dispatched against
+   `ci/windows-shard2-serial` with `target=full-shard-2` and `iterations=3`.
+   Each iteration ran both parts of shard 2 under serial execution.
 
 The commands were run from the isolated
 `ci/windows-shard2-serial` worktree.
@@ -32,6 +35,31 @@ The commands were run from the isolated
   draft-release block. Neither finding is in the changed Windows invocation.
   The repository's `lint-workflows` gate disables shellcheck, so the
   repository-equivalent actionlint command above is the relevant clean gate.
+- CI run `33712499816` previously completed `test (windows-latest, 2/2)` with
+  `5377 pass, 1 fail`. The single failure that triggered this investigation
+  was:
+  `omo setup credential inheritance > #given pinned omp and gjc databases #when accepted #then allow-listed rows import and unknown schema is noticed`.
+  The job did not time out.
+- Soak run `33713505691` completed successfully with three full iterations:
+  - iteration 1: `89 pass / 0 fail` and `5379 pass / 0 fail`;
+  - iteration 2: `89 pass / 0 fail` and `5379 pass / 0 fail`;
+  - iteration 3: `89 pass / 0 fail` and `5379 pass / 0 fail`.
+- The soak therefore executed `16404` tests under serial execution with zero
+  failures.
+- The Windows shard-2 job duration increased from approximately `7m44s` with
+  `--parallel` to `10m38s` under serial execution, remaining far below the
+  60-minute job timeout.
+- The three clean serial iterations show that the earlier credential-
+  inheritance failure was an intermittent flake, not a regression caused by
+  serialization. Serializing Windows shard 2 is safe.
+
+## Known Defect
+
+The `.github/workflows/windows-flake-soak.yml` job summary reported
+`SOAK_ITERATIONS_RAN=0` even though the run logs prove that all three requested
+iterations completed. This counter defect is intentionally not fixed in this
+PR. It must be addressed as follow-up work before relying on the summary for
+trustworthy 20-pass receipts.
 
 ## Why It Is Enough
 
@@ -49,6 +77,11 @@ The combined regression run also proves that:
 
 Actionlint provides the closest local execution surface for validating that
 the edited GitHub Actions workflow remains structurally valid.
+
+The dedicated Windows soak directly exercised both parts of shard 2 three
+times with the proposed serial invocation. Its `16404` passing executions
+cover the suspected module-state-leak risk and distinguish the prior isolated
+failure from a deterministic serialization regression.
 
 ## What Was Omitted
 

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/actionlint.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/actionlint.txt
@@ -1,0 +1,6 @@
+Command:
+actionlint -shellcheck="" .github/workflows/ci.yml
+
+Observed:
+exit code 0
+stdout/stderr empty

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/green.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/green.txt
@@ -1,0 +1,8 @@
+bun test v1.3.14 (0d9b296a)
+
+ 17 pass
+ 0 fail
+ 96 expect() calls
+Ran 17 tests across 1 file. [576.00ms]
+
+Command exited with code 0

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/red.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/red.txt
@@ -1,0 +1,22 @@
+$ bun test ./script/ci-root-test-partition.test.ts
+bun test v1.3.14 (0d9b296a)
+
+script/ci-root-test-partition.test.ts:
+[test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...
+81 |
+82 |     const windowsStep = job.slice(windowsStepStart, windowsStepEnd)
+83 |     if (windowsStep.includes('"--parallel"')) {
+84 |       throw new Error(
+85 |         "windows shard 2 must remain serial while five-gate repairs are pending",
+86 |       )
+           ^
+error: windows shard 2 must remain serial while five-gate repairs are pending
+      at <anonymous> (/Users/sungsoopark/Documents/GitHub/oh-my-openagent/.local-ignore/pr-worktrees/windows-shard2-serial/script/ci-root-test-partition.test.ts:86:7)
+(fail) root test CI partition > #given Windows shard 2 #when the remainder runs #then it remains serial [0.18ms]
+
+ 16 pass
+ 1 fail
+ 94 expect() calls
+Ran 17 tests across 1 file. [3.40s]
+
+Command exited with code 1

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/verification.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/verification.txt
@@ -1,0 +1,8 @@
+bun test v1.3.14 (0d9b296a)
+
+ 28 pass
+ 0 fail
+ 203 expect() calls
+Ran 28 tests across 3 files. [613.00ms]
+
+Command exited with code 0

--- a/script/ci-root-test-partition.test.ts
+++ b/script/ci-root-test-partition.test.ts
@@ -66,13 +66,36 @@ describe("root test CI partition", () => {
     expect(matrix).not.toContain("parallel_args:")
   })
 
+  test("#given Windows shard 2 #when the remainder runs #then it remains serial", () => {
+    const job = rootTestJob()
+    const windowsStepStart = job.indexOf(
+      "runner.os == 'Windows' && matrix.shard == '2/2'",
+    )
+    const windowsStepEnd = job.indexOf(
+      "      - name: Upload Windows post-test telemetry",
+      windowsStepStart,
+    )
+
+    expect(windowsStepStart).toBeGreaterThanOrEqual(0)
+    expect(windowsStepEnd).toBeGreaterThan(windowsStepStart)
+
+    const windowsStep = job.slice(windowsStepStart, windowsStepEnd)
+    if (windowsStep.includes('"--parallel"')) {
+      throw new Error(
+        "windows shard 2 must remain serial while five-gate repairs are pending",
+      )
+    }
+
+    expect(windowsStep).toContain('-Invocation "shard-2-remainder"')
+    expect(windowsStep).toContain(
+      '-TestArguments @("--config=bunfig.win2.parallel.toml", "test")',
+    )
+  })
+
   test("#given global zauc mocks #when Windows root tests are partitioned #then omo-opencode stays in one process", () => {
     const job = rootTestJob()
 
     expect(job).toContain("bun test packages/omo-opencode packages/memory-core")
-    expect(job).toContain(
-      '-TestArguments @("--config=bunfig.win2.parallel.toml", "test", "--parallel")',
-    )
     expect(existsSync(win2ConfigPath)).toBe(true)
     expect(existsSync(win2ParallelConfigPath)).toBe(true)
     expect(quotedPatterns(readFileSync(win2ConfigPath, "utf8"))).toContain("packages/omo-opencode/**")


### PR DESCRIPTION
## Summary

Temporarily serialize only the Windows shard-2 root-test remainder by removing its `--parallel` argument. The existing `windows-ci-telemetry.ps1` wrapper, serial quarantine command, test inventory, timeout, and all other workflow behavior remain unchanged.

## History

Commit `8a4d426ab` on 2026-08-26 parallelized the POSIX root-test legs. Commit `ec342f00b` on 2026-08-27 reverted the POSIX remainder to serial with the message "keep the POSIX root-test remainder serial". Windows was not reverted and has been the only platform running the shard-2 remainder in parallel since `6eff0edbc` on 2026-08-18. This PR aligns that Windows invocation with the POSIX serial behavior while five-gate repairs are pending.

## Changes

- Add a failing-first workflow contract that rejects a Windows shard-2 remainder containing `--parallel` with the required stable diagnostic.
- Remove only `--parallel` from the telemetry-wrapped Windows `shard-2-remainder` invocation.
- Preserve the separate serial quarantine command and every test.

## QA and Evidence

- RED: `bun test script/ci-root-test-partition.test.ts` failed with `windows shard 2 must remain serial while five-gate repairs are pending`.
- GREEN: the same command passed with 17 tests and 0 failures after the workflow edit.
- Required regression set passed: 28 tests, 0 failures across `script/ci-root-test-partition.test.ts`, `script/ci-job-summary-workflow.test.ts`, and `script/windows-flake-soak-workflow.test.ts`. The job-summary contract confirms every step-based job still writes a Markdown job summary.
- Repository-equivalent `actionlint -shellcheck="" .github/workflows/ci.yml` exited 0.
- Reviewer-readable artifacts: `.omo/evidence/omo-senpi-adapter/20260903-windows-shard2-serial/`.

## Windows Soak Follow-up

- CI run `33712499816` completed Windows shard 2 with `5377 pass, 1 fail`; the single failure was `omo setup credential inheritance > #given pinned omp and gjc databases #when accepted #then allow-listed rows import and unknown schema is noticed`. The job did not time out.
- Windows flake soak run `33713505691` targeted `full-shard-2` for three iterations against this branch and completed successfully.
- Each iteration ran both parts of shard 2 with `89 pass / 0 fail` and `5379 pass / 0 fail`, for `16404` serial test executions with zero failures overall.
- The shard-2 duration changed from approximately `7m44s` with `--parallel` to `10m38s` serial, still far below the 60-minute timeout.
- Conclusion: the earlier credential-inheritance failure was an intermittent flake, not a serialization regression. Serializing Windows shard 2 is safe.
- Known follow-up defect: `.github/workflows/windows-flake-soak.yml` reported `SOAK_ITERATIONS_RAN=0` in the job summary even though the logs prove all three iterations ran. This PR intentionally does not fix that counter; it needs separate follow-up before trusting 20-pass receipts.

## Scope Limit

`--parallel` only affects shard 2. It does not affect the separate `senpi-compatibility` job, and it does not affect shard 1. This change is expected to help only shard-2 flakes, for example the OpenClaw reply-listener startup test and the `script/senpi-hooks-state.test.ts` legacy-boundary test. It does not claim to fix `senpi-compatibility` flakes.

No test is skipped or retried, no timeout is added or raised, Windows remains required, `bunfig.win2.parallel.toml` is untouched, and `.github/workflows/windows-flake-soak.yml` is untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily makes the Windows shard-2 root-test remainder run serially by removing `--parallel` from the telemetry-wrapped test invocation, matching the POSIX root-test remainder while five-gate repairs are pending.

**Changes**
- Adds a failing-first workflow contract that rejects a Windows shard-2 remainder containing `--parallel`.
- Rebased onto the setup-import SQLite handle fix that root-caused the earlier flaky credential-inheritance failure.
- A soak run of three full shard-2 iterations passed 16,404 tests with zero failures; serial duration (~10m38s) stays far below the 60-minute timeout.
- Only shard 2 changes; shard 1 and `senpi-compatibility` are untouched, and no tests are skipped, retried, or given new timeouts.
- Leaves the known `SOAK_ITERATIONS_RAN=0` counter defect in `windows-flake-soak.yml` unfixed for follow-up.

<sup>Written for commit e2b14e0787d81b0ae0bc7c8ffb9bf4f92eec7e98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

