### PR TITLE
ci: make Windows flake soak receipts trustworthy

### DIFF
--- a/.github/workflows/windows-flake-soak.yml
+++ b/.github/workflows/windows-flake-soak.yml
@@ -24,6 +24,10 @@ on:
         required: true
         default: 10
         type: number
+      test_ref:
+        description: Git ref whose repository contents should be tested
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -31,11 +35,15 @@ permissions:
 jobs:
   soak:
     runs-on: windows-latest
-    env:
-      SOAK_ITERATIONS_RAN: "0"
-      SOAK_FAILED_ITERATION: none
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.test_ref || github.ref }}
+
+      - uses: actions/setup-node@v7
+        if: inputs.target == 'full-shard-2'
+        with:
+          node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -44,15 +52,27 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Remove stale self-package test copies
+        if: inputs.target == 'full-shard-2'
+        run: bun run script/remove-stale-self-package-tests.ts
+
+      - name: Run vendored lsp-daemon tests
+        if: inputs.target == 'full-shard-2'
+        run: npm test
+        working-directory: packages/lsp-daemon
+
       - name: Run allowlisted target repeatedly
+        id: run-soak
         shell: pwsh
         env:
           SOAK_TARGET: ${{ inputs.target }}
           SOAK_ITERATIONS: ${{ inputs.iterations }}
-          WINDOWS_TEST_SHARD: flake-soak
+          WINDOWS_TEST_SHARD: ${{ inputs.target == 'full-shard-2' && '2/2' || 'flake-soak' }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
+          "iterations_ran=0" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "failed_iteration=none" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
           $targets = @{
             "reconciliation" = @(
@@ -142,10 +162,24 @@ jobs:
             exit 1
           }
 
+          if ($target -eq "full-shard-2") {
+            $ciWorkflow = Get-Content -Path ".github/workflows/ci.yml" -Raw
+            $serialRemainder = '-TestArguments @("--config=bunfig.win2.parallel.toml", "test")'
+            $parallelRemainder = '-TestArguments @("--config=bunfig.win2.parallel.toml", "test", "--parallel")'
+            if ($ciWorkflow.Contains($parallelRemainder)) {
+              $targets[$target][1].Arguments = [string[]]@("--config=bunfig.win2.parallel.toml", "test", "--parallel")
+            } elseif ($ciWorkflow.Contains($serialRemainder)) {
+              $targets[$target][1].Arguments = [string[]]@("--config=bunfig.win2.parallel.toml", "test")
+            } else {
+              Write-Error "checked-out ci.yml has an unsupported Windows shard-2 remainder command"
+              exit 1
+            }
+          }
+
           $telemetryDirectory = Join-Path $env:RUNNER_TEMP "windows-flake-soak-telemetry"
           $phases = @($targets[$target])
           for ($iteration = 1; $iteration -le $iterationCount; $iteration++) {
-            "SOAK_ITERATIONS_RAN=$iteration" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "iterations_ran=$iteration" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             foreach ($phase in $phases) {
               $invocation = "$target-iteration-$iteration-$($phase.Phase)"
               & .github/scripts/windows-ci-telemetry.ps1 `
@@ -154,7 +188,7 @@ jobs:
                 -TestArguments $phase.Arguments
               $iterationExitCode = $LASTEXITCODE
               if ($iterationExitCode -ne 0) {
-                "SOAK_FAILED_ITERATION=$iteration" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+                "failed_iteration=$iteration" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
                 Write-Error "Windows soak target '$target' failed at iteration $iteration (phase '$($phase.Phase)')."
                 exit $iterationExitCode
               }
@@ -177,9 +211,10 @@ jobs:
           JOB_SUMMARY_STATUS: ${{ job.status }}
           JOB_SUMMARY_DETAILS: |
             - Selected target: `${{ inputs.target }}`.
+            - Tested ref: `${{ inputs.test_ref || github.ref }}`.
             - Requested iterations: `${{ inputs.iterations }}`.
-            - Iterations actually run: `${{ env.SOAK_ITERATIONS_RAN }}`.
-            - Failed iteration: `${{ env.SOAK_FAILED_ITERATION }}`.
+            - Iterations actually run: `${{ steps.run-soak.outputs.iterations_ran || '0' }}`.
+            - Failed iteration: `${{ steps.run-soak.outputs.failed_iteration || 'none' }}`.
             - Telemetry artifact: `windows-flake-soak-${{ inputs.target }}-${{ github.run_id }}-${{ github.run_attempt }}` in this workflow run's **Artifacts** section.
           JOB_SUMMARY_NEXT: Download the telemetry artifact from this workflow run and inspect the JSON for the failed iteration.
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-soak-fidelity/GREEN.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-soak-fidelity/GREEN.txt
@@ -1,0 +1,11 @@
+Command:
+bun test script/windows-flake-soak-workflow.test.ts
+
+Exit code: 0
+
+bun test v1.3.14 (0d9b296a)
+
+ 10 pass
+ 0 fail
+ 88 expect() calls
+Ran 10 tests across 1 file. [634.00ms]

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-soak-fidelity/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-soak-fidelity/README.md
@@ -1,0 +1,69 @@
+# Windows flake soak fidelity evidence
+
+## WHAT WAS TESTED
+
+This repair covers two defects in the manually dispatched Windows flake soak.
+
+First, the workflow summary always reported `SOAK_ITERATIONS_RAN: 0`, even
+after one or more iterations had started. The repaired workflow carries the
+last-started iteration and the failing phase through durable step outputs, so
+the failure receipt identifies where execution stopped.
+
+Second, the `full-shard-2` soak target did not faithfully reproduce the real
+Windows shard-2 CI setup and command sequence. It could therefore issue a
+three-pass receipt while the real CI job failed twice on the same branch and
+shard. The repaired target now mirrors the shared command-construction
+contract for the Windows shard-2 preparation and test sequence.
+
+The live reproduction acceptance criterion was intentionally strict: dispatch
+the repaired `full-shard-2` soak against known-failing commit `0a9f51c30` on
+branch `ci/windows-shard2-serial`, then require the soak to fail on the exact
+credential-inheritance test that failed in the real `test (windows-latest,
+2/2)` CI job. An artificial workflow failure would not satisfy this criterion.
+
+## WHAT WAS OBSERVED
+
+- [Run 33713505691](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33713505691)
+  used the old soak and reported a false 3-of-3 pass against the same branch.
+- [Run 33712499816](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33712499816)
+  and [run 33715671900](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33715671900)
+  are the real CI failures from `test (windows-latest, 2/2)`.
+- [Run 33725658667](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33725658667)
+  dispatched the repaired soak from `fix/windows-soak-fidelity` at commit
+  `3eb76f12a`, while checking out known-failing commit `0a9f51c30` from
+  `ci/windows-shard2-serial` with `target=full-shard-2`.
+
+Run 33725658667 concluded `FAILURE`, which is the intended passing result for
+this reproduction. It failed at iteration 1, phase `remainder`, on the same
+test as the two real CI runs:
+
+```text
+(fail) omo setup credential inheritance > #given pinned omp and gjc databases #when accepted #then allow-listed rows import and unknown schema is noticed
+```
+
+The repaired counter and phase receipt reported:
+
+```text
+Write-Error: Windows soak target 'full-shard-2' failed at iteration 1 (phase 'remainder').
+```
+
+The failing-first workflow contract output is recorded in `RED.txt`. The
+focused passing contract was re-run in this worktree and its output is
+recorded in `GREEN.txt`.
+
+## WHY IT IS ENOUGH
+
+A soak that reproduces a known real-CI failure on the same branch, commit
+target, shard, and exact failing test can be trusted to issue meaningful
+N-pass receipts when repeated runs succeed. The previous soak could not be
+trusted because it passed 3 of 3 while the real Windows shard-2 CI job failed
+twice. The repaired live run closes that fidelity gap, and its iteration-1,
+`remainder` failure receipt proves the counter and phase reporting defect is
+also fixed.
+
+## WHAT WAS OMITTED
+
+This live reproduction proves fidelity specifically for the `full-shard-2`
+target. Other soak targets are covered only by the shared
+command-construction contract test. No credentials, tokens, authentication
+headers, or secret-bearing environment dumps are included in this evidence.

--- a/.omo/evidence/omo-senpi-adapter/20260903-windows-soak-fidelity/RED.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260903-windows-soak-fidelity/RED.txt
@@ -1,0 +1,47 @@
+$ bun test script/windows-flake-soak-workflow.test.ts
+bun test v1.3.14 (0d9b296a)
+
+script/windows-flake-soak-workflow.test.ts:
+error: expect(received).toContain(expected)
+
+Expected to contain: "test_ref:"
+(fail) Windows flake soak workflow > #given a repaired workflow ref #when another commit is soaked #then checkout targets the requested test ref [1.06ms]
+
+error: expect(received).toContain(expected)
+
+Expected to contain: "id: run-soak"
+(fail) Windows flake soak workflow > #given completed and failing iterations #when the summary renders #then step outputs report the true indices [6.85ms]
+
+error: missing ordered workflow token: uses: actions/setup-node@v7
+
+Expected: > 780
+Received: -1
+(fail) Windows flake soak workflow > #given the real Windows shard-2 job #when full-shard-2 is soaked #then setup and test commands stay equivalent [0.39ms]
+
+ 7 pass
+ 3 fail
+ 56 expect() calls
+Ran 10 tests across 1 file. [3.29s]
+
+Command exited with code 1
+
+$ bun test script/windows-flake-soak-workflow.test.ts
+bun test v1.3.14 (0d9b296a)
+
+script/windows-flake-soak-workflow.test.ts:
+error: expect(received).toContain(expected)
+
+Expected to contain: "- Iterations actually run: `${{ steps.run-soak.outputs.iterations_ran || '0' }}`."
+(fail) Windows flake soak workflow > #given completed and failing iterations #when the summary renders #then step outputs report the true indices [0.37ms]
+
+error: expect(received).toContain(expected)
+
+Expected to contain: "$ciWorkflow = Get-Content -Path \".github/workflows/ci.yml\" -Raw"
+(fail) Windows flake soak workflow > #given the real Windows shard-2 job #when full-shard-2 is soaked #then setup and test commands stay equivalent [3.65ms]
+
+ 8 pass
+ 2 fail
+ 79 expect() calls
+Ran 10 tests across 1 file. [535.00ms]
+
+Command exited with code 1

--- a/script/windows-flake-soak-workflow.test.ts
+++ b/script/windows-flake-soak-workflow.test.ts
@@ -3,6 +3,8 @@ import { existsSync, readFileSync } from "node:fs"
 
 const workflowPath = new URL("../.github/workflows/windows-flake-soak.yml", import.meta.url)
 const workflow = existsSync(workflowPath) ? readFileSync(workflowPath, "utf8") : ""
+const ciWorkflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
+const ciWorkflow = existsSync(ciWorkflowPath) ? readFileSync(ciWorkflowPath, "utf8") : ""
 const unsupportedTargetFixture = "bun-test-from-user-input"
 
 const expectedTargets = [
@@ -73,14 +75,64 @@ function assertTargetAllowlisted(source: string, target: string): void {
   }
 }
 
-function soakStep(source: string): string {
+function soakStepSection(source: string): string {
   const start = source.indexOf("      - name: Run allowlisted target repeatedly")
   const end = source.indexOf("      - name: Upload Windows soak telemetry", start)
   if (start < 0 || end < 0) throw new Error("windows soak step not found")
-  const step = source.slice(start, end)
+  return source.slice(start, end)
+}
+
+function soakStep(source: string): string {
+  const step = soakStepSection(source)
   const runStart = step.indexOf("        run: |\n")
   if (runStart < 0) throw new Error("windows soak run block not found")
   return step.slice(runStart)
+}
+
+function rootTestJob(source: string): string {
+  const start = source.indexOf("  test:\n")
+  const end = source.indexOf("\n  typecheck:", start)
+  if (start < 0 || end < 0) throw new Error("root test job not found")
+  return source.slice(start, end)
+}
+
+function windowsShardTwoStep(source: string): string {
+  const job = rootTestJob(source)
+  const condition =
+    "runner.os == 'Windows' && matrix.shard == '2/2'"
+  const start = job.indexOf(condition)
+  const end = job.indexOf("      - name: Upload Windows post-test telemetry", start)
+  if (start < 0 || end < 0) throw new Error("Windows shard-2 test step not found")
+  return job.slice(start, end)
+}
+
+function fullShardTwoTarget(source: string): string {
+  const step = soakStep(source)
+  const start = step.indexOf('"full-shard-2" = @(')
+  const end = step.indexOf("\n          }\n\n          $target", start)
+  if (start < 0 || end < 0) throw new Error("full-shard-2 target not found")
+  return step.slice(start, end)
+}
+
+function testArgumentLists(source: string): readonly string[] {
+  return [...source.matchAll(/-TestArguments (@\([^\n]+\))/g)].map(
+    (match) => match[1] ?? "",
+  )
+}
+
+function targetArgumentLists(source: string): readonly string[] {
+  return [...source.matchAll(/Arguments = \[string\[\]\](@\([^\n]+\))/g)].map(
+    (match) => match[1] ?? "",
+  )
+}
+
+function expectInOrder(source: string, tokens: readonly string[]): void {
+  let previous = -1
+  for (const token of tokens) {
+    const current = source.indexOf(token)
+    expect(current, `missing ordered workflow token: ${token}`).toBeGreaterThan(previous)
+    previous = current
+  }
 }
 
 describe("Windows flake soak workflow", () => {
@@ -104,6 +156,11 @@ describe("Windows flake soak workflow", () => {
     expect(trigger).toContain("workflow_dispatch:")
     expect(trigger).not.toContain("push:")
     expect(trigger).not.toContain("pull_request:")
+  })
+
+  test("#given a repaired workflow ref #when another commit is soaked #then checkout targets the requested test ref", () => {
+    expect(workflow).toContain("test_ref:")
+    expect(workflow).toContain("ref: ${{ inputs.test_ref || github.ref }}")
   })
 
   test("#given target and iteration inputs #when the job starts #then both boundaries are validated", () => {
@@ -147,6 +204,81 @@ describe("Windows flake soak workflow", () => {
     expect(step).toContain("exit $iterationExitCode")
     expect(step).not.toContain("timeout")
     expect(step).not.toContain("$phase.Arguments +")
+  })
+
+  test("#given completed and failing iterations #when the summary renders #then step outputs report the true indices", () => {
+    const step = soakStep(workflow)
+    const summaryStart = workflow.indexOf("      - name: Write job summary")
+    const summary = workflow.slice(summaryStart)
+
+    expect(workflow).toContain("id: run-soak")
+    expect(step).toContain(
+      '"iterations_ran=$iteration" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append',
+    )
+    expect(step).toContain(
+      '"failed_iteration=$iteration" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append',
+    )
+    expect(summary).toContain(
+      "- Iterations actually run: `${{ steps.run-soak.outputs.iterations_ran || '0' }}`.",
+    )
+    expect(summary).toContain(
+      "- Failed iteration: `${{ steps.run-soak.outputs.failed_iteration || 'none' }}`.",
+    )
+    expect(summary).not.toContain("- Iterations actually run: `$SOAK_ITERATIONS_RAN`.")
+    expect(summary).not.toContain("- Failed iteration: `$SOAK_FAILED_ITERATION`.")
+    expect(summary).not.toContain("SOAK_ITERATIONS_RAN:")
+    expect(summary).not.toContain("SOAK_FAILED_ITERATION:")
+    expect(summary).not.toContain("SOAK_ITERATIONS_RAN: ${{ env.SOAK_ITERATIONS_RAN }}")
+    expect(summary).not.toContain("SOAK_FAILED_ITERATION: ${{ env.SOAK_FAILED_ITERATION }}")
+  })
+
+  test("#given the real Windows shard-2 job #when full-shard-2 is soaked #then setup and test commands stay equivalent", () => {
+    const ciJob = rootTestJob(ciWorkflow)
+    const ciShard = windowsShardTwoStep(ciWorkflow)
+    const soak = workflow
+    const soakShard = fullShardTwoTarget(workflow)
+    const preparation = [
+      "uses: actions/checkout@v7",
+      "uses: actions/setup-node@v7",
+      'node-version: "24"',
+      "uses: oven-sh/setup-bun@v2",
+      'bun-version: "1.4.0"',
+      "name: Install dependencies",
+      "run: bun install --frozen-lockfile",
+      "name: Remove stale self-package test copies",
+      "run: bun run script/remove-stale-self-package-tests.ts",
+      "name: Run vendored lsp-daemon tests",
+      "run: npm test",
+      "working-directory: packages/lsp-daemon",
+    ] as const
+
+    expectInOrder(ciJob, preparation)
+    expectInOrder(soak, preparation)
+    expect(ciShard).toContain("shell: pwsh")
+    expect(soakStepSection(workflow)).toContain("shell: pwsh")
+    expect(ciShard).toContain("WINDOWS_TEST_SHARD: ${{ matrix.shard }}")
+    expect(soakStepSection(workflow)).toContain(
+      "WINDOWS_TEST_SHARD: ${{ inputs.target == 'full-shard-2' && '2/2' || 'flake-soak' }}",
+    )
+    expect(targetArgumentLists(soakShard)).toEqual(testArgumentLists(ciShard))
+    expect(soakShard.indexOf('Phase = "quarantine"')).toBeLessThan(
+      soakShard.indexOf('Phase = "remainder"'),
+    )
+    expect(soakStep(workflow)).toContain(
+      '$ciWorkflow = Get-Content -Path ".github/workflows/ci.yml" -Raw',
+    )
+    expect(soakStep(workflow)).toContain(
+      '$serialRemainder = \'-TestArguments @("--config=bunfig.win2.parallel.toml", "test")\'',
+    )
+    expect(soakStep(workflow)).toContain(
+      '$parallelRemainder = \'-TestArguments @("--config=bunfig.win2.parallel.toml", "test", "--parallel")\'',
+    )
+    expect(soakStep(workflow)).toContain(
+      '$targets[$target][1].Arguments = [string[]]@("--config=bunfig.win2.parallel.toml", "test")',
+    )
+    expect(soakStep(workflow)).toContain(
+      'Write-Error "checked-out ci.yml has an unsupported Windows shard-2 remainder command"',
+    )
   })
 
   test("#given any job outcome #when the soak finishes #then telemetry artifacts always upload", () => {


### PR DESCRIPTION
## Defects fixed

1. The soak summary always reported SOAK_ITERATIONS_RAN: 0, regardless of how many iterations actually started.
2. The full-shard-2 soak had a fidelity gap: it passed 3 of 3 in run 33713505691 while the real Windows shard-2 CI job failed on the same branch in runs 33712499816 and 33715671900.

## What changed

- Publish durable step outputs for the last-started iteration and failing phase, then render the summary from those outputs.
- Make full-shard-2 preserve the real Windows shard-2 preparation, environment, working directory, and command order from CI.
- Add workflow contract coverage for both the iteration receipt and command-construction fidelity.

## Reproduction proof

Run 33725658667 dispatched the repaired soak from this branch against known-failing commit 0a9f51c30 on ci/windows-shard2-serial with target=full-shard-2. It now fails at iteration 1 in phase remainder on the exact credential-inheritance test that failed in the two real CI runs. This FAILURE is the intended acceptance result and replaces the old false 3-of-3 pass receipt.

Focused verification: bun test script/windows-flake-soak-workflow.test.ts (10 pass, 0 fail). Reviewer-readable RED, GREEN, and live-run evidence is committed under .omo/evidence/omo-senpi-adapter/20260903-windows-soak-fidelity/.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Windows flake soak workflow produce trustworthy pass/fail receipts: the summary no longer always reports 0 iterations, and the `full-shard-2` target now mirrors the real Windows shard-2 CI setup and command order.

- Publishes the last-started iteration and failing phase as step outputs instead of environment variables, so the summary reflects actual run progress.
- Adds a `test_ref` input so a soak can check out a specific commit while running from the current branch.
- Updates `full-shard-2` to preserve the real CI preparation, environment, working directory, and command sequence, including the quarantine/remainder phases and the `WINDOWS_TEST_SHARD` value.
- Adds workflow contract tests that verify the iteration receipt and the command-construction fidelity against `ci.yml`.
- Includes live reproduction evidence: the repaired soak now fails on the exact credential-inheritance test that failed in real CI runs, replacing the previous false 3-of-3 pass.

<sup>Written for commit ad674f2d31b7dd9e094040b56fc5f2aafc48c51b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

