### PR TITLE
fix(omo-opencode): stop treating an active status as sync task progress

### DIFF
--- a/packages/omo-opencode/src/tools/delegate-task/sync-poll-timeout.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-poll-timeout.test.ts
@@ -128,6 +128,119 @@ describe("syncPollTimeoutMs threading", () => {
           expect(messageCallCount).toBe(3)
         })
       })
+
+      test("#then a busy session whose messages already look complete is not cut short until it goes idle", async () => {
+        const { pollSyncSession } = require("./sync-session-poller")
+        let statusCallCount = 0
+        const completeMessages = [
+          { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+          {
+            info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "stop" },
+            parts: [{ type: "text", text: "done" }],
+          },
+        ]
+        const mockClient = {
+          session: {
+            abort: async () => {},
+            messages: async () => ({ data: completeMessages }),
+            status: async () => {
+              statusCallCount++
+              return { data: { ses_busy_complete: { type: statusCallCount < 5 ? "busy" : "idle" } } }
+            },
+          },
+        }
+
+        await withMockedDateNow(1_000, async () => {
+          const result = await pollSyncSession(createMockCtx(), mockClient, {
+            sessionID: "ses_busy_complete",
+            agentToUse: "oracle",
+            toastManager: null,
+            taskId: undefined,
+          }, 120_000)
+
+          expect(result).toBeNull()
+          expect(statusCallCount).toBe(5)
+        })
+      })
+
+      test("#then message progress under a constant busy status keeps resetting the inactivity timeout", async () => {
+        const { pollSyncSession } = require("./sync-session-poller")
+        let abortCount = 0
+        let statusCallCount = 0
+        let messageCallCount = 0
+        const mockClient = {
+          session: {
+            abort: async () => {
+              abortCount++
+            },
+            messages: async () => {
+              messageCallCount++
+              const turns = Array.from({ length: messageCallCount }, (_, index) => ({
+                info: { id: `msg_a${String(index + 2).padStart(3, "0")}`, role: "assistant", time: { created: 2000 + index }, finish: "tool-calls" },
+                parts: [{ type: "text", text: `step ${index}` }],
+              }))
+              const done = statusCallCount >= 300
+                ? [{ info: { id: "msg_a999", role: "assistant", time: { created: 9000 }, finish: "stop" }, parts: [{ type: "text", text: "done" }] }]
+                : []
+              return { data: [{ info: { id: "msg_001", role: "user", time: { created: 1000 } } }, ...turns, ...done] }
+            },
+            status: async () => {
+              statusCallCount++
+              return { data: { ses_progress: { type: statusCallCount < 300 ? "busy" : "idle" } } }
+            },
+          },
+        }
+
+        await withMockedDateNow(1_000, async () => {
+          const result = await pollSyncSession(createMockCtx(), mockClient, {
+            sessionID: "ses_progress",
+            agentToUse: "oracle",
+            toastManager: null,
+            taskId: undefined,
+            maxAssistantTurns: 1_000,
+          }, 120_000)
+
+          expect(result).toBeNull()
+          expect(abortCount).toBe(0)
+          expect(statusCallCount).toBe(300)
+          expect(messageCallCount).toBeGreaterThan(20)
+        })
+      })
+
+      test("#then a child looping through turns while busy is stopped by the assistant turn budget", async () => {
+        const { pollSyncSession } = require("./sync-session-poller")
+        let abortCount = 0
+        let messageCallCount = 0
+        const mockClient = {
+          session: {
+            abort: async () => {
+              abortCount++
+            },
+            messages: async () => {
+              messageCallCount++
+              const turns = Array.from({ length: messageCallCount }, (_, index) => ({
+                info: { id: `msg_a${String(index + 2).padStart(3, "0")}`, role: "assistant", time: { created: 2000 + index }, finish: "tool-calls" },
+                parts: [{ type: "text", text: `loop ${index}` }],
+              }))
+              return { data: [{ info: { id: "msg_001", role: "user", time: { created: 1000 } } }, ...turns] }
+            },
+            status: async () => ({ data: { ses_loop: { type: "busy" } } }),
+          },
+        }
+
+        await withMockedDateNow(1_000, async () => {
+          const result = await pollSyncSession(createMockCtx(), mockClient, {
+            sessionID: "ses_loop",
+            agentToUse: "oracle",
+            toastManager: null,
+            taskId: undefined,
+            maxAssistantTurns: 3,
+          }, 120_000)
+
+          expect(result).toContain("exceeded 3 assistant turns")
+          expect(abortCount).toBe(1)
+        })
+      })
     })
 
     describe("#when timeoutMs is omitted", () => {

--- a/packages/omo-opencode/src/tools/delegate-task/sync-poll-timeout.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-poll-timeout.test.ts
@@ -93,13 +93,16 @@ describe("syncPollTimeoutMs threading", () => {
             messages: async () => {
               messageCallCount++
               return {
-                data: [
-                  { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
-                  {
-                    info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "stop" },
-                    parts: [{ type: "text", text: "done" }],
-                  },
-                ],
+                data:
+                  statusCallCount >= 3
+                    ? [
+                        { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+                        {
+                          info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "stop" },
+                          parts: [{ type: "text", text: "done" }],
+                        },
+                      ]
+                    : [{ info: { id: "msg_001", role: "user", time: { created: 1000 } } }],
               }
             },
             status: async () => {
@@ -122,7 +125,7 @@ describe("syncPollTimeoutMs threading", () => {
           expect(result).toBeNull()
           expect(abortCount).toBe(0)
           expect(statusCallCount).toBe(3)
-          expect(messageCallCount).toBe(1)
+          expect(messageCallCount).toBe(3)
         })
       })
     })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.test.ts
@@ -64,6 +64,52 @@ describe("pollSyncSession", () => {
       expect(result).toBe("Forbidden: Selected provider is forbidden")
     })
 
+    test("surfaces terminal errors even when status remains busy", async () => {
+      const { pollSyncSession } = require("./sync-session-poller")
+      const controller = new AbortController()
+      let statusCallCount = 0
+      let messageCallCount = 0
+      const terminalError = "Provider quota exceeded"
+      const mockClient = {
+        session: {
+          messages: async () => {
+            messageCallCount++
+            return {
+              data: [
+                { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+                {
+                  info: {
+                    id: "msg_002",
+                    role: "assistant",
+                    time: { created: 2000 },
+                    error: { data: { message: terminalError } },
+                  },
+                  parts: [],
+                },
+              ],
+            }
+          },
+          status: async () => {
+            statusCallCount++
+            if (statusCallCount >= 3) controller.abort()
+            return { data: { ses_busy_error: { type: "busy" } } }
+          },
+          abort: async () => ({}),
+        },
+      }
+
+      const result = await pollSyncSession({ ...createMockCtx(), abort: controller.signal }, mockClient, {
+        sessionID: "ses_busy_error",
+        agentToUse: "test-agent",
+        toastManager: null,
+        taskId: undefined,
+      }, 50)
+
+      expect(result).toBe(terminalError)
+      expect(messageCallCount).toBe(1)
+      expect(statusCallCount).toBe(1)
+    })
+
     test("ignores stale prior-turn assistant errors after a new user turn starts", async () => {
       // given: prior error exists but user sent new message
       const { pollSyncSession } = require("./sync-session-poller")
@@ -496,24 +542,29 @@ describe("pollSyncSession", () => {
   })
 
   describe("non-idle session status", () => {
-    test("skips message check when session is not idle", async () => {
+    test("inspects messages while active but only completes once the session is idle", async () => {
       // given: session is running (not idle)
       const { pollSyncSession } = require("./sync-session-poller")
 
       let statusCallCount = 0
       let messageCallCount = 0
+      let messageCallsWhileActive = 0
        const mockClient = {
          session: {
            messages: async () => {
              messageCallCount++
+             if (statusCallCount <= 2) messageCallsWhileActive++
              return {
-               data: [
-                 { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
-                 {
-                   info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn" },
-                   parts: [{ type: "text", text: "Done" }],
-                 },
-               ],
+               data:
+                 statusCallCount >= 3
+                   ? [
+                       { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+                       {
+                         info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn" },
+                         parts: [{ type: "text", text: "Done" }],
+                       },
+                     ]
+                   : [{ info: { id: "msg_001", role: "user", time: { created: 1000 } } }],
              }
            },
            status: async () => {
@@ -534,9 +585,12 @@ describe("pollSyncSession", () => {
         taskId: undefined,
       })
 
-      // then: waits for idle before checking messages
+      // then: messages were inspected while the status was still active (terminal errors
+      // must surface there), and completion was only declared once the session went idle
       expect(result).toBeNull()
       expect(statusCallCount).toBeGreaterThanOrEqual(3)
+      expect(messageCallsWhileActive).toBeGreaterThanOrEqual(1)
+      expect(messageCallCount).toBeGreaterThanOrEqual(2)
     })
   })
 

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
@@ -83,6 +83,8 @@ export async function pollSyncSession(
   let timedOut = false
   let assistantTurnCount = 0
   let lastSeenAssistantId: string | undefined
+  let lastObservedAssistantId: string | undefined
+  let lastObservedMessageCount: number | undefined
   const childSettleMs = input.childWakeGraceMs ?? CHILD_WAKE_GRACE_MS
   let childWaitAssistantId: string | undefined
   let childSettleStartedAt = 0
@@ -185,14 +187,16 @@ export async function pollSyncSession(
       })
     }
 
-    if (isActiveSessionStatus(sessionStatus)) {
-      inactiveStart = Date.now()
-      continue
-    }
-
-    nonActivePollsSinceMessageFetch++
-    const statusRevision = sessionStatus && (sessionStatus.updatedAt ?? sessionStatus.revision ?? sessionStatus.messageCount)
+    const isActive = isActiveSessionStatus(sessionStatus)
+    const statusRevision = sessionStatus && (sessionStatus.updatedAt ?? sessionStatus.revision ?? sessionStatus.messageCount ?? sessionStatus.type)
     const statusChanged = statusRevision !== undefined && String(statusRevision) !== lastStatusRevision
+    if (statusChanged) inactiveStart = Date.now()
+
+    // An active status (busy/retry/running) is not progress by itself: a child that hit a
+    // terminal provider error can sit in "busy" forever with an unchanged message set.
+    // Keep inspecting messages on the same staleness cadence so the error surfaces and the
+    // inactivity timer only resets on observable change.
+    nonActivePollsSinceMessageFetch++
     if (hasFetchedNonActiveMessages && !statusChanged && nonActivePollsSinceMessageFetch < MAX_NON_ACTIVE_STATUS_STALENESS_POLLS) {
       continue
     }
@@ -211,14 +215,25 @@ export async function pollSyncSession(
 
     if (!hasMessagesAfterAnchor(messages, input.anchorMessageID, input.anchorMessageCount)) continue
 
+    const currentAssistantId = [...messages].reverse().find((m) => m.info?.role === "assistant")?.info?.id
+    const messageStateChanged =
+      lastObservedMessageCount !== undefined &&
+      (messages.length !== lastObservedMessageCount || currentAssistantId !== lastObservedAssistantId)
+    lastObservedMessageCount = messages.length
+    lastObservedAssistantId = currentAssistantId
+    if (messageStateChanged) inactiveStart = Date.now()
+
     const sessionError = getTerminalSessionError(messages)
     if (sessionError) {
       log("[task] Poll detected terminal session error", { sessionID: input.sessionID, sessionError })
       return sessionError
     }
 
+    // Completion is only judged once the session has left its active status; a busy child
+    // whose last assistant turn merely looks finished is still working.
+    if (isActive) continue
+
     if (isSessionComplete(messages)) {
-      const currentAssistantId = [...messages].reverse().find((m) => m.info?.role === "assistant")?.info?.id
       if (isAwaitingChildContinuation(currentAssistantId)) {
         continue
       }

--- a/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts
@@ -231,9 +231,7 @@ export async function pollSyncSession(
 
     // Completion is only judged once the session has left its active status; a busy child
     // whose last assistant turn merely looks finished is still working.
-    if (isActive) continue
-
-    if (isSessionComplete(messages)) {
+    if (!isActive && isSessionComplete(messages)) {
       if (isAwaitingChildContinuation(currentAssistantId)) {
         continue
       }
@@ -241,7 +239,9 @@ export async function pollSyncSession(
       break
     }
 
-    // Count new assistant turns to circuit-break infinite loops
+    // Count new assistant turns to circuit-break infinite loops. This runs while the status
+    // is still active too: a child looping through tool calls never leaves "busy", and every
+    // new turn resets the inactivity timer above, so the turn budget is its only bound.
     const lastAssistant = [...messages].reverse().find((m) => m.info?.role === "assistant")
     if (lastAssistant?.info?.id && lastAssistant.info.id !== lastSeenAssistantId) {
       lastSeenAssistantId = lastAssistant.info.id
@@ -257,6 +257,8 @@ export async function pollSyncSession(
         return `Task aborted: subagent exceeded ${maxTurns} assistant turns without completing. This usually indicates an infinite tool-call loop. Session ID: ${input.sessionID}`
       }
     }
+
+    if (isActive) continue
 
     const hasAssistantText = messages.some((m) => {
       if (m.info?.role !== "assistant") return false


### PR DESCRIPTION
## Summary

Fixes #7671. `pollSyncSession()` implemented `syncPollTimeoutMs` as an inactivity timer, but every active status (`busy`/`retry`/`running`) reset the timer and `continue`d before any message inspection. A child whose provider returned a terminal error and then stayed `busy` with no new messages therefore never timed out and never surfaced the error (15h13m observed by the reporter).

Changes in `packages/omo-opencode/src/tools/delegate-task/sync-session-poller.ts`:
- the inactivity timer resets only on observable change: status revision (`updatedAt`/`revision`/`messageCount`/`type`), message count, or last assistant id;
- messages are fetched on the existing staleness cadence (`MAX_NON_ACTIVE_STATUS_STALENESS_POLLS`) while the status is active, so `getTerminalSessionError` runs and returns promptly;
- completion (`isSessionComplete` / assistant-text fallback) is still evaluated only once the session is no longer active, so a busy child that merely looks finished is not cut short.

No new config key; `syncPollTimeoutMs` keeps its inactivity semantics.

## Verification

- New test `surfaces terminal errors even when status remains busy` captured RED on the unchanged poller (looped until abort), GREEN after the fix.
- Existing `non-idle session status` test updated to pin the new contract: messages inspected while active, completion only after idle.
- `bun test packages/omo-opencode/src/tools/delegate-task/`: 489 pass, 0 fail. `bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json`: exit 0. biome clean. Tests are fake-client driven, no real sleeps added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7671: `pollSyncSession` no longer treats an unchanged `busy`/`retry`/`running` status as progress. It now inspects messages while active to surface terminal provider errors, resets the inactivity timer only for observable progress, and waits for an inactive status before accepting completion.

- The assistant-turn circuit breaker also runs while active, bounding children that loop through tool calls without leaving `busy`.
- `syncPollTimeoutMs` keeps its inactivity semantics; status revisions, message counts, and assistant IDs count as progress.
- Regression tests cover terminal errors, delayed completion, message progress, and active turn limits.
- 492 delegate-task tests pass; `tsgo --noEmit` and Biome are clean.

<sup>Written for commit 2179edcd239373ffcb3d583c5c5d42a664897c64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Review follow-up

- Reviewer showed the two load-bearing hunks were unpinned (deleting the active-status completion gate or the message-progress timer reset kept the suite green). Added three tests in `sync-poll-timeout.test.ts`; each was mutation-checked: removing the completion gate fails "busy session whose messages already look complete is not cut short", removing the message-progress reset fails "message progress under a constant busy status keeps resetting the inactivity timeout", and skipping the turn counter while active fails "child looping through turns while busy is stopped by the assistant turn budget".
- The assistant-turn circuit breaker now also runs while the status is active (previously unreachable for an always-busy loop), so the looping variant of #7671 is bounded by `maxAssistantTurns`.
- Known, unchanged: a `busy<->retry` oscillation still counts as a status revision change (`type` fallback) and resets the timer; left as-is because dropping `type` would make a status object without revision fields unable to signal progress at all.
- `bun test packages/omo-opencode/src/tools/delegate-task/`: 492 pass, 0 fail; tsgo clean; biome clean.