### PR TITLE
test(senpi): terminate timed-out hooks-state writers on Windows

### DIFF
--- a/.omo/evidence/20260903-hooks-state-writer-cleanup/README.md
+++ b/.omo/evidence/20260903-hooks-state-writer-cleanup/README.md
@@ -1,0 +1,95 @@
+# Hooks-State Writer Cleanup Evidence
+
+## WHAT WAS TESTED
+
+1. `git grep -n 'spawnSync("kill"'`
+   - Established the baseline blast radius before implementation.
+2. `git grep -n 'skipIf(process.platform === "win32")' -- script/senpi-hooks-state.test.ts`
+   - Confirmed that only the two POSIX mode tests skipped Windows while the legacy truncate/write recovery test remained active there.
+3. `bun test script/senpi-hooks-state.test.ts`
+   - RED: exercised the new deterministic cleanup-helper tests before adding the Windows branch.
+   - GREEN: exercised simulated Windows tree termination, POSIX process-group signaling, survivor detection, and the existing hooks-state scenarios.
+4. `bun test script/senpi-hooks-state.test.ts script/senpi-hooks-state-errors.test.ts`
+   - Exercised the changed recovery path together with publication and cleanup error handling.
+5. `bun run typecheck:script`
+   - Typechecked every top-level `script/*.ts` file with the repository's script project.
+6. The programming-skill no-excuse audit and pure-line count.
+   - Checked the changed TypeScript for forbidden escape hatches and measured the file at 234 pure lines.
+
+## WHAT WAS OBSERVED
+
+### RED
+
+The simulated Windows test failed because the POSIX-only implementation never invoked `taskkill.exe`:
+
+```text
+error: expect(received).toEqual(expected)
+
+- [
+-   {
+-     "args": [
+-       "/PID",
+-       "4242",
+-       "/T",
+-       "/F",
+-     ],
+-     "command": "taskkill.exe",
+-   },
+- ]
++ []
+
+- Expected  - 11
++ Received  + 1
+```
+
+The full RED output is in `red.txt`.
+
+### GREEN
+
+```text
+9 pass
+0 fail
+14 expect() calls
+Ran 9 tests across 1 file. [689.00ms]
+```
+
+The full GREEN output is in `green.txt`.
+
+The paired regression run passed 12 tests with 20 assertions. `bun run typecheck:script` exited 0. The TypeScript no-excuse audit reported no violations.
+
+The final helper:
+
+- invokes `taskkill.exe /PID <pid> /T /F` for simulated `win32`;
+- sends `SIGTERM` to `-pid` for POSIX process-group termination;
+- polls the writer PID with a bounded 20-attempt verification;
+- returns `{ phase: "verify-exit", pid }` only after the PID is dead;
+- throws a typed cleanup error carrying the failed phase and PID when termination or verification fails;
+- is awaited before `rmSync(root, ...)`, so the temporary root is not removed before writer death is verified.
+
+The baseline repository scan found exactly one `spawnSync("kill"` call:
+
+```text
+script/senpi-hooks-state.test.ts:56:        if (writerPid !== undefined) spawnSync("kill", ["-TERM", `-${writerPid}`])
+```
+
+The same baseline file skipped Windows only at lines 101 and 109:
+
+```text
+script/senpi-hooks-state.test.ts:101:  test.skipIf(process.platform === "win32")("preserves an existing POSIX snapshot mode under a restrictive umask", () => {
+script/senpi-hooks-state.test.ts:109:  test.skipIf(process.platform === "win32")("creates a new POSIX snapshot with mode 0600 under a permissive umask", () => {
+```
+
+The recovery test itself remains enabled on Windows. Its 60,000 ms test budget, 10,000 ms child timeout, and assertions are unchanged.
+
+## WHY IT IS ENOUGH
+
+The RED result proves the regression test distinguishes the old POSIX-only command selection from the required Windows behavior. The GREEN result proves both platform branches and the phase-and-PID survivor failure deterministically without requiring a Windows host. The existing recovery test proves the helper is wired into the ETIMEDOUT path, while the paired error suite and script typecheck cover adjacent behavior and type safety.
+
+The PID verification is part of the helper's success contract, and temporary-root removal occurs only after the awaited success report. This directly covers the leaked-writer and held-lock risk.
+
+## WHAT WAS OMITTED
+
+- No real Windows runner was available; the Windows branch was verified through the requested injected command and liveness seams.
+- The editor LSP attached to the parent workspace could not resolve Bun/Node modules for this nested worktree and reported the same environment-wide import errors across `script/`. The authoritative `bun run typecheck:script` project check passed.
+- Raw environment dumps, credentials, tokens, auth headers, and unrelated build logs were not captured.
+- `bun install --frozen-lockfile` installed dependencies but its automatic prepare build later failed while initializing local shared-skill submodules because Git disallowed the local `file` transport. The requested tests and typecheck ran successfully from the worktree after dependency installation.

