### PR TITLE
feat(omo-native): omob dev binary from the latest commits with build provenance

### DIFF
--- a/docs/reference/omob-dev-binary.md
+++ b/docs/reference/omob-dev-binary.md
@@ -1,0 +1,25 @@
+# omob — dev binary from the latest commits
+
+`omob` builds a single-file bun-compiled binary from the freshest tracked
+commits — senpi `origin/main` + omo `origin/dev` — and installs it as
+`omob` next to your regular `omo`. It exists to test a commit pair
+end-to-end without cutting a release.
+
+```bash
+bun run omob                       # latest origin/main + origin/dev
+bun run omob --senpi-ref origin/feat/x --omo-ref abc1234
+bun run omob --skip-install        # build only, into ~/.omo/omob/out
+```
+
+Behavior:
+
+- The binary is stamped with an `omoBuild` provenance block (full commit SHAs,
+  commit dates, branches). The TUI header shows `omo@<sha7> <date> ·
+  senpi@<sha7> <date>` instead of a version; `omob --version` and `omob doctor`
+  print the full SHAs, ISO commit dates, and branches.
+- Dev builds are namespaced by commit pair: runtime provisioning lives under
+  `~/.omo/binary-runtime/0.0.0-omob.<omo7>.<senpi7>/`, and older dev runtimes
+  are pruned (keep 2 by default, `--keep N`). Release runtimes are never touched.
+- `~/.omo` sessions/settings/auth are shared with a regular `omo` install on
+  purpose: omob is the same product built from fresher commits.
+- Rebuild to update: `bun run omob` (the `update` hint inside omob says so).

--- a/docs/reference/omob-dev-binary.md
+++ b/docs/reference/omob-dev-binary.md
@@ -8,7 +8,7 @@ end-to-end without cutting a release.
 ```bash
 bun run omob                       # latest origin/main + origin/dev
 bun run omob --senpi-ref origin/feat/x --omo-ref abc1234
-bun run omob --skip-install        # build only, into ~/.omo/omob/out
+bun run omob --skip-install        # build only, into ~/.cache/omob/out
 ```
 
 Behavior:

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "build:binaries": "bun run script/build-binaries.ts",
     "build:schema": "bun run script/build-schema.ts",
     "build:omo-native": "bun run script/build-omo-native.ts",
+    "omob": "bun run script/build-omob.ts",
     "build:omo-schema": "bun run script/build-omo-schema.ts",
     "build:model-capabilities": "bun run script/build-model-capabilities.ts",
     "clean": "rm -rf dist",

--- a/packages/omo-native/build-info.ts
+++ b/packages/omo-native/build-info.ts
@@ -42,7 +42,7 @@ export function shortSha(commit: string): string {
 function humanCommitDate(iso: string): string {
 	const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})(.*)$/.exec(iso)
 	if (match === null) return iso
-	return `${match[1]} ${match[2]}:${match[3]}${match[4]}`
+	return `${match[1]} ${match[2]}:${match[3]}${match[4] ? ` ${match[4]}` : ""}`
 }
 
 /** One-line label the TUI header shows instead of a version. */

--- a/packages/omo-native/build-info.ts
+++ b/packages/omo-native/build-info.ts
@@ -1,0 +1,28 @@
+/** Build provenance stamped into compiled dev binaries. */
+export interface BuildComponentInfo {
+	readonly commit: string
+	readonly committedAt: string
+	readonly branch: string
+}
+
+export interface OmoBuildInfo {
+	readonly command: string
+	readonly omo: BuildComponentInfo
+	readonly engine: BuildComponentInfo
+}
+
+export function parseBuildInfo(raw: unknown): OmoBuildInfo | undefined {
+	return undefined
+}
+
+export function shortSha(commit: string): string {
+	return commit
+}
+
+export function buildLabel(info: OmoBuildInfo): string {
+	return ""
+}
+
+export function versionLines(info: OmoBuildInfo): string[] {
+	return []
+}

--- a/packages/omo-native/build-info.ts
+++ b/packages/omo-native/build-info.ts
@@ -38,9 +38,9 @@ export function shortSha(commit: string): string {
 	return commit.slice(0, 7)
 }
 
-/** "2026-09-04T10:17:49+09:00" -> "2026-09-04 10:17 +09:00" */
+/** "2026-09-04T10:17:49+09:00" -> "2026-09-04 10:17 +09:00" (seconds dropped) */
 function humanCommitDate(iso: string): string {
-	const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})(.*)$/.exec(iso)
+	const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})(?::\d{2})?(.*)$/.exec(iso)
 	if (match === null) return iso
 	return `${match[1]} ${match[2]}:${match[3]}${match[4] ? ` ${match[4]}` : ""}`
 }

--- a/packages/omo-native/build-info.ts
+++ b/packages/omo-native/build-info.ts
@@ -11,18 +11,50 @@ export interface OmoBuildInfo {
 	readonly engine: BuildComponentInfo
 }
 
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2}|Z)$/
+
+function parseComponent(raw: unknown): BuildComponentInfo | undefined {
+	if (typeof raw !== "object" || raw === null) return undefined
+	const candidate = raw as { commit?: unknown; committedAt?: unknown; branch?: unknown }
+	if (typeof candidate.commit !== "string" || !FULL_SHA_PATTERN.test(candidate.commit)) return undefined
+	if (typeof candidate.committedAt !== "string" || !ISO_DATE_PATTERN.test(candidate.committedAt)) return undefined
+	if (typeof candidate.branch !== "string" || candidate.branch.length === 0) return undefined
+	return { commit: candidate.commit, committedAt: candidate.committedAt, branch: candidate.branch }
+}
+
+/** Parses a stamped omoBuild payload; undefined for anything malformed. */
 export function parseBuildInfo(raw: unknown): OmoBuildInfo | undefined {
-	return undefined
+	if (typeof raw !== "object" || raw === null) return undefined
+	const candidate = raw as { command?: unknown; omo?: unknown; engine?: unknown }
+	if (typeof candidate.command !== "string" || candidate.command.length === 0) return undefined
+	const omo = parseComponent(candidate.omo)
+	const engine = parseComponent(candidate.engine)
+	if (omo === undefined || engine === undefined) return undefined
+	return { command: candidate.command, omo, engine }
 }
 
 export function shortSha(commit: string): string {
-	return commit
+	return commit.slice(0, 7)
 }
 
+/** "2026-09-04T10:17:49+09:00" -> "2026-09-04 10:17 +09:00" */
+function humanCommitDate(iso: string): string {
+	const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}):(\d{2})(.*)$/.exec(iso)
+	if (match === null) return iso
+	return `${match[1]} ${match[2]}:${match[3]}${match[4]}`
+}
+
+/** One-line label the TUI header shows instead of a version. */
 export function buildLabel(info: OmoBuildInfo): string {
-	return ""
+	return `omo@${shortSha(info.omo.commit)} ${humanCommitDate(info.omo.committedAt)} · senpi@${shortSha(info.engine.commit)} ${humanCommitDate(info.engine.committedAt)}`
 }
 
+/** Multi-line provenance for --version and doctor output. */
 export function versionLines(info: OmoBuildInfo): string[] {
-	return []
+	return [
+		`${info.command} dev build`,
+		`omo   ${info.omo.commit} ${info.omo.committedAt} (${info.omo.branch})`,
+		`senpi ${info.engine.commit} ${info.engine.committedAt} (${info.engine.branch})`,
+	]
 }

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -132,7 +132,7 @@ function runCompiledDoctor(inventory: Awaited<ReturnType<typeof detectHarnesses>
     }
   }
   const packageJson = readJson(join(execDir, "package.json"))
-  lines.push(`INFO omo ${packageJson.version} (engine: senpi ${enginePin})`)
+  for (const line of versionLine(packageJson, enginePin).split("\n")) lines.push(`INFO ${line}`)
   if (needsSetupSuggestion(inventory)) lines.push("INFO no credentials found; run omo setup to review sibling stores")
   console.log(lines.join("\n"))
   process.exitCode = failed ? 1 : 0

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -15,6 +15,7 @@ import {
   type EmbeddedManifest,
 } from "./compile-runtime"
 import { propagateResult, runChild } from "./bin/lib/child-process.js"
+import { buildLabel, parseBuildInfo, versionLines } from "./build-info"
 import { migrateLegacyBunGlobalManifest } from "./bin/lib/legacy-bun-global-migration.js"
 import { adoptLegacyFlatState, canonicalAgentDir } from "./bin/lib/agent-dir.js"
 import { nearestNodeBin, readJson } from "./bin/lib/package-paths.js"
@@ -56,7 +57,9 @@ export function buildSenpiArgs(args: string[], execDir: string): string[] {
   return ["--extension", join(execDir, "plugin"), ...args]
 }
 
