### PR TITLE
fix(omo-opencode): keep the flat model variant on background wake

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.test.ts
@@ -261,6 +261,25 @@ describe("findNearestMessageExcludingCompaction", () => {
         tools: { bash: true },
       })
     })
+
+    test("#given a compaction checkpoint with a variant #when the model comes from the checkpoint #then the variant is kept", () => {
+      // given
+      setCompactionAgentConfigCheckpoint("ses_checkpoint", {
+        agent: "sisyphus",
+        model: { providerID: "openai", modelID: "gpt-5", variant: "max" },
+      })
+      writeFileSync(join(tempDir, "001.json"), JSON.stringify({ tools: { bash: true } }))
+
+      // when
+      const result = findNearestMessageExcludingCompaction(tempDir, "ses_checkpoint")
+
+      // then
+      expect(result).toEqual({
+        agent: "sisyphus",
+        model: { providerID: "openai", modelID: "gpt-5", variant: "max" },
+        tools: { bash: true },
+      })
+    })
   })
 })
 

--- a/packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.test.ts
@@ -307,4 +307,27 @@ describe("resolvePromptContextFromSessionMessages", () => {
       tools: { bash: true },
     })
   })
+
+  test("#given session message info with a flat variant #when converted #then the stored message keeps the variant", () => {
+    // given
+    const messages = [
+      {
+        info: {
+          agent: "sisyphus",
+          providerID: "openai",
+          modelID: "gpt-5.5",
+          variant: "max",
+        },
+      },
+    ]
+
+    // when
+    const result = resolvePromptContextFromSessionMessages(messages)
+
+    // then
+    expect(result).toEqual({
+      agent: "sisyphus",
+      model: { providerID: "openai", modelID: "gpt-5.5", variant: "max" },
+    })
+  })
 })

--- a/packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.ts
+++ b/packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.ts
@@ -124,6 +124,7 @@ function mergeStoredMessages(
     merged.model = {
       providerID: checkpoint.model.providerID,
       modelID: checkpoint.model.modelID,
+      ...(checkpoint.model.variant ? { variant: checkpoint.model.variant } : {}),
     }
   }
 

--- a/packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.ts
+++ b/packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.ts
@@ -21,6 +21,7 @@ type SessionMessage = {
     }
     providerID?: string
     modelID?: string
+    variant?: string
     tools?: StoredMessage["tools"]
   }
   parts?: Array<{ type?: string }>
@@ -51,6 +52,7 @@ function convertSessionMessageToStoredMessage(message: SessionMessage): StoredMe
 
   const providerID = info.model?.providerID ?? info.providerID
   const modelID = info.model?.modelID ?? info.modelID
+  const variant = info.model?.variant ?? info.variant
 
   return {
     ...(info.agent ? { agent: info.agent } : {}),
@@ -59,7 +61,7 @@ function convertSessionMessageToStoredMessage(message: SessionMessage): StoredMe
           model: {
             providerID,
             modelID,
-            ...(info.model?.variant ? { variant: info.model.variant } : {}),
+            ...(variant ? { variant } : {}),
           },
         }
       : {}),

--- a/packages/omo-opencode/src/hooks/compaction-context-injector/session-prompt-config-resolver.test.ts
+++ b/packages/omo-opencode/src/hooks/compaction-context-injector/session-prompt-config-resolver.test.ts
@@ -14,7 +14,11 @@ type SessionMessage = {
     model?: {
       providerID?: string
       modelID?: string
+      variant?: string
     }
+    providerID?: string
+    modelID?: string
+    variant?: string
     tools?: Record<string, boolean | "allow" | "deny" | "ask">
   }
 }
@@ -68,6 +72,31 @@ describe("session prompt config resolver", () => {
     expect(promptConfig).toEqual({
       agent: "atlas",
       model: { providerID: "openai", modelID: "gpt-5" },
+      tools: { bash: true },
+    })
+  })
+
+  it("captures a flat model variant into the checkpoint model", async () => {
+    // given: OpenCode assistant messages carry providerID/modelID/variant flat, not nested
+    const ctx = createMockContext([
+      {
+        info: {
+          agent: "sisyphus",
+          providerID: "openai",
+          modelID: "gpt-5",
+          variant: "max",
+          tools: { bash: true },
+        },
+      },
+    ])
+
+    // when
+    const promptConfig = await resolveSessionPromptConfig(ctx, sessionID)
+
+    // then
+    expect(promptConfig).toEqual({
+      agent: "sisyphus",
+      model: { providerID: "openai", modelID: "gpt-5", variant: "max" },
       tools: { bash: true },
     })
   })

