### PR TITLE
test(git-bash-mcp): retry temp-dir removal on Windows EBUSY

### DIFF
--- a/packages/git-bash-mcp/src/runner.test.ts
+++ b/packages/git-bash-mcp/src/runner.test.ts
@@ -14,7 +14,9 @@ function createTemporaryDirectory(prefix: string): string {
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
-    rmSync(directory, { recursive: true, force: true });
+    // Windows can transiently report EBUSY while the OS releases the fake bash.exe image of
+    // the just-exited child; retrying the removal is a no-op on POSIX platforms.
+    rmSync(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
   }
 });
 


### PR DESCRIPTION
The git-bash-mcp runner tests spawn a fake bash executable; on Windows the OS can transiently hold the just-exited child image, so the afterEach rmSync hit EBUSY and failed the "Git Bash runner" case in the v5.0.0-beta.37 release-state PR windows leg (job 100631161074). Retry the removal (maxRetries: 10, retryDelay: 100) - a no-op on POSIX. The other two windows failures from that job (x-search-backtest / x-search-live-e2e) were already fixed on dev by #7695 (fix/ci-windows-senpi-compat); this closes the last one. classification.md attached under the run evidence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries temporary directory cleanup in the `git-bash-mcp` runner tests to fix a Windows-only flake where `rmSync` failed with EBUSY after the fake bash process exited. The retry is a no-op on POSIX.

<sup>Written for commit e336e43729d1ac5b1e5287500c353a9b5fcebec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

