### PR TITLE
test(script): assert omob default dirs with the host path separator

### DIFF
--- a/script/build-omob.test.ts
+++ b/script/build-omob.test.ts
@@ -1,6 +1,7 @@
 // Contract tests for script/build-omob.ts.
 
 import { describe, expect, test } from "bun:test"
+import { join } from "node:path"
 import { deriveOmobAiVersion, hostTargetFor, parseOmobArgs, planRuntimePrune, selectPruneEntries } from "./build-omob"
 
 describe("parseOmobArgs", () => {
@@ -11,8 +12,8 @@ describe("parseOmobArgs", () => {
 		expect(parsed.name).toBe("omob")
 		expect(parsed.keep).toBe(2)
 		expect(parsed.target).toBe("darwin-arm64")
-		expect(parsed.installDir).toBe("/home/dev/.local/bin")
-		expect(parsed.cacheDir).toBe("/home/dev/.cache/omob")
+		expect(parsed.installDir).toBe(join("/home/dev", ".local", "bin"))
+		expect(parsed.cacheDir).toBe(join("/home/dev", ".cache", "omob"))
 		expect(parsed.skipFetch).toBe(false)
 		expect(parsed.skipInstall).toBe(false)
 	})


### PR DESCRIPTION
## Problem

`script/build-omob.test.ts` pins `installDir`/`cacheDir` to POSIX literals (`/home/dev/.local/bin`, `/home/dev/.cache/omob`). `parseOmobArgs` builds them with `node:path` `join()`, which is correct for the host and yields backslashes on Windows. Result on the Windows shard of the full CI matrix (job `test (windows-latest, 2/2)`), seen on the beta.41 release-state PR #7752 (attempts 1 and 2) and on #7753's `ci:full-matrix` run:

```
Expected: "/home/dev/.local/bin"
Received: "\home\dev\.local\bin"
```

PR CI never showed it because the Windows shard only runs with the `ci:full-matrix` label; the release-state branch always runs the full matrix, so this latent break blocks every omo beta publish.

## Fix

The contract under test is "default dirs hang off `homeDir`", not "use forward slashes". The expectations now compose with the same `join()`. No production change.

## Verification

- mengmotaMac (Darwin arm64, bun 1.4.0): `bun test script/build-omob.test.ts` → 10 pass / 0 fail.
- Windows: this PR carries `ci:full-matrix`; `test (windows-latest, 2/2)` must go green here where it was red on #7752 / #7753.
- TEST-ONLY change: the previous literal is the mutation, and it is exactly what the Windows job was failing on.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `script/build-omob.test.ts` failing on Windows by asserting default omob directories with the host path separator instead of POSIX literals.

The test expected `installDir` and `cacheDir` to equal hardcoded forward-slash paths, but `parseOmobArgs` builds them with `node:path` `join()`, which produces backslashes on Windows. The test now constructs its expectations with the same `join()` calls, matching the contract that default dirs hang off the home directory. No production code changes.

<sup>Written for commit 3d159cad9b21b1f8d06b6af1a2d5d108c9a92f65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

