### PR TITLE
fix(senpi): use valid directory descriptor paths

### DIFF
--- a/packages/omo-senpi/scripts/qa/isolation-state.mjs
+++ b/packages/omo-senpi/scripts/qa/isolation-state.mjs
@@ -329,11 +329,10 @@ function collectFilesBounded(currentRoot, state, boundRoot = currentRoot) {
 				code: "FILE_REPLACED",
 			});
 		const descriptorRoot = directoryDescriptorPath(directoryFd);
-		if (descriptorRoot === null)
-			throw Object.assign(new Error("DIRECTORY_IDENTITY_UNAVAILABLE"), {
-				code: "DIRECTORY_IDENTITY_UNAVAILABLE",
-			});
-		directory = io.opendirSync(descriptorRoot);
+		// The descriptor still anchors identity checks, but some platforms do not
+		// expose a directory path for an open fd. Traverse the original path there
+		// and re-check its identity before and after traversal.
+		directory = io.opendirSync(descriptorRoot ?? boundRoot);
 		assertDirectoryPathIdentity(currentRoot, beforeMetadata, io);
 	} catch (error) {
 		state.errors.push({
@@ -350,10 +349,7 @@ function collectFilesBounded(currentRoot, state, boundRoot = currentRoot) {
 	let traversalFailed = false;
 	try {
 		const descriptorRoot = directoryDescriptorPath(directoryFd);
-		if (descriptorRoot === null)
-			throw Object.assign(new Error("DIRECTORY_IDENTITY_UNAVAILABLE"), {
-				code: "DIRECTORY_IDENTITY_UNAVAILABLE",
-			});
+		const traversalRoot = descriptorRoot ?? boundRoot;
 		state.snapshot.set(currentRel, "directory");
 		const entries = [];
 		while (true) {
@@ -364,7 +360,7 @@ function collectFilesBounded(currentRoot, state, boundRoot = currentRoot) {
 				relative(state.root, path),
 				state.pathStyle,
 			);
-			const boundPath = join(descriptorRoot, entry.name);
+			const boundPath = join(traversalRoot, entry.name);
 			let pathStat;
 			try {
 				pathStat = io.lstatSync(boundPath, { bigint: true });
@@ -495,7 +491,6 @@ function assertDirectoryPathIdentity(path, expected, io) {
 
 function directoryDescriptorPath(fd) {
 	if (process.platform === "linux") return `/proc/self/fd/${fd}`;
-	if (process.platform === "darwin") return `/dev/fd/${fd}`;
 	return null;
 }
 


### PR DESCRIPTION
## Root cause

The isolation walker assumed every platform could turn an open directory fd into a second directory path. On macOS, `/dev/fd/<fd>` is not accepted by Bun's `opendirSync` as a directory (`ENOTDIR`); on Windows there is no descriptor namespace, so `directoryDescriptorPath()` returns `null` and the old code throws `DIRECTORY_IDENTITY_UNAVAILABLE`. The fd remains useful for identity verification (`fstat` plus path identity checks), so the correct cross-platform behavior is to traverse `boundRoot` when no descriptor path is available, while retaining the fd/path identity checks before and after traversal.

## Why the release-state comparison was misleading

The claimed passing #7749 jobs were not green test executions: their job metadata shows `Install dependencies`, `Run Senpi compatibility tests`, and all test steps as `skipped`. The requested release-state comparison is therefore not evidence that version stamps caused the failures. On `mengmotaMac`, both `b50af2e69` and `13ac0d860` reproduce the same descriptor failure with the same source; the failure is platform capability, not a version-derived root or test ordering mutation.

## Windows explanation

On Windows, `directoryDescriptorPath()` returns `null`. Before this fix, setup threw `DIRECTORY_IDENTITY_UNAVAILABLE` before directory enumeration, hence `readCalls: 0`, `truncated: false`, and the cascade of failures. Normally Windows passes when the fallback path is used: `openSync(boundRoot, O_DIRECTORY | O_NOFOLLOW)` (where available), `fstat` validates the opened directory identity, and `assertDirectoryPathIdentity` validates the original path before/after traversal. The same fallback also fixes macOS; Linux continues to use `/proc/self/fd/<fd>`.

## Evidence

- Failing macOS attempt 1: [33848707889](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33848707889), job `100946431433`.
- Failing macOS attempt 2: job `100952377359`; the run failed again.
- Failing Windows attempt 1: job `100946431342`; the log reports `DIRECTORY_IDENTITY_UNAVAILABLE` and `readCalls: 0`.
- Both failing attempts use Bun `1.4.0+34cbb9a40`; Linux passes because it has the `/proc/self/fd` descriptor path.

## Remote receipts (mengmotaMac)

All commands redirected output to files under `/tmp/remote-fixed` or `/tmp/remote-repro` and were read back with `machine.shell`.

| Tree / mutation | Result |
| --- | --- |
| `13ac0d860` baseline isolation suite | 25 pass / 31 fail across 56 tests (descriptor failure) |
| fixed branch, one run | 56 pass / 0 fail |
| fixed branch, 20-run loop | 20/20 runs completed with `Ran 56 tests`; all logs were green |
| mutation: restored old macOS `/dev/fd/<fd>` path | RED: exit 1, 2 pass / 10 fail in `isolation-state.test.mjs` |

The same host also reproduced the old failure at `b50af2e69`, so the release-state bisect is negative rather than causal. The initial full-package command was additionally blocked by the repository preload's vendored-lsp `npm ci` timeout; the isolated QA loop used an empty Bun config to remove that unrelated setup dependency.

## Change

Use the open fd for identity and race checks, but fall back to the original bound path for `opendirSync` and child entry traversal when the platform has no usable descriptor path. No sleeps, polling, environment mutation, or test weakening are involved.
