### PR TITLE
fix(ulw-loop): explain quality gate enum defects

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/skills/ulw-loop/references/full-workflow.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/skills/ulw-loop/references/full-workflow.md
@@ -210,6 +210,8 @@ Trigger only for the final aggregate goal after every criterion in every goal is
 ```sh
 omo-agent-toolkit ulw-loop checkpoint --goal-id <id> --status complete --evidence "<e2e evidence + manual QA notes>" --codex-goal-json <snapshot> --quality-gate-json <json-or-path> --json
 ```
+`--quality-gate-json` shape. In `manualQa.artifactRefs`, `kind` must be one of `cli-transcript`, `log`, `screenshot`, `image`, `http-dump`, or `data-diff`; review and QA reports belong in `codeReview.reportPath` or `gateReview.reportPath`, not `artifactRefs`. `surfaceEvidence.surface` must be one of `cli`, `http`, `tmux`, `browser`, `gui`, or `data`. Compatibility is `cli`/`tmux` -> `cli-transcript`/`log`, `http` -> `http-dump`, `browser`/`gui` -> `screenshot`/`image`, and `data` -> `data-diff`.
+
 `--quality-gate-json` shape:
 ```json
 {

--- a/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate-artifacts.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate-artifacts.ts
@@ -11,6 +11,9 @@ import {
 } from "./quality-gate-fields.js";
 import type { UlwLoopManualQaArtifactKind, UlwLoopManualQaArtifactRef, UlwLoopManualQaSurface } from "./types.js";
 
+const SUPPORTED_SURFACES = "cli, http, tmux, browser, gui, data";
+const SUPPORTED_KINDS = "cli-transcript, log, screenshot, image, http-dump, data-diff";
+
 export function surfaceField(value: unknown, field: string): UlwLoopManualQaSurface {
 	if (
 		value === "cli" ||
@@ -21,7 +24,7 @@ export function surfaceField(value: unknown, field: string): UlwLoopManualQaSurf
 		value === "data"
 	)
 		return value;
-	invalid(`${field} must be a supported manual QA surface.`, field);
+	invalid(`${field} must be a supported manual QA surface (${SUPPORTED_SURFACES}).`, field);
 	return "cli";
 }
 export function kindField(value: unknown, field: string): UlwLoopManualQaArtifactKind {
@@ -34,7 +37,10 @@ export function kindField(value: unknown, field: string): UlwLoopManualQaArtifac
 		value === "data-diff"
 	)
 		return value;
-	invalid(`${field} must be a supported artifact kind.`, field);
+	invalid(
+		`${field} must be a supported artifact kind (${SUPPORTED_KINDS}); review/QA reports belong in codeReview.reportPath or gateReview.reportPath, not artifactRefs.`,
+		field,
+	);
 	return "log";
 }
 export function artifactCompatible(surface: UlwLoopManualQaSurface, kind: UlwLoopManualQaArtifactKind): boolean {

--- a/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate-artifacts.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate-artifacts.ts
@@ -11,54 +11,49 @@ import {
 } from "./quality-gate-fields.js";
 import type { UlwLoopManualQaArtifactKind, UlwLoopManualQaArtifactRef, UlwLoopManualQaSurface } from "./types.js";
 
-const SUPPORTED_SURFACES = "cli, http, tmux, browser, gui, data";
-const SUPPORTED_KINDS = "cli-transcript, log, screenshot, image, http-dump, data-diff";
+export const SUPPORTED_SURFACES: readonly UlwLoopManualQaSurface[] = ["cli", "http", "tmux", "browser", "gui", "data"];
+export const SUPPORTED_KINDS: readonly UlwLoopManualQaArtifactKind[] = [
+	"cli-transcript",
+	"log",
+	"screenshot",
+	"image",
+	"http-dump",
+	"data-diff",
+];
+const COMPATIBLE_KINDS: Readonly<Record<UlwLoopManualQaSurface, readonly UlwLoopManualQaArtifactKind[]>> = {
+	cli: ["cli-transcript", "log"],
+	tmux: ["cli-transcript", "log"],
+	http: ["http-dump"],
+	browser: ["screenshot", "image"],
+	gui: ["screenshot", "image"],
+	data: ["data-diff"],
+};
+
+function isSupportedSurface(value: unknown): value is UlwLoopManualQaSurface {
+	return SUPPORTED_SURFACES.some((surface) => surface === value);
+}
+function isSupportedKind(value: unknown): value is UlwLoopManualQaArtifactKind {
+	return SUPPORTED_KINDS.some((kind) => kind === value);
+}
 
 export function surfaceField(value: unknown, field: string): UlwLoopManualQaSurface {
-	if (
-		value === "cli" ||
-		value === "http" ||
-		value === "tmux" ||
-		value === "browser" ||
-		value === "gui" ||
-		value === "data"
-	)
-		return value;
-	invalid(`${field} must be a supported manual QA surface (${SUPPORTED_SURFACES}).`, field);
+	if (isSupportedSurface(value)) return value;
+	invalid(`${field} must be a supported manual QA surface (${SUPPORTED_SURFACES.join(", ")}).`, field);
 	return "cli";
 }
 export function kindField(value: unknown, field: string): UlwLoopManualQaArtifactKind {
-	if (
-		value === "cli-transcript" ||
-		value === "log" ||
-		value === "screenshot" ||
-		value === "image" ||
-		value === "http-dump" ||
-		value === "data-diff"
-	)
-		return value;
+	if (isSupportedKind(value)) return value;
 	invalid(
-		`${field} must be a supported artifact kind (${SUPPORTED_KINDS}); review/QA reports belong in codeReview.reportPath or gateReview.reportPath, not artifactRefs.`,
+		`${field} must be a supported artifact kind (${SUPPORTED_KINDS.join(", ")}); review/QA reports belong in codeReview.reportPath or gateReview.reportPath, not artifactRefs.`,
 		field,
 	);
 	return "log";
 }
+export function compatibleKindsFor(surface: UlwLoopManualQaSurface): readonly UlwLoopManualQaArtifactKind[] {
+	return COMPATIBLE_KINDS[surface];
+}
 export function artifactCompatible(surface: UlwLoopManualQaSurface, kind: UlwLoopManualQaArtifactKind): boolean {
-	switch (surface) {
-		case "cli":
-		case "tmux":
-			return kind === "cli-transcript" || kind === "log";
-		case "http":
-			return kind === "http-dump";
-		case "browser":
-		case "gui":
-			return kind === "screenshot" || kind === "image";
-		case "data":
-			return kind === "data-diff";
-		default:
-			invalid("manualQa.surfaceEvidence has an unsupported surface.", "manualQa.surfaceEvidence.surface");
-			return false;
-	}
+	return compatibleKindsFor(surface).includes(kind);
 }
 export function checkFile(path: string, field: string, opts?: ValidateQualityGateOptions): void {
 	if (opts?.repoRoot === undefined || opts.fs === undefined || isPoisoned(field)) return;

--- a/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate.ts
@@ -168,8 +168,16 @@ function parseSurfaceEvidence(
 		for (const artifact of artifacts) {
 			if (isPoisoned(`manualQa.surfaceEvidence[${index}].surface`) || isPoisonedArtifactKind(artifact.id)) continue;
 			if (!artifactCompatible(surface, artifact.kind)) {
+				const compatibleKinds =
+					surface === "cli" || surface === "tmux"
+						? "cli-transcript, log"
+						: surface === "http"
+							? "http-dump"
+							: surface === "browser" || surface === "gui"
+								? "screenshot, image"
+								: "data-diff";
 				invalid(
-					`manualQa.surfaceEvidence ${surface} artifact ${artifact.kind} is incompatible.`,
+					`manualQa.surfaceEvidence ${surface} artifact ${artifact.kind} is incompatible; surface "${surface}" accepts artifact kinds: ${compatibleKinds}.`,
 					"manualQa.surfaceEvidence",
 				);
 			}

--- a/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/quality-gate.ts
@@ -2,6 +2,7 @@ import {
 	artifactCompatible,
 	artifactMap,
 	checkFile,
+	compatibleKindsFor,
 	parseArtifactRefs,
 	referencedArtifacts,
 	surfaceField,
@@ -168,16 +169,8 @@ function parseSurfaceEvidence(
 		for (const artifact of artifacts) {
 			if (isPoisoned(`manualQa.surfaceEvidence[${index}].surface`) || isPoisonedArtifactKind(artifact.id)) continue;
 			if (!artifactCompatible(surface, artifact.kind)) {
-				const compatibleKinds =
-					surface === "cli" || surface === "tmux"
-						? "cli-transcript, log"
-						: surface === "http"
-							? "http-dump"
-							: surface === "browser" || surface === "gui"
-								? "screenshot, image"
-								: "data-diff";
 				invalid(
-					`manualQa.surfaceEvidence ${surface} artifact ${artifact.kind} is incompatible; surface "${surface}" accepts artifact kinds: ${compatibleKinds}.`,
+					`manualQa.surfaceEvidence ${surface} artifact ${artifact.kind} is incompatible; surface "${surface}" accepts artifact kinds: ${compatibleKindsFor(surface).join(", ")}.`,
 					"manualQa.surfaceEvidence",
 				);
 			}

--- a/packages/omo-codex/plugin/components/ulw-loop/test/quality-gate.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/quality-gate.test.ts
@@ -166,20 +166,60 @@ describe("validateQualityGate", () => {
 		expect(error.message).toContain("missing-artifact");
 	});
 
-	it("#given incompatible surface artifact kind #when validated #then it rejects the gate", () => {
+	it("#given incompatible surface artifact kind #when validated #then it rejects the gate with compatible kinds", () => {
 		// when
 		const error = getQualityGateError(
 			makeGate({
 				manualQa: {
 					...VALID_GATE.manualQa,
-					artifactRefs: [{ ...VALID_GATE.manualQa.artifactRefs[0], kind: "http-dump" }],
+					artifactRefs: [
+						{ ...VALID_GATE.manualQa.artifactRefs[0], kind: "http-dump" },
+						VALID_GATE.manualQa.artifactRefs[1],
+					],
 				},
 			}),
 		);
 
 		// then
 		expect(error.code).toBe("ULW_LOOP_QUALITY_GATE_INVALID");
-		expect(error.message).toContain("cli");
+		expect(error.message).toContain(
+			'manualQa.surfaceEvidence cli artifact http-dump is incompatible; surface "cli" accepts artifact kinds: cli-transcript, log.',
+		);
+	});
+
+	it("#given an unsupported artifact kind #when validated #then it lists allowed kinds and report path guidance", () => {
+		const error = getQualityGateError(
+			makeGate({
+				manualQa: {
+					...VALID_GATE.manualQa,
+					artifactRefs: [
+						{ ...VALID_GATE.manualQa.artifactRefs[0], kind: "review-report" },
+						VALID_GATE.manualQa.artifactRefs[1],
+					],
+				},
+			}),
+		);
+
+		expect(error.code).toBe("ULW_LOOP_QUALITY_GATE_INVALID");
+		expect(error.message).toContain(
+			"manualQa.artifactRefs[0].kind must be a supported artifact kind (cli-transcript, log, screenshot, image, http-dump, data-diff); review/QA reports belong in codeReview.reportPath or gateReview.reportPath, not artifactRefs.",
+		);
+	});
+
+	it("#given an unsupported manual QA surface #when validated #then it lists allowed surfaces", () => {
+		const error = getQualityGateError(
+			makeGate({
+				manualQa: {
+					...VALID_GATE.manualQa,
+					surfaceEvidence: [{ ...VALID_GATE.manualQa.surfaceEvidence[0], surface: "terminal" }],
+				},
+			}),
+		);
+
+		expect(error.code).toBe("ULW_LOOP_QUALITY_GATE_INVALID");
+		expect(error.message).toContain(
+			"manualQa.surfaceEvidence[0].surface must be a supported manual QA surface (cli, http, tmux, browser, gui, data).",
+		);
 	});
 
 	it("#given placeholder evidence and artifact path #when validated #then it rejects placeholders", () => {

--- a/packages/omo-senpi/skills/ulw-loop/references/full-workflow.md
+++ b/packages/omo-senpi/skills/ulw-loop/references/full-workflow.md
@@ -163,6 +163,8 @@ Trigger only for the final aggregate goal after every criterion in every goal is
 ```sh
 omo-agent-toolkit ulw-loop checkpoint --goal-id <id> --status complete --evidence "<e2e evidence + manual QA notes>" --codex-goal-json <snapshot> --quality-gate-json <json-or-path> --json
 ```
+`--quality-gate-json` shape. In `manualQa.artifactRefs`, `kind` must be one of `cli-transcript`, `log`, `screenshot`, `image`, `http-dump`, or `data-diff`; review and QA reports belong in `codeReview.reportPath` or `gateReview.reportPath`, not `artifactRefs`. `surfaceEvidence.surface` must be one of `cli`, `http`, `tmux`, `browser`, `gui`, or `data`. Compatibility is `cli`/`tmux` -> `cli-transcript`/`log`, `http` -> `http-dump`, `browser`/`gui` -> `screenshot`/`image`, and `data` -> `data-diff`.
+
 `--quality-gate-json` shape:
 ```json
 {


### PR DESCRIPTION
## Problem
Quality-gate enum validation errors were opaque: invalid artifact kinds and manual-QA surfaces did not list valid values, and incompatible surface/kind errors did not identify the accepted kinds. This caused avoidable retry loops, including the 2026-09-03 incident where `review-report` was supplied as an artifact kind for a gate-review report.

## Root cause
The validator used fixed generic error strings for `kindField()` and `surfaceField()`, while the compatibility failure only named the surface and artifact kind.

## Fix
- Enumerate all supported artifact kinds and manual-QA surfaces in validation defects.
- Explain that review/QA reports belong in `codeReview.reportPath` or `gateReview.reportPath`, not `manualQa.artifactRefs`.
- Include the compatible artifact kinds for the rejected surface.
- Add focused tests for kind, surface, and compatibility messages.
- Document the enums, compatibility mapping, and reportPath rule in both ulw-loop workflow references.

## Test evidence
- RED before implementation: focused quality-gate tests reported 18 passing and 3 failing assertions against the old opaque messages.
- GREEN after implementation and rebase: focused quality-gate tests reported 21 passing, 0 failing, 33 assertions.
- Component typecheck, lint, and build pass on the bunshin remote mesh.
- Senpi agent-toolkit staging succeeds; no committed runtime bundle exists in this branch, so no bundle refresh commit was needed.

## Incident reference
2026-09-03 senpi session `01a06520`: `review-report` was incorrectly placed in `manualQa.artifactRefs`; the improved defect now directs reports to `codeReview.reportPath` / `gateReview.reportPath`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quality-gate validation errors now list the valid artifact kinds and manual-QA surfaces, and compatibility errors name the accepted kinds for the rejected surface. The old opaque messages caused avoidable retry loops, including a 2026-09-03 incident where `review-report` was mistakenly supplied as an artifact kind.

**Bug Fixes**
- Review/QA reports are now explicitly directed to `codeReview.reportPath` or `gateReview.reportPath` instead of `manualQa.artifactRefs`.
- Supported surfaces, kinds, and the compatibility mapping now live in one table in `quality-gate-artifacts.ts`; validation checks and error messages both derive from it so the printed lists cannot drift from what is accepted.
- Adds focused tests for kind, surface, and compatibility messages.
- Documents the enums, compatibility mapping, and reportPath rule in both ulw-loop workflow references.

<sup>Written for commit 11cbb5705a2c4fa587d26f7f60b88e0366bfdbec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

