### PR TITLE
refactor(skills): rewrite shipped skill descriptions as situation-led routing text

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/skills/ulw-loop/SKILL.md
+++ b/packages/omo-codex/plugin/components/ulw-loop/skills/ulw-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-loop
-description: Goal-like loop that uses ultrawork mode to decompose work into systematic, evidence-bound steps.
+description: "A goal-like loop that decomposes work into systematic, evidence-bound ultrawork steps. Use when the user wants a goal loop or durable, checkpointed execution."
 metadata:
   short-description: Goal-like ultrawork loop for systematic decomposition
 ---

--- a/packages/omo-opencode/src/plugin-handlers/command-config-handler.test.ts
+++ b/packages/omo-opencode/src/plugin-handlers/command-config-handler.test.ts
@@ -9,6 +9,7 @@ import { OhMyOpenCodeConfigSchema, type OhMyOpenCodeConfig } from "../config";
 import type { LoadedSkill } from "../features/opencode-skill-loader/types";
 import type { PluginComponents } from "./plugin-components-loader";
 import { applyCommandConfig } from "./command-config-handler";
+import { initDeepSkill } from "@oh-my-opencode/skills-loader-core/builtin-skills/skills/init-deep";
 import {
   getAgentDisplayName,
   getAgentListDisplayName,
@@ -184,7 +185,8 @@ describe("applyCommandConfig", () => {
 
     // then
     const commandConfig = config.command as Record<string, { description?: string; template?: string }>;
-    expect(commandConfig["init-deep"]?.description).toContain("Initialize hierarchical AGENTS.md");
+    // The command carries the shipped skill description verbatim; pin the source value, not a phrase.
+    expect(commandConfig["init-deep"]?.description).toBe(initDeepSkill.description);
     expect(commandConfig["init-deep"]?.template).toContain("<skill-instruction>");
     expect(commandConfig["init-deep"]?.template).toContain("$ARGUMENTS");
     expect(commandConfig["security-review"]?.template).toContain("<skill-instruction>");

--- a/packages/omo-senpi/plugin/skills/init-deep/SKILL.md
+++ b/packages/omo-senpi/plugin/skills/init-deep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: init-deep
-description: "(builtin) Initialize hierarchical AGENTS.md knowledge base"
+description: "Initializes a hierarchical AGENTS.md knowledge base for a project. Use when a repo needs its structure, commands, and conventions documented for agents."
 ---
 # /init-deep
 

--- a/packages/omo-senpi/plugin/skills/onboarding/SKILL.md
+++ b/packages/omo-senpi/plugin/skills/onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboarding
-description: "Onboarding tour for first-time omo users"
+description: "Guides a first-time omo user through setup and the core workflow. Use when a new user asks to get started with omo."
 ---
 
 # onboarding - the first conversation with omo

--- a/packages/omo-senpi/skills/dag-library/SKILL.md
+++ b/packages/omo-senpi/skills/dag-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dag-library
-description: "Store a dag definition once and re-run it in one or two lines, instead of pasting the full definition JSON into every eval cell. MUST USE whenever the user wants to save a DAG for reuse, run a previously saved/named DAG, schedule the same graph repeatedly (nightly/weekly audits, recurring multi-agent pipelines), or asks where to put a dag definition file. Triggers: dag library, save this dag, reuse a dag, run the saved dag, stored dag definition, recurring dag, nightly dag, dag 정의 저장, 저장된 dag 실행, dag 반복 실행, DAG 만들어두고 여러 번."
+description: "Stores a DAG definition once and re-runs it by name, instead of pasting the definition into every run. Use when the user wants to save a DAG, run a saved one, or schedule the same multi-agent graph repeatedly."
 metadata:
   short-description: Store and re-run named dag definitions
 ---

--- a/packages/omo-senpi/skills/give-me-tips/SKILL.md
+++ b/packages/omo-senpi/skills/give-me-tips/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: give-me-tips
-description: "Explains any senpi tip in depth - startup tips, working tips, and any Tip: line shown in the TUI (including the Fable-5-refusal fallback tip). Use when the user asks about a Tip: line, says give-me-tips, asks what a tip means, how a tipped feature works, or which tips they can see. Queries the live tip list (senpi --list-tips) first, checks what THIS user can actually see, then verifies the real feature code before explaining."
+description: "Explains any senpi tip in depth, including Tip: lines in the TUI. Use when the user asks about a tip, what a tipped feature does, or which tips they can see."
 metadata:
   short-description: Deep, verified, brag-worthy explanations of any senpi tip
 ---

--- a/packages/omo-senpi/skills/hyperplan/SKILL.md
+++ b/packages/omo-senpi/skills/hyperplan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyperplan
-description: "Adversarial multi-agent planning skill for omo-senpi. Self-orchestrates a 5-member hostile team (categories unspecified-low, unspecified-high, deep, ultrabrain, artistry) via the native lead team tools for ruthless cross-critique debate, distills only the insights that survive the attacks, then MANDATORILY hands the distilled bundle to a planner task (load_skills ulw-plan) for executable plan formalization. Use when planning needs maximum rigor and surfacing of weak assumptions, blind spots, and over-engineering. Triggers: 'hyperplan', 'hpp', 'adversarial plan', 'hostile planning', 'cross-critique plan', '하이퍼플랜', '적대적 계획', '교차 비평'."
+description: "Adversarial multi-agent planning: a hostile team cross-critiques a plan before it is formalized. Use when planning needs maximum rigor or the user asks for a hyperplan / adversarial or cross-critique plan."
 metadata:
   short-description: Adversarial 5-member cross-critique planning, then a planner formalizes the survivors
 ---

--- a/packages/omo-senpi/skills/init-deep/SKILL.md
+++ b/packages/omo-senpi/skills/init-deep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: init-deep
-description: "(builtin) Initialize hierarchical AGENTS.md knowledge base"
+description: "Initializes a hierarchical AGENTS.md knowledge base for a project. Use when a repo needs its structure, commands, and conventions documented for agents."
 ---
 # /init-deep
 

--- a/packages/omo-senpi/skills/mass-ulw/SKILL.md
+++ b/packages/omo-senpi/skills/mass-ulw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mass-ulw
-description: Drive dependency-ordered child work through the native workflow tool, one run per phase, recovering inside a run with retry, amend, and send. Use when the user asks for mass-ulw, a DAG of tasks, fan-out/fan-in work, or multi-agent execution where some tasks must wait on others.
+description: "Drives dependency-ordered child work through the native workflow tool, one run per phase with retry/amend/send recovery. Use when the user asks for mass-ulw, a DAG of tasks, or fan-out work where some tasks must wait on others."
 metadata:
   short-description: Dependency-graph orchestration of child agents
 ---

--- a/packages/omo-senpi/skills/onboarding/SKILL.md
+++ b/packages/omo-senpi/skills/onboarding/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: onboarding
-description: "Onboarding tour for first-time omo users"
+description: "Guides a first-time omo user through setup and the core workflow. Use when a new user asks to get started with omo."
 ---
 
 # onboarding - the first conversation with omo

--- a/packages/omo-senpi/skills/ultrawork/SKILL.md
+++ b/packages/omo-senpi/skills/ultrawork/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultrawork
-description: Binding ultrawork mode directive for omo-senpi. When a prompt contains ultrawork or ulw, the omo input hook injects the full directive as a hidden custom message (customType omo-ultrawork:directive, display false) ahead of the user's text, which is left untouched; a prompt queued while the agent is streaming instead carries the directive appended inside that same message. The directive is present in the conversation context; on the idle path it is not shown in the visible prompt, while a queued prompt carries the directive visibly (exactly as before this change). When the directive is already present in the conversation, do not read this file again - this file is that same directive. Read this file only when ultrawork mode is requested and the directive is not already present in the conversation.
+description: "The binding ultrawork-mode directive. This file IS the directive; read it only when ultrawork mode is requested and the directive is not already in the conversation."
 metadata:
   short-description: Binding ultrawork mode directive
 ---

--- a/packages/omo-senpi/skills/ulw-loop/SKILL.md
+++ b/packages/omo-senpi/skills/ulw-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-loop
-description: Goal-like loop that uses ultrawork mode to decompose work into systematic, evidence-bound steps.
+description: "A goal-like loop that decomposes work into systematic, evidence-bound ultrawork steps. Use when the user wants a goal loop or durable, checkpointed execution."
 metadata:
   short-description: Goal-like ultrawork loop for systematic decomposition
 ---

--- a/packages/omo-senpi/skills/ulw-plan/SKILL.md
+++ b/packages/omo-senpi/skills/ulw-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-plan
-description: "ACTIVATES ONLY on an explicit user request for the ulw-plan workflow: the user themselves saying ulw-plan, ulw plan, /skill:ulw-plan, or asking in their own words for a work plan before coding. NEVER self-activates: a bare ulw/ultrawork run, an agent-side routing decision, or reading this file is not a request, and the plan-gated reviewers (metis/momus) stay locked without a user request plus a written .omo/plans plan file. Explore-first planning consultant (Prometheus) that grounds in the codebase, asks only the forks exploration cannot resolve - or researches them to best practice when the intent is fuzzy - waits for explicit approval, then writes ONE decision-complete work plan a worker executes with zero further interview. Triggers: ulw-plan, ulw plan, plan this, make a plan, plan before coding, interview me, break this down, start planning, plan mode."
+description: "Explore-first planning consultant that writes one decision-complete work plan before coding. Use only on an explicit user request for the ulw-plan workflow or a plan before implementation; it never self-activates on a bare ulw run."
 metadata:
   short-description: Explore-first planning consultant that waits for your okay before planning
 ---

--- a/packages/omo-senpi/skills/ulw-research/SKILL.md
+++ b/packages/omo-senpi/skills/ulw-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-research
-description: "Team-first maximum-saturation research orchestration. ALWAYS asks which final format to render (PDF+DOCX default), then stands up a max-size cooperating team (team_create): one member per axis plus skeptic/red-team members for ultradebate/hyperdebate cross-critique, explore/librarian lanes, live journaling, an EXPAND loop until leads run dry, claims proven by code or the claim-graph gate, and a cited synthesis with charts/Mermaid/assets behind visual-QA and `writing` proofread gates. ACTIVATES ONLY on an explicit user demand for research: the word 'ulw-research' in any prefix form, any 'ulw' research wording including combined invocations like 'mass ulw research', 'ultradebate' or 'hyperdebate' research requests, or an explicit request for research / deep research / an ultra-precise investigation, in any language. Never self-activates for ordinary questions, debugging, or implementation context-gathering. While active it overrides exploration-bounding defaults: exhaustive coverage is the goal."
+description: "Runs maximum-saturation research with a cooperating team, claim-graph gating, and a cited, QA'd deliverable. Use when the user explicitly asks for research or a deep investigation, including any 'ulw' research wording."
 metadata:
   short-description: Team-default saturation research with debate cross-critique and cited synthesis
 ---

--- a/packages/shared-skills/skills/ast-grep/SKILL.md
+++ b/packages/shared-skills/skills/ast-grep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ast-grep
-description: "Use ast-grep (sg) for AST-aware code search and rewrite across 25 languages. Trigger for structural code matching or deterministic codemods: find every function/call/class/import shaped like X, rewrite console.log to logger.info, strip `as any`, migrate require() to import, find empty catch blocks or missing await, and scan/apply YAML rules. Prefer this over rg/grep when the target is syntax shape rather than text; use rg for string contents, comments, filenames, or regex-style byte searches."
+description: "Searches and rewrites code by AST shape across 25 languages. Use when the target is a syntax pattern (every call/class/import shaped like X, a codemod, a YAML rule) rather than literal text; for plain strings, comments, or filenames, use rg."
 ---
 
 # ast-grep

--- a/packages/shared-skills/skills/coding-agent-sessions/SKILL.md
+++ b/packages/shared-skills/skills/coding-agent-sessions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-agent-sessions
-description: "MUST USE when asked to find, read, list, search, inspect, fetch, export, or reconstruct coding-agent sessions across Codex, Claude Code/Desktop, OpenCode, OMO/Senpi/pi, oh-my-pi (omp), gajae-code (gjc), OpenClaw, Factory Droid, Amp, Gemini/Kimi/Qwen CLIs, Codebuff, Roo/Kilo/Cline, Kodu, Cursor CLI, Aider, Aside browser-agent sessions, or unknown local agent logs. Covers transcripts, session IDs, rollout JSONL, state SQLite, Claude projects/pre-compact histories, OpenCode messages/parts, child/subagent linkage, cwd/model/time/token filters, archives, and cost clues. Expands fuzzy recall into parallel query lanes and first probes known stores so absent platforms are skipped cheaply. Triggers: coding agent sessions, Codex/Claude/OpenCode/OMO/Senpi/pi/oh-my-pi/omp/gajae-code/gjc/OpenClaw/Droid/Amp/Kodu/Cursor/Aider/Aside sessions, transcript search, session history, session ID, read transcript, token usage, subagent sessions, what did I do yesterday, did we already do this."
+description: "Finds, reads, and reconstructs coding-agent sessions across Codex, Claude, OpenCode, OMO/Senpi, and other local agent logs. Use when asked to find or search past sessions, transcripts, or subagent runs, or to recover what an earlier session did."
 ---
 
 # Coding Agent Sessions

--- a/packages/shared-skills/skills/data-scientist/SKILL.md
+++ b/packages/shared-skills/skills/data-scientist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-scientist
-description: "Expert data processing with a hybrid engine strategy: resident-kernel engines first - DuckDB plus a resident Python stack (Polars/numpy/matplotlib) in persistent js/py eval kernels where the harness has them, bun/uv one-shots elsewhere - and per-action placement judgment (in-memory vs streaming vs remote-in-place). Triggers: 'analyze the data', 'what is in this CSV/parquet/json', 'summarize this', 'group by', 'filter rows', 'sort by', 'join these files', 'merge datasets', 'time series trend', 'compare yesterday and today', 'distribution/histogram', 'correlation', 'clean duplicates', 'handle missing values', 'dataset larger than RAM', 'SQL query on files', 'DataFrame operations', 'chart/plot this data', DuckDB vs Polars selection, quick data exploration CLI. NOT for plain text/code inspection, configs, or tiny inline math."
+description: "Processes and analyzes data with resident-kernel engines (DuckDB, Polars) and one-shot tools. Use for CSV/parquet/JSON analysis, group-by/join/aggregation, time series, distributions, cleaning, or plotting a dataset."
 ---
 
 # Data Scientist: Hybrid-Engine Data Processing

--- a/packages/shared-skills/skills/debugging/SKILL.md
+++ b/packages/shared-skills/skills/debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging
-description: "MUST USE for any real runtime debugging across ANY language or binary — crashes, silent failures, wrong responses, stuck processes, memory leaks, async misbehavior, unexplained timing, reverse engineering. Runs a hypothesis-driven loop: form ≥3 hypotheses, investigate in parallel, after 2 failed rounds spawn Oracles from orthogonal angles, confirm root cause, lock with a failing test, fix minimally, QA by actually USING the system, scrub artifacts. The actual HOW lives in `references/` — READ THEM. Triggers: 'debug this', 'why is X not working', 'hanging', 'attach a debugger', 'reverse engineer', 'pwndbg', 'gdb', 'lldb', 'node inspect', 'pdb', 'dlv', 'delve', 'rust-gdb', 'set a breakpoint', 'context window exploded', 'why is the response empty', 'why is this happening', 'trace this bug', 'reproduce and fix', 'silent failure', 'HTTP 200 but empty', 'why did it stop', 'inspect the binary', 'playwright', 'flaky test', 'fails intermittently', 'passes in isolation', 'only fails in CI'."
+description: "Runs a hypothesis-driven debugging loop across any language or binary, escalating to orthogonal oracle angles and locking the fix with a failing test. Use for crashes, silent failures, hangs, wrong responses, memory leaks, async misbehavior, or reverse engineering."
 ---
 
 # Debugging

--- a/packages/shared-skills/skills/frontend/SKILL.md
+++ b/packages/shared-skills/skills/frontend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend
-description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff; plus curl-only lazyweb real-app-screen research and the beui.dev interaction catalog. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, interaction, micro-interaction, make it feel alive, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand, lazyweb, design research."
+description: "Builds, styles, and polishes web UI and UX. Use for any frontend, page, component, styling, layout, animation, or visual-quality task, or when asked to make an interface look or feel a certain way."
 ---
 
 # Frontend

--- a/packages/shared-skills/skills/git-master/SKILL.md
+++ b/packages/shared-skills/skills/git-master/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-master
-description: "MUST USE whenever a task needs a commit or git-history investigation. Covers atomic commits, staging, commit-message style, rebase, squash, fixup/autosquash, blame, bisect, reflog, git log -S/-G, and questions like who wrote this or when was this added. Do not use for ordinary code edits unless the user asks for git work."
+description: "Handles git work: atomic commits, rebase, squash, blame, bisect, reflog, and history questions. Use whenever a task needs a commit or a git-history investigation; skip for ordinary code edits."
 ---
 
 # Git Master

--- a/packages/shared-skills/skills/init-deep/SKILL.md
+++ b/packages/shared-skills/skills/init-deep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: init-deep
-description: "(builtin) Initialize hierarchical AGENTS.md knowledge base"
+description: "Initializes a hierarchical AGENTS.md knowledge base for a project. Use when a repo needs its structure, commands, and conventions documented for agents."
 ---
 # /init-deep
 

--- a/packages/shared-skills/skills/lsp-setup/SKILL.md
+++ b/packages/shared-skills/skills/lsp-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lsp-setup
-description: "Configure a Language Server (LSP) for a specific language so editor/agent tooling — diagnostics, go-to-definition, find-references, rename — works. Use when you need to: configure LSP, lsp setup, set up or install a language server, fix 'no LSP server configured' / 'server not installed', choose between servers (basedpyright vs pyright vs ty vs ruff), or wire .codex/lsp-client.json / .opencode/lsp.json. 언어서버 설정. Routes by file extension to references/<language>/README.md for the exact builtin server, per-OS install commands (macOS/Linux/Windows), config snippets for both config files, initialization options, alternatives, and troubleshooting. Ships scripts: detect-lsp.ts (scan a project for languages + each server's install/config status) and verify-lsp.ts (run a real diagnostics roundtrip). Covers typescript, python, go, rust, c/c++, java, kotlin, c#/razor, swift, ruby, php, dart, elixir, zig, lua, bash, yaml, terraform, haskell, julia."
+description: "Configures a language server so editor/agent tooling (diagnostics, go-to-definition, references, rename) works. Use when a project needs an LSP installed or wired, or a 'no LSP server configured' error appears."
 ---
 
 # LSP Setup

--- a/packages/shared-skills/skills/programming/SKILL.md
+++ b/packages/shared-skills/skills/programming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: programming
-description: "MUST USE for ANY work on .py .pyi .rs .ts .tsx .mts .cts .go files. One philosophy: strict types, modern stacks (Pydantic v2 / serde+thiserror / Zod / gin+sqlc+pgx+slog), modern toolchains (uv+basedpyright+ruff / cargo+clippy+miri / Bun+Biome+tsc / gofumpt+golangci-lint v2+nilaway+go-race), parse-don't-validate, exhaustive match, typed errors, no any/unwrap/panic, 250 LOC ceiling, TDD, consumer-routed logging. Routes to references/{python,rust,typescript,rust-ub,go}/ + references/logging.md. Triggers: write/edit Python/Rust/TypeScript/Go code, new project, gin server, bubbletea TUI, CJK IME, connect-go RPC, sqlc pgx, branded ids, exhaustive match, unsafe Rust, miri, oversized file, refactor, TDD, e2e test, logging, log levels, structured logging, observability, arena, allocator, bumpalo, const fn, const generics, comptime, zero-alloc, bitfield, repr, scopeguard, errdefer, Zig-like, zerocopy, packed struct."
+description: "Applies strict, modern language practice (typed errors, exhaustive match, TDD) for Python, Rust, TypeScript, and Go. Use for work on .py, .rs, .ts, or .go files."
 ---
 
 # Programming

--- a/packages/shared-skills/skills/refactor/SKILL.md
+++ b/packages/shared-skills/skills/refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-description: "Intelligent refactor command. Triggers: refactor, refactoring, cleanup, restructure, extract, simplify, modernize."
+description: "Guides a refactor, cleanup, or restructure with the right decomposition. Use when the user asks to refactor, simplify, extract, or modernize code."
 ---
 
 export const REFACTOR_TEMPLATE = `# Intelligent Refactor Command

--- a/packages/shared-skills/skills/remove-ai-slops/SKILL.md
+++ b/packages/shared-skills/skills/remove-ai-slops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remove-ai-slops
-description: "Remove AI-generated code smells (slop) from branch changes or an explicit file list. Locks behavior with regression tests FIRST, then runs categorized cleanup via parallel `deep` agents in batches of 5, then verifies with quality gates. Covers 10 slop categories including performance equivalences, excessive complexity (object annotations, if/elif variant chains), and oversized modules (250+ pure LOC with mandatory modular refactoring). MUST USE when the user asks to \"remove slop\", \"clean AI code\", \"deslop\", \"clean up AI-generated code\", \"remove AI slop\", or wants to clean up AI-generated patterns from recent changes. Triggers - \"remove ai slops\", \"clean ai code\", \"deslop\", \"cleanup AI generated\", \"remove AI slop\", \"clean up AI-generated code\", \"strip slop\", \"ai-slop cleanup\"."
+description: "Removes AI-generated code smells from branch changes or an explicit file list behind regression tests. Use when the user asks to clean up, deslop, or remove AI-slop patterns from recent changes."
 ---
 
 # Remove AI Slops Skill

--- a/packages/shared-skills/skills/review-work/SKILL.md
+++ b/packages/shared-skills/skills/review-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-work
-description: "Reviews completed work from five angles (goal, code quality, security, QA execution, context) before handoff. Use before a PR handoff or when the user asks to review or verify changes."
+description: "Post-implementation gate review: run manual QA on the real surface yourself, then launch ONE gate reviewer (never a panel) to audit goal, constraints, code quality, security, missed context, and QA evidence. Use before a PR handoff or when the user explicitly asks to review completed work."
 ---
 ## Codex Harness Tool Compatibility
 

--- a/packages/shared-skills/skills/review-work/SKILL.md
+++ b/packages/shared-skills/skills/review-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-work
-description: "Post-implementation gate review. You run manual QA on the real surface yourself, then launch ONE gate reviewer sub-agent (oracle on OpenCode; the surface's gate-reviewer agent elsewhere) that audits goal, constraints, correctness, code quality, security, missed context, and your QA evidence. Passes only on a clean QA matrix plus APPROVE - one reviewer, never a panel. MUST USE before a PR handoff or when the user explicitly asks to review completed work. Triggers: 'review work', 'review my work', 'review changes', 'QA my work', 'verify implementation', 'check my work', 'validate changes', 'post-implementation review'."
+description: "Reviews completed work from five angles (goal, code quality, security, QA execution, context) before handoff. Use before a PR handoff or when the user asks to review or verify changes."
 ---
 ## Codex Harness Tool Compatibility
 

--- a/packages/shared-skills/skills/ultimate-browsing/SKILL.md
+++ b/packages/shared-skills/skills/ultimate-browsing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ultimate-browsing
-description: "Escalation skill for blocked or hard-to-reach web access — load it when a normal browse/fetch is blocked (WAF, 403, Cloudflare, JS-only render, login-gated, or a platform a generic fetcher cannot read). Tiered router: TIER 1 insane-search (headless extraction + WAF bypass via curl_cffi TLS impersonation, yt-dlp, Jina Reader, public APIs, Playwright real-Chrome fallback); TIER 1.5 agent-reach (platform-native readers for Chinese and social platforms: Xiaohongshu, Douyin, Weibo, Bilibili, V2EX, WeChat, plus Twitter/Reddit/LinkedIn/GitHub); TIER 2 Chrome stealth (CloakBrowser stealth Chromium + agent-browser CDP for clicks, forms, screenshots, video, cookie login). Triggers: blocked site, bypass bot detection, cloudflare/WAF bypass, scrape, stealth browser, import cookies, fill form, screenshot, play youtube, xiaohongshu, douyin, weibo, bilibili, v2ex, wechat article, podcast transcript. NOT for simple searches (use web-search) or plain fetches (use webfetch)."
+description: "Escalates blocked or hard-to-reach web access through WAF bypass, platform-native readers, and stealth Chrome. Use when a normal browse or fetch is blocked, login-gated, JS-only, or a platform a generic fetcher cannot read."
 ---
 
 # Ultimate Browsing

--- a/packages/shared-skills/skills/ulw-execute/SKILL.md
+++ b/packages/shared-skills/skills/ulw-execute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-execute
-description: "Execute a Prometheus work plan with Boulder state, evidence ledger updates, worktree discipline, parallel subagents, and Stop-hook continuation. Use after planning when the user says ulw-execute, execute plan, continue plan, resume plan, or asks to run a .omo/plans plan."
+description: "Executes a written Prometheus work plan with Boulder state, evidence ledger, worktree discipline, and parallel subagents. Use when the user says ulw-execute or asks to run a .omo/plans plan."
 ---
 
 ## ABSOLUTE RULE: YOU ARE AN ORCHESTRATOR — NEVER THE IMPLEMENTER

--- a/packages/shared-skills/skills/ulw-plan/SKILL.md
+++ b/packages/shared-skills/skills/ulw-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-plan
-description: "ACTIVATES ONLY on an explicit user request for the ulw-plan workflow: the user themselves saying ulw-plan, ulw plan, /skill:ulw-plan, or asking in their own words for a work plan before coding. NEVER self-activates: a bare ulw/ultrawork run, an agent-side routing decision, or reading this file is not a request, and the plan-gated reviewers (metis/momus) stay locked without a user request plus a written .omo/plans plan file. Explore-first planning consultant (Prometheus) that grounds in the codebase, asks only the forks exploration cannot resolve - or researches them to best practice when the intent is fuzzy - waits for explicit approval, then writes ONE decision-complete work plan a worker executes with zero further interview. Triggers: ulw-plan, ulw plan, plan this, make a plan, plan before coding, interview me, break this down, start planning, plan mode."
+description: "Explore-first planning consultant that writes one decision-complete work plan before coding. Use only on an explicit user request for the ulw-plan workflow or a plan before implementation; it never self-activates on a bare ulw run."
 metadata:
   short-description: Explore-first planning consultant that waits for your okay before planning
 ---

--- a/packages/shared-skills/skills/ulw-research/SKILL.md
+++ b/packages/shared-skills/skills/ulw-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ulw-research
-description: "Maximum-saturation research orchestration: ALWAYS proposes the final materials first (PDF+DOCX default), then parallel explore+librarian swarms across codebase, web, official docs, and OSS repos — max-roster teammode when the harness has it — with live journaling, a recursive EXPAND loop driven by leads workers return in message text, empirical verification by running code, and a cited synthesis with charts/Mermaid/assets behind a mandatory visual-QA gate. ACTIVATES ONLY on an explicit user demand for research — the word 'ulw-research' in any prefix form, any 'ulw' research wording including combined invocations like 'mass ulw research', 'ultradebate' or 'hyperdebate' research requests, or an explicit request for research / deep research / an ultra-precise investigation, in any language. Never self-activates for ordinary questions, debugging, or implementation context-gathering. While active it overrides exploration-bounding defaults: exhaustive coverage is the goal."
+description: "Runs maximum-saturation research with a cooperating team, claim-graph gating, and a cited, QA'd deliverable. Use when the user explicitly asks for research or a deep investigation, including any 'ulw' research wording."
 ---
 
 ## Codex Harness Tool Compatibility

--- a/packages/shared-skills/skills/visual-qa/SKILL.md
+++ b/packages/shared-skills/skills/visual-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-qa
-description: "MUST USE after building/changing any UI or when asked whether a page, component, or TUI looks right. Rigorous visual QA across web/page, terminal, and paginated-document surfaces. Prefer browser:control-in-app-browser for unauthenticated browser/page QA in Codex, then Playwright/agent-browser/dev-browser. Captures screenshot/TUI evidence with bundled diff scripts, runs design-system/functional and visual-fidelity/CJK reviewer passes, then synthesizes a good/bad verdict. Triggers: visual QA, screenshot/pixel diff, UI looks wrong, reference fidelity, design system check, responsive check, CJK text clipping, TUI alignment, box-drawing drift, PDF page check, deck review, blank or near-empty page, wrong page break."
+description: "Runs rigorous visual QA across web, terminal, and paginated surfaces with screenshot evidence and a verdict. Use for any UI build or change, or when asked whether a page, component, or TUI looks right."
 ---
 
 # Visual QA - Dual-Oracle Web and TUI Verification

--- a/packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md
+++ b/packages/skills-loader-core/src/features/builtin-skills/frontend/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend
-description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff; plus curl-only lazyweb real-app-screen research and the beui.dev interaction catalog. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, interaction, micro-interaction, make it feel alive, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand, lazyweb, design research."
+description: "Builds, styles, and polishes web UI and UX. Use for any frontend, page, component, styling, layout, animation, or visual-quality task, or when asked to make an interface look or feel a certain way."
 ---
 
 # Frontend

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/debugging.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/debugging.ts
@@ -4,6 +4,6 @@ import type { BuiltinSkill } from "../types"
 export const debuggingSkill: BuiltinSkill = {
 	name: "debugging",
 	description:
-		"MUST USE for any real runtime debugging across ANY language or binary — crashes, silent failures, wrong responses, stuck processes, memory leaks, async misbehavior, unexplained timing, reverse engineering. Runs a hypothesis-driven loop: form ≥3 hypotheses, investigate in parallel, after 2 failed rounds spawn Oracles from orthogonal angles, confirm root cause, lock with a failing test, fix minimally, QA by actually USING the system, scrub artifacts. The actual HOW lives in `references/` — READ THEM. Triggers: 'debug this', 'why is X not working', 'hanging', 'attach a debugger', 'reverse engineer', 'pwndbg', 'gdb', 'lldb', 'node inspect', 'pdb', 'dlv', 'delve', 'rust-gdb', 'set a breakpoint', 'context window exploded', 'why is the response empty', 'why is this happening', 'trace this bug', 'reproduce and fix', 'silent failure', 'HTTP 200 but empty', 'why did it stop', 'inspect the binary', 'playwright', 'flaky test', 'fails intermittently', 'passes in isolation', 'only fails in CI'.",
+		"Runs a hypothesis-driven debugging loop across any language or binary, escalating to orthogonal oracle angles and locking the fix with a failing test. Use for crashes, silent failures, hangs, wrong responses, memory leaks, async misbehavior, or reverse engineering.",
 	template: loadSharedSkillTemplate("debugging"),
 }

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/frontend.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/frontend.ts
@@ -3,6 +3,6 @@ import type { BuiltinSkill } from "../types"
 
 export const frontendSkill: BuiltinSkill = {
 	name: "frontend",
-	description: "MUST USE for frontend/web UI/UX/visual work: building, styling, redesigning pages/components, React setup, performance audits, visual QA, taste, and polish. Routes four rulesets: design taste router and brand references; perfection for Playwright/Chromium Lighthouse/Core Web Vitals; ui-ux-db palettes/fonts/guidelines; designpowers personas/accessibility/critique/handoff; plus curl-only lazyweb real-app-screen research and the beui.dev interaction catalog. Triggers: frontend, UI, UX, design, redesign, styling, layout, animation, motion, interaction, micro-interaction, make it feel alive, premium, luxury, minimal, brutalist, Awwwards, DESIGN.md, mockup, React, Lighthouse, accessibility, WCAG, Core Web Vitals, looks generic, make it pretty, like X brand, lazyweb, design research.",
+	description: "Builds, styles, and polishes web UI and UX. Use for any frontend, page, component, styling, layout, animation, or visual-quality task, or when asked to make an interface look or feel a certain way.",
 	template: loadSharedSkillTemplate("frontend"),
 }

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/init-deep.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/init-deep.ts
@@ -3,7 +3,7 @@ import type { BuiltinSkill } from "../types"
 
 export const initDeepSkill: BuiltinSkill = {
 	name: "init-deep",
-	description: "(builtin) Initialize hierarchical AGENTS.md knowledge base",
+	description: "Initializes a hierarchical AGENTS.md knowledge base for a project. Use when a repo needs its structure, commands, and conventions documented for agents.",
 	template: loadSharedSkillTemplate("init-deep"),
 	argumentHint: "[--create-new] [--max-depth=N]",
 }

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/remove-ai-slops.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/remove-ai-slops.ts
@@ -4,6 +4,6 @@ import type { BuiltinSkill } from "../types"
 export const removeAiSlopsSkill: BuiltinSkill = {
 	name: "remove-ai-slops",
 	description:
-		'Remove AI-generated code smells (slop) from branch changes or an explicit file list. Locks behavior with regression tests FIRST, then runs categorized cleanup via parallel `deep` agents in batches of 5, then verifies with quality gates. Covers 10 slop categories including performance equivalences, excessive complexity (object annotations, if/elif variant chains), and oversized modules (250+ pure LOC with mandatory modular refactoring). MUST USE when the user asks to "remove slop", "clean AI code", "deslop", "clean up AI-generated code", "remove AI slop", or wants to clean up AI-generated patterns from recent changes. Triggers - "remove ai slops", "clean ai code", "deslop", "cleanup AI generated", "remove AI slop", "clean up AI-generated code", "strip slop", "ai-slop cleanup".',
+		"Removes AI-generated code smells from branch changes or an explicit file list behind regression tests. Use when the user asks to clean up, deslop, or remove AI-slop patterns from recent changes.",
 	template: loadSharedSkillTemplate("remove-ai-slops"),
 }

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/review-work.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/review-work.ts
@@ -4,6 +4,6 @@ import type { BuiltinSkill } from "../types"
 export const reviewWorkSkill: BuiltinSkill = {
 	name: "review-work",
 	description:
-		"Post-implementation gate review. You run manual QA on the real surface yourself, then launch ONE gate reviewer sub-agent (oracle on OpenCode; the surface's gate-reviewer agent elsewhere) that audits goal, constraints, correctness, code quality, security, missed context, and your QA evidence. Passes only on a clean QA matrix plus APPROVE - one reviewer, never a panel. MUST USE before a PR handoff or when the user explicitly asks to review completed work. Triggers: 'review work', 'review my work', 'review changes', 'QA my work', 'verify implementation', 'check my work', 'validate changes', 'post-implementation review'.",
+		"Post-implementation gate review: run manual QA on the real surface yourself, then launch ONE gate reviewer (never a panel) to audit goal, constraints, code quality, security, missed context, and QA evidence. Use before a PR handoff or when the user explicitly asks to review completed work.",
 	template: loadSharedSkillTemplate("review-work"),
 }

--- a/packages/skills-loader-core/src/features/builtin-skills/skills/visual-qa.ts
+++ b/packages/skills-loader-core/src/features/builtin-skills/skills/visual-qa.ts
@@ -4,6 +4,6 @@ import type { BuiltinSkill } from "../types"
 export const visualQaSkill: BuiltinSkill = {
 	name: "visual-qa",
 	description:
-		"MUST USE after building/changing any UI or when asked whether a page, component, or TUI looks right. Rigorous visual QA across web/page, terminal, and paginated-document surfaces. Prefer browser:control-in-app-browser for unauthenticated browser/page QA in Codex, then Playwright/agent-browser/dev-browser. Captures screenshot/TUI evidence with bundled diff scripts, runs design-system/functional and visual-fidelity/CJK reviewer passes, then synthesizes a good/bad verdict. Triggers: visual QA, screenshot/pixel diff, UI looks wrong, reference fidelity, design system check, responsive check, CJK text clipping, TUI alignment, box-drawing drift, PDF page check, deck review, blank or near-empty page, wrong page break.",
+		"Runs rigorous visual QA across web, terminal, and paginated surfaces with screenshot evidence and a verdict. Use for any UI build or change, or when asked whether a page, component, or TUI looks right.",
 	template: loadSharedSkillTemplate("visual-qa"),
 }


### PR DESCRIPTION
## Summary

Every shipped skill description was a `MUST USE` + `Triggers:` keyword wall — **3,432 o200k tokens across 24 skills**, 19 of them over 60 tokens, 3 carrying Hangul. The description's only job is to decide whether the model opens the file, so each is now one to three English sentences: what the skill does, and the SITUATION that selects it, with a boundary sentence only where two skills genuinely overlap (ast-grep vs rg, git-master vs ordinary edits, ulw-plan's no-self-activation rule).

Edited at the real homes — `packages/shared-skills/skills` (17), `packages/omo-senpi/skills` (10 native, including the `init-deep` / `ulw-plan` / `ulw-research` overrides) and the `omo-codex` `ulw-loop` copy — then `sync-skills.mjs` regenerated `packages/omo-senpi/plugin/skills`. Bodies untouched: every file is exactly `1 insertion(+), 1 deletion(-)`.

Part of the prompt-token diet (senpi #1345 dedup, #1348 eval diet, #1349 skills alias, #1351 schedule_wakeup deferral; omo #7737 tasklist tools -> tool_search, #7738 task/memory diets).

## Measured (o200k, 24 shipped skills)

| | Before | After |
|---|---:|---:|
| description tokens | 3,432 | **1,048** (-2,384, **-69%**) |
| descriptions over 60 tokens | 19 | 0 |
| descriptions containing Hangul | 3 | 0 |

The companion `~/.agents/skills` root (121 personal skills) went 11,821 -> 4,652 in the same pass, so the whole skills section drops from 15,253 to 5,700 tokens.

## Verification

- `bun packages/omo-senpi/plugin/scripts/sync-skills.mjs` regenerates the plugin roster; checker script (English-only, <= 60 tokens, situation clause present, no trigger lists) reports ALL PASS on the synced output and on the personal root.
- `bun test packages/omo-senpi/src/skills-sync.test.ts packages/shared-skills` on mengmotaMac.
- Body-preservation proof: `git diff --numstat` is `1 1` for all 28 files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites all shipped skill descriptions from `MUST USE` + `Triggers:` keyword walls to short situation-led routing text, cutting description tokens from 3,432 to 1,048 (-69%) across 24 skills.

**Changes**
- Each description is now one to two English sentences: what the skill does and the situation that selects it.
- Boundary sentences remain only where skills genuinely overlap (ast-grep vs rg, git-master vs ordinary edits, `ulw-plan`'s no-self-activation rule).
- Removed all Hangul trigger lists; no description exceeds 60 tokens.
- The six extracted builtin skills (`remove-ai-slops`, `review-work`, `frontend`, `init-deep`, `debugging`, `visual-qa`) carry the same descriptions in their `.ts` sources so extraction tests stay byte-equal.
- Edited at the source homes (`packages/shared-skills/skills`, `packages/omo-senpi/skills`, `omo-codex` `ulw-loop`); `sync-skills.mjs` regenerated the plugin roster.

**Verification**
- Checker (English-only, ≤60 tokens, situation clause, no trigger lists) passes on the synced output and the personal root.
- Tests pass on skills sync and `packages/shared-skills`; the `omo-opencode` init-deep assertion now pins `initDeepSkill.description`.
- Every file changed by exactly one insertion and one deletion, proving bodies are untouched.

<sup>Written for commit 5b82c679f4d6c91a2e6b4610ba3516cbbe0be6c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

