### PR TITLE
fix(omo-native): resolve the hoisted bin dir for scoped engine packages

### DIFF
--- a/packages/omo-native/bin/lib/package-paths.js
+++ b/packages/omo-native/bin/lib/package-paths.js
@@ -66,9 +66,11 @@ export function resolveSenpi(options = {}) {
 export function nearestNodeBin(startPath) {
   // Hoisted layouts place the engine package inside a shared node_modules (…/node_modules/senpi),
   // whose .bin is a sibling, not a child - starting the climb inside node_modules would walk to the
-  // filesystem root and never find it. Begin at the package's parent so that sibling .bin is seen.
+  // filesystem root and never find it. For unscoped packages begin at the package's parent; for
+  // scoped packages (…/node_modules/@scope/package), begin at the parent of node_modules instead.
   let current = basename(startPath) === "node_modules" ? dirname(startPath)
     : basename(dirname(startPath)) === "node_modules" ? dirname(dirname(startPath))
+    : basename(dirname(dirname(startPath))) === "node_modules" ? dirname(dirname(dirname(startPath)))
     : startPath
   const root = parse(current).root
   while (true) {

--- a/packages/omo-native/test/launcher.test.ts
+++ b/packages/omo-native/test/launcher.test.ts
@@ -38,7 +38,7 @@ function expandShortPath(path: string): string {
   }
 }
 
-function createFixture(options: { hoisted?: boolean; shim?: boolean; installLayout?: InstallLayout } = {}): Fixture {
+function createFixture(options: { hoisted?: boolean; scopedEngine?: boolean; shim?: boolean; installLayout?: InstallLayout } = {}): Fixture {
   // Windows hands back the 8.3 short form (RUNNER~1) here while the launcher reports the long path, so
   // the fixture root is canonicalized once and every derived path inherits the same spelling.
   const root = expandShortPath(realpathSync(mkdtempSync(join(tmpdir(), "omo-launcher-"))))
@@ -75,7 +75,10 @@ function createFixture(options: { hoisted?: boolean; shim?: boolean; installLayo
   }
 
   const modulesRoot = options.hoisted ? join(root, "node_modules") : join(packageRoot, "node_modules")
-  const senpiRoot = join(modulesRoot, "@code-yeongyu", "senpi")
+  const senpiRoot = options.scopedEngine
+    ? join(packageRoot, "node_modules", "@code-yeongyu", "senpi")
+    : join(modulesRoot, "@code-yeongyu", "senpi")
+  if (options.scopedEngine) writeFile(join(senpiRoot, "node_modules", ".bin", "dummy"), "decoy\n", 0o755)
   writeFile(join(senpiRoot, "package.json"), JSON.stringify({
     name: "@code-yeongyu/senpi",
     version: "2026.8.9",
@@ -94,7 +97,8 @@ process.exit(Number(process.env.FAKE_EXIT ?? 0))
 
   let shimPath: string | undefined
   if (options.shim !== false) {
-    shimPath = join(modulesRoot, ".bin", process.platform === "win32" ? "senpi.cmd" : "senpi")
+    const shimRoot = options.scopedEngine ? join(packageRoot, "node_modules") : modulesRoot
+    shimPath = join(shimRoot, ".bin", process.platform === "win32" ? "senpi.cmd" : "senpi")
     writeFile(shimPath, "fixture shim\n", 0o755)
     shimPath = expandShortPath(realpathSync(shimPath))
   }
@@ -193,6 +197,14 @@ describe("omo launcher", () => {
         expect(existsSync(environment.OMO_BIN ?? "")).toBe(true)
         expect((environment.OMO_BIN ?? "").replace(/\\/g, "/")).toMatch(/\/bin\/omo\.js$/)
         expect(environment.OMO_BIN).not.toBe(environment.SENPI_BIN)
+      })
+
+      test("#then scoped engine packages resolve the hoisted senpi shim", () => {
+        const fixture = createFixture({ scopedEngine: true })
+        const result = run(fixture, ["say", "hi"])
+        expect(result.status).toBe(0)
+        expect(capture(fixture).env.SENPI_BIN).toBe(fixture.shimPath)
+        expect(existsSync(capture(fixture).env.SENPI_BIN ?? "")).toBe(true)
       })
 
       test("#then SENPI_BIN stays absent when no shim exists", () => {


### PR DESCRIPTION
## Summary
Resolve the hoisted `.bin` directory for scoped engine packages so launcher child processes receive `SENPI_BIN`.

## Root cause
`nearestNodeBin()` treated `node_modules/@scope/package` as if the package were directly under `node_modules`. It found the scoped engine package's decoy `node_modules/.bin` instead of the sibling hoisted shim directory.

## Changes
- Detect scoped package paths and begin the climb at the parent of the enclosing `node_modules` directory.
- Add a launcher fixture with a scoped engine, decoy package-local `.bin`, and real hoisted `senpi` shim.

## Verification
RED command:
```text
cd /Volumes/mengmotaStorage/local-workspaces/omo-wt/fix/launcher-scoped-node-bin && bun test packages/omo-native/test/launcher.test.ts
```
Excerpt:
```text
error: expect(received).toBe(expected)
Expected: "/private/var/folders/.../omo-launcher-.../app/node_modules/.bin/senpi"
Received: undefined
1 tests failed:
37 pass
1 fail
```

GREEN command:
```text
cd /Volumes/mengmotaStorage/local-workspaces/omo-wt/fix/launcher-scoped-node-bin && bun test packages/omo-native/test/launcher.test.ts
```
Excerpt:
```text
38 pass
0 fail
135 expect() calls
Ran 38 tests across 1 file.
```

## Risk
Low. The existing bare `node_modules` and unscoped package cases remain unchanged; only scoped package path detection is added.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `nearestNodeBin()` for scoped engine packages so launcher child processes receive `SENPI_BIN` from the hoisted `.bin` shim instead of a decoy package-local `.bin` or nothing. Scoped paths (`node_modules/@scope/package`) now begin the climb at the parent of `node_modules`; bare and unscoped cases are unchanged.

- Adds a fixture with a scoped engine, decoy package-local `.bin`, and real hoisted `senpi` shim to cover the case.

<sup>Written for commit 8c8025723bc19058f7afa8f1789592f398160cdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

