### PR TITLE
fix(script,omo-native): close architect blockers in the omob pipeline

### DIFF
--- a/docs/reference/omob-dev-binary.md
+++ b/docs/reference/omob-dev-binary.md
@@ -7,7 +7,7 @@ end-to-end without cutting a release.
 
 ```bash
 bun run omob                       # latest origin/main + origin/dev
-bun run omob --senpi-ref origin/feat/x --omo-ref abc1234
+bun run omob --senpi-ref origin/feat/x --omo-ref abc1234   # omo refs must already contain the omob build-info support
 bun run omob --skip-install        # build only, into ~/.cache/omob/out
 ```
 

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -69,6 +69,12 @@ export function updateAssetSlug(platform: NodeJS.Platform, arch: string): string
   return platform === "win32" ? `${slug}.exe` : slug
 }
 
+/** A dev build is refreshed by rebuilding it; only release binaries come from the curl line. */
+export function updateHint(rawBuildInfo: unknown, platform: NodeJS.Platform = process.platform, arch: string = process.arch): string {
+  const info = parseBuildInfo(rawBuildInfo)
+  return info === undefined ? updateLine(platform, arch) : `rebuild with: bun run ${info.command}`
+}
+
 export function updateLine(platform: NodeJS.Platform, arch: string): string {
   const asset = updateAssetSlug(platform, arch)
   const dest = platform === "win32" ? "omo.exe" : "omo"
@@ -152,7 +158,7 @@ export function answerCompiledFastPath(args: string[], manifest: Pick<EmbeddedMa
     return true
   }
   if (isSelfUpdate(args)) {
-    console.log(updateLine(process.platform, process.arch))
+    console.log(updateHint(manifest.buildInfo))
     return true
   }
   return false
@@ -170,7 +176,7 @@ export function shouldPrintCompiledBanner(args: string[], stderrIsTTY: boolean):
 }
 
 export async function runCompiledLauncher(args: string[], execDir: string, enginePin = "unknown", compiledPackageRoot?: string): Promise<boolean> {
-  const packageJson = readJson(join(execDir, "package.json"))
+  const packageJson = readJson(join(execDir, "package.json")) as { version: string; omoBuild?: unknown }
   migrateLegacyBunGlobalManifest(execDir)
   adoptLegacyFlatState()
   const command = args[0]
@@ -183,7 +189,7 @@ export async function runCompiledLauncher(args: string[], execDir: string, engin
   }
   if (command === "setup") { printSetupReport(await detectHarnesses()); process.exitCode = 0; return true }
   if ((command === "--version" || command === "-v") && args.length === 1) { console.log(versionLine(packageJson, enginePin ?? "unknown")); return true }
-  if (isSelfUpdate(args)) { console.log(updateLine(process.platform, process.arch)); return true }
+  if (isSelfUpdate(args)) { console.log(updateHint(packageJson.omoBuild)); return true }
   return false
 }
 
