### PR TITLE
fix(memory): add a body-preserving frontmatter field writer

### DIFF
--- a/packages/omo-senpi/src/components/memory/commands/skill-frontmatter.test.ts
+++ b/packages/omo-senpi/src/components/memory/commands/skill-frontmatter.test.ts
@@ -8,6 +8,7 @@ import {
   formatSkillNameFrontmatterRepairReport,
   repairMissingSkillNameFrontmatter,
   repairSkillNameFrontmatterContent,
+  setSkillFrontmatterField,
 } from "./skill-frontmatter"
 
 const tempDirs: string[] = []
@@ -131,5 +132,129 @@ describe("repairMissingSkillNameFrontmatter", () => {
     expect(report).toContain("skills/commit/SKILL.md")
     expect(report).toContain("skills/broken/SKILL.md")
     expect(report).toContain("missing YAML frontmatter")
+  })
+})
+
+// Regression guard for the 2026-09-04 skill-body wipe: an ad-hoc description
+// rewrite used /^(---\n[\s\S]*?)(\ndescription:)([^\n]*(?:\n\s+[^\n]*)*)([\s\S]*?\n---)/
+// and rebuilt the file as m1+m2+new+m4. Group 4 ran to the CLOSING delimiter, so
+// every byte after the frontmatter was discarded: 38 SKILL.md files under
+// ~/.agents/skills were left frontmatter-only, and 47 symlinks propagated the
+// damage into their оpenclaw originals. Any frontmatter write MUST leave the
+// body byte-identical, which is what these cases pin.
+describe("setSkillFrontmatterField", () => {
+  function bodyOf(content: string): string {
+    const match = content.match(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/)
+    return match ? content.slice(match[0].length) : content
+  }
+
+  test("#given a skill with a body #when the description is rewritten #then the body bytes are identical", () => {
+    // given
+    const body = "# Commit\n\nStep one.\n\n## Rules\n\n- never force push\n"
+    const content = `---\nname: commit\ndescription: "old"\n---\n${body}`
+
+    // when
+    const result = setSkillFrontmatterField(content, "description", "new routing line")
+
+    // then
+    expect(result.changed).toBe(true)
+    expect(bodyOf(result.content)).toBe(body)
+    expect(result.content).toContain('description: "new routing line"')
+    expect(result.content).not.toContain('description: "old"')
+  })
+
+  test("#given a body containing a --- horizontal rule #when rewritten #then nothing after the frontmatter is lost", () => {
+    // given — the exact shape that made the original regex destructive
+    const body = "# Skill\n\nIntro.\n\n---\n\n## Section\n\nTail line.\n"
+    const content = `---\nname: x\ndescription: old\n---\n${body}`
+
+    // when
+    const result = setSkillFrontmatterField(content, "description", "replacement")
+
+    // then
+    expect(bodyOf(result.content)).toBe(body)
+    expect(result.content.endsWith("Tail line.\n")).toBe(true)
+  })
+
+  test("#given a multi-line folded description #when rewritten #then continuation lines are replaced and the body survives", () => {
+    // given
+    const body = "Body stays.\n"
+    const content = `---\nname: x\ndescription: first line\n  continued line\n  another\nlicense: MIT\n---\n${body}`
+
+    // when
+    const result = setSkillFrontmatterField(content, "description", "single line now")
+
+    // then
+    expect(bodyOf(result.content)).toBe(body)
+    expect(result.content).toContain("license: MIT")
+    expect(result.content).not.toContain("continued line")
+  })
+
+  test("#given CRLF frontmatter #when rewritten #then the body keeps its bytes and CRLF endings", () => {
+    // given
+    const body = "line one\r\nline two\r\n"
+    const content = `---\r\nname: x\r\ndescription: old\r\n---\r\n${body}`
+
+    // when
+    const result = setSkillFrontmatterField(content, "description", "new")
+
+    // then
+    expect(result.changed).toBe(true)
+    expect(bodyOf(result.content)).toBe(body)
+    expect(result.content).toContain("---\r\nname: x\r\ndescription: new\r\n---\r\n")
+  })
+
+  test("#given no frontmatter #when rewritten #then the content is refused untouched", () => {
+    // given
+    const content = "# Just a document\n\nNo frontmatter here.\n"
+
+    // when
+    const result = setSkillFrontmatterField(content, "description", "x")
+
+    // then
+    expect(result.changed).toBe(false)
+    expect(result.content).toBe(content)
+    expect(result.reason).toBe("missing YAML frontmatter")
+  })
+
+  test("#given the same value already quoted #when rewritten #then it reports no change", () => {
+    // given
+    const content = '---\nname: x\ndescription: "same"\n---\nBody\n'
+
+    // when
+    const result = setSkillFrontmatterField(content, "description", "same")
+
+    // then
+    expect(result.changed).toBe(false)
+    expect(result.content).toBe(content)
+  })
+
+  test("#given a missing field #when set #then it is appended to the frontmatter and the body survives", () => {
+    // given
+    const body = "# Doc\n\nText.\n"
+    const content = `---\nname: x\n---\n${body}`
+
+    // when
+    const result = setSkillFrontmatterField(content, "description", "added line")
+
+    // then
+    expect(result.changed).toBe(true)
+    expect(result.content).toBe(`---\nname: x\ndescription: "added line"\n---\n${body}`)
+  })
+
+  test("#given the exact regex that caused the 2026-09-04 wipe #when compared #then the helper keeps what it destroyed", () => {
+    // given — verbatim from the incident record; group 4 runs to the closing ---
+    const destructive = /^(---\n[\s\S]*?)(\ndescription:)([^\n]*(?:\n\s+[^\n]*)*)([\s\S]*?\n---)/
+    const body = "# Skill\n\nBody that must survive.\n"
+    const content = `---\nname: x\ndescription: old\n---\n${body}`
+
+    // when
+    const match = content.match(destructive)
+    const wiped = match ? `${match[1]}${match[2]} new${match[4]}` : content
+    const repaired = setSkillFrontmatterField(content, "description", "new")
+
+    // then
+    expect(bodyOf(wiped)).toBe("")
+    expect(bodyOf(repaired.content)).toBe(body)
   })
 })

