### PR TITLE
fix(senpi): fall back to original path when fd descriptor path is unavailable

### DIFF
--- a/packages/omo-senpi/scripts/qa/isolation-state.mjs
+++ b/packages/omo-senpi/scripts/qa/isolation-state.mjs
@@ -329,11 +329,11 @@ function collectFilesBounded(currentRoot, state, boundRoot = currentRoot) {
 				code: "FILE_REPLACED",
 			});
 		const descriptorRoot = directoryDescriptorPath(directoryFd);
-		if (descriptorRoot === null)
-			throw Object.assign(new Error("DIRECTORY_IDENTITY_UNAVAILABLE"), {
-				code: "DIRECTORY_IDENTITY_UNAVAILABLE",
-			});
-		directory = io.opendirSync(descriptorRoot);
+		// On platforms where the descriptor path is unavailable (macOS, Windows),
+		// fall back to the original path.  Identity is still verified via the fd
+		// opened above and the assertDirectoryPathIdentity call below.
+		const opendirRoot = descriptorRoot ?? boundRoot;
+		directory = io.opendirSync(opendirRoot);
 		assertDirectoryPathIdentity(currentRoot, beforeMetadata, io);
 	} catch (error) {
 		state.errors.push({
@@ -350,10 +350,7 @@ function collectFilesBounded(currentRoot, state, boundRoot = currentRoot) {
 	let traversalFailed = false;
 	try {
 		const descriptorRoot = directoryDescriptorPath(directoryFd);
-		if (descriptorRoot === null)
-			throw Object.assign(new Error("DIRECTORY_IDENTITY_UNAVAILABLE"), {
-				code: "DIRECTORY_IDENTITY_UNAVAILABLE",
-			});
+		const traversalRoot = descriptorRoot ?? boundRoot;
 		state.snapshot.set(currentRel, "directory");
 		const entries = [];
 		while (true) {
@@ -364,7 +361,7 @@ function collectFilesBounded(currentRoot, state, boundRoot = currentRoot) {
 				relative(state.root, path),
 				state.pathStyle,
 			);
-			const boundPath = join(descriptorRoot, entry.name);
+			const boundPath = join(traversalRoot, entry.name);
 			let pathStat;
 			try {
 				pathStat = io.lstatSync(boundPath, { bigint: true });
@@ -495,7 +492,9 @@ function assertDirectoryPathIdentity(path, expected, io) {
 
 function directoryDescriptorPath(fd) {
 	if (process.platform === "linux") return `/proc/self/fd/${fd}`;
-	if (process.platform === "darwin") return `/dev/fd/${fd}`;
+	// macOS /dev/fd/N is a character device — opendirSync("/dev/fd/N") fails
+	// with ENOTDIR.  Windows has no equivalent.  Return null so callers
+	// fall back to the original path with identity re-verification.
 	return null;
 }
 

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -32,6 +32,7 @@ const workflowExpectations = [
   { path: ".github/workflows/cla.yml", jobs: ["cla"] },
   { path: ".github/workflows/bot-merge.yml", jobs: ["merge"] },
   { path: ".github/workflows/lint-workflows.yml", jobs: ["actionlint"] },
+  { path: ".github/workflows/npm-dist-tag-rollback.yml", jobs: ["retag"] },
   { path: ".github/workflows/package-labels.yml", jobs: ["ensure-labels", "label-pull-request", "label-issue"] },
   { path: ".github/workflows/publish-platform.yml", jobs: ["build", "publish", "smoke-linux-arm64"] },
   {


### PR DESCRIPTION
## Problem

macOS `/dev/fd/N` is a character device — `opendirSync("/dev/fd/N")` fails with `ENOTDIR`. Windows has no `/proc/self/fd` or `/dev/fd` equivalent at all. This breaks 8 tests in `isolation-review-blockers.test.mjs` on macOS and Windows CI since #7718.

## Root Cause

`directoryDescriptorPath()` returned `/dev/fd/N` on macOS, but unlike Linux's `/proc/self/fd/N` (a real symlink), macOS's `/dev/fd/N` is a character device that cannot serve as a directory path for `opendirSync` or path-based `lstatSync`.

## Fix

When `directoryDescriptorPath()` returns `null` (macOS, Windows), fall back to the original bound path for `opendirSync` and entry traversal. Identity verification is still provided by:
- The fd opened with `O_DIRECTORY | O_NOFOLLOW` + `fstatSync(fd)`
- `assertDirectoryPathIdentity()` re-checking the original path

Linux continues to use `/proc/self/fd/N` as before.

## Test

All isolation tests pass locally on macOS (56 tests across 5 files, 0 fail):
- `isolation-review-blockers.test.mjs` — 22 pass (was 8 fail)
- `isolation-certification.test.mjs` — 2 pass
- `isolation-state.test.mjs` — 20 pass
- `isolation-state-races.test.mjs` — 10 pass
- `isolation-ultrabrain-blockers.test.mjs` — 2 pass

Fixes #7731

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Falls back to the original bound path when the fd descriptor path is unavailable on macOS and Windows, fixing 8 isolation tests that broke on those platforms. Previously, `directoryDescriptorPath()` returned `/dev/fd/N` on macOS (a character device that fails with `ENOTDIR`) or threw `DIRECTORY_IDENTITY_UNAVAILABLE`; now it returns `null` and callers use `boundRoot` for `opendirSync` and traversal. Identity is still verified via the fd opened with `O_DIRECTORY | O_NOFOLLOW` and `assertDirectoryPathIdentity()`. Linux continues to use `/proc/self/fd/N`. Also adds the `npm-dist-tag-rollback` workflow to the CI job summary allowlist. Fixes #7731.

<sup>Written for commit 10e311573d90b5c8432fc016b4f87a4691b0907c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

