### PR TITLE
ci: add npm dist-tag rollback workflow

### DIFF
--- a/.github/workflows/npm-dist-tag-rollback.yml
+++ b/.github/workflows/npm-dist-tag-rollback.yml
@@ -1,0 +1,78 @@
+name: npm-dist-tag-rollback
+run-name: "dist-tag ${{ inputs.dist_tag }} -> ${{ inputs.version }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing published version to point the dist-tag at (e.g., 5.0.0-beta.36)"
+        required: true
+        type: string
+      dist_tag:
+        description: "npm dist-tag to move"
+        required: true
+        type: string
+        default: beta
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  retag:
+    if: github.repository == 'code-yeongyu/oh-my-openagent'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Validate inputs
+        env:
+          VERSION: ${{ inputs.version }}
+          DIST_TAG: ${{ inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]] || { echo "::error::Invalid version: $VERSION"; exit 1; }
+          [[ "$DIST_TAG" =~ ^[a-z][a-z0-9-]*$ ]] || { echo "::error::Invalid dist_tag: $DIST_TAG"; exit 1; }
+          if [ "$DIST_TAG" = "latest" ]; then echo "::error::latest is never moved by this workflow"; exit 1; fi
+
+      - name: Move dist-tags
+        env:
+          VERSION: ${{ inputs.version }}
+          DIST_TAG: ${{ inputs.dist_tag }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          OMO_AI_VERSION="${VERSION/-/-0.}"
+          PLATFORMS=(darwin-arm64 darwin-x64 darwin-x64-baseline linux-x64 linux-x64-baseline linux-arm64 linux-x64-musl linux-x64-musl-baseline linux-arm64-musl windows-x64 windows-x64-baseline windows-arm64)
+          retag() {
+            local pkg="$1" ver="$2"
+            if [ "$(npm view "$pkg@$ver" version 2>/dev/null || true)" != "$ver" ]; then
+              echo "::error::$pkg@$ver is not published"; exit 1
+            fi
+            npm dist-tag add "$pkg@$ver" "$DIST_TAG"
+            echo "$pkg $DIST_TAG -> $(npm view "$pkg" "dist-tags.$DIST_TAG")"
+          }
+          retag oh-my-opencode "$VERSION"
+          retag oh-my-openagent "$VERSION"
+          retag lazycodex-ai "$VERSION"
+          retag omo-ai "$OMO_AI_VERSION"
+          for plat in "${PLATFORMS[@]}"; do
+            retag "oh-my-opencode-$plat" "$VERSION"
+            retag "oh-my-openagent-$plat" "$VERSION"
+          done
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## npm dist-tag rollback"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Result | \`${{ job.status }}\` |"
+            echo "| Version | \`${{ inputs.version }}\` |"
+            echo "| Dist tag | \`${{ inputs.dist_tag }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Emergency operations: `npm-dist-tag-rollback` (workflow_dispatch) repoints the `beta` dist-tag of oh-my-opencode, oh-my-openagent, lazycodex-ai, omo-ai (mapped `-0.` version) and all 24 platform packages to an already-published version. It never moves `latest` and fails closed when the target version is not on the registry.

## Why
beta.37-39 ship a senpi regression (Anthropic native tool-search tool name rejected with `invalid_request_error`). beta.36 is the last known-good; users on `@beta` need an immediate rollback while the fix lands.

## QA
- actionlint clean.
- First dispatch (`version=5.0.0-beta.36`, `dist_tag=beta`) will be recorded on this PR with the registry read-back.

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an emergency `npm-dist-tag-rollback` workflow that repoints the `beta` dist-tag to an already-published version without republishing. beta.37-39 shipped a regression (Anthropic native tool-search tool name rejected with `invalid_request_error`); beta.36 is the last known-good.

- Moves the `beta` dist-tag for `oh-my-opencode`, `oh-my-openagent`, `lazycodex-ai`, `omo-ai` (with `-0.` version mapping), and all 24 platform packages.
- Fails closed if the target version isn't on the registry and never moves `latest`.

<sup>Written for commit adb12591f6a6eb12f69514a384d2b91e3baa7ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