--- a/packages/omo-senpi/src/components/memory/commands/skill-frontmatter.ts
+++ b/packages/omo-senpi/src/components/memory/commands/skill-frontmatter.ts
@@ -22,6 +22,12 @@ interface SkillNameFrontmatterContentRepairResult {
   readonly reason?: string
 }
 
+export interface SkillFrontmatterFieldWriteResult {
+  readonly content: string
+  readonly changed: boolean
+  readonly reason?: string
+}
+
 const FRONTMATTER_REGEX = /^(---\r?\n)([\s\S]*?)(\r?\n---(?:\r?\n|$))/
 
 async function pathExists(path: string): Promise<boolean> {
@@ -90,6 +96,77 @@ export function repairSkillNameFrontmatterContent(
   }
 
   const nextContent = `${opening}${lines.join(newline)}${closing}${content.slice(match[0].length)}`
+  return { content: nextContent, changed: true }
+}
+
+/**
+ * Sets one frontmatter field, leaving the body BYTE-IDENTICAL.
+ *
+ * Use this for every programmatic frontmatter edit. Writing your own regex is how
+ * the 2026-09-04 skill wipe happened: a description rewrite matched through to the
+ * CLOSING `---` and rebuilt the file from that match, so 38 SKILL.md files under
+ * ~/.agents/skills lost their entire body (47 of them symlinks, which propagated
+ * the damage into their оpenclaw originals). Nothing was under version control, so
+ * five skills were never recovered.
+ *
+ * The body is never part of the replacement here: only the frontmatter block is
+ * rebuilt, and `content.slice(match[0].length)` is re-appended untouched.
+ */
+export function setSkillFrontmatterField(
+  content: string,
+  field: string,
+  value: string,
+): SkillFrontmatterFieldWriteResult {
+  if (!field.trim()) {
+    return { content, changed: false, reason: "field name is empty" }
+  }
+
+  const match = content.match(FRONTMATTER_REGEX)
+  if (!match) {
+    return { content, changed: false, reason: "missing YAML frontmatter" }
+  }
+
+  const opening = match[1] ?? ""
+  const frontmatter = match[2] ?? ""
+  const closing = match[3] ?? ""
+  const body = content.slice(match[0].length)
+  const newline = opening.includes("\r\n") ? "\r\n" : "\n"
+
+  const lines = frontmatter.replace(/\r\n/g, "\n").split("\n")
+  const keyPattern = new RegExp(`^\\s*${field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*:`)
+  const index = lines.findIndex((line) => keyPattern.test(line))
+
+  // An existing value already equal to `value` is a no-op, whichever YAML quoting
+  // style it was written in: re-serializing it would report a spurious change and
+  // rewrite a file that did not need touching.
+  if (index >= 0) {
+    const current = (lines[index] ?? "").replace(keyPattern, "").trim()
+    const unquoted =
+      (current.startsWith('"') && current.endsWith('"') && current.length >= 2) ||
+      (current.startsWith("'") && current.endsWith("'") && current.length >= 2)
+        ? current.slice(1, -1)
+        : current
+    if (unquoted === value) {
+      return { content, changed: false }
+    }
+  }
+
+  const nextLine = `${field}: ${formatYamlScalar(value)}`
+
+  if (index < 0) {
+    const nextFrontmatter = [...lines, nextLine].join(newline)
+    return { content: `${opening}${nextFrontmatter}${closing}${body}`, changed: true }
+  }
+
+  // A YAML scalar may fold onto following indented lines; they belong to this key.
+  let end = index + 1
+  while (end < lines.length && /^\s+\S/.test(lines[end] ?? "")) end += 1
+
+  const replaced = [...lines.slice(0, index), nextLine, ...lines.slice(end)]
+  const nextContent = `${opening}${replaced.join(newline)}${closing}${body}`
+  if (nextContent === content) {
+    return { content, changed: false }
+  }
   return { content: nextContent, changed: true }
 }
 


