### PR TITLE
test(omo-native): guard the engine-owned Anthropic tool-search contract

### DIFF
--- a/packages/omo-native/test/anthropic-tool-search-compat.test.ts
+++ b/packages/omo-native/test/anthropic-tool-search-compat.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+/**
+ * The Anthropic native tool-search contract (`tool_search_tool_bm25_20251119`, the
+ * `defer_loading` / `tool_reference` payload transform) is owned exclusively by the
+ * pinned engine, in `@code-yeongyu/senpi` `dist/core/extensions/builtin/tool-search/`.
+ *
+ * omo-ai ships a byte-rewriting postinstall (`bin/senpi-patch.mjs`) that edits files
+ * inside that installed engine, so this package is one edit away from carrying its own
+ * copy of the wire contract. A second copy would silently diverge from the engine on
+ * the next Anthropic revision and pin the beta channel to a stale tool type.
+ *
+ * These assertions guard one machine-consumed value: the exact wire token the API
+ * dispatches on. The dependency pin itself is owned by `senpi-pin.test.ts`, which
+ * holds the single `SENPI_PIN` constant every release bump updates; re-asserting a
+ * version literal here would add a second place to update and go red on any bump.
+ */
+const PACKAGE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
+
+/** The engine-owned Anthropic wire tokens this package must never re-declare. */
+const ENGINE_OWNED_TOOL_SEARCH_TOKENS = [
+  "tool_search_tool_bm25_20251119",
+  "defer_loading",
+  "tool_reference",
+] as const
+
+/**
+ * `files` is `["bin", "plugin"]`; `plugin/` is a gitignored build artifact staged by
+ * `bun run build:omo-native`, so `bin/` is the whole committed publish surface.
+ */
+function shippedSourceFiles(): string[] {
+  const collected: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir).sort()) {
+      const path = join(dir, entry)
+      if (statSync(path).isDirectory()) walk(path)
+      else collected.push(path)
+    }
+  }
+  walk(join(PACKAGE_ROOT, "bin"))
+  return collected
+}
+
+describe("anthropic tool-search compatibility", () => {
+  describe("#given the committed omo-ai publish surface", () => {
+    describe("#when every shipped file is scanned for engine-owned tool-search tokens", () => {
+      test("#then the scan reads the real launcher sources", () => {
+        const files = shippedSourceFiles()
+        expect(files).toContain(join(PACKAGE_ROOT, "bin", "senpi-patch.mjs"))
+        expect(files).toContain(join(PACKAGE_ROOT, "bin", "omo.js"))
+      })
+
+      test("#then no shipped file re-declares the Anthropic native tool-search contract", () => {
+        const offenders = shippedSourceFiles().flatMap((path) => {
+          const source = readFileSync(path, "utf8")
+          return ENGINE_OWNED_TOOL_SEARCH_TOKENS.filter((token) => source.includes(token)).map(
+            (token) => `${path.slice(PACKAGE_ROOT.length + 1)}: ${token}`,
+          )
+        })
+        expect(offenders).toEqual([])
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Adds one regression test guarding that omo-ai never re-declares the Anthropic native tool-search wire contract, which is owned solely by the pinned `@code-yeongyu/senpi` engine.

## Why
omo-ai ships a byte-rewriting postinstall (`bin/senpi-patch.mjs`) that edits files inside the installed engine, so this package is one edit away from carrying its own copy of the wire tokens (`tool_search_tool_bm25_20251119`, `defer_loading`, `tool_reference`). A second copy would silently diverge from the engine on the next Anthropic revision and pin the beta channel to a stale tool contract — the exact class of bug that just caused the `invalid_request_error` on beta.37-39. The test scans the whole committed publish surface (`bin/**`; `plugin/` is a gitignored build artifact) for those tokens.

## Design note
Asserts **no version literal**: `senpi-pin.test.ts` already owns the cross-manifest pin via a single `SENPI_PIN` constant, so re-pinning a version here would add a second update site and go red on every bump.

## Verification (mengmotaMac, bunshin; no local test)
- GREEN: 2 pass / 0 fail.
- Mutation proof: injecting `tool_search_tool_bm25_20251119` into `bin/lib/launcher.js` drives it RED naming that exact file+token (exit 1); revert restores sha256 `74ca0a06…` matching the local worktree byte-for-byte, GREEN again.
- Rebased onto current dev (`c6e7dd7fb`); single new file, no conflicts; sandboxes torn down with receipts.

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test that prevents `omo-native` from re-declaring the Anthropic tool-search wire tokens (`tool_search_tool_bm25_20251119`, `defer_loading`, `tool_reference`) owned exclusively by the pinned `@code-yeongyu/senpi` engine. Because `omo-native` ships a byte-rewriting postinstall, a second copy of these tokens would silently diverge on future engine revisions and break the beta channel. The test scans the committed `bin/` surface and deliberately asserts no version literal to keep the dependency pin single-sourced in `senpi-pin.test.ts`.

<sup>Written for commit 3106eb5bdad752bd918540ec4ca85eeed7cbaafd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

