### PR TITLE
fix(shared-skills): call the CloakBrowser venv interpreter in the launch step too

### DIFF
--- a/packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
+++ b/packages/shared-skills/skills/ultimate-browsing/ATTRIBUTION.md
@@ -103,7 +103,7 @@ SOFTWARE.
 ## 4. agent-browser (vercel-labs) — Tier-2 CDP automation CLI (runtime dependency)
 
 The Tier-2 automation CLI is **agent-browser**, installed at runtime via `npm`
-(`npm i -g agent-browser`). No agent-browser source is vendored in this repository.
+(`bun add -g agent-browser`). No agent-browser source is vendored in this repository.
 
 - Source: https://github.com/vercel-labs/agent-browser
 - Pinned runtime version: **0.34.0** (documented in `references/chrome-stealth.md`;

--- a/packages/shared-skills/skills/ultimate-browsing/references/chrome-stealth.md
+++ b/packages/shared-skills/skills/ultimate-browsing/references/chrome-stealth.md
@@ -43,8 +43,9 @@ Verify CloakBrowser:
 NEVER clear cookies, cache, or site data (`Network.clearBrowserCookies`, `Storage.clearCookies`, `chrome.browsingData.remove`, "clear browsing data") on the user's real/main browser profile — it wipes their logged-in state everywhere. If you need that profile's login state, clone it first (`rsync -a <profile>/ <tmp-clone>/`) and launch with the clone as the user-data-dir; run any clearing on the clone only.
 
 ```bash
-# 1. Launch CloakBrowser with CDP on :9242 (background). With the venv active:
-python -c "import asyncio,cloakbrowser; asyncio.run(cloakbrowser.launch_async(headless=False, stealth_args=True, args=['--remote-debugging-port=9242']))" &
+# 1. Launch CloakBrowser with CDP on :9242 (background). cloakbrowser lives only in the venv,
+#    so call its interpreter by absolute path — this works in any shell, activated or not:
+"$HOME/.agents/cloak-venv/bin/python" -c "import asyncio,cloakbrowser; asyncio.run(cloakbrowser.launch_async(headless=False, stealth_args=True, args=['--remote-debugging-port=9242']))" &
 
 # 2. CloakBrowser launches tabless -> agent-browser would say "No page found".
 #    Open the first tab via CDP before any agent-browser command:


### PR DESCRIPTION
## What

PR #7751 pinned the CloakBrowser venv at `~/.agents/cloak-venv` and said "every command below calls its interpreter by absolute path — no `activate` step to forget". The launch step did not: it still ran a bare `python -c "import ... cloakbrowser ..."` under a "with the venv active" comment. `cloakbrowser` is installed only inside that venv, so following the document in a fresh shell fails at the first launch command — the exact footgun the fixed path was meant to remove.

`ATTRIBUTION.md` also still described the agent-browser install as `npm i -g` while the reference now uses `bun add -g`; the two disagreed about the same command.

## Why

Found by the gate review of #7750/#7751 (browser-routing rewrites). Both items are internal contradictions introduced by that pair, so they are fixed here rather than left as follow-ups.

## Evidence

- `rg '^\s*python -c' references/chrome-stealth.md` → no matches; venv-absolute interpreter calls: 5.
- `rg 'npm i -g|npm install -g'` across the skill → no matches.
- shared-skills gates (`ultimate-browsing-runtime-pins`, `depersonalization-gate`, `provenance-gate`) run in the PR thread; runtime pins are untouched (cloakbrowser 0.5.7, agent-browser 0.34.0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CloakBrowser launch step in the `ultimate-browsing` reference doc to call the venv interpreter by absolute path instead of bare `python`, so the documented flow works in any fresh shell without an activate step. Also aligns the `agent-browser` install command in `ATTRIBUTION.md` with the reference doc (`bun add -g` instead of `npm i -g`).

<sup>Written for commit 49da890844773a9965aec8efa0a06a74b3f482a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

