### PR TITLE
fix(background-agent): do not fork a competing parent loop after noReply admission

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-active-defer-ceiling.test.ts
@@ -180,7 +180,63 @@ describe("parent wake active defer ceiling", () => {
     }
   })
 
-  test("#given retained noReply wake and fresh activity exceed active ceiling #then it dispatches once safe", async () => {
+  test("#given retained noReply wake ages while parent stays busy after tools return #then it does not fork a competing reply", async () => {
+    // given: all-complete reminder already deposited as noReply while the parent
+    // was blocked on background_output. The tool then returns and the original
+    // turn keeps generating (session busy, history looks "safe"). The 60s active
+    // defer ceiling must not start a second assistant loop.
+    const originalDateNow = Date.now
+    let now = 100_000
+    Date.now = () => now
+    let messages: SessionMessageStub[] = BLOCKED_MESSAGES
+    const sessionStatuses: Record<string, { type: string }> = { "parent-1": { type: "idle" } }
+    const { notifier, promptAsyncCalls } = createNotifier({
+      sessionStatuses,
+      messagesProvider: () => messages,
+    })
+    notifier.queuePendingParentWake("parent-1", FINAL_WAKE, { agent: "sisyphus" }, true)
+
+    try {
+      // when: admit-only deposit while background_output is still running
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.noReplyAdmittedAt).toBeDefined()
+
+      // when: tool returned, original turn still generating, wake aged past 60s
+      now = 220_000
+      messages = SAFE_MESSAGES
+      sessionStatuses["parent-1"] = { type: "busy" }
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: no competing reply-producing wake
+      expect(promptAsyncCalls).toHaveLength(1)
+      expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+      expect(notifier.getPendingParentWakeTimers().has("parent-1")).toBe(true)
+
+      // when: the live turn ends
+      now = 221_000
+      sessionStatuses["parent-1"] = { type: "idle" }
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: exactly one reply-producing resume after idle
+      expect(promptAsyncCalls).toHaveLength(2)
+      expect(promptAsyncCalls[1]?.body.noReply).not.toBe(true)
+      expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
+    } finally {
+      Date.now = originalDateNow
+      notifier.shutdown()
+    }
+  })
+
+  test("#given retained noReply wake and fresh activity exceed active ceiling #then it waits for idle before reply", async () => {
     // given
     const originalDateNow = Date.now
     let now = 100_000
@@ -195,7 +251,7 @@ describe("parent wake active defer ceiling", () => {
     notifier.recordParentSessionActivity("parent-1")
 
     try {
-      // when
+      // when: admit-only because activity is fresh
       await notifier.flushPendingParentWake("parent-1")
       now = 220_000
       sessionStatuses["parent-1"] = { type: "busy" }
@@ -204,9 +260,20 @@ describe("parent wake active defer ceiling", () => {
       notifier.recordParentSessionActivity("parent-1")
       await notifier.flushPendingParentWake("parent-1")
 
-      // then
-      expect(promptAsyncCalls).toHaveLength(2)
+      // then: ceiling must not fork a competing reply while the parent is still busy
+      expect(promptAsyncCalls).toHaveLength(1)
       expect(promptAsyncCalls[0]?.body.noReply).toBe(true)
+      expect(notifier.getPendingParentWakes().get("parent-1")?.shouldReply).toBe(true)
+
+      // when: parent becomes idle after the activity window expires
+      now = 401_000
+      sessionStatuses["parent-1"] = { type: "idle" }
+      releaseParentWakeHold("parent-1")
+      notifier.clearPendingParentWakeTimer("parent-1")
+      await notifier.flushPendingParentWake("parent-1")
+
+      // then: exactly one reply-producing resume
+      expect(promptAsyncCalls).toHaveLength(2)
       expect(promptAsyncCalls[1]?.body.noReply).not.toBe(true)
       expect(notifier.getPendingParentWakes().has("parent-1")).toBe(false)
     } finally {

--- a/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
+++ b/packages/omo-opencode/src/features/background-agent/parent-wake-flush-runner.ts
@@ -254,6 +254,15 @@ export class ParentWakeFlushRunner {
   }
 
   private shouldForceDispatchAfterActiveDefer(wake: PendingParentWake): boolean {
+    // A noReply admission already deposited the reminder into the live turn.
+    // Forcing a reply-producing wake while that session is still active forks a
+    // second assistant loop (duplicate [ALL BACKGROUND TASKS COMPLETE] parent
+    // message, cache-busting dual chain). Resume only after the session goes
+    // idle; dropAdmittedWakeConsumedByParent drops the follow-up if the live
+    // turn already consumed the deposit.
+    if (wake.noReplyAdmittedAt !== undefined) {
+      return false
+    }
     return wake.shouldReply && this.getQueuedAgeMs(wake) >= PENDING_PARENT_WAKE_MAX_ACTIVE_DEFER_MS
   }
 


### PR DESCRIPTION
## Problem

When all background tasks complete while the parent is still in a live turn (typical: blocked on `background_output(..., block: true)`), the parent-wake pipeline correctly deposits `[ALL BACKGROUND TASKS COMPLETE]` as `noReply`. After `PENDING_PARENT_WAKE_MAX_ACTIVE_DEFER_MS` (60s), `shouldForceDispatchAfterActiveDefer` then sent a **reply-producing** wake anyway.

That injects a second user message (`OMO_INTERNAL_INITIATOR`, no `NOREPLY`) and starts a second assistant loop on the same session while the original loop is still running.

Observed in production: two overlapping parent chains, Anthropic prompt-cache prefix stuck at ~78k, **7M+ cache writes** in ~20 minutes, session hit the token limit and stopped responding.

The flush-runner comment already names this failure (`fork a concurrent assistant chain`). `dropAdmittedWakeConsumedByParent` only drops after *completed* assistant output after admission, so it misses the in-flight turn that just unblocked from `background_output`.

## Change

`shouldForceDispatchAfterActiveDefer` is false once `noReplyAdmittedAt` is set. The live turn already has the deposit. Resume only after the session goes idle (or drop if the live turn consumed the reminder).

Aged wakes that were **never** admitted still force-dispatch while busy (deadlock escape unchanged).

## Test

Red/green on `parent-wake-active-defer-ceiling.test.ts`:

- **Repro:** noReply while `background_output` is running → tool returns, parent stays `busy`, history looks “safe”, wake aged past 60s → must **not** send a competing reply → idle → exactly one `shouldReply`.
- Existing “fresh activity exceed active ceiling” case now waits for idle instead of forking.

`bun test packages/omo-opencode/src/features/background-agent/parent-wake-*.test.ts` — 93 pass.

## Related

- #4874 (noReply visibility vs shouldReply liveness)
- #5175 (duplicate completion notifications, closed unmerged)
- #6546 (sibling complete while parent streaming)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the parent-wake pipeline forking a competing assistant loop after an all-tasks-complete reminder was deposited as noReply while the parent is still in a live turn. This caused duplicate `[ALL BACKGROUND TASKS COMPLETE]` parent messages, cache-busting dual chains, and token-limit failures in production.

**Behavior**
- Once a noReply reminder is admitted to the live turn, the 60s active-defer ceiling no longer forces a reply-producing wake; the session resumes only after going idle, or drops if the live turn consumed the deposit.
- Aged wakes that were never admitted still force-dispatch while busy, preserving the deadlock escape.

<sup>Written for commit 3538c2653d23a0039175f887782737d5dd688534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