### PR DESCRIPTION
fix(memory): add a body-preserving frontmatter field writer

On 2026-09-04 a description-normalization pass rewrote every skill's
frontmatter with

  /^(---\n[\s\S]*?)(\ndescription:)([^\n]*(?:\n\s+[^\n]*)*)([\s\S]*?\n---)/

and rebuilt each file as m1+m2+newDesc+m4. Group 4 runs to the CLOSING
delimiter, so every byte after the frontmatter was discarded: 38 SKILL.md
under ~/.agents/skills were left frontmatter-only, and because 47 entries
are symlinks the damage reached their upstream originals. Five skills had
no recoverable copy anywhere.

The repair path here already split frontmatter from body correctly, but
only for the `name` key, so a caller wanting to touch `description` had
no supported entry point and wrote its own regex. setSkillFrontmatterField
closes that gap for any field: it rebuilds only the frontmatter block and
re-appends content.slice(match[0].length) untouched.

Covers folded scalars (indented continuation lines belong to the key),
CRLF, appending a missing field, refusing a file with no frontmatter, and
idempotence across quoting styles. One case pins the incident regex itself
against the helper on the same input.

Verified on mengmotaMac and locally: 16/16 pass; reverting the
implementation drops the suite to 0 pass / 1 error, and the isolated
mutation harness shows the old regex destroying the body on all three LF
shapes (50->0B, 45->0B, 12->0B) where the helper is byte-identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `setSkillFrontmatterField` so frontmatter edits rebuild only the frontmatter block and re-append the body untouched, preventing another 2026-09-04-style incident where a description rewrite stripped bodies from 38 skill files (47 via symlinks, 5 unrecoverable).

**Bug Fixes**
- Handles folded scalars, CRLF, missing fields, files without frontmatter, and idempotent writes across quoting styles.
- Tests pin the destructive incident regex against the helper to guarantee the body stays byte-identical.

<sup>Written for commit 2d2ad3ce5d4fd0d2ecd7655209dd3efd4ddc4fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