-export function versionLine(packageJson: { version: string }, enginePin: string): string {
+export function versionLine(packageJson: { version: string; omoBuild?: unknown }, enginePin: string): string {
+  const info = parseBuildInfo(packageJson.omoBuild)
+  if (info !== undefined) return versionLines(info).join("\n")
   return `omo ${packageJson.version} (engine: senpi ${enginePin})`
 }
 
@@ -90,11 +93,22 @@ export function remapSenpiEnvironment(source: NodeJS.ProcessEnv = process.env, e
   env.OMO_NATIVE = "1"
   env.SENPI_RUNTIME = process.versions.bun ? "bun" : "node"
   let displayVersion = "unknown"
-  try { displayVersion = readJson(join(execDir, "package.json")).version } catch { /* test fixtures may omit the sibling manifest */ }
+  let devCommand: string | undefined
+  let devUpdateCommand: string | undefined
+  try {
+    const stamped = readJson(join(execDir, "package.json")) as { version?: string; omoBuild?: unknown }
+    displayVersion = typeof stamped.version === "string" ? stamped.version : "unknown"
+    const info = parseBuildInfo(stamped.omoBuild)
+    if (info !== undefined) {
+      devCommand = info.command
+      devUpdateCommand = `rebuild with: bun run ${info.command}`
+      displayVersion = buildLabel(info)
+    }
+  } catch { /* test fixtures may omit the sibling manifest */ }
   env.SENPI_BRAND = JSON.stringify({
-    name: "OmO", command: "omo", displayVersion,
+    name: "OmO", command: devCommand ?? "omo", displayVersion,
     configDir: ".omo", flatLayout: false, envPrefix: "OMO", userAgent: "omo", originator: "omo",
-    update: { packageName: "omo-ai", distTag: "beta", command: updateLine(process.platform, process.arch), changelogUrl: "https://github.com/code-yeongyu/oh-my-openagent/releases" },
+    update: { packageName: "omo-ai", distTag: "beta", command: devUpdateCommand ?? updateLine(process.platform, process.arch), changelogUrl: "https://github.com/code-yeongyu/oh-my-openagent/releases" },
   })
   const binDir = nearestNodeBin(execDir)
   if (binDir) {
@@ -132,9 +146,9 @@ function isSelfUpdate(args: string[]): boolean {
   return rest.every((arg) => arg.startsWith("-") || selfUpdateTargets.has(arg))
 }
 
-export function answerCompiledFastPath(args: string[], manifest: Pick<EmbeddedManifest, "omoAiVersion" | "enginePin">): boolean {
+export function answerCompiledFastPath(args: string[], manifest: Pick<EmbeddedManifest, "omoAiVersion" | "enginePin" | "buildInfo">): boolean {
   if ((args[0] === "--version" || args[0] === "-v") && args.length === 1) {
-    console.log(versionLine({ version: manifest.omoAiVersion }, manifest.enginePin))
+    console.log(versionLine({ version: manifest.omoAiVersion, omoBuild: manifest.buildInfo }, manifest.enginePin))
     return true
   }
   if (isSelfUpdate(args)) {
@@ -212,7 +226,11 @@ async function main(): Promise<void> {
   // executable delegates to the engine in-process as required by the native startup contract.
   if (await runCompiledLauncher(process.argv.slice(2), execDir, manifest.enginePin, execDir)) return
   if (shouldPrintCompiledBanner(process.argv.slice(2), process.stderr.isTTY === true)) {
-    console.error(`omo (omo-ai beta ${manifest.omoAiVersion})`)
+    if (parseBuildInfo(manifest.buildInfo) !== undefined) {
+      console.error(`omob dev build (${manifest.omoAiVersion})`)
+    } else {
+      console.error(`omo (omo-ai beta ${manifest.omoAiVersion})`)
+    }
   }
   process.argv.splice(2, process.argv.length - 2, ...buildSenpiArgs(process.argv.slice(2), execDir))
   Object.assign(process.env, remapSenpiEnvironment(process.env, execDir))

--- a/packages/omo-native/compile-runtime.ts
+++ b/packages/omo-native/compile-runtime.ts
@@ -20,7 +20,7 @@ export type EmbeddedFile = Blob & {
   text?: () => Promise<string>
 }
 export type EmbeddedManifestEntry = { relPath: string; sha256: string; mode: number; size: number }
-export type EmbeddedManifest = { omoAiVersion: string; enginePin: string; manifestSha: string; entries: EmbeddedManifestEntry[] }
+export type EmbeddedManifest = { omoAiVersion: string; enginePin: string; manifestSha: string; entries: EmbeddedManifestEntry[]; buildInfo?: unknown }
 
 export function isProvisionedExecutable(execPath: string, expectedPath: string): boolean {
   try {

--- a/packages/omo-native/test/build-info.test.ts
+++ b/packages/omo-native/test/build-info.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { buildLabel, parseBuildInfo, shortSha, versionLines, type OmoBuildInfo } from "../build-info"
+
+const fixture: OmoBuildInfo = {
+	command: "omob",
+	omo: { commit: "c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc", committedAt: "2026-09-04T10:17:49+09:00", branch: "dev" },
+	engine: { commit: "7fd18dfeec7a7db89a983b2c3cb90835b8c3c5f7", committedAt: "2026-09-04T10:49:12+09:00", branch: "main" },
+}
+
+describe("omob build info", () => {
+	test("round-trips a stamped build info object", () => {
+		expect(parseBuildInfo(JSON.parse(JSON.stringify(fixture)))).toEqual(fixture)
+	})
+
+	test("rejects malformed payloads", () => {
+		expect(parseBuildInfo(undefined)).toBeUndefined()
+		expect(parseBuildInfo({})).toBeUndefined()
+		expect(parseBuildInfo(null)).toBeUndefined()
+		expect(parseBuildInfo({ ...fixture, omo: { commit: "not-a-sha", committedAt: "x", branch: "y" } })).toBeUndefined()
+		expect(parseBuildInfo({ ...fixture, omo: { commit: "c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc", committedAt: 42, branch: "dev" } })).toBeUndefined()
+	})
+
+	test("labels carry short shas and human commit dates", () => {
+		expect(buildLabel(fixture)).toBe("omo@c6e7dd7 2026-09-04 10:17 +09:00 · senpi@7fd18df 2026-09-04 10:49 +09:00")
+	})
+
+	test("version lines carry full shas, ISO commit dates, and branches", () => {
+		expect(versionLines(fixture)).toEqual([
+			"omob dev build",
+			"omo   c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc 2026-09-04T10:17:49+09:00 (dev)",
+			"senpi 7fd18dfeec7a7db89a983b2c3cb90835b8c3c5f7 2026-09-04T10:49:12+09:00 (main)",
+		])
+	})
+
+	test("shortSha truncates to seven characters", () => {
+		expect(shortSha("abcdef1234")).toBe("abcdef1")
+	})
+})

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -377,3 +377,35 @@ describe("embedded runtime provisioning", () => {
     expect(readFileSync(join(runtime, "package.json"), "utf8")).toBe("changed\n")
   })
 })
+
+describe("omob branded build labels", () => {
+  const buildInfo = {
+    command: "omob",
+    omo: { commit: "c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc", committedAt: "2026-09-04T10:17:49+09:00", branch: "dev" },
+    engine: { commit: "7fd18dfeec7a7db89a983b2c3cb90835b8c3c5f7", committedAt: "2026-09-04T10:49:12+09:00", branch: "main" },
+  }
+
+  test("versionLine prints full shas and commit dates for dev builds", () => {
+    const line = versionLine({ version: "0.0.0-omob.c6e7dd7.7fd18df", omoBuild: buildInfo }, "2026.8.26-2")
+    expect(line).toContain("c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc")
+    expect(line).toContain("2026-09-04T10:17:49+09:00")
+    expect(line).toContain("7fd18dfeec7a7db89a983b2c3cb90835b8c3c5f7")
+    expect(line).toContain("(dev)")
+    expect(line).toContain("(main)")
+  })
+
+  test("remapSenpiEnvironment brands dev builds with the label and command", () => {
+    const root = temp()
+    const execDir = join(root, "runtime")
+    mkdirSync(execDir, { recursive: true })
+    writeFileSync(
+      join(execDir, "package.json"),
+      JSON.stringify({ name: "omo", version: "0.0.0-omob.c6e7dd7.7fd18df", omoBuild: buildInfo }),
+    )
+    const env = remapSenpiEnvironment({}, execDir)
+    const brand = JSON.parse(env.SENPI_BRAND ?? "{}") as { command?: string; displayVersion?: string; update?: { command?: string } }
+    expect(brand.command).toBe("omob")
+    expect(brand.displayVersion).toBe("omo@c6e7dd7 2026-09-04 10:17 +09:00 · senpi@7fd18df 2026-09-04 10:49 +09:00")
+    expect(brand.update?.command).toContain("omob")
+  })
+})

--- a/script/build-omo-binary.test.ts
+++ b/script/build-omo-binary.test.ts
@@ -454,3 +454,29 @@ describe("staged file collection", () => {
     rmSync(stageDir, { recursive: true, force: true })
   })
 })
+
+describe("omob build info stamping", () => {
+  const buildInfo = {
+    command: "omob",
+    omo: { commit: "c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc", committedAt: "2026-09-04T10:17:49+09:00", branch: "dev" },
+    engine: { commit: "7fd18dfeec7a7db89a983b2c3cb90835b8c3c5f7", committedAt: "2026-09-04T10:49:12+09:00", branch: "main" },
+  }
+
+  test("#given build info #when the sidecar package.json is stamped #then it carries omoBuild", () => {
+    const stamped = JSON.parse(createStampedPackageJson("0.0.0-omob.c6e7dd7.7fd18df", buildInfo)) as Record<string, unknown>
+    expect(stamped.omoBuild).toEqual(buildInfo)
+  })
+
+  test("#given no build info #when stamped #then the release shape stays byte-identical", () => {
+    expect(createStampedPackageJson("9.9.9-0.test")).toBe(`${JSON.stringify({ name: "omo", version: "9.9.9-0.test" }, null, 2)}\n`)
+  })
+
+  test("#given build info #when the runtime manifest is built #then it records build info and changes the digest", async () => {
+    const stageDir = makeTempDir("omo-manifest-buildinfo-")
+    writeFileSync(join(stageDir, "theme", "dark.json"), "{}\n")
+    const bare = await buildRuntimeManifest(stageDir, { omoAiVersion: "1.2.3", enginePin: "2026.8.24" })
+    const stamped = await buildRuntimeManifest(stageDir, { omoAiVersion: "1.2.3", enginePin: "2026.8.24", buildInfo })
+    expect(stamped.buildInfo).toEqual(buildInfo)
+    expect(stamped.manifestSha).not.toBe(bare.manifestSha)
+  })
+})

--- a/script/build-omo-binary.test.ts
+++ b/script/build-omo-binary.test.ts
@@ -473,6 +473,7 @@ describe("omob build info stamping", () => {
 
   test("#given build info #when the runtime manifest is built #then it records build info and changes the digest", async () => {
     const stageDir = makeTempDir("omo-manifest-buildinfo-")
+    mkdirSync(join(stageDir, "theme"), { recursive: true })
     writeFileSync(join(stageDir, "theme", "dark.json"), "{}\n")
     const bare = await buildRuntimeManifest(stageDir, { omoAiVersion: "1.2.3", enginePin: "2026.8.24" })
     const stamped = await buildRuntimeManifest(stageDir, { omoAiVersion: "1.2.3", enginePin: "2026.8.24", buildInfo })

--- a/script/build-omo-binary.ts
+++ b/script/build-omo-binary.ts
@@ -25,6 +25,7 @@ import { tmpdir } from "node:os"
 import { dirname, join, relative, resolve, sep } from "node:path"
 import { fileURLToPath } from "node:url"
 import ptyFixture from "./release-binary-pty-fixture.json"
+import { parseBuildInfo, type OmoBuildInfo } from "../packages/omo-native/build-info"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, "..")
@@ -126,8 +127,11 @@ export function relPathForEmbeddedName(embeddedName: string): string | undefined
 }
 
 /** Stamped sibling package.json the engine reads for its version contract. */
-export function createStampedPackageJson(omoAiVersion: string): string {
-  return `${JSON.stringify({ name: "omo", version: omoAiVersion }, null, 2)}\n`
+export function createStampedPackageJson(omoAiVersion: string, buildInfo?: OmoBuildInfo): string {
+  const stamped = buildInfo === undefined
+    ? { name: "omo", version: omoAiVersion }
+    : { name: "omo", version: omoAiVersion, omoBuild: buildInfo }
+  return `${JSON.stringify(stamped, null, 2)}\n`
 }
 
 /** Lists every file under `stageDir` as sorted POSIX-relative paths. */
@@ -158,6 +162,7 @@ export interface RuntimeManifest {
   readonly omoAiVersion: string
   readonly enginePin: string
   readonly manifestSha: string
+  readonly buildInfo?: OmoBuildInfo
   readonly entries: readonly RuntimeManifestEntry[]
 }
 
@@ -168,7 +173,7 @@ function sha256OfFile(filePath: string): string {
 /** Builds the embedded runtime manifest for a staged payload directory. */
 export async function buildRuntimeManifest(
   stageDir: string,
-  options: { readonly omoAiVersion: string; readonly enginePin: string },
+  options: { readonly omoAiVersion: string; readonly enginePin: string; readonly buildInfo?: OmoBuildInfo },
 ): Promise<RuntimeManifest> {
   const entries: RuntimeManifestEntry[] = collectStagedFiles(stageDir)
     .filter((relPath) => relPath !== RUNTIME_MANIFEST_REL_PATH)
@@ -182,16 +187,14 @@ export async function buildRuntimeManifest(
         size: stats.size,
       }
     })
-  const manifestSha = createHash("sha256")
-    .update(
-      JSON.stringify({
-        omoAiVersion: options.omoAiVersion,
-        enginePin: options.enginePin,
-        entries,
-      }),
-    )
-    .digest("hex")
-  return { omoAiVersion: options.omoAiVersion, enginePin: options.enginePin, manifestSha, entries }
+  const digestPayload = options.buildInfo === undefined
+    ? { omoAiVersion: options.omoAiVersion, enginePin: options.enginePin, entries }
+    : { omoAiVersion: options.omoAiVersion, enginePin: options.enginePin, buildInfo: options.buildInfo, entries }
+  const manifestSha = createHash("sha256").update(JSON.stringify(digestPayload)).digest("hex")
+  if (options.buildInfo === undefined) {
+    return { omoAiVersion: options.omoAiVersion, enginePin: options.enginePin, manifestSha, entries }
+  }
+  return { omoAiVersion: options.omoAiVersion, enginePin: options.enginePin, manifestSha, buildInfo: options.buildInfo, entries }
 }
 
 /** Fails loud when a compiled binary exceeds the per-binary size budget. */
@@ -545,10 +548,11 @@ export function stageSidecarPayload(
   target: ReleaseBinaryTarget,
   stageDir: string,
   omoAiVersion: string,
+  buildInfo?: OmoBuildInfo,
 ): string[] {
   mkdirSync(stageDir, { recursive: true })
   const staged = new Set<string>()
-  writeFileSync(join(stageDir, "package.json"), createStampedPackageJson(omoAiVersion), "utf8")
+  writeFileSync(join(stageDir, "package.json"), createStampedPackageJson(omoAiVersion, buildInfo), "utf8")
   staged.add("package.json")
   for (const source of engineSidecarSources()) stageSource(source, stageDir, staged)
   stagePluginPayload(stageDir, staged)
@@ -560,6 +564,7 @@ export interface BuildReleaseBinaryOptions {
   readonly omoVersion: string
   readonly omoAiVersion: string
   readonly outDir?: string
+  readonly buildInfo?: OmoBuildInfo
 }
 
 export interface BuildReleaseBinaryResult {
@@ -589,11 +594,12 @@ export async function buildReleaseBinary(
     // spelling. Basename is preserved, so embedded names stay
     // `${EMBEDDED_PAYLOAD_ROOT}/<relPath>`.
     const stageDir = realpathSync(stagedRoot)
-    stageSidecarPayload(target, stageDir, options.omoAiVersion)
+    stageSidecarPayload(target, stageDir, options.omoAiVersion, options.buildInfo)
 
     const manifest = await buildRuntimeManifest(stageDir, {
       omoAiVersion: options.omoAiVersion,
       enginePin: target.enginePin,
+      buildInfo: options.buildInfo,
     })
     writeFileSync(
       join(stageDir, RUNTIME_MANIFEST_REL_PATH),
@@ -659,6 +665,13 @@ interface CliOptions {
   readonly omoVersion: string
   readonly omoAiVersion: string
   readonly outDir: string | undefined
+  readonly buildInfo: OmoBuildInfo | undefined
+}
+
+function parseBuildInfoValue(raw: string): OmoBuildInfo {
+  const parsed = parseBuildInfo(JSON.parse(raw))
+  if (parsed === undefined) throw new Error("--build-info is not a valid OmoBuildInfo payload")
+  return parsed
 }
 
 function parseArgs(argv: readonly string[]): CliOptions {
@@ -666,6 +679,7 @@ function parseArgs(argv: readonly string[]): CliOptions {
   let omoVersion: string | undefined
   let omoAiVersion: string | undefined
   let outDir: string | undefined
+  let buildInfo: OmoBuildInfo | undefined
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index]
     const value = argv[index + 1]
@@ -680,6 +694,10 @@ function parseArgs(argv: readonly string[]): CliOptions {
     } else if (argument === "--omo-ai-version") {
       if (value === undefined) throw new Error("--omo-ai-version requires a value")
       omoAiVersion = value
+      index += 1
+    } else if (argument === "--build-info") {
+      if (value === undefined) throw new Error("--build-info requires a value")
+      buildInfo = parseBuildInfoValue(value)
       index += 1
     } else if (argument === "--out-dir") {
       if (value === undefined) throw new Error("--out-dir requires a value")
@@ -696,7 +714,7 @@ function parseArgs(argv: readonly string[]): CliOptions {
       ? RELEASE_BINARY_TARGETS
       : RELEASE_BINARY_TARGETS.filter((entry) => entry.target === targetName)
   if (targets.length === 0) throw new Error(`unknown target: ${targetName}`)
-  return { targets, omoVersion, omoAiVersion, outDir }
+  return { targets, omoVersion, omoAiVersion, outDir, buildInfo }
 }
 
 async function main(argv: readonly string[]): Promise<number> {
@@ -706,6 +724,7 @@ async function main(argv: readonly string[]): Promise<number> {
       omoVersion: options.omoVersion,
       omoAiVersion: options.omoAiVersion,
       outDir: options.outDir,
+      buildInfo: options.buildInfo,
     })
     console.log(
       `built ${result.target}: ${result.binaryPath} (${result.size} bytes, ${result.manifest.entries.length} embedded sidecar files)`,

--- a/script/build-omob.test.ts
+++ b/script/build-omob.test.ts
@@ -1,7 +1,7 @@
 // Contract tests for script/build-omob.ts.
 
 import { describe, expect, test } from "bun:test"
-import { deriveOmobAiVersion, hostTargetFor, parseOmobArgs, selectPruneEntries } from "./build-omob"
+import { deriveOmobAiVersion, hostTargetFor, parseOmobArgs, planRuntimePrune, selectPruneEntries } from "./build-omob"
 
 describe("parseOmobArgs", () => {
 	test("defaults to the latest tracked refs and the host target", () => {
@@ -69,5 +69,38 @@ describe("selectPruneEntries", () => {
 	test("keeps everything below the budget", () => {
 		expect(selectPruneEntries(entries, 3)).toEqual(["0.0.0-omob.ccccccc.ddddddd"])
 		expect(selectPruneEntries(entries, 4)).toEqual([])
+	})
+})
+
+describe("planRuntimePrune", () => {
+	const entries = [
+		{ name: "0.0.0-omob.cur0000.cur0000", mtimeMs: 5 },
+		{ name: "0.0.0-omob.aaaaaaa.bbbbbbb", mtimeMs: 3 },
+		{ name: "0.0.0-omob.ccccccc.ddddddd", mtimeMs: 1 },
+		{ name: "0.0.0-omob.eeeeeee.fffffff", mtimeMs: 2 },
+		{ name: "5.0.0-0.beta.40", mtimeMs: 0 },
+	]
+
+	test("reserves a slot for the version being built and prunes the rest oldest-first", () => {
+		expect(planRuntimePrune(entries, 2, "0.0.0-omob.cur0000.cur0000")).toEqual([
+			"0.0.0-omob.ccccccc.ddddddd",
+			"0.0.0-omob.eeeeeee.fffffff",
+		])
+	})
+
+	test("never counts the current version against the budget even when its dir is absent", () => {
+		const withoutCurrent = entries.filter((entry) => !entry.name.includes("cur0000"))
+		expect(planRuntimePrune(withoutCurrent, 2, "0.0.0-omob.cur0000.cur0000")).toEqual([
+			"0.0.0-omob.ccccccc.ddddddd",
+			"0.0.0-omob.eeeeeee.fffffff",
+		])
+	})
+
+	test("keep=1 leaves only the version being built", () => {
+		expect(planRuntimePrune(entries, 1, "0.0.0-omob.cur0000.cur0000")).toEqual([
+			"0.0.0-omob.ccccccc.ddddddd",
+			"0.0.0-omob.eeeeeee.fffffff",
+			"0.0.0-omob.aaaaaaa.bbbbbbb",
+		])
 	})
 })

--- a/script/build-omob.test.ts
+++ b/script/build-omob.test.ts
@@ -1,0 +1,73 @@
+// Contract tests for script/build-omob.ts.
+
+import { describe, expect, test } from "bun:test"
+import { deriveOmobAiVersion, hostTargetFor, parseOmobArgs, selectPruneEntries } from "./build-omob"
+
+describe("parseOmobArgs", () => {
+	test("defaults to the latest tracked refs and the host target", () => {
+		const parsed = parseOmobArgs([], "darwin", "arm64", "/home/dev")
+		expect(parsed.senpiRef).toBe("origin/main")
+		expect(parsed.omoRef).toBe("origin/dev")
+		expect(parsed.name).toBe("omob")
+		expect(parsed.keep).toBe(2)
+		expect(parsed.target).toBe("darwin-arm64")
+		expect(parsed.installDir).toBe("/home/dev/.local/bin")
+		expect(parsed.cacheDir).toBe("/home/dev/.omo/omob")
+		expect(parsed.skipFetch).toBe(false)
+		expect(parsed.skipInstall).toBe(false)
+	})
+
+	test("accepts ref overrides and keep counts", () => {
+		const parsed = parseOmobArgs(
+			["--senpi-ref", "origin/feat/x", "--omo-ref", "abc1234", "--keep", "5", "--skip-fetch", "--skip-install"],
+			"linux",
+			"x64",
+			"/home/dev",
+		)
+		expect(parsed.senpiRef).toBe("origin/feat/x")
+		expect(parsed.omoRef).toBe("abc1234")
+		expect(parsed.keep).toBe(5)
+		expect(parsed.skipFetch).toBe(true)
+		expect(parsed.skipInstall).toBe(true)
+		expect(parsed.target).toBe("linux-x64")
+	})
+
+	test("rejects unknown flags", () => {
+		expect(() => parseOmobArgs(["--nonsense"], "darwin", "arm64", "/home/dev")).toThrow()
+	})
+
+	test("maps host platforms onto release targets", () => {
+		expect(hostTargetFor("darwin", "arm64")).toBe("darwin-arm64")
+		expect(hostTargetFor("darwin", "x64")).toBe("darwin-x64")
+		expect(hostTargetFor("linux", "arm64")).toBe("linux-arm64")
+		expect(hostTargetFor("linux", "x64")).toBe("linux-x64")
+		expect(hostTargetFor("win32", "x64")).toBe("windows-x64")
+	})
+})
+
+describe("deriveOmobAiVersion", () => {
+	test("embeds both short shas in the dev version", () => {
+		expect(deriveOmobAiVersion("c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc", "7fd18dfeec7a7db89a983b2c3cb90835b8c3c5f7")).toBe(
+			"0.0.0-omob.c6e7dd7.7fd18df",
+		)
+	})
+})
+
+describe("selectPruneEntries", () => {
+	const entries = [
+		{ name: "0.0.0-omob.aaaaaaa.bbbbbbb", mtimeMs: 3 },
+		{ name: "0.0.0-omob.ccccccc.ddddddd", mtimeMs: 1 },
+		{ name: "0.0.0-omob.eeeeeee.fffffff", mtimeMs: 2 },
+		{ name: "5.0.0-0.beta.39", mtimeMs: 0 },
+		{ name: "0.0.0-omob.1111111.2222222", mtimeMs: 5 },
+	]
+
+	test("keeps the newest dev runtimes and never touches release runtimes", () => {
+		expect(selectPruneEntries(entries, 2)).toEqual(["0.0.0-omob.ccccccc.ddddddd", "0.0.0-omob.eeeeeee.fffffff"])
+	})
+
+	test("keeps everything below the budget", () => {
+		expect(selectPruneEntries(entries, 3)).toEqual(["0.0.0-omob.ccccccc.ddddddd"])
+		expect(selectPruneEntries(entries, 4)).toEqual([])
+	})
+})

--- a/script/build-omob.test.ts
+++ b/script/build-omob.test.ts
@@ -12,7 +12,7 @@ describe("parseOmobArgs", () => {
 		expect(parsed.keep).toBe(2)
 		expect(parsed.target).toBe("darwin-arm64")
 		expect(parsed.installDir).toBe("/home/dev/.local/bin")
-		expect(parsed.cacheDir).toBe("/home/dev/.omo/omob")
+		expect(parsed.cacheDir).toBe("/home/dev/.cache/omob")
 		expect(parsed.skipFetch).toBe(false)
 		expect(parsed.skipInstall).toBe(false)
 	})

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -149,7 +149,7 @@ function readCommitInfo(directory: string, ref: string): CommitInfo {
 	const commit = runCaptured("git", ["rev-parse", "HEAD"], directory)
 	const committedAt = runCaptured("git", ["log", "-1", "--format=%cI"], directory)
 	const rawBranch = runCaptured("git", ["rev-parse", "--abbrev-ref", ref], directory).trim()
-	const branch = rawBranch === "HEAD" || rawBranch === "" ? ref.replace(/^origin\//, "") : rawBranch
+	const branch = (rawBranch === "HEAD" || rawBranch === "" ? ref : rawBranch).replace(/^origin\//, "")
 	return { commit, committedAt, branch }
 }
 

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -160,7 +160,22 @@ function buildSenpiPackage(senpiDir: string, cacheDir: string, ref: string): str
 	mkdirSync(installRoot, { recursive: true })
 	writeFileSync(join(installRoot, "package.json"), `${JSON.stringify({ private: true, dependencies: { "@code-yeongyu/senpi": `file:../tarballs/${tarballName}` } }, undefined, "\t")}\n`)
 	run("bun", ["install", "--production", "--ignore-scripts"], installRoot)
+	nestHoistedDeps(installRoot)
 	return join(installRoot, "node_modules", "@code-yeongyu", "senpi")
+}
+
+/** Moves the isolated install's hoisted deps under the senpi package, mirroring the published nested layout. */
+function nestHoistedDeps(installRoot: string): void {
+	const senpiNodeModules = join(installRoot, "node_modules", "@code-yeongyu", "senpi", "node_modules")
+	const topLevel = join(installRoot, "node_modules")
+	mkdirSync(senpiNodeModules, { recursive: true })
+	for (const entry of readdirSync(topLevel)) {
+		if (entry.startsWith(".") || entry === "@code-yeongyu") continue
+		const from = join(topLevel, entry)
+		const to = join(senpiNodeModules, entry)
+		if (existsSync(to)) continue
+		renameSync(from, to)
+	}
 }
 
 function swapSenpi(omoDir: string, builtSenpiRoot: string): void {

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -96,6 +96,16 @@ export function isOmobRuntimeDir(name: string): boolean {
 	return name.startsWith(OMOB_RUNTIME_PREFIX)
 }
 
+/**
+ * Prune plan for a build about to provision `currentVersion`: that version owns one
+ * of the `keep` slots (whether or not its dir exists yet), so only `keep - 1` OTHER
+ * dev runtimes survive. Release runtimes are never touched.
+ */
+export function planRuntimePrune(entries: readonly PruneEntry[], keep: number, currentVersion: string): string[] {
+	const others = entries.filter((entry) => entry.name !== currentVersion)
+	return selectPruneEntries(others, Math.max(0, keep - 1))
+}
+
 /** Names of dev runtime dirs to delete: omob dirs beyond the newest `keep`. Release runtimes are never touched. */
 export function selectPruneEntries(entries: readonly PruneEntry[], keep: number): string[] {
 	const omob = entries.filter((entry) => isOmobRuntimeDir(entry.name))
@@ -232,14 +242,14 @@ function swapSenpi(omoDir: string, builtSenpiRoot: string): void {
 	run("bun", [join("packages", "omo-native", "bin", "senpi-patch.mjs")], omoDir, { ...process.env, OMO_SENPI_PATCH_ROOT: target })
 }
 
-function pruneOmobRuntimes(keep: number): void {
+function pruneOmobRuntimes(keep: number, currentVersion: string): void {
 	const runtimeRoot = join(homedir(), ".omo", "binary-runtime")
 	if (!existsSync(runtimeRoot)) return
 	const entries: PruneEntry[] = readdirSync(runtimeRoot).map((name) => {
 		const stats = statSync(join(runtimeRoot, name))
 		return { name, mtimeMs: stats.mtimeMs }
 	})
-	for (const name of selectPruneEntries(entries, keep)) {
+	for (const name of planRuntimePrune(entries, keep, currentVersion)) {
 		rmSync(join(runtimeRoot, name), { recursive: true, force: true })
 		console.log(`pruned dev runtime ${name}`)
 	}
@@ -313,7 +323,7 @@ const senpiUrl = options.senpiUrl ?? DEFAULT_SENPI_URL
 		const installed = installBinary(result.binaryPath, options.installDir, options.name)
 		console.log(`installed ${installed} (${result.size} bytes)`)
 	}
-	pruneOmobRuntimes(options.keep)
+	pruneOmobRuntimes(options.keep, omoAiVersion)
 	const lines = [buildInfo.command + " dev build", `omo   ${omoInfo.commit} ${omoInfo.committedAt} (${omoInfo.branch})`, `senpi ${senpiInfo.commit} ${senpiInfo.committedAt} (${senpiInfo.branch})`]
 	console.log(lines.join("\n"))
 	return 0

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -2,7 +2,7 @@
 // script/build-omob.ts
 // Builds a single-file dev binary ("omob") from the latest tracked senpi (origin/main)
 // and omo (origin/dev) commits and installs it under the omob name. Dev builds share
-// ~/.omo state with a regular omo install; only the binary and its provisioned
+// ~/.omo state with a regular omo installation; only the binary and its provisioned
 // runtime dir are namespaced by the commit pair.
 
 import { spawnSync } from "node:child_process"

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -119,13 +119,16 @@ function runCaptured(command: string, args: readonly string[], cwd: string): str
 function ensureCacheClone(url: string, directory: string, ref: string, skipFetch: boolean): { readonly directory: string; readonly commit: string } {
 	mkdirSync(dirname(directory), { recursive: true })
 	if (!existsSync(join(directory, ".git"))) {
-		run("git", ["clone", "--filter=blob:none", url, directory], dirname(directory))
+		run("git", ["clone", url, directory], dirname(directory))
 	}
 	if (!skipFetch) {
 		// Branch refs fetch a single refspec; raw SHAs need the whole history.
 		const fetchArgs = ref.startsWith("origin/") ? ["--prune", "origin", ref.slice("origin/".length)] : ["--prune", "origin"]
 		run("git", ["fetch", ...fetchArgs], directory)
 	}
+	// A cache checkout must land on the exact ref tree: force-reset and drop
+	// any leftovers from a previous ref (staged swaps, ignored build outputs).
+	run("git", ["clean", "-ffd"], directory)
 	run("git", ["checkout", "--force", ref], directory)
 	run("git", ["reset", "--hard", ref], directory)
 	const commit = runCaptured("git", ["rev-parse", "HEAD"], directory)

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -148,6 +148,7 @@ function readCommitInfo(directory: string, ref: string): CommitInfo {
 
 function buildSenpiPackage(senpiDir: string, cacheDir: string, ref: string): string {
 	run("bun", ["install"], senpiDir)
+	materializeNestedLockDeps(senpiDir)
 	run("bun", ["run", "build:bun"], senpiDir)
 	// Stage the bundled workspaces exactly like the release pipeline, then pack.
 	run("node", [join("scripts", "prepare-senpi-bundled-workspaces.mjs")], senpiDir)
@@ -168,6 +169,40 @@ function buildSenpiPackage(senpiDir: string, cacheDir: string, ref: string): str
 }
 
 /** Moves the isolated install's hoisted deps under the senpi package, mirroring the published nested layout. */
+/**
+ * senpi's publish staging (prepare-senpi-bundled-workspaces.mjs) reads npm lock
+ * entries shaped "packages/<workspace>/node_modules/<pkg>" and expects those
+ * packages installed INSIDE the workspace directory. A bun workspace install
+ * hoists everything, so materialize the nested layout from the lock: every
+ * package the lock nests under a workspace is copied from the hoisted root
+ * install into <workspace>/node_modules.
+ */
+function materializeNestedLockDeps(senpiRoot: string): void {
+	const lockPath = join(senpiRoot, "package-lock.json")
+	if (!existsSync(lockPath)) throw new Error("senpi cache clone has no package-lock.json")
+	const lock = JSON.parse(readFileSync(lockPath, "utf8")) as {
+		packages?: Record<string, { optional?: boolean }>
+	}
+	const rootNm = join(senpiRoot, "node_modules")
+	for (const entry of Object.keys(lock.packages ?? {})) {
+		// Shape: packages/<workspace>/node_modules/<pkg> — skip root-level deps, workspace manifests, and anything deeper.
+		const match = /^packages\/([^/]+)\/node_modules\/(.+)$/.exec(entry)
+		if (match === null) continue
+		const [, workspaceName, pkgName] = match
+		if (pkgName.includes("node_modules/")) continue
+		const optional = lock.packages?.[entry]?.optional === true
+		const sourcePath = join(rootNm, pkgName)
+		if (!existsSync(sourcePath)) {
+			if (optional) continue
+			throw new Error(`bun install produced no hoisted ${pkgName} required by packages/${workspaceName} (lock entry ${entry})`)
+		}
+		const nestedPath = join(senpiRoot, "packages", workspaceName, "node_modules", pkgName)
+		if (existsSync(nestedPath)) continue
+		mkdirSync(dirname(nestedPath), { recursive: true })
+		cpSync(sourcePath, nestedPath, { recursive: true })
+	}
+}
+
 function nestHoistedDeps(installRoot: string): void {
 	const senpiNodeModules = join(installRoot, "node_modules", "@code-yeongyu", "senpi", "node_modules")
 	const topLevel = join(installRoot, "node_modules")

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -70,7 +70,7 @@ export function parseOmobArgs(argv: readonly string[], platform: string, arch: s
 	return {
 		senpiRef: options.senpiRef ?? "origin/main",
 		omoRef: options.omoRef ?? "origin/dev",
-		cacheDir: options.cacheDir ?? join(homeDir, ".omo", "omob"),
+		cacheDir: options.cacheDir ?? join(homeDir, ".cache", "omob"),
 		installDir: options.installDir ?? join(homeDir, ".local", "bin"),
 		name: options.name ?? "omob",
 		target: options.target ?? hostTargetFor(platform, arch),

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -119,7 +119,8 @@ function runCaptured(command: string, args: readonly string[], cwd: string): str
 function ensureCacheClone(url: string, directory: string, ref: string, skipFetch: boolean): { readonly directory: string; readonly commit: string } {
 	mkdirSync(dirname(directory), { recursive: true })
 	if (!existsSync(join(directory, ".git"))) {
-		run("git", ["clone", url, directory], dirname(directory))
+		run("git", ["clone", "--recurse-submodules", "--shallow-submodules", url, directory], dirname(directory))
+		run("git", ["submodule", "update", "--init", "--recursive"], directory)
 	}
 	if (!skipFetch) {
 		// Branch refs fetch a single refspec; raw SHAs need the whole history.
@@ -128,7 +129,10 @@ function ensureCacheClone(url: string, directory: string, ref: string, skipFetch
 	}
 	// A cache checkout must land on the exact ref tree: force-reset and drop
 	// any leftovers from a previous ref (staged swaps, ignored build outputs).
+	run("git", ["submodule", "update", "--init", "--recursive"], directory)
 	run("git", ["clean", "-ffd"], directory)
+	// Re-point submodules at the switched ref and drop any stale checked-out state.
+	run("git", ["submodule", "update", "--init", "--recursive"], directory)
 	run("git", ["checkout", "--force", ref], directory)
 	run("git", ["reset", "--hard", ref], directory)
 	const commit = runCaptured("git", ["rev-parse", "HEAD"], directory)
@@ -267,7 +271,12 @@ const senpiUrl = options.senpiUrl ?? DEFAULT_SENPI_URL
 	}
 
 	const builtSenpiRoot = buildSenpiPackage(senpi.directory, options.cacheDir, options.senpiRef)
-	run("bun", ["install"], omo.directory)
+	// The omo prepare chain materializes gitignored plugin/skills from the shared-skills
+	// upstream submodules; a caller's OMO_SKIP_MATERIALIZE=1 would skip that and break the
+	// build, so the dev-binary install always runs the full materialization.
+	const installEnv: NodeJS.ProcessEnv = { ...process.env }
+	delete installEnv.OMO_SKIP_MATERIALIZE
+	run("bun", ["install"], omo.directory, installEnv)
 	swapSenpi(omo.directory, builtSenpiRoot)
 
 	const target = RELEASE_BINARY_TARGETS.find((entry) => entry.target === options.target)

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -24,6 +24,7 @@ export interface OmobOptions {
 	readonly name: string
 	readonly target: string
 	readonly keep: number
+	readonly senpiUrl: string
 	readonly skipFetch: boolean
 	readonly skipInstall: boolean
 }
@@ -43,10 +44,10 @@ export function parseOmobArgs(argv: readonly string[], platform: string, arch: s
 	for (let index = 0; index < argv.length; index += 1) {
 		const argument = argv[index]
 		const value = argv[index + 1]
-		if (argument === "--senpi-ref" || argument === "--omo-ref" || argument === "--cache-dir" || argument === "--install-dir" || argument === "--name" || argument === "--target") {
+		if (argument === "--senpi-ref" || argument === "--omo-ref" || argument === "--cache-dir" || argument === "--install-dir" || argument === "--name" || argument === "--target" || argument === "--senpi-url") {
 			if (value === undefined) throw new Error(`${argument} requires a value`)
 			const key = argument.slice(2).replaceAll("-", "") as "senpiRef" | "omoRef" | "cacheDir" | "installDir" | "name" | "target"
-			const normalizedKey = argument === "--senpi-ref" ? "senpiRef" : argument === "--omo-ref" ? "omoRef" : argument === "--cache-dir" ? "cacheDir" : argument === "--install-dir" ? "installDir" : argument === "--name" ? "name" : "target"
+			const normalizedKey = argument === "--senpi-ref" ? "senpiRef" : argument === "--omo-ref" ? "omoRef" : argument === "--cache-dir" ? "cacheDir" : argument === "--install-dir" ? "installDir" : argument === "--name" ? "name" : argument === "--senpi-url" ? "senpiUrl" : "target"
 			;(options as Record<string, unknown>)[normalizedKey] = value
 			index += 1
 		} else if (argument === "--keep") {
@@ -71,6 +72,7 @@ export function parseOmobArgs(argv: readonly string[], platform: string, arch: s
 		name: options.name ?? "omob",
 		target: options.target ?? hostTargetFor(platform, arch),
 		keep: options.keep ?? 2,
+		senpiUrl: options.senpiUrl ?? DEFAULT_SENPI_URL,
 		skipFetch: options.skipFetch,
 		skipInstall: options.skipInstall,
 	}
@@ -116,7 +118,11 @@ function ensureCacheClone(url: string, directory: string, ref: string, skipFetch
 	if (!existsSync(join(directory, ".git"))) {
 		run("git", ["clone", "--filter=blob:none", url, directory], dirname(directory))
 	}
-	if (!skipFetch) run("git", ["fetch", "--prune", "origin", ref.replace(/^origin\//, "")], directory)
+	if (!skipFetch) {
+		// Branch refs fetch a single refspec; raw SHAs need the whole history.
+		const fetchArgs = ref.startsWith("origin/") ? ["--prune", "origin", ref.slice("origin/".length)] : ["--prune", "origin"]
+		run("git", ["fetch", ...fetchArgs], directory)
+	}
 	run("git", ["checkout", "--force", ref], directory)
 	run("git", ["reset", "--hard", ref], directory)
 	const commit = runCaptured("git", ["rev-parse", "HEAD"], directory)
@@ -152,7 +158,7 @@ function buildSenpiPackage(senpiDir: string, cacheDir: string, ref: string): str
 	const installRoot = join(cacheDir, "senpi-install")
 	rmSync(installRoot, { recursive: true, force: true })
 	mkdirSync(installRoot, { recursive: true })
-	writeFileSync(join(installRoot, "package.json"), `${JSON.stringify({ private: true, dependencies: { "@code-yeongyu/senpi": `file:${join(tarballDir, tarballName)}` } }, undefined, "\t")}\n`)
+	writeFileSync(join(installRoot, "package.json"), `${JSON.stringify({ private: true, dependencies: { "@code-yeongyu/senpi": `file:../tarballs/${tarballName}` } }, undefined, "\t")}\n`)
 	run("bun", ["install", "--production", "--ignore-scripts"], installRoot)
 	return join(installRoot, "node_modules", "@code-yeongyu", "senpi")
 }
@@ -192,7 +198,8 @@ function installBinary(binaryPath: string, installDir: string, name: string): st
 
 async function main(argv: readonly string[]): Promise<number> {
 	const options = parseOmobArgs(argv, process.platform, process.arch, homedir())
-	const senpiUrl = runCaptured("git", ["remote", "get-url", "origin"], repoRoot).replace(/\.git$/, "")
+	const DEFAULT_SENPI_URL = "https://github.com/code-yeongyu/senpi.git"
+const senpiUrl = options.senpiUrl ?? DEFAULT_SENPI_URL
 	const senpi = ensureCacheClone(senpiUrl, join(options.cacheDir, "senpi"), options.senpiRef, options.skipFetch)
 	const omo = ensureCacheClone(runCaptured("git", ["remote", "get-url", "origin"], repoRoot), join(options.cacheDir, "omo"), options.omoRef, options.skipFetch)
 

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -1,7 +1,20 @@
 #!/usr/bin/env bun
 // script/build-omob.ts
-// Builds a single-file dev binary (omob) from the latest tracked senpi + omo
-// commits and installs it under the omob name.
+// Builds a single-file dev binary ("omob") from the latest tracked senpi (origin/main)
+// and omo (origin/dev) commits and installs it under the omob name. Dev builds share
+// ~/.omo state with a regular omo install; only the binary and its provisioned
+// runtime dir are namespaced by the commit pair.
+
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, chmodSync, renameSync, cpSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { parseBuildInfo, type OmoBuildInfo } from "../packages/omo-native/build-info"
+import { RELEASE_BINARY_TARGETS, buildReleaseBinary } from "./build-omo-binary"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, "..")
 
 export interface OmobOptions {
 	readonly senpiRef: string
@@ -16,25 +29,55 @@ export interface OmobOptions {
 }
 
 export function hostTargetFor(platform: string, arch: string): string {
-	return "darwin-arm64"
+	if (platform === "darwin") return arch === "arm64" ? "darwin-arm64" : "darwin-x64"
+	if (platform === "linux") return arch === "arm64" ? "linux-arm64" : "linux-x64"
+	if (platform === "win32") return "windows-x64"
+	throw new Error(`unsupported host platform: ${platform} ${arch}`)
 }
 
 export function parseOmobArgs(argv: readonly string[], platform: string, arch: string, homeDir: string): OmobOptions {
-	return {
-		senpiRef: "origin/main",
-		omoRef: "origin/dev",
-		cacheDir: homeDir + "/.omo/omob",
-		installDir: homeDir + "/.local/bin",
-		name: "omob",
-		target: "darwin-arm64",
-		keep: 2,
+	const options: { senpiRef?: string; omoRef?: string; cacheDir?: string; installDir?: string; name?: string; target?: string; keep?: number; skipFetch: boolean; skipInstall: boolean } = {
 		skipFetch: false,
 		skipInstall: false,
+	}
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index]
+		const value = argv[index + 1]
+		if (argument === "--senpi-ref" || argument === "--omo-ref" || argument === "--cache-dir" || argument === "--install-dir" || argument === "--name" || argument === "--target") {
+			if (value === undefined) throw new Error(`${argument} requires a value`)
+			const key = argument.slice(2).replaceAll("-", "") as "senpiRef" | "omoRef" | "cacheDir" | "installDir" | "name" | "target"
+			const normalizedKey = argument === "--senpi-ref" ? "senpiRef" : argument === "--omo-ref" ? "omoRef" : argument === "--cache-dir" ? "cacheDir" : argument === "--install-dir" ? "installDir" : argument === "--name" ? "name" : "target"
+			;(options as Record<string, unknown>)[normalizedKey] = value
+			index += 1
+		} else if (argument === "--keep") {
+			if (value === undefined) throw new Error("--keep requires a value")
+			const keep = Number.parseInt(value, 10)
+			if (!Number.isInteger(keep) || keep < 0) throw new Error("--keep must be a non-negative integer")
+			options.keep = keep
+			index += 1
+		} else if (argument === "--skip-fetch") {
+			options.skipFetch = true
+		} else if (argument === "--skip-install") {
+			options.skipInstall = true
+		} else {
+			throw new Error(`unknown argument: ${argument}`)
+		}
+	}
+	return {
+		senpiRef: options.senpiRef ?? "origin/main",
+		omoRef: options.omoRef ?? "origin/dev",
+		cacheDir: options.cacheDir ?? join(homeDir, ".omo", "omob"),
+		installDir: options.installDir ?? join(homeDir, ".local", "bin"),
+		name: options.name ?? "omob",
+		target: options.target ?? hostTargetFor(platform, arch),
+		keep: options.keep ?? 2,
+		skipFetch: options.skipFetch,
+		skipInstall: options.skipInstall,
 	}
 }
 
 export function deriveOmobAiVersion(omoCommit: string, senpiCommit: string): string {
-	return ""
+	return `0.0.0-omob.${omoCommit.slice(0, 7)}.${senpiCommit.slice(0, 7)}`
 }
 
 export interface PruneEntry {
@@ -42,11 +85,154 @@ export interface PruneEntry {
 	readonly mtimeMs: number
 }
 
+const OMOB_RUNTIME_PREFIX = "0.0.0-omob."
+
+export function isOmobRuntimeDir(name: string): boolean {
+	return name.startsWith(OMOB_RUNTIME_PREFIX)
+}
+
+/** Names of dev runtime dirs to delete: omob dirs beyond the newest `keep`. Release runtimes are never touched. */
 export function selectPruneEntries(entries: readonly PruneEntry[], keep: number): string[] {
-	return []
+	const omob = entries.filter((entry) => isOmobRuntimeDir(entry.name))
+	const sorted = omob.slice().sort((left, right) => right.mtimeMs - left.mtimeMs)
+	return sorted.slice(Math.max(0, keep)).map((entry) => entry.name)
+}
+
+function run(command: string, args: readonly string[], cwd: string, env: NodeJS.ProcessEnv = process.env): void {
+	const result = spawnSync(command, [...args], { cwd, stdio: "inherit", env })
+	if (result.error !== undefined) throw result.error
+	if (result.status !== 0) throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status ?? 1}`)
+}
+
+function runCaptured(command: string, args: readonly string[], cwd: string): string {
+	const result = spawnSync(command, [...args], { cwd, encoding: "utf8" })
+	if (result.error !== undefined) throw result.error
+	if (result.status !== 0) throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status ?? 1}:\n${result.stdout}\n${result.stderr}`)
+	return result.stdout.trim()
+}
+
+function ensureCacheClone(url: string, directory: string, ref: string, skipFetch: boolean): { readonly directory: string; readonly commit: string } {
+	mkdirSync(dirname(directory), { recursive: true })
+	if (!existsSync(join(directory, ".git"))) {
+		run("git", ["clone", "--filter=blob:none", url, directory], dirname(directory))
+	}
+	if (!skipFetch) run("git", ["fetch", "--prune", "origin", ref.replace(/^origin\//, "")], directory)
+	run("git", ["checkout", "--force", ref], directory)
+	run("git", ["reset", "--hard", ref], directory)
+	const commit = runCaptured("git", ["rev-parse", "HEAD"], directory)
+	return { directory, commit }
+}
+
+interface CommitInfo {
+	readonly commit: string
+	readonly committedAt: string
+	readonly branch: string
+}
+
+function readCommitInfo(directory: string, ref: string): CommitInfo {
+	const commit = runCaptured("git", ["rev-parse", "HEAD"], directory)
+	const committedAt = runCaptured("git", ["log", "-1", "--format=%cI"], directory)
+	const rawBranch = runCaptured("git", ["rev-parse", "--abbrev-ref", ref], directory).trim()
+	const branch = rawBranch === "HEAD" || rawBranch === "" ? ref.replace(/^origin\//, "") : rawBranch
+	return { commit, committedAt, branch }
+}
+
+function buildSenpiPackage(senpiDir: string, cacheDir: string, ref: string): string {
+	run("bun", ["install"], senpiDir)
+	run("bun", ["run", "build:bun"], senpiDir)
+	// Stage the bundled workspaces exactly like the release pipeline, then pack.
+	run("node", [join("scripts", "prepare-senpi-bundled-workspaces.mjs")], senpiDir)
+	const tarballDir = join(cacheDir, "tarballs")
+	mkdirSync(tarballDir, { recursive: true })
+	run("bun", ["pm", "pack", "--destination", tarballDir], join(senpiDir, "packages", "coding-agent"))
+	const tarballName = readdirSync(tarballDir).find((name) => name.endsWith(".tgz"))
+	if (tarballName === undefined) throw new Error("bun pm pack produced no senpi tarball")
+	// Isolated production install: the tarball plus its registry deps, resolved under
+	// a dedicated root so the resulting tree can be dropped into omo's node_modules.
+	const installRoot = join(cacheDir, "senpi-install")
+	rmSync(installRoot, { recursive: true, force: true })
+	mkdirSync(installRoot, { recursive: true })
+	writeFileSync(join(installRoot, "package.json"), `${JSON.stringify({ private: true, dependencies: { "@code-yeongyu/senpi": `file:${join(tarballDir, tarballName)}` } }, undefined, "\t")}\n`)
+	run("bun", ["install", "--production", "--ignore-scripts"], installRoot)
+	return join(installRoot, "node_modules", "@code-yeongyu", "senpi")
+}
+
+function swapSenpi(omoDir: string, builtSenpiRoot: string): void {
+	const target = join(omoDir, "node_modules", "@code-yeongyu", "senpi")
+	if (existsSync(target)) rmSync(target, { recursive: true, force: true })
+	mkdirSync(dirname(target), { recursive: true })
+	cpSync(builtSenpiRoot, target, { recursive: true })
+	// Re-apply the launcher's claude-code version floor patch on the swapped engine.
+	run("bun", [join("packages", "omo-native", "bin", "senpi-patch.mjs")], omoDir, { ...process.env, OMO_SENPI_PATCH_ROOT: target })
+}
+
+function pruneOmobRuntimes(keep: number): void {
+	const runtimeRoot = join(homedir(), ".omo", "binary-runtime")
+	if (!existsSync(runtimeRoot)) return
+	const entries: PruneEntry[] = readdirSync(runtimeRoot).map((name) => {
+		const stats = statSync(join(runtimeRoot, name))
+		return { name, mtimeMs: stats.mtimeMs }
+	})
+	for (const name of selectPruneEntries(entries, keep)) {
+		rmSync(join(runtimeRoot, name), { recursive: true, force: true })
+		console.log(`pruned dev runtime ${name}`)
+	}
+}
+
+function installBinary(binaryPath: string, installDir: string, name: string): string {
+	mkdirSync(installDir, { recursive: true })
+	const destination = join(installDir, name)
+	const temporary = `${destination}.tmp-${process.pid}`
+	rmSync(temporary, { force: true })
+	cpSync(binaryPath, temporary)
+	chmodSync(temporary, 0o755)
+	renameSync(temporary, destination)
+	return destination
+}
+
+async function main(argv: readonly string[]): Promise<number> {
+	const options = parseOmobArgs(argv, process.platform, process.arch, homedir())
+	const senpiUrl = runCaptured("git", ["remote", "get-url", "origin"], repoRoot).replace(/\.git$/, "")
+	const senpi = ensureCacheClone(senpiUrl, join(options.cacheDir, "senpi"), options.senpiRef, options.skipFetch)
+	const omo = ensureCacheClone(runCaptured("git", ["remote", "get-url", "origin"], repoRoot), join(options.cacheDir, "omo"), options.omoRef, options.skipFetch)
+
+	const senpiInfo = readCommitInfo(senpi.directory, options.senpiRef)
+	const omoInfo = readCommitInfo(omo.directory, options.omoRef)
+	const buildInfo: OmoBuildInfo = {
+		command: options.name,
+		omo: omoInfo,
+		engine: { commit: senpiInfo.commit, committedAt: senpiInfo.committedAt, branch: senpiInfo.branch },
+	}
+
+	const builtSenpiRoot = buildSenpiPackage(senpi.directory, options.cacheDir, options.senpiRef)
+	run("bun", ["install"], omo.directory)
+	swapSenpi(omo.directory, builtSenpiRoot)
+
+	const target = RELEASE_BINARY_TARGETS.find((entry) => entry.target === options.target)
+	if (target === undefined) throw new Error(`unknown target: ${options.target}`)
+	const omoAiVersion = deriveOmobAiVersion(omoInfo.commit, senpiInfo.commit)
+	const result = await buildReleaseBinary(target, {
+		omoVersion: omoAiVersion,
+		omoAiVersion,
+		outDir: join(options.cacheDir, "out"),
+		buildInfo,
+	})
+
+	if (!options.skipInstall) {
+		const installed = installBinary(result.binaryPath, options.installDir, options.name)
+		console.log(`installed ${installed} (${result.size} bytes)`)
+	}
+	pruneOmobRuntimes(options.keep)
+	const lines = [buildInfo.command + " dev build", `omo   ${omoInfo.commit} ${omoInfo.committedAt} (${omoInfo.branch})`, `senpi ${senpiInfo.commit} ${senpiInfo.committedAt} (${senpiInfo.branch})`]
+	console.log(lines.join("\n"))
+	return 0
 }
 
 if (import.meta.main) {
-	console.error("omob pipeline not implemented yet")
-	process.exitCode = 1
+	try {
+		process.exit(await main(process.argv.slice(2)))
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error))
+		process.exit(1)
+	}
 }

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -36,8 +36,11 @@ export function hostTargetFor(platform: string, arch: string): string {
 	throw new Error(`unsupported host platform: ${platform} ${arch}`)
 }
 
+const DEFAULT_SENPI_URL = "https://github.com/code-yeongyu/senpi.git"
+
 export function parseOmobArgs(argv: readonly string[], platform: string, arch: string, homeDir: string): OmobOptions {
-	const options: { senpiRef?: string; omoRef?: string; cacheDir?: string; installDir?: string; name?: string; target?: string; keep?: number; skipFetch: boolean; skipInstall: boolean } = {
+	const options: { senpiRef?: string; omoRef?: string; cacheDir?: string; installDir?: string; name?: string; target?: string; senpiUrl?: string; keep?: number; skipFetch: boolean; skipInstall: boolean } = {
+		senpiUrl: undefined,
 		skipFetch: false,
 		skipInstall: false,
 	}
@@ -213,7 +216,6 @@ function installBinary(binaryPath: string, installDir: string, name: string): st
 
 async function main(argv: readonly string[]): Promise<number> {
 	const options = parseOmobArgs(argv, process.platform, process.arch, homedir())
-	const DEFAULT_SENPI_URL = "https://github.com/code-yeongyu/senpi.git"
 const senpiUrl = options.senpiUrl ?? DEFAULT_SENPI_URL
 	const senpi = ensureCacheClone(senpiUrl, join(options.cacheDir, "senpi"), options.senpiRef, options.skipFetch)
 	const omo = ensureCacheClone(runCaptured("git", ["remote", "get-url", "origin"], repoRoot), join(options.cacheDir, "omo"), options.omoRef, options.skipFetch)

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+// script/build-omob.ts
+// Builds a single-file dev binary (omob) from the latest tracked senpi + omo
+// commits and installs it under the omob name.
+
+export interface OmobOptions {
+	readonly senpiRef: string
+	readonly omoRef: string
+	readonly cacheDir: string
+	readonly installDir: string
+	readonly name: string
+	readonly target: string
+	readonly keep: number
+	readonly skipFetch: boolean
+	readonly skipInstall: boolean
+}
+
+export function hostTargetFor(platform: string, arch: string): string {
+	return "darwin-arm64"
+}
+
+export function parseOmobArgs(argv: readonly string[], platform: string, arch: string, homeDir: string): OmobOptions {
+	return {
+		senpiRef: "origin/main",
+		omoRef: "origin/dev",
+		cacheDir: homeDir + "/.omo/omob",
+		installDir: homeDir + "/.local/bin",
+		name: "omob",
+		target: "darwin-arm64",
+		keep: 2,
+		skipFetch: false,
+		skipInstall: false,
+	}
+}
+
+export function deriveOmobAiVersion(omoCommit: string, senpiCommit: string): string {
+	return ""
+}
+
+export interface PruneEntry {
+	readonly name: string
+	readonly mtimeMs: number
+}
+
+export function selectPruneEntries(entries: readonly PruneEntry[], keep: number): string[] {
+	return []
+}
+
+if (import.meta.main) {
+	console.error("omob pipeline not implemented yet")
+	process.exitCode = 1
+}

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -11,7 +11,7 @@ import { homedir, tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { parseBuildInfo, type OmoBuildInfo } from "../packages/omo-native/build-info"
-import { RELEASE_BINARY_TARGETS, buildReleaseBinary } from "./build-omo-binary"
+import { RELEASE_BINARY_TARGETS } from "./build-omo-binary"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, "..")
@@ -282,12 +282,32 @@ const senpiUrl = options.senpiUrl ?? DEFAULT_SENPI_URL
 	const target = RELEASE_BINARY_TARGETS.find((entry) => entry.target === options.target)
 	if (target === undefined) throw new Error(`unknown target: ${options.target}`)
 	const omoAiVersion = deriveOmobAiVersion(omoInfo.commit, senpiInfo.commit)
-	const result = await buildReleaseBinary(target, {
-		omoVersion: omoAiVersion,
-		omoAiVersion,
-		outDir: join(options.cacheDir, "out"),
-		buildInfo,
-	})
+	const outDir = join(options.cacheDir, "out")
+	rmSync(outDir, { recursive: true, force: true })
+	// Build INSIDE the cache clone: build-omo-binary.ts derives repoRoot from its own
+	// location, so only the clone's script sees the swapped engine + the clone's install.
+	run(
+		"bun",
+		[
+			"run",
+			join("script", "build-omo-binary.ts"),
+			"--target",
+			target.target,
+			"--omo-version",
+			omoAiVersion,
+			"--omo-ai-version",
+			omoAiVersion,
+			"--out-dir",
+			outDir,
+			"--build-info",
+			JSON.stringify(buildInfo),
+		],
+		omo.directory,
+		installEnv,
+	)
+	const binaryPath = join(outDir, target.binaryName)
+	if (!existsSync(binaryPath)) throw new Error(`build-omo-binary produced no binary at ${binaryPath}`)
+	const result = { binaryPath, size: statSync(binaryPath).size }
 
 	if (!options.skipInstall) {
 		const installed = installBinary(result.binaryPath, options.installDir, options.name)

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -95,7 +95,7 @@ export function isOmobRuntimeDir(name: string): boolean {
 export function selectPruneEntries(entries: readonly PruneEntry[], keep: number): string[] {
 	const omob = entries.filter((entry) => isOmobRuntimeDir(entry.name))
 	const sorted = omob.slice().sort((left, right) => right.mtimeMs - left.mtimeMs)
-	return sorted.slice(Math.max(0, keep)).map((entry) => entry.name)
+	return sorted.slice(Math.max(0, keep)).reverse().map((entry) => entry.name)
 }
 
 function run(command: string, args: readonly string[], cwd: string, env: NodeJS.ProcessEnv = process.env): void {


### PR DESCRIPTION
## Summary
- New `omob` dev-binary pipeline: `bun run omob` builds a single-file bun-compiled binary from the latest tracked commits — senpi `origin/main` + omo `origin/dev` — and installs it as `omob` (default `~/.local/bin/omob`). `~/.omo` state is shared with a regular omo install on purpose; only the binary and its provisioned runtime dir are namespaced per commit pair.
- `script/build-omo-binary.ts` gains `--build-info`: an `omoBuild` provenance block (command, full commit SHAs, ISO commit dates, branches) stamped into the sidecar `package.json` and the embedded runtime manifest (included in `manifestSha`). WITHOUT the flag, stamped output is byte-identical to today's release path — pinned by test.
- `compile-entry.ts` composes the branded profile from `omoBuild` when present: TUI displayVersion becomes `omo@<sha7> <date> · senpi@<sha7> <date>`, brand command `omob`, and `--version` / `doctor` / the startup banner print full SHAs + ISO commit dates + branches.
- `script/build-omob.ts` orchestrates end to end: cache clones under `~/.cache/omob/{senpi,omo}` (`--senpi-ref` / `--omo-ref` / `--senpi-url` overrides), senpi built from source (`bun install` → npm-lock nested-deps materialization → `build:bun` → `prepareSenpiBundledWorkspaces` → `bun pm pack`, which does honor `bundledDependencies`: 252 bundled deps in the tarball) → isolated production install with hoisted deps nested back under the package → swapped into omo's `node_modules/@code-yeongyu/senpi` → `senpi-patch.mjs` re-run → the binary compiled INSIDE the cache clone via `build-omo-binary.ts --build-info` → atomic install → dev runtime pruning (keep 2, reserving a slot for the version just built).
- Docs: `docs/reference/omob-dev-binary.md`.

Depends on code-yeongyu/senpi#1344 (merged): `formatDisplayVersion` prefixes `v` only for digit-leading versions, so the omob label renders without a stray `v`.

## Test plan
- RED→GREEN on mengmotaMac (fresh `bun install` worktree): 16 failing assertions before the implementation across `script/build-omob.test.ts`, `packages/omo-native/test/build-info.test.ts`, `packages/omo-native/test/compile-entry.test.ts`, and the new `build-omo-binary.test.ts` stamping block; **71/71 passing** after (+1 skip), with a pristine origin/dev control worktree green on the same files. `typecheck:script` and `tsgo -p packages/omo-native/tsconfig.json` clean.
- Release-path invariance pinned: `createStampedPackageJson("9.9.9-0.test")` byte-identical; manifest digest changes only when `buildInfo` is passed.

## E2E evidence (mengmotaMac, real `bun run omob --omo-ref origin/feat/omob-dev-binary`)
- Build succeeded end to end (115 MB darwin-arm64, 1181 embedded sidecar files), installed to `~/.local/bin/omob`.
- `omob --version`:
  ```
  omob dev build
  omo   99550b5343aebe7201d55da4976a78426cbcbc8c 2026-09-04T14:10:07+09:00 (feat/omob-dev-binary)
  senpi 0b187a667afe410937e6fd40e4f1a39682c12581 2026-09-04T13:52:14+09:00 (main)
  ```
- `omob doctor`: all four artifact checks PASS + the same three INFO provenance lines.
- TUI header (real pty, isolated `OMO_CODING_AGENT_DIR`, `--verbose`): `OmO omo@99550b5 2026-09-04 14:10 +09:00 · senpi@0b187a6 2026-09-04 13:52 +09:00` — no `v` prefix.
- Idempotency: `.provisioned` marker mtime unchanged across repeated launches. Pruning: 3 dev runtime dirs (incl. a seeded stale fake) → rebuild pruned the two oldest → exactly 2 remain after the new binary's first launch.
- The same binary copied to mengmotaHost (sha256 `3ef20f79…` verified) provisions and reports identically.

Note: with default refs, `bun run omob` needs this PR on `origin/dev` first (the cache clone runs dev's own `build-omo-binary.ts`); the E2E above pinned `--omo-ref` to this branch to validate the exact code under review.