--- a/.omo/evidence/20260903-hooks-state-writer-cleanup/green.txt
+++ b/.omo/evidence/20260903-hooks-state-writer-cleanup/green.txt
@@ -1,0 +1,9 @@
+$ bun test script/senpi-hooks-state.test.ts
+bun test v1.3.14 (0d9b296a)
+
+ 9 pass
+ 0 fail
+ 14 expect() calls
+Ran 9 tests across 1 file. [689.00ms]
+
+Command exited with code 0.

--- a/.omo/evidence/20260903-hooks-state-writer-cleanup/red.txt
+++ b/.omo/evidence/20260903-hooks-state-writer-cleanup/red.txt
@@ -1,0 +1,39 @@
+$ bun test script/senpi-hooks-state.test.ts
+bun test v1.3.14 (0d9b296a)
+
+script/senpi-hooks-state.test.ts:
+[test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...
+125 |         signal: () => undefined,
+126 |       },
+127 |       { isAlive: () => false, pause: () => Promise.resolve(), pollAttempts: 1 },
+128 |     )
+129 |
+130 |     expect(calls).toEqual([{
+                        ^
+error: expect(received).toEqual(expected)
+
+- [
+-   {
+-     "args": [
+-       "/PID",
+-       "4242",
+-       "/T",
+-       "/F",
+-     ],
+-     "command": "taskkill.exe",
+-   },
+- ]
++ []
+
+- Expected  - 11
++ Received  + 1
+
+      at <anonymous> (/Users/sungsoopark/Documents/GitHub/oh-my-openagent/.local-ignore/pr-worktrees/hooks-state-writer-cleanup/script/senpi-hooks-state.test.ts:130:19)
+(fail) timed-out hooks-state writer cleanup > uses forced taskkill tree termination on win32 and reports the writer [1.25ms]
+
+ 8 pass
+ 1 fail
+ 13 expect() calls
+Ran 9 tests across 1 file. [3.94s]
+
+Command exited with code 1.

--- a/.omo/evidence/20260903-hooks-state-writer-cleanup/repository-scan.txt
+++ b/.omo/evidence/20260903-hooks-state-writer-cleanup/repository-scan.txt
@@ -1,0 +1,10 @@
+$ git grep -n 'spawnSync("kill"'
+script/senpi-hooks-state.test.ts:56:        if (writerPid !== undefined) spawnSync("kill", ["-TERM", `-${writerPid}`])
+
+Baseline result: this was the only `spawnSync("kill"` site in the repository.
+
+$ git grep -n 'skipIf(process.platform === "win32")' -- script/senpi-hooks-state.test.ts
+script/senpi-hooks-state.test.ts:101:  test.skipIf(process.platform === "win32")("preserves an existing POSIX snapshot mode under a restrictive umask", () => {
+script/senpi-hooks-state.test.ts:109:  test.skipIf(process.platform === "win32")("creates a new POSIX snapshot with mode 0600 under a permissive umask", () => {
+
+Baseline result: the two POSIX mode tests skipped Windows, but the legacy truncate/write recovery test at line 49 did not.

--- a/.omo/evidence/20260903-hooks-state-writer-cleanup/verification.txt
+++ b/.omo/evidence/20260903-hooks-state-writer-cleanup/verification.txt
@@ -1,0 +1,24 @@
+$ bun test script/senpi-hooks-state.test.ts script/senpi-hooks-state-errors.test.ts
+bun test v1.3.14 (0d9b296a)
+
+ 12 pass
+ 0 fail
+ 20 expect() calls
+Ran 12 tests across 2 files. [762.00ms]
+
+Command exited with code 0.
+
+$ bun run typecheck:script
+$ tsgo --noEmit -p script/tsconfig.json
+
+Command exited with code 0.
+
+$ bun run /Users/sungsoopark/.config/opencode/node_modules/oh-my-openagent/packages/shared-skills/skills/programming/scripts/typescript/check-no-excuse-rules.ts script/senpi-hooks-state.test.ts
+No violations in 1 file(s).
+
+Command exited with code 0.
+
+$ awk '!/^[[:space:]]*$/ && !/^[[:space:]]*(\/\/|#|--)/' script/senpi-hooks-state.test.ts | wc -l
+234
+
+The changed test file is in the programming skill's 200-250 warning band and remains below its 250 pure-line defect threshold.

--- a/script/senpi-hooks-state.test.ts
+++ b/script/senpi-hooks-state.test.ts
@@ -14,6 +14,90 @@ import { dirname, join } from "node:path"
 import { CONFIG_DIR_NAME } from "../node_modules/@code-yeongyu/senpi/dist/config.js"
 import { FileHookStateStorage } from "../node_modules/@code-yeongyu/senpi/dist/core/extensions/builtin/hooks/trust-storage.js"
 
+type WriterCleanupPhase = "terminate" | "verify-exit"
+
+interface WriterCleanupReport {
+  readonly phase: WriterCleanupPhase
+  readonly pid: number
+}
+
+interface WriterTermination {
+  readonly platform: NodeJS.Platform
+  readonly run: (command: string, args: readonly string[]) => {
+    readonly error?: Error
+    readonly status: number | null
+    readonly stderr?: string | null
+  }
+  readonly signal: (pid: number, signal: NodeJS.Signals) => void
+}
+
+interface WriterExitVerification {
+  readonly isAlive: (pid: number) => boolean
+  readonly pause: (ms: number) => Promise<void>
+  readonly pollAttempts: number
+}
+
+class TimedOutWriterCleanupError extends Error {
+  constructor(
+    readonly phase: WriterCleanupPhase,
+    readonly pid: number,
+    reason: string,
+  ) {
+    super(`Hooks-state writer cleanup failed during ${phase} for pid ${pid}: ${reason}`)
+  }
+}
+
+const defaultWriterTermination: WriterTermination = {
+  platform: process.platform,
+  run: (command, args) => spawnSync(command, [...args], { encoding: "utf8" }),
+  signal: process.kill.bind(process),
+}
+
+const defaultWriterExitVerification: WriterExitVerification = {
+  isAlive: (pid) => {
+    try {
+      process.kill(pid, 0)
+      return true
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
+      const code = "code" in error ? error.code : undefined
+      if (code === "ESRCH") return false
+      if (code === "EPERM") return true
+      throw error
+    }
+  },
+  pause: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  pollAttempts: 20,
+}
+
+async function terminateTimedOutWriter(
+  pid: number,
+  termination: WriterTermination = defaultWriterTermination,
+  verification: WriterExitVerification = defaultWriterExitVerification,
+): Promise<WriterCleanupReport> {
+  if (termination.platform === "win32") {
+    const result = termination.run("taskkill.exe", ["/PID", String(pid), "/T", "/F"])
+    if (result.error !== undefined || result.status !== 0) {
+      const reason = result.error?.message
+        ?? result.stderr?.trim()
+        ?? `taskkill exited with status ${result.status}`
+      throw new TimedOutWriterCleanupError("terminate", pid, reason)
+    }
+  } else {
+    try {
+      termination.signal(-pid, "SIGTERM")
+    } catch (error) {
+      throw new TimedOutWriterCleanupError("terminate", pid, error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  for (let attempt = 0; attempt < verification.pollAttempts; attempt += 1) {
+    if (!verification.isAlive(pid)) return { phase: "verify-exit", pid }
+    if (attempt + 1 < verification.pollAttempts) await verification.pause(10)
+  }
+  throw new TimedOutWriterCleanupError("verify-exit", pid, "writer remained alive after termination")
+}
+
 function withStorage(run: (fixture: {
   root: string
   statePath: string
@@ -36,6 +120,66 @@ function temporarySnapshots(statePath: string): string[] {
   return readdirSync(dirname(statePath)).filter((name) => name.startsWith(prefix) && name.endsWith(".tmp"))
 }
 
+describe("timed-out hooks-state writer cleanup", () => {
+  test("uses forced taskkill tree termination on win32 and reports the writer", async () => {
+    const calls: Array<{ readonly args: readonly string[]; readonly command: string }> = []
+
+    const report = await terminateTimedOutWriter(
+      4242,
+      {
+        platform: "win32",
+        run: (command, args) => {
+          calls.push({ args, command })
+          return { status: 0 }
+        },
+        signal: () => undefined,
+      },
+      { isAlive: () => false, pause: () => Promise.resolve(), pollAttempts: 1 },
+    )
+
+    expect(calls).toEqual([{
+      command: "taskkill.exe",
+      args: ["/PID", "4242", "/T", "/F"],
+    }])
+    expect(report).toEqual({ phase: "verify-exit", pid: 4242 })
+  })
+
+  test("signals the POSIX writer process group and reports the writer", async () => {
+    const signals: Array<{ readonly pid: number; readonly signal: NodeJS.Signals }> = []
+
+    const report = await terminateTimedOutWriter(
+      5151,
+      {
+        platform: "linux",
+        run: () => {
+          throw new Error("unexpected command spawn")
+        },
+        signal: (pid, signal) => signals.push({ pid, signal }),
+      },
+      { isAlive: () => false, pause: () => Promise.resolve(), pollAttempts: 1 },
+    )
+
+    expect(signals).toEqual([{ pid: -5151, signal: "SIGTERM" }])
+    expect(report).toEqual({ phase: "verify-exit", pid: 5151 })
+  })
+
+  test("reports the verification phase and pid when the writer survives", async () => {
+    const cleanup = terminateTimedOutWriter(
+      6161,
+      {
+        platform: "linux",
+        run: () => {
+          throw new Error("unexpected command spawn")
+        },
+        signal: () => undefined,
+      },
+      { isAlive: () => true, pause: () => Promise.resolve(), pollAttempts: 1 },
+    )
+
+    await expect(cleanup).rejects.toMatchObject({ phase: "verify-exit", pid: 6161 })
+  })
+})
+
 describe("patched Senpi hooks state snapshots", () => {
   test("reads the last complete snapshot while the exact writer lock is held", () => {
     withStorage(({ statePath, storage }) => {
@@ -46,14 +190,14 @@ describe("patched Senpi hooks state snapshots", () => {
     })
   })
 
-  test("recovers a trusted snapshot at a synchronized legacy truncate/write boundary", () => {
+  test("recovers a trusted snapshot at a synchronized legacy truncate/write boundary", async () => {
     const runner = join(import.meta.dir, "fixtures", "senpi-hooks-state-legacy-reader.ts")
     const child = spawnSync(process.execPath, [runner], { encoding: "utf8", timeout: 10_000 })
     if (child.error !== undefined && "code" in child.error && child.error.code === "ETIMEDOUT") {
       const marker = join(tmpdir(), `omo-hooks-legacy-reader-${child.pid}.json`)
       try {
         const { root, writerPid } = JSON.parse(readFileSync(marker, "utf8")) as { root: string; writerPid?: number }
-        if (writerPid !== undefined) spawnSync("kill", ["-TERM", `-${writerPid}`])
+        if (writerPid !== undefined) await terminateTimedOutWriter(writerPid)
         rmSync(root, { recursive: true, force: true })
       } finally {
         rmSync(marker, { force: true })


### PR DESCRIPTION
## Summary

The ETIMEDOUT cleanup used spawnSync('kill', ['-TERM', '-<pid>']), which is POSIX-only. On Windows, a timed-out writer could therefore leak while still holding the hooks-state lock and state file.

This replaces that cleanup with cross-platform process-tree termination plus bounded PID-death verification before temporary-root removal. Windows uses taskkill.exe /PID <pid> /T /F, while POSIX preserves the existing process-group SIGTERM. The test remains enabled on Windows, and neither the 60,000 ms test budget nor the 10,000 ms child timeout was increased.

## Verification

- RED: bun test script/senpi-hooks-state.test.ts failed on the missing Windows taskkill invocation.
- GREEN: the same command passed 9 tests with 14 assertions.
- bun test script/senpi-hooks-state.test.ts script/senpi-hooks-state-errors.test.ts passed 12 tests with 20 assertions.
- bun run typecheck:script passed.
- Reviewer-readable artifacts: .omo/evidence/20260903-hooks-state-writer-cleanup/README.md

## Risk

The Windows command branch is covered deterministically through injected command and liveness seams because this worktree runs on macOS. Survivor handling is also covered and reports the cleanup phase and writer PID.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes timed-out hooks-state writer cleanup on Windows so writers no longer leak while holding the hooks-state lock and state file. The old cleanup used a POSIX-only `kill -TERM -<pid>` call; the new helper uses `taskkill.exe /PID <pid> /T /F` on Windows, keeps process-group SIGTERM on POSIX, and verifies the writer PID has exited before removing the temporary root.

**Testing**
- Added deterministic helper tests covering Windows taskkill, POSIX SIGTERM, and survivor detection; the RED run confirmed the Windows branch was missing.
- GREEN run passed 9 tests with 14 assertions; the paired error suite passed 12 tests with 20 assertions, and `bun run typecheck:script` passed.
- Test budgets and timeouts are unchanged; the Windows branch is covered via injected seams because this worktree runs on macOS.

<sup>Written for commit 090bd9fcdc5de50ea2b6022ec47472952b29f3ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