@@ -226,8 +232,10 @@ async function main(): Promise<void> {
   // executable delegates to the engine in-process as required by the native startup contract.
   if (await runCompiledLauncher(process.argv.slice(2), execDir, manifest.enginePin, execDir)) return
   if (shouldPrintCompiledBanner(process.argv.slice(2), process.stderr.isTTY === true)) {
-    if (parseBuildInfo(manifest.buildInfo) !== undefined) {
-      console.error(`omob dev build (${manifest.omoAiVersion})`)
+    const bannerInfo = parseBuildInfo(manifest.buildInfo)
+    if (bannerInfo !== undefined) {
+      // Same provenance contract as --version and doctor: full SHAs, ISO commit dates, branches.
+      for (const line of versionLines(bannerInfo)) console.error(line)
     } else {
       console.error(`omo (omo-ai beta ${manifest.omoAiVersion})`)
     }

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -10,6 +10,7 @@ import {
   runCompiledLauncher,
   shouldPrintCompiledBanner,
   updateLine,
+  updateHint,
   versionLine,
 } from "../compile-entry"
 import { loadOpenAICodexOAuth } from "../../../node_modules/@code-yeongyu/senpi/node_modules/@earendil-works/pi-ai/dist/auth/oauth/load.js"
@@ -407,5 +408,40 @@ describe("omob branded build labels", () => {
     expect(brand.command).toBe("omob")
     expect(brand.displayVersion).toBe("omo@c6e7dd7 2026-09-04 10:17 +09:00 · senpi@7fd18df 2026-09-04 10:49 +09:00")
     expect(brand.update?.command).toContain("omob")
+  })
+})
+
+describe("omob provenance degrades sanely", () => {
+  const malformed = { command: "omob", omo: { commit: "not-a-sha", committedAt: "nope", branch: "" }, engine: {} }
+
+  test("remapSenpiEnvironment falls back to the plain version and omo command for malformed build info", () => {
+    const root = temp()
+    const execDir = join(root, "runtime")
+    mkdirSync(execDir, { recursive: true })
+    writeFileSync(join(execDir, "package.json"), JSON.stringify({ name: "omo", version: "5.0.0-beta.40", omoBuild: malformed }))
+
+    const env = remapSenpiEnvironment({}, execDir)
+    const brand = JSON.parse(env.SENPI_BRAND ?? "{}") as { command?: string; displayVersion?: string }
+
+    expect(brand.displayVersion).toBe("5.0.0-beta.40")
+    expect(brand.command).toBe("omo")
+  })
+
+  test("versionLine falls back to the release one-liner for malformed build info", () => {
+    expect(versionLine({ version: "5.0.0-beta.40", omoBuild: malformed }, "2026.9.4")).toBe(
+      "omo 5.0.0-beta.40 (engine: senpi 2026.9.4)",
+    )
+  })
+
+  test("updateHint tells dev builds to rebuild and release builds to curl", () => {
+    const info = {
+      command: "omob",
+      omo: { commit: "c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc", committedAt: "2026-09-04T10:17:49+09:00", branch: "dev" },
+      engine: { commit: "7fd18dfeec7a7db89a983b2c3cb90835b8c3c5f7", committedAt: "2026-09-04T10:49:12+09:00", branch: "main" },
+    }
+
+    expect(updateHint(info)).toBe("rebuild with: bun run omob")
+    expect(updateHint(malformed, "darwin", "arm64")).toBe(updateLine("darwin", "arm64"))
+    expect(updateHint(undefined, "darwin", "arm64")).toBe(updateLine("darwin", "arm64"))
   })
 })

--- a/script/build-omo-binary.test.ts
+++ b/script/build-omo-binary.test.ts
@@ -480,4 +480,16 @@ describe("omob build info stamping", () => {
     expect(stamped.buildInfo).toEqual(buildInfo)
     expect(stamped.manifestSha).not.toBe(bare.manifestSha)
   })
+
+  test("#given no build info #when the runtime manifest is built #then its key order matches the release contract", async () => {
+    const stageDir = makeTempDir("omo-manifest-keyorder-")
+    mkdirSync(join(stageDir, "theme"), { recursive: true })
+    writeFileSync(join(stageDir, "theme", "dark.json"), "{}\n")
+
+    const bare = await buildRuntimeManifest(stageDir, { omoAiVersion: "1.2.3", enginePin: "2026.8.24" })
+
+    // release manifest key order — a reordering would change the embedded JSON bytes
+    expect(Object.keys(bare)).toEqual(["omoAiVersion", "enginePin", "manifestSha", "entries"])
+    expect("buildInfo" in bare).toBe(false)
+  })
 })

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -49,7 +49,6 @@ export function parseOmobArgs(argv: readonly string[], platform: string, arch: s
 		const value = argv[index + 1]
 		if (argument === "--senpi-ref" || argument === "--omo-ref" || argument === "--cache-dir" || argument === "--install-dir" || argument === "--name" || argument === "--target" || argument === "--senpi-url") {
 			if (value === undefined) throw new Error(`${argument} requires a value`)
-			const key = argument.slice(2).replaceAll("-", "") as "senpiRef" | "omoRef" | "cacheDir" | "installDir" | "name" | "target"
 			const normalizedKey = argument === "--senpi-ref" ? "senpiRef" : argument === "--omo-ref" ? "omoRef" : argument === "--cache-dir" ? "cacheDir" : argument === "--install-dir" ? "installDir" : argument === "--name" ? "name" : argument === "--senpi-url" ? "senpiUrl" : "target"
 			;(options as Record<string, unknown>)[normalizedKey] = value
 			index += 1
@@ -137,14 +136,15 @@ function ensureCacheClone(url: string, directory: string, ref: string, skipFetch
 		const fetchArgs = ref.startsWith("origin/") ? ["--prune", "origin", ref.slice("origin/".length)] : ["--prune", "origin"]
 		run("git", ["fetch", ...fetchArgs], directory)
 	}
-	// A cache checkout must land on the exact ref tree: force-reset and drop
-	// any leftovers from a previous ref (staged swaps, ignored build outputs).
-	run("git", ["submodule", "update", "--init", "--recursive"], directory)
+	// A cache checkout must land on the exact ref tree: drop leftovers from a previous
+	// ref (tracked deletions, staged swaps). `clean -ffd` deliberately omits `-x`, so
+	// ignored build outputs and node_modules survive for cache reuse.
 	run("git", ["clean", "-ffd"], directory)
-	// Re-point submodules at the switched ref and drop any stale checked-out state.
-	run("git", ["submodule", "update", "--init", "--recursive"], directory)
 	run("git", ["checkout", "--force", ref], directory)
 	run("git", ["reset", "--hard", ref], directory)
+	// checkout/reset do not recurse, so submodule pointers only match the ref AFTER it
+	// lands; omo materializes plugin skills from these upstreams during its build.
+	run("git", ["submodule", "update", "--init", "--recursive", "--force"], directory)
 	const commit = runCaptured("git", ["rev-parse", "HEAD"], directory)
 	return { directory, commit }
 }
@@ -163,17 +163,24 @@ function readCommitInfo(directory: string, ref: string): CommitInfo {
 	return { commit, committedAt, branch }
 }
 
-function buildSenpiPackage(senpiDir: string, cacheDir: string, ref: string): string {
+function buildSenpiPackage(senpiDir: string, cacheDir: string): string {
 	run("bun", ["install"], senpiDir)
 	materializeNestedLockDeps(senpiDir)
 	run("bun", ["run", "build:bun"], senpiDir)
 	// Stage the bundled workspaces exactly like the release pipeline, then pack.
 	run("node", [join("scripts", "prepare-senpi-bundled-workspaces.mjs")], senpiDir)
+	// The tarball name carries senpi's package version, so a version bump would leave
+	// two candidates in a reused cache and an arbitrary pick would install the OLD
+	// engine under the NEW provenance stamp. Start from an empty directory every time.
 	const tarballDir = join(cacheDir, "tarballs")
+	rmSync(tarballDir, { recursive: true, force: true })
 	mkdirSync(tarballDir, { recursive: true })
 	run("bun", ["pm", "pack", "--destination", tarballDir], join(senpiDir, "packages", "coding-agent"))
-	const tarballName = readdirSync(tarballDir).find((name) => name.endsWith(".tgz"))
-	if (tarballName === undefined) throw new Error("bun pm pack produced no senpi tarball")
+	const tarballs = readdirSync(tarballDir).filter((name) => name.endsWith(".tgz"))
+	if (tarballs.length !== 1) {
+		throw new Error(`expected exactly one senpi tarball in ${tarballDir}, found ${tarballs.length}: ${tarballs.join(", ")}`)
+	}
+	const tarballName = tarballs[0] as string
 	// Isolated production install: the tarball plus its registry deps, resolved under
 	// a dedicated root so the resulting tree can be dropped into omo's node_modules.
 	const installRoot = join(cacheDir, "senpi-install")
@@ -226,6 +233,18 @@ function nestHoistedDeps(installRoot: string): void {
 	mkdirSync(senpiNodeModules, { recursive: true })
 	for (const entry of readdirSync(topLevel)) {
 		if (entry.startsWith(".") || entry === "@code-yeongyu") continue
+		// A scope directory may already exist under the package from bundling; moving the
+		// whole scope would silently drop its hoisted siblings, so merge child by child.
+		if (entry.startsWith("@")) {
+			const scopeTarget = join(senpiNodeModules, entry)
+			mkdirSync(scopeTarget, { recursive: true })
+			for (const child of readdirSync(join(topLevel, entry))) {
+				const childTarget = join(scopeTarget, child)
+				if (existsSync(childTarget)) continue
+				renameSync(join(topLevel, entry, child), childTarget)
+			}
+			continue
+		}
 		const from = join(topLevel, entry)
 		const to = join(senpiNodeModules, entry)
 		if (existsSync(to)) continue
@@ -280,7 +299,7 @@ const senpiUrl = options.senpiUrl ?? DEFAULT_SENPI_URL
 		engine: { commit: senpiInfo.commit, committedAt: senpiInfo.committedAt, branch: senpiInfo.branch },
 	}
 
-	const builtSenpiRoot = buildSenpiPackage(senpi.directory, options.cacheDir, options.senpiRef)
+	const builtSenpiRoot = buildSenpiPackage(senpi.directory, options.cacheDir)
 	// The omo prepare chain materializes gitignored plugin/skills from the shared-skills
 	// upstream submodules; a caller's OMO_SKIP_MATERIALIZE=1 would skip that and break the
 	// build, so the dev-binary install always runs the full materialization.
@@ -323,7 +342,9 @@ const senpiUrl = options.senpiUrl ?? DEFAULT_SENPI_URL
 		const installed = installBinary(result.binaryPath, options.installDir, options.name)
 		console.log(`installed ${installed} (${result.size} bytes)`)
 	}
-	pruneOmobRuntimes(options.keep, omoAiVersion)
+	// Pruning is only safe once the new binary is in place: a --skip-install run would
+	// otherwise delete the runtime a still-installed (possibly running) omob depends on.
+	if (!options.skipInstall) pruneOmobRuntimes(options.keep, omoAiVersion)
 	const lines = [buildInfo.command + " dev build", `omo   ${omoInfo.commit} ${omoInfo.committedAt} (${omoInfo.branch})`, `senpi ${senpiInfo.commit} ${senpiInfo.committedAt} (${senpiInfo.branch})`]
 	console.log(lines.join("\n"))
 	return 0


### PR DESCRIPTION
## Summary
Closes the three blockers an architecture review raised against #7740, plus the cheap notes from the same review.

### Blockers
- **Stale tarball could ship the wrong engine under fresh provenance.** `buildSenpiPackage` packed into a never-cleared `~/.cache/omob/tarballs` and picked `readdirSync(...).find(.tgz)`. Because the tarball name carries senpi's package version, the first senpi version bump after the cache exists left two candidates and an arbitrary pick installed the OLD engine while the build stamped the NEW SHA — the exact "rebuild to update" path the docs sell. The directory is now rebuilt per run and the code requires exactly one tarball.
- **Submodules were synced before the ref landed.** `git submodule update` ran while HEAD was still the previous ref, and neither `checkout --force` nor `reset --hard` recurses. Any ref that moved a `packages/shared-skills/upstreams/*` pointer therefore built stale skill content under a new omo SHA. The sync now runs after `reset --hard` (with `--force`), and the redundant pre-checkout calls are gone.
- **Startup banner did not meet the provenance contract.** It printed short SHAs only and hardcoded `omob` while discarding `info.command`. It now renders `versionLines()`, the same source as `--version` and `doctor`.

### Notes addressed
- `nestHoistedDeps` moved whole scope directories, silently dropping hoisted `@scope/*` siblings when the scope already existed from bundling; scopes are now merged child by child.
- Pruning ran even under `--skip-install`, where it could delete the runtime of a still-installed binary; it is now gated on an actual install.
- `omob update` printed the release curl line; a new `updateHint()` returns `rebuild with: bun run <command>` for dev builds and the release line otherwise.
- Dead `key` const, unused `ref` parameter, and a doc note that `--omo-ref` targets must already contain the build-info support.

## Test plan
- Unit on mengmotaMac (fresh install worktree): **78 pass / 0 fail** across `script/build-omob.test.ts`, `script/build-omo-binary.test.ts`, `packages/omo-native/test/build-info.test.ts`, `packages/omo-native/test/compile-entry.test.ts`.
- `bun run typecheck:script` and `tsgo --noEmit -p packages/omo-native/tsconfig.json` both exit 0.
- New coverage for the gaps the review named: malformed `omoBuild` degrades to the release version/command in both `remapSenpiEnvironment` and `versionLine`; `updateHint` dev-vs-release branching; and the release manifest's **key order** is pinned (previously only digest inequality was asserted, which would not catch a serialization reorder).
- Release-path invariance independently corroborated by the omo-desktop-app runtime build at omo dev `96de945`: 33 plugin artifacts verified, BUN_BE_BUN helper exit 0, bundle manifest 619/619 sha parity.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three architect blockers in the omob dev-binary pipeline where stale cache state or mis-ordered git operations could stamp new provenance onto an old engine or stale skill content. `--omo-ref` targets must already contain the omob build-info support.

**Bug Fixes**
- Rebuilds the tarball directory per run and requires exactly one tarball, so a senpi version bump can no longer install the old engine under fresh provenance.
- Syncs submodules after `reset --hard` (with `--force`); checkout and reset don't recurse, so moved upstream pointers previously built stale skills under a new omo SHA.
- Replaces the startup banner's short SHAs and hardcoded `omob` with `versionLines()`, matching the `--version` and `doctor` provenance contract.
- Merges hoisted `@scope/*` directories child-by-child instead of moving whole scope dirs, which silently dropped hoisted siblings.
- Gates runtime pruning on an actual install so `--skip-install` no longer deletes the runtime of a still-installed binary.
- Adds `updateHint()` so dev builds print "rebuild with: bun run <command>" while release builds keep the curl line.

<sup>Written for commit 2c7cb7e25a07e8eeb97a586493547894ec50f806. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