--- a/packages/omo-opencode/src/hooks/compaction-context-injector/validated-model.ts
+++ b/packages/omo-opencode/src/hooks/compaction-context-injector/validated-model.ts
@@ -6,9 +6,11 @@ type PromptConfigInfo = {
   model?: {
     providerID?: string
     modelID?: string
+    variant?: string
   }
   providerID?: string
   modelID?: string
+  variant?: string
 }
 
 export function resolveValidatedModel(
@@ -20,12 +22,13 @@ export function resolveValidatedModel(
 
   const providerID = info?.model?.providerID ?? info?.providerID
   const modelID = info?.model?.modelID ?? info?.modelID
+  const variant = info?.model?.variant ?? info?.variant
 
   if (!providerID || !modelID) {
     return undefined
   }
 
-  return { providerID, modelID }
+  return { providerID, modelID, ...(variant ? { variant } : {}) }
 }
 
 export function validateCheckpointModel(

--- a/packages/omo-opencode/src/shared/compaction-agent-config-checkpoint.ts
+++ b/packages/omo-opencode/src/shared/compaction-agent-config-checkpoint.ts
@@ -1,6 +1,6 @@
 export type CompactionAgentConfigCheckpoint = {
   agent?: string
-  model?: { providerID: string; modelID: string }
+  model?: { providerID: string; modelID: string; variant?: string }
   tools?: Record<string, boolean>
 }
 
@@ -16,6 +16,7 @@ function cloneCheckpoint(
           model: {
             providerID: checkpoint.model.providerID,
             modelID: checkpoint.model.modelID,
+            ...(checkpoint.model.variant ? { variant: checkpoint.model.variant } : {}),
           },
         }
       : {}),


### PR DESCRIPTION
## Summary

Fixes #7686. `convertSessionMessageToStoredMessage` in `packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.ts` had flat fallbacks for `providerID`/`modelID` but built `variant` from `info.model?.variant` only, so a `[BACKGROUND TASK COMPLETED]` wake ran at default reasoning when the session info carried `variant` at the top level. Same root cause as #7462 (`resolve-message-info.ts:45` already has the flat fallback); this is the second seam.

## Verification

- New test `#given session message info with a flat variant #when converted #then the stored message keeps the variant` was captured RED on the unchanged code, GREEN after the one-line fix (mutation check: reverting the production hunk fails it).
- `bun test packages/omo-opencode/src/features/background-agent/compaction-aware-message-resolver.test.ts`: 19 pass. `bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json`: exit 0. biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7686 by preserving the selected model variant when a background-agent wake rebuilds its stored message or uses a compaction checkpoint. Previously flat session variants and checkpoint data were dropped, so wakes could use the provider's default reasoning effort; they now retain the requested variant.

- Reads variants from nested or flat session message info and stores them in the checkpoint capture path.
- Clones and merges checkpoint variants during prompt reconstruction, with regression coverage for both paths.

<sup>Written for commit 7347c96654a59a5b3487786c5726234dc767a55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Review follow-up

- Reviewer found the compaction-checkpoint branch (`mergeStoredMessages` fallback to `getCompactionAgentConfigCheckpoint`) also dropped the variant, and `CompactionAgentConfigCheckpoint.model` had no `variant` field. Second commit adds the field, clones it, and spreads it in the fallback; new test `#given a compaction checkpoint with a variant ... #then the variant is kept`.
- Remaining known seam (pre-existing, not introduced here): `findNearestMessageExcludingCompaction` raw-casts on-disk JSON without flat-shape normalization; tracked as a follow-up rather than widened into this PR.
- `bun test` on background-agent + shared + compaction-context-injector: 1109 pass; tsgo clean.

### Second follow-up
- Re-review showed the capture side never populated the new field: `resolveValidatedModel` (compaction-context-injector/validated-model.ts) built `{ providerID, modelID }` only. It now reads the variant (nested or flat) and `session-prompt-config-resolver.test.ts` pins the capture path with a flat-shape message (`captures a flat model variant into the checkpoint model`). Suite: 1839 pass across background-agent + shared + compaction-context-injector; tsgo/biome clean.