### PR TITLE
fix(team-mode): enforce read-only members and report idle duration

### DIFF
--- a/packages/omo-opencode/src/features/team-mode/member-guidance.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/member-guidance.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import { TeamModeConfigSchema } from "../../config/schema/team-mode"
+import type { TeamModeConfig } from "../../config/schema/team-mode"
+import { buildTeammateCommunicationAddendum } from "./member-guidance"
+
+function createConfig(): TeamModeConfig {
+  return TeamModeConfigSchema.parse({ base_dir: "/tmp", enabled: true })
+}
+
+describe("buildTeammateCommunicationAddendum", () => {
+  test("includes long-running command guidance for non-strict members", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig())
+
+    // then
+    expect(addendum).toContain("## Long-running commands")
+    expect(addendum).toContain("nohup pnpm dev > /tmp/dev-<name>.log 2>&1 & echo $!")
+    expect(addendum).toContain("for i in $(seq 1 30); do curl -sf localhost:PORT && break || sleep 2; done")
+  })
+
+  test("omits long-running command guidance for strict read-only members", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig(), "strict")
+
+    // then
+    expect(addendum).not.toContain("## Long-running commands")
+    expect(addendum).not.toContain("nohup")
+  })
+
+  test("includes file ownership coordination guidance", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig())
+
+    // then
+    expect(addendum).toContain("Coordinate file ownership with teammates")
+    expect(addendum).toContain("work within its own file/directory scope")
+  })
+
+  test("omits read-only section when readOnly is falsy", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig())
+
+    // then
+    expect(addendum).not.toContain("## Read-only mode")
+  })
+
+  test("adds read-only section when readOnly is true", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig(), true)
+
+    // then
+    expect(addendum).toContain("## Read-only mode")
+    expect(addendum).toContain("HARD-DENIED at the session permission level")
+    expect(addendum).not.toContain("bash is also denied in strict read-only mode")
+  })
+
+  test("adds strict bash note when readOnly is strict", () => {
+    // when
+    const addendum = buildTeammateCommunicationAddendum(createConfig(), "strict")
+
+    // then
+    expect(addendum).toContain("## Read-only mode")
+    expect(addendum).toContain("bash is also denied in strict read-only mode")
+  })
+})

--- a/packages/omo-opencode/src/features/team-mode/member-guidance.ts
+++ b/packages/omo-opencode/src/features/team-mode/member-guidance.ts
@@ -1,6 +1,9 @@
 import type { TeamModeConfig } from "../../config/schema/team-mode"
 
