### PR TITLE
fix(ci): add npm-dist-tag-rollback to workflow summary allowlist

### DIFF
--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -32,6 +32,7 @@ const workflowExpectations = [
   { path: ".github/workflows/cla.yml", jobs: ["cla"] },
   { path: ".github/workflows/bot-merge.yml", jobs: ["merge"] },
   { path: ".github/workflows/lint-workflows.yml", jobs: ["actionlint"] },
+  { path: ".github/workflows/npm-dist-tag-rollback.yml", jobs: ["retag"] },
   { path: ".github/workflows/package-labels.yml", jobs: ["ensure-labels", "label-pull-request", "label-issue"] },
   { path: ".github/workflows/publish-platform.yml", jobs: ["build", "publish", "smoke-linux-arm64"] },
   {


### PR DESCRIPTION
The new `npm-dist-tag-rollback.yml` workflow was added but not registered in `ci-job-summary-workflow.test.ts`, breaking CI on dev.

Adds the `retag` job to the workflow expectations allowlist.

**Test:** `bun test script/ci-job-summary-workflow.test.ts` — 4 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI breaking on dev by adding the new `npm-dist-tag-rollback.yml` workflow to the workflow summary allowlist test. The `retag` job is now registered in `script/ci-job-summary-workflow.test.ts`, so the test suite passes again.

<sup>Written for commit 6d14bcec73588942f326c35c893a3509befe9608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

