### PR TITLE
fix(omo-native): stop the launcher dying with spawn EINVAL on Windows npm bun shims

### DIFF
--- a/packages/omo-native/bin/lib/bun-runtime.js
+++ b/packages/omo-native/bin/lib/bun-runtime.js
@@ -70,10 +70,25 @@ export function isUnderBunGlobalTree(scriptRealPath, options = {}) {
   return normalize(scriptRealPath).startsWith(`${root}${GLOBAL_TREE_MARKER}`)
 }
 
+// Only real executables qualify on win32. npm installs bun as a `bun.cmd` shim next to the real
+// binary, and Node refuses to spawn .cmd/.bat files without a shell (spawn EINVAL, CVE-2024-27980),
+// so a shim can neither answer the version probe nor host the re-exec. PATHEXT still decides which
+// executable spellings exist; batch-file spellings are dropped. Lower-case first, so the path
+// returned matches how the file is spelled on disk.
+const WIN32_EXECUTABLE_EXTENSIONS = new Set([".exe", ".com"])
+
 function pathExtensions(env, platform) {
   if (platform !== "win32") return [""]
   const configured = env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD"
-  return configured.split(";").filter(Boolean)
+  const spellings = []
+  for (const raw of configured.split(";")) {
+    const extension = raw.trim()
+    if (!WIN32_EXECUTABLE_EXTENSIONS.has(extension.toLowerCase())) continue
+    for (const spelling of [extension.toLowerCase(), extension]) {
+      if (!spellings.includes(spelling)) spellings.push(spelling)
+    }
+  }
+  return spellings.length > 0 ? spellings : [...WIN32_EXECUTABLE_EXTENSIONS]
 }
 
 /**
@@ -129,19 +144,25 @@ export function probeBunVersion(bunPath, options = {}) {
   const execFile = options.execFile ?? nodeExecFile
   const env = options.env ?? process.env
   return new Promise((resolve) => {
-    execFile(
-      bunPath,
-      ["--version"],
-      { encoding: "utf8", env, timeout: VERSION_PROBE_TIMEOUT_MS, windowsHide: true },
-      (error, stdout) => {
-        if (error) {
-          resolve(undefined)
-          return
-        }
-        const version = String(stdout).trim()
-        resolve(version === "" ? undefined : version)
-      },
-    )
+    try {
+      execFile(
+        bunPath,
+        ["--version"],
+        { encoding: "utf8", env, timeout: VERSION_PROBE_TIMEOUT_MS, windowsHide: true },
+        (error, stdout) => {
+          if (error) {
+            resolve(undefined)
+            return
+          }
+          const version = String(stdout).trim()
+          resolve(version === "" ? undefined : version)
+        },
+      )
+    } catch {
+      // Node throws synchronously for a batch file spawned without a shell (spawn EINVAL); that is
+      // "not a bun we can trust", never a launcher crash.
+      resolve(undefined)
+    }
   })
 }
 

--- a/packages/omo-native/test/bun-runtime.test.ts
+++ b/packages/omo-native/test/bun-runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { posix, win32 } from "node:path"
-import { findBunBinary, isUnderBunGlobalTree } from "../bin/lib/bun-runtime.js"
+import { findBunBinary, isUnderBunGlobalTree, probeBunVersion } from "../bin/lib/bun-runtime.js"
 
 type Options = {
   env?: Record<string, string | undefined>
@@ -225,6 +225,53 @@ describe("bun runtime detection", () => {
         // then
         expect(found).toBeUndefined()
       })
+    })
+  })
+
+  describe("#given a Windows PATH that only carries an npm-installed bun.cmd shim", () => {
+    test("#then the shim is not a bun the launcher can run and lookup reports absence", () => {
+      // given: npm's global prefix holds bun.cmd / bun (no bun.exe), and ~/.bun does not exist
+      const npmPrefix = String.raw`C:\Users\dev\AppData\Roaming\npm`
+      const found = findBunBinary({
+        env: { Path: npmPrefix, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+        homedir: () => WIN_HOME,
+        platform: "win32",
+        exists: existsOnly(win32.join(npmPrefix, "bun.CMD"), win32.join(npmPrefix, "bun.cmd"), win32.join(npmPrefix, "bun")),
+        realpath: identityRealpath,
+      })
+
+      // then: a .cmd shim cannot be probed or re-exec'd without a shell (Node rejects it with
+      // spawn EINVAL), so it must never be selected
+      expect(found).toBeUndefined()
+    })
+
+    test("#then a real bun.exe next to the shim is still found", () => {
+      const npmPrefix = String.raw`C:\Users\dev\AppData\Roaming\npm`
+      const found = findBunBinary({
+        env: { Path: npmPrefix, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+        homedir: () => WIN_HOME,
+        platform: "win32",
+        exists: existsOnly(win32.join(npmPrefix, "bun.cmd"), win32.join(npmPrefix, "bun.exe")),
+        realpath: identityRealpath,
+      })
+      expect(found).toBe(win32.join(npmPrefix, "bun.exe"))
+    })
+  })
+
+  describe("#given a bun probe whose spawn throws synchronously", () => {
+    test("#then the probe resolves undefined instead of rejecting", async () => {
+      // given: Node throws spawn EINVAL synchronously for batch files spawned without a shell
+      const execFile = () => {
+        const error = new Error("spawn EINVAL") as NodeJS.ErrnoException
+        error.code = "EINVAL"
+        throw error
+      }
+
+      // when
+      const version = await probeBunVersion(String.raw`C:\bun\bun.cmd`, { execFile: execFile as never })
+
+      // then
+      expect(version).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
## Summary

Windows field report tonight (beta.37/38): `omo --version` prints `omo: spawn EINVAL` while `senpi --version` works. Root cause is in the bun re-exec introduced by #7680:

- `findBunBinary` walks PATH with every `PATHEXT` spelling, so on a machine where bun was installed through npm it selects the `bun.cmd` shim in the npm prefix.
- `probeBunVersion` calls `execFile` on that path. Node (>= 20.12/24, CVE-2024-27980 guard) throws `spawn EINVAL` **synchronously** for a batch file spawned without a shell, so the throw happens inside the Promise executor, the probe rejects instead of resolving `undefined`, and the launcher's top-level handler prints the error and exits.

## Fix

- Only real executables (`.exe`/`.com`, lower-case spelling first, then the configured spelling) qualify as bun candidates on win32; `.cmd`/`.bat` shims are skipped because they can neither be probed nor host the re-exec without a shell.
- `probeBunVersion` wraps `execFile` so a synchronous spawn failure resolves `undefined` ("not a bun we can trust") and the launcher stays on node.

## Verification

- RED: three new tests in `packages/omo-native/test/bun-runtime.test.ts` failed on the unchanged code (shim selected as `bun.CMD`; `bun.exe` next to a shim not found; probe rejected). GREEN after the fix.
- `bun test packages/omo-native/test/`: bun-runtime + decision suites pass (33/33). The four `omo doctor` failures in that directory are pre-existing on `dev` (same 4 fail with this change stashed; they read host settings) and unrelated.
- biome clean, tsgo clean. Windows proof = this PR's `ci:full-matrix` run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `omo` launcher crashing with `spawn EINVAL` on Windows when bun was installed through npm. Previously `omo --version` died with that error; now the launcher skips batch-file shims and stays on node when a bun candidate can’t be probed.

- On Windows, npm-installed bun is a `bun.cmd` shim, and Node refuses to spawn `.cmd` files without a shell.
- Bun discovery on win32 now only accepts `.exe`/`.com` candidates while still respecting `PATHEXT` order and spellings.
- `probeBunVersion` resolves `undefined` when spawning throws synchronously, so a bad candidate can’t crash the launcher.
- Adds regression tests for shim-only PATHs, a real `bun.exe` next to a shim, and synchronous spawn failures.

<sup>Written for commit cc966e556372a6369fb807b3e81401a14251a136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