-export function buildTeammateCommunicationAddendum(_config: TeamModeConfig): string {
+export function buildTeammateCommunicationAddendum(
+  _config: TeamModeConfig,
+  readOnly?: boolean | "strict",
+): string {
   return `
 # Team Communication
 
@@ -35,7 +38,24 @@ Going idle after sending a message is the expected flow — it does NOT mean you
 - Do NOT send structured JSON status messages like \`{"type":"idle",...}\` or \`{"type":"task_completed",...}\`. Communicate in plain natural language when you message teammates.
 - Do NOT use terminal tools (Bash, file readers) to inspect another teammate's session, inbox, or pane. Send a \`team_send_message\` instead.
 - Always refer to teammates by their NAME (e.g., \`to: "lead"\`, \`to: "researcher"\`), never by internal session IDs.
+- Coordinate file ownership with teammates: each member should work within its own file/directory scope to avoid conflicts on the shared worktree. If you must touch a file another member owns, message them first.
 
+${readOnly !== "strict" ? `
+## Long-running commands
+
+Never run blocking services (dev servers, watch mode) in the foreground — the call will hang until timeout. Instead:
+1. Start in background with a log file: \`nohup pnpm dev > /tmp/dev-<name>.log 2>&1 & echo $!\`
+2. Poll readiness with a bounded loop: \`for i in $(seq 1 30); do curl -sf localhost:PORT && break || sleep 2; done\`
+3. Verify via the log: \`tail -50 /tmp/dev-<name>.log\`
+4. Kill by the recorded PID when done.
+` : ""}${readOnly ? `
+
+## Read-only mode
+
+You are a read-only team member. File-editing tools (edit/write/multiedit) are HARD-DENIED at the session permission level — attempts will be rejected. Do NOT try to write files, create directories, or modify anything on disk. Prepare your analysis and deliverables as message text, and send them to the lead via \`team_send_message\`. Do not attempt to work around the restriction with bash shell redirection (echo > file, sed -i) — that is a violation.${readOnly === "strict" ? `
+
+Additionally, bash is also denied in strict read-only mode — you cannot run shell commands at all. Do all work through read-only tools and message text.` : ""}
+` : ""}
 ## Wrap-up
 
 When you finish your assigned work, ALWAYS, in this order:

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
@@ -225,6 +225,80 @@ describe("createTeamRun", () => {
     expect(firstPrompt).toContain("Lead-only tools you must NOT call")
   })
 
+  test("readOnly member gets edit-denied sessionPermission and read-only guidance", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-readonly-"))
+    temporaryDirectories.push(baseDir)
+    const { manager, launchMock } = createManager(baseDir, async () => ({
+      id: "task-1",
+      sessionId: "session-1",
+      status: "running",
+    } as BackgroundTask))
+    const spec: TeamSpec = {
+      ...createSpec(1),
+      members: [{ ...createSpec(1).members[0]!, readOnly: true }],
+    }
+
+    // when
+    await createTeamRun(spec, "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+    const firstLaunch = (launchMock.mock.calls as Array<[LaunchInput]>)[0]?.[0]
+
+    // then
+    expect(firstLaunch?.sessionPermission).toEqual([
+      { permission: "question", action: "deny", pattern: "*" },
+      { permission: "edit", action: "deny", pattern: "*" },
+    ])
+    expect(firstLaunch?.prompt).toContain("## Read-only mode")
+  })
+
+  test("strict readOnly member gets bash-denied sessionPermission and strict guidance", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-readonly-strict-"))
+    temporaryDirectories.push(baseDir)
+    const { manager, launchMock } = createManager(baseDir, async () => ({
+      id: "task-1",
+      sessionId: "session-1",
+      status: "running",
+    } as BackgroundTask))
+    const spec: TeamSpec = {
+      ...createSpec(1),
+      members: [{ ...createSpec(1).members[0]!, readOnly: "strict" }],
+    }
+
+    // when
+    await createTeamRun(spec, "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+    const firstLaunch = (launchMock.mock.calls as Array<[LaunchInput]>)[0]?.[0]
+
+    // then
+    expect(firstLaunch?.sessionPermission).toEqual([
+      { permission: "question", action: "deny", pattern: "*" },
+      { permission: "edit", action: "deny", pattern: "*" },
+      { permission: "bash", action: "deny", pattern: "*" },
+    ])
+    expect(firstLaunch?.prompt).toContain("bash is also denied in strict read-only mode")
+  })
+
+  test("non-readOnly member keeps question-denied sessionPermission", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-non-readonly-"))
+    temporaryDirectories.push(baseDir)
+    const { manager, launchMock } = createManager(baseDir, async () => ({
+      id: "task-1",
+      sessionId: "session-1",
+      status: "running",
+    } as BackgroundTask))
+
+    // when
+    await createTeamRun(createSpec(1), "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+    const firstLaunch = (launchMock.mock.calls as Array<[LaunchInput]>)[0]?.[0]
+
+    // then
+    expect(firstLaunch?.sessionPermission).toEqual([
+      { permission: "question", action: "deny", pattern: "*" },
+    ])
+    expect(firstLaunch?.prompt).not.toContain("## Read-only mode")
+  })
+
   test("rolls back launched members in reverse order when a later spawn fails", async () => {
     // given
     const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-rollback-"))

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
@@ -2,7 +2,7 @@ import { access, mkdir } from "node:fs/promises"
 import path from "node:path"
 
 import type { TeamModeConfig } from "../../../config/schema/team-mode"
-import { QUESTION_DENIED_SESSION_PERMISSION } from "../../../shared/question-denied-session-permission"
+import { QUESTION_DENIED_SESSION_PERMISSION, READ_ONLY_SESSION_PERMISSION, READ_ONLY_STRICT_SESSION_PERMISSION } from "../../../shared/question-denied-session-permission"
 import type { ExecutorContext } from "../../../tools/delegate-task/executor-types"
 import type { BackgroundTask } from "../../background-agent/types"
 import type { BackgroundManager } from "../../background-agent/manager"
@@ -103,7 +103,7 @@ function buildMemberPrompt(
   const promptLines = [`Team: ${spec.name}`, `TeamRunId: ${teamRunId}`, `Member: ${member.name}`]
   if (worktreePath) promptLines.push(`Worktree: ${worktreePath}`)
   if (member.prompt) promptLines.push(member.prompt)
-  promptLines.push(buildTeammateCommunicationAddendum(config))
+  promptLines.push(buildTeammateCommunicationAddendum(config, member.readOnly))
   return promptLines.join("\n")
 }
 
@@ -204,7 +204,11 @@ export async function createTeamRun(
             fallbackChain: resolvedMember.fallbackChain,
             skillContent: resolvedMember.systemContent,
             category: member.kind === "category" ? member.category : undefined,
-            sessionPermission: QUESTION_DENIED_SESSION_PERMISSION,
+            sessionPermission: member.readOnly === "strict"
+              ? READ_ONLY_STRICT_SESSION_PERMISSION
+              : member.readOnly
+                ? READ_ONLY_SESSION_PERMISSION
+                : QUESTION_DENIED_SESSION_PERMISSION,
             onSessionCreated: async (sessionId) => {
               registerTeamSession(sessionId, {
                 teamRunId: runtimeState.teamRunId,

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/status.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/status.test.ts
@@ -10,7 +10,7 @@ import type { TeamModeConfig } from "../../../config/schema/team-mode"
 import { createTask } from "../team-tasklist/store"
 import { createTaskInput } from "../team-tasklist/test-support"
 import { getInboxDir, getTasksDir, resolveBaseDir } from "../team-registry/paths"
-import { createRuntimeState, saveRuntimeState } from "../team-state-store/store"
+import { createRuntimeState, loadRuntimeState, saveRuntimeState } from "../team-state-store/store"
 import { aggregateStatus } from "./status"
 
 async function createTemporaryBaseDir(): Promise<string> {
@@ -139,5 +139,31 @@ describe("aggregateStatus", () => {
     expect(result.concurrency.runningOnSameModel).toBe(5)
     expect(result.concurrency.queuedOnSameModel).toBe(3)
     expect(result.concurrency.teamRunIdSpecific).toBe(4)
+  })
+
+  test("reports idleDurationMs for idle members with a lastActiveAt timestamp", async () => {
+    // given
+    const baseDir = await createTemporaryBaseDir()
+    temporaryDirectories.push(baseDir)
+    const config = createConfig(baseDir)
+    const teamRunId = await seedRuntimeState(baseDir, "team-delta", "lead-4", ["session-idle"])
+    const lastActiveAt = Date.now() - 5_000
+    const updatedRuntimeState = {
+      ...(await loadRuntimeState(teamRunId, config)),
+      members: (await loadRuntimeState(teamRunId, config)).members.map((member) =>
+        member.name === "member-1" ? { ...member, status: "idle" as const, lastActiveAt } : member,
+      ),
+    }
+    await saveRuntimeState(updatedRuntimeState, config)
+
+    // when
+    const result = await aggregateStatus(teamRunId, config)
+
+    // then
+    const idleMember = result.members.find((member) => member.name === "member-1")
+    expect(idleMember?.status).toBe("idle")
+    expect(idleMember?.lastActiveAt).toBe(lastActiveAt)
+    expect(idleMember?.idleDurationMs).toBeGreaterThanOrEqual(5_000)
+    expect(result.members.find((member) => member.name === "member-2")?.idleDurationMs).toBeUndefined()
   })
 })

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/status.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/status.ts
@@ -23,6 +23,8 @@ export interface TeamStatus {
     worktreePath?: string
     unreadMessages: number
     paneId?: string
+    lastActiveAt?: number
+    idleDurationMs?: number
   }>
   tasks: {
     pending: number
@@ -144,6 +146,8 @@ export async function aggregateStatus(
       worktreePath: member.worktreePath,
       unreadMessages,
       paneId: member.tmuxPaneId,
+      lastActiveAt: member.lastActiveAt,
+      idleDurationMs: member.status === "idle" && member.lastActiveAt ? Date.now() - member.lastActiveAt : undefined,
     })),
     tasks: countTasks(tasks),
     shutdownRequests: runtimeState.shutdownRequests,

--- a/packages/omo-opencode/src/hooks/team-session-events/team-member-status-handler.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-member-status-handler.test.ts
@@ -89,12 +89,12 @@ describe("createTeamMemberStatusHandler", () => {
     expect(runtimeState.members[0]?.status).toBe("idle")
   })
 
-  test("leaves an already-idle member untouched on a subsequent session.idle", async () => {
+  test("keeps an already-idle member idle but refreshes lastActiveAt on a subsequent session.idle", async () => {
     // given
     const baseDir = await createTemporaryBaseDir()
     const config = createConfig(baseDir)
     const teamRunId = randomUUID()
-    await seedRuntimeState(createRuntimeState(teamRunId, buildMember({ status: "idle" })), config)
+    await seedRuntimeState(createRuntimeState(teamRunId, buildMember({ status: "idle", lastActiveAt: 12345 })), config)
     const handler = createTeamMemberStatusHandler(config)
 
     // when
@@ -103,6 +103,7 @@ describe("createTeamMemberStatusHandler", () => {
     // then
     const runtimeState = await loadRuntimeState(teamRunId, config)
     expect(runtimeState.members[0]?.status).toBe("idle")
+    expect(runtimeState.members[0]?.lastActiveAt).toBeGreaterThan(12345)
   })
 
   test("never overrides a terminal errored status on session.idle", async () => {

--- a/packages/omo-opencode/src/hooks/team-session-events/team-member-status-handler.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-member-status-handler.ts
@@ -10,7 +10,7 @@ export type HookImpl = (input: HookInput) => Promise<void>
 
 type MemberStatus = RuntimeStateMember["status"]
 
-const IDLE_TRANSITION_SOURCE_STATUSES: ReadonlySet<MemberStatus> = new Set(["running"])
+const IDLE_TRANSITION_SOURCE_STATUSES: ReadonlySet<MemberStatus> = new Set(["running", "idle"])
 const COMPLETED_TRANSITION_SOURCE_STATUSES: ReadonlySet<MemberStatus> = new Set(["running", "idle", "pending"])
 
 function getSessionIDFromIdleEvent(properties: unknown): string | undefined {
@@ -38,7 +38,7 @@ async function transitionMemberStatus(
     ...currentRuntimeState,
     members: currentRuntimeState.members.map((member) => (
       member.name === runtimeMember.memberName
-        ? { ...member, status: nextStatus }
+        ? { ...member, status: nextStatus, lastActiveAt: Date.now() }
         : member
     )),
   }), config)

--- a/packages/omo-opencode/src/hooks/team-tool-gating/hook.test.ts
+++ b/packages/omo-opencode/src/hooks/team-tool-gating/hook.test.ts
@@ -166,6 +166,46 @@ describe("createTeamToolGating", () => {
     await expect(result).resolves.toBeUndefined()
   })
 
+  test("rejects delegate-task from a read-only member", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    const readOnlyState: RuntimeState = {
+      ...createRuntimeState(),
+      members: [
+        { name: "m1", sessionId: "member-session-1", agentType: "general-purpose", status: "running", pendingInjectedMessageIds: [], readOnly: true },
+        { name: "m2", sessionId: "member-session-2", agentType: "general-purpose", status: "running", pendingInjectedMessageIds: [] },
+      ],
+    }
+    await seedTeams(baseDir, readOnlyState)
+
+    // when
+    const result = runHook("delegate-task", "member-session-1", {}, undefined, baseDir)
+
+    // then
+    await expect(result).rejects.toThrow("read-only team members must not spawn child agents")
+  })
+
+  test("rejects delegate-task from a strict read-only member", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))
+    temporaryDirectories.push(baseDir)
+    const strictReadOnlyState: RuntimeState = {
+      ...createRuntimeState(),
+      members: [
+        { name: "m1", sessionId: "member-session-1", agentType: "general-purpose", status: "running", pendingInjectedMessageIds: [], readOnly: "strict" },
+        { name: "m2", sessionId: "member-session-2", agentType: "general-purpose", status: "running", pendingInjectedMessageIds: [] },
+      ],
+    }
+    await seedTeams(baseDir, strictReadOnlyState)
+
+    // when
+    const result = runHook("delegate-task", "member-session-1", {}, undefined, baseDir)
+
+    // then
+    await expect(result).rejects.toThrow("read-only team members must not spawn child agents")
+  })
+
   test("allows team_delete for the lead of the target team", async () => {
     // given
     const baseDir = await mkdtemp(path.join(tmpdir(), "team-tool-gating-"))

--- a/packages/omo-opencode/src/hooks/team-tool-gating/hook.ts
+++ b/packages/omo-opencode/src/hooks/team-tool-gating/hook.ts
@@ -96,6 +96,14 @@ export function createTeamToolGating(_ctx: PluginInput, config: TeamModeConfig |
       const participant = await resolveParticipant(input.sessionID, config)
 
       if (toolName === "delegate-task") {
+        if (participant.role === "member") {
+          const runtimeState = await loadRuntimeState(participant.teamRunId, config).catch(() => undefined)
+          const member = runtimeState?.members.find((candidate) => candidate.name === participant.memberName)
+          if (member?.readOnly) {
+            throw new Error("delegate-task denied: read-only team members must not spawn child agents")
+          }
+        }
+
         return
       }
 

--- a/packages/omo-opencode/src/shared/question-denied-session-permission.ts
+++ b/packages/omo-opencode/src/shared/question-denied-session-permission.ts
@@ -7,3 +7,13 @@ export type SessionPermissionRule = {
 export const QUESTION_DENIED_SESSION_PERMISSION: SessionPermissionRule[] = [
   { permission: "question", action: "deny", pattern: "*" },
 ]
+
+export const READ_ONLY_SESSION_PERMISSION: SessionPermissionRule[] = [
+  ...QUESTION_DENIED_SESSION_PERMISSION,
+  { permission: "edit", action: "deny", pattern: "*" },
+]
+
+export const READ_ONLY_STRICT_SESSION_PERMISSION: SessionPermissionRule[] = [
+  ...READ_ONLY_SESSION_PERMISSION,
+  { permission: "bash", action: "deny", pattern: "*" },
+]

--- a/packages/team-core/src/team-state-store/store.ts
+++ b/packages/team-core/src/team-state-store/store.ts
@@ -141,6 +141,7 @@ export async function createRuntimeState(
       status: "pending",
       color: member.color,
       worktreePath: member.worktreePath,
+      readOnly: member.readOnly,
       lastInjectedTurnMarker: undefined,
       pendingInjectedMessageIds: [],
     })),

--- a/packages/team-core/src/types.ts
+++ b/packages/team-core/src/types.ts
@@ -32,6 +32,7 @@ const MemberBaseSchema = z.object({
   backendType: z.enum(["in-process", "tmux"]).default("in-process"),
   color: z.string().optional(),
   isActive: z.boolean().default(true),
+  readOnly: z.union([z.boolean(), z.literal("strict")]).optional(),
 }).strict()
 
 export const CategoryMemberSchema = MemberBaseSchema.extend({
@@ -144,8 +145,10 @@ const RuntimeStateMemberSchema = z.object({
   status: z.enum(["pending", "running", "idle", "errored", "completed", "shutdown_approved"]),
   color: z.string().optional(),
   worktreePath: z.string().optional(),
+  readOnly: z.union([z.boolean(), z.literal("strict")]).optional(),
   lastInjectedTurnMarker: z.string().optional(),
   pendingInjectedMessageIds: z.array(z.string()).default([]),
+  lastActiveAt: z.number().int().positive().optional(),
 }).strict()
 
 const RuntimeBoundsSchema = z.object({


### PR DESCRIPTION
## What this does

Two changes to Team Mode, split into two commits:

### 1. Read-only members are now actually read-only (`fix(team-mode): actually enforce read-only members`)

Before, marking a member `readOnly: true` only added a paragraph to its prompt asking it nicely not to edit files. Nothing stopped it at the tool level. And any member could call `delegate-task`, whose child session had *no* restrictions — so a read-only member could get full edit/bash rights with a single tool call.

Now:

- `readOnly: true` denies `edit` at the session-permission level; `readOnly: "strict"` additionally denies `bash`. The prompt text stays as an explanation, not as the enforcement.
- `delegate-task` is rejected for read-only members (fail-closed), and the runtime state persists the flag so the gating hook can see it.
- Member guidance explains the restriction, asks teammates to coordinate file ownership on the shared worktree, and shows how to run long-lived commands in the background instead of blocking the session (that section is skipped for strict members, who cannot run bash at all).

### 2. Status reports how long each member has been idle (`feat(team-mode): report how long each member has been idle`)

The lead could not tell whether an idle member was stuck or just waiting for input: status showed "idle" with no sense of duration.

Member status transitions now stamp `lastActiveAt`, and a member that goes idle again after being woken up refreshes that timestamp instead of keeping a stale one — so `idleDurationMs` in the aggregated status always counts from the most recent idle. Runtime state written before this change still parses (the field is optional), and terminal statuses (completed/errored) are never overwritten by idle events.

## Notes

- Related to #5333 (inline file protection): this adds a member-level hard deny, which is complementary to the per-assignment `allowedPaths` approach discussed there.
- Idle *wake* reliability is a separate problem (#5657, fixed from the delivery side in #7451); this PR only makes idle duration visible to the lead.

## Testing

- `bun test packages/omo-opencode/src/features/team-mode/ packages/omo-opencode/src/hooks/team-tool-gating/hook.test.ts packages/omo-opencode/src/hooks/team-session-events/team-member-status-handler.test.ts` → 322 tests, 0 failures
- `bun run typecheck` (tsgo --noEmit) clean for both `omo-opencode` and `team-core`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Team Mode so `readOnly` members are actually blocked from editing files and spawning child agents, and adds idle duration to member status so leads can tell whether an idle member is stuck or just waiting.

**Bug Fixes**
- `readOnly: true` now denies `edit` at the session-permission level; `readOnly: "strict"` also denies `bash`. The prompt text stays as guidance, not enforcement.
- `delegate-task` is rejected for read-only members; the flag is persisted in runtime state so the gating hook can see it.

**New Features**
- Status now reports `idleDurationMs` per member, counted from the most recent idle transition.
- Re-idling a member refreshes `lastActiveAt` so the duration never counts from a stale timestamp; the field is optional so older runtime state still parses, and terminal statuses are never overwritten by idle events.

<sup>Written for commit 96a0fd07fc783a8025eb85605a9529bd54db899d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

