### PR TITLE
fix(omo-senpi): make the Windows senpi-compatibility job green again

### DIFF
--- a/packages/omo-senpi/scripts/qa/x-search-backtest.test.mjs
+++ b/packages/omo-senpi/scripts/qa/x-search-backtest.test.mjs
@@ -3,15 +3,16 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { buildXSearchRequest, CARRIER_MODELS, PROMPT_VARIANTS } from "../../src/components/x-search/client.ts";
 import { fixtureKey, materializeDates } from "./x-search-backtest-core.mjs";
 
-const ROOT = new URL("./", import.meta.url).pathname;
+const ROOT = fileURLToPath(new URL("./", import.meta.url));
 const CLI = join(ROOT, "x-search-backtest.mjs");
 
 function run(args, env = {}) {
   return new Promise((resolve) => {
-    const child = spawn("bun", [CLI, ...args], { cwd: join(ROOT, "../../../../.."), env: { ...process.env, XAI_API_KEY: "test-secret", ...env } });
+    const child = spawn(process.execPath, [CLI, ...args], { cwd: join(ROOT, "../../../../.."), env: { ...process.env, XAI_API_KEY: "test-secret", ...env } });
     let stdout = "", stderr = "";
     child.stdout.on("data", (chunk) => { stdout += chunk; });
     child.stderr.on("data", (chunk) => { stderr += chunk; });

--- a/packages/omo-senpi/scripts/qa/x-search-live-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/x-search-live-e2e.mjs
@@ -3,9 +3,10 @@ import { randomBytes } from "node:crypto"
 import { spawnSync } from "node:child_process"
 import { accessSync, constants, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { delimiter, dirname, join, resolve } from "node:path"
+import { delimiter, dirname, extname, join, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 import { createSandbox, seedSandbox, snapshotDirectory, changedSnapshotPaths, credentialDigest } from "./drive.mjs"
+import { resolveSenpiInvocation } from "./team-e2e-runtime.mjs"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, "../../../../")
@@ -67,26 +68,67 @@ function executable(path) {
   }
 }
 
-export function resolveSenpiBin({ env = process.env, root = repoRoot, cwd = process.cwd() } = {}) {
-  const requested = env.SENPI_BIN?.trim()
-  if (requested) {
-    const candidate = resolve(cwd, requested)
-    if (executable(candidate)) return { path: candidate, source: "SENPI_BIN" }
-  }
+function senpiCandidates(bin, pathExt) {
+  if (process.platform !== "win32" || extname(bin) !== "") return [bin]
+  // PATHEXT is conventionally upper-case while npm writes lower-case launchers (senpi.cmd);
+  // the file system is case-insensitive, so probe the lower-case spelling first to return the
+  // path as it is written on disk.
+  const extensions = (pathExt?.trim() || ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((extension) => extension.trim().toLowerCase())
+    .filter((extension) => extension.length > 0)
+  return [...extensions.map((extension) => `${bin}${extension}`), bin]
+}
 
-  const peer = resolve(root, "node_modules/.bin/senpi")
-  if (executable(peer)) return { path: peer, source: "peer-dependency" }
-
-  for (const dir of (env.PATH ?? "").split(delimiter)) {
-    const candidate = resolve(dir || ".", "senpi")
-    if (executable(candidate)) return { path: candidate, source: "PATH", warning: "Using PATH senpi fallback; peer-dependency binary was unavailable." }
+function resolveExecutable(bin, pathExt) {
+  for (const candidate of senpiCandidates(bin, pathExt)) {
+    if (executable(candidate)) return candidate
   }
   return null
 }
 
+export function resolveSenpiBin({ env = process.env, root = repoRoot, cwd = process.cwd() } = {}) {
+  const requested = env.SENPI_BIN?.trim()
+  if (requested) {
+    const candidate = resolveExecutable(resolve(cwd, requested), env.PATHEXT)
+    if (candidate) return { path: candidate, source: "SENPI_BIN" }
+  }
+
+  const peer = resolveExecutable(resolve(root, "node_modules/.bin/senpi"), env.PATHEXT)
+  if (peer) return { path: peer, source: "peer-dependency" }
+
+  for (const dir of (env.PATH ?? "").split(delimiter)) {
+    const candidate = resolveExecutable(resolve(dir || ".", "senpi"), env.PATHEXT)
+    if (candidate) return { path: candidate, source: "PATH", warning: "Using PATH senpi fallback; peer-dependency binary was unavailable." }
+  }
+  return null
+}
+
+function quoteForCmd(arg) {
+  return `"${String(arg).replace(/"/g, '\\"')}"`
+}
+
+// A Windows senpi launcher is a .cmd shim that spawnSync cannot execute directly. Prefer the
+// package CLI behind the shim (the same mapping the team QA runtime uses); when the shim has
+// no adjacent package CLI (bare fixtures), run it through the command interpreter instead.
+export function spawnSenpi(path, args, options) {
+  const ext = extname(path).toLowerCase()
+  if (process.platform !== "win32" || (ext !== ".cmd" && ext !== ".bat")) return spawnSync(path, args, options)
+  try {
+    const { command, prefixArgs } = resolveSenpiInvocation(path)
+    if (command !== path) return spawnSync(command, [...prefixArgs, ...args], options)
+  } catch {
+    // fall through to the interpreter
+  }
+  // cmd.exe /S strips the first and last quote of the /C argument, so the whole command line
+  // is wrapped in one extra pair of quotes (the same shape Node's shell: true produces).
+  const commandLine = `"${[path, ...args].map(quoteForCmd).join(" ")}"`
+  return spawnSync(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", commandLine], { ...options, windowsVerbatimArguments: true })
+}
+
 export function senpiVersion(path) {
   if (!path) return null
-  const result = spawnSync(path, ["--version"], { encoding: "utf8", timeout: 10000 })
+  const result = spawnSenpi(path, ["--version"], { encoding: "utf8", timeout: 10000 })
   if (result.status !== 0) return null
   return String(result.stdout ?? "").split(/\r?\n/, 1)[0].trim() || null
 }
@@ -235,12 +277,12 @@ function runScenario(scenario, prompt, outDir) {
   if (senpi) {
     const common = ["-e", mockProviderEntry, ...(sandboxExtensionPath ? ["-e", sandboxExtensionPath] : []), "-p", "--mode", "json", "--provider", "omo-mock", "--model", "mock-1", "--session-dir", join(sandbox.root, "sessions")]
     const runOptions = { cwd: sandbox.cwd, env: scrubbedEnv, encoding: "utf8", timeout: 120000, maxBuffer: 64 * 1024 * 1024 }
-    const runs = [spawnSync(senpi, [...common, prompt], runOptions)]
+    const runs = [spawnSenpi(senpi, [...common, prompt], runOptions)]
     if (scenario === "reload") {
       writeFileSync(join(sandbox.cwd, "mock-script.json"), `${JSON.stringify(scriptFor("reload-initial"))}\n`)
-      runs.push(spawnSync(senpi, [...common, "--continue", "/reload"], runOptions))
+      runs.push(spawnSenpi(senpi, [...common, "--continue", "/reload"], runOptions))
       writeFileSync(join(sandbox.cwd, "mock-script.json"), `${JSON.stringify(scriptFor(scenario))}\n`)
-      runs.push(spawnSync(senpi, [...common, "--continue", prompt], runOptions))
+      runs.push(spawnSenpi(senpi, [...common, "--continue", prompt], runOptions))
     }
     run = { status: (runs[0]?.status === 0 && runs.at(-1)?.status === 0) ? 0 : 1, stdout: runs.map((item) => item.stdout ?? "").join("\n"), stderr: runs.map((item) => item.stderr ?? "").join("\n") }
   }

--- a/packages/omo-senpi/scripts/qa/x-search-live-e2e.test.mjs
+++ b/packages/omo-senpi/scripts/qa/x-search-live-e2e.test.mjs
@@ -9,19 +9,22 @@ import { createScrubbedEnvironment, observeChildXSearchCall, resolveSenpiBin, sc
 describe("x-search live QA isolation helpers", () => {
   test("resolves SENPI_BIN, then the peer dependency, then PATH", () => {
     const root = mkdtempSync(join(tmpdir(), "omo-x-search-bin-test-"))
-    const requested = join(root, "requested-senpi")
-    const peer = join(root, "node_modules", ".bin", "senpi")
+    const win32 = process.platform === "win32"
+    const shim = win32 ? "senpi.cmd" : "senpi"
+    const requested = join(root, win32 ? "requested-senpi.cmd" : "requested-senpi")
+    const peer = join(root, "node_modules", ".bin", shim)
     const pathDir = join(root, "path")
     mkdirSync(join(root, "node_modules", ".bin"), { recursive: true })
     mkdirSync(pathDir, { recursive: true })
-    for (const path of [requested, peer, join(pathDir, "senpi")]) writeFileSync(path, "#!/bin/sh\nprintf '2026.9.2-4\\n'\n", { mode: 0o755 })
+    const body = win32 ? "@echo 2026.9.2-4\n" : "#!/bin/sh\nprintf '2026.9.2-4\\n'\n"
+    for (const path of [requested, peer, join(pathDir, shim)]) writeFileSync(path, body, { mode: 0o755 })
     try {
       expect(resolveSenpiBin({ root, cwd: root, env: { SENPI_BIN: requested, PATH: pathDir } })).toEqual({ path: requested, source: "SENPI_BIN" })
       rmSync(requested)
       expect(resolveSenpiBin({ root, cwd: root, env: { SENPI_BIN: requested, PATH: pathDir } })).toEqual({ path: peer, source: "peer-dependency" })
       rmSync(peer)
-      expect(resolveSenpiBin({ root, cwd: root, env: { SENPI_BIN: requested, PATH: pathDir } })).toEqual({ path: join(pathDir, "senpi"), source: "PATH", warning: expect.any(String) })
-      expect(senpiVersion(join(pathDir, "senpi"))).toBe("2026.9.2-4")
+      expect(resolveSenpiBin({ root, cwd: root, env: { SENPI_BIN: requested, PATH: pathDir } })).toEqual({ path: join(pathDir, shim), source: "PATH", warning: expect.any(String) })
+      expect(senpiVersion(join(pathDir, shim))).toBe("2026.9.2-4")
     } finally {
       rmSync(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary

`dev` CI has been red on `senpi-compatibility (windows-latest)` since the x_search QA scripts landed (run [33747716388](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33747716388), again at 7364462 in run 33749802940). Three of the four failing tests were the x_search QA scripts; the fourth (`gitToplevel`) was fixed separately in #7696, so this PR is rebased on top of it and carries only the x_search part.

- `x-search-backtest.test.mjs` (2 tests): `new URL("./", import.meta.url).pathname` yields `/D:/a/...` on Windows and `spawn("bun", ...)` hit `ENOENT: uv_spawn 'bun'`. Now uses `fileURLToPath` and `process.execPath`.
- `x-search-live-e2e.test.mjs`: `resolveSenpiBin`/`senpiVersion` only knew POSIX executables; on win32 the launcher is `senpi.cmd`/`senpi.exe` and a `.cmd` shim cannot be spawned directly. The driver now probes the PATHEXT launcher forms and runs `.cmd`/`.bat` shims through `ComSpec` with a quoted path; the fixture writes platform-appropriate shims.

No behaviour change on macOS/Linux; no bundle change (scripts/qa is not bundled).

## Verification

- Full CI matrix on the pre-rebase head was green, including `senpi-compatibility (windows-latest)`: https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33751610704
- `bun test packages/omo-senpi/scripts/qa/x-search-backtest.test.mjs packages/omo-senpi/scripts/qa/x-search-live-e2e.test.mjs packages/omo-senpi/src/components/init-deep-advisor/git-helpers.test.ts`: 25 pass, 0 fail (macOS, after rebase).
- `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json`: exit 0. `bunx biome check` on changed files: exit 0.
