### PR TITLE
test(memory-core): avoid Windows unmerged-entry timeout

### DIFF
--- a/packages/memory-core/src/git/path-state.test.ts
+++ b/packages/memory-core/src/git/path-state.test.ts
@@ -15,8 +15,12 @@ async function fixture(seedFiles: Array<{ relativePath: string; content: string 
   return { dir, repo }
 }
 
-async function git(dir: string, argv: readonly string[]) {
-  const result = await createNodeGitExec().run(argv, { cwd: dir, timeoutMs: 30_000 })
+async function git(dir: string, argv: readonly string[], stdin?: string) {
+  const result = await createNodeGitExec().run(argv, {
+    cwd: dir,
+    timeoutMs: 30_000,
+    ...(stdin === undefined ? {} : { stdin }),
+  })
   if (result.code !== 0) throw new Error(result.stderr || result.stdout)
   return result.stdout.trim()
 }
@@ -157,16 +161,17 @@ describe("GitPathStateStore", () => {
 
   it("rejects unmerged entries", async () => {
     const { dir, repo } = await fixture([{ relativePath: "conflict.md", content: "base\n" }])
-    await git(dir, ["checkout", "-b", "other"])
-    await writeFile(join(dir, "conflict.md"), "other\n")
-    await git(dir, ["add", "--", "conflict.md"])
-    await git(dir, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "other"])
-    await git(dir, ["checkout", "main"])
-    await writeFile(join(dir, "conflict.md"), "main\n")
-    await git(dir, ["add", "--", "conflict.md"])
-    await git(dir, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "main"])
-    const merge = await createNodeGitExec().run(["merge", "other"], { cwd: dir, timeoutMs: 30_000 })
-    expect(merge.code).not.toBe(0)
+    const base = await repo.pathState.capture("conflict.md")
+    if (base.index === null) throw new Error("expected base index entry")
+
+    const other = await repo.pathState.hashWorktreeBlob("other\n", true)
+    const main = await repo.pathState.hashWorktreeBlob("main\n", true)
+    await git(dir, ["update-index", "--index-info"], [
+      `100644 ${base.index.oid} 1\tconflict.md`,
+      `100644 ${main} 2\tconflict.md`,
+      `100644 ${other} 3\tconflict.md`,
+      "",
+    ].join("\n"))
 
     const error = await rejectedError(repo.pathState.capture("conflict.md"))
     expect(error).toBeInstanceOf(GitPathStateError)


### PR DESCRIPTION
## What failed
The Windows shard failure was Bun's effective default per-test timeout, not a git exec timeout or assertion: the full log says `this test timed out after 5000ms` for `rejects unmerged entries` after 13,975.94 ms. The per-command `createNodeGitExec().run` timeout was 30 seconds and never fired.

## Root cause
`packages/memory-core/src/git/path-state.test.ts` constructed the conflict through eight sequential git subprocesses (branch, checkout, add, commit, checkout, add, commit, merge). That setup cost exceeded Bun's 5-second test budget on a cold Windows runner, making the test timing-dependent. The test now uses git plumbing to hash the two side contents and write real stage 1/2/3 index entries in one `update-index --index-info` call, while retaining the same `capture("conflict.md")` GitPathStateError assertion.

## Timing receipts
| run | runs | max wall time | result |
|---|---:|---:|---|
| baseline branch/checkout/commit/merge fixture (macOS) | 30 | 2,650 ms | 30/30 pass |
| optimized stage-index fixture (macOS) | 30 | 2,960 ms | 30/30 pass |
| CI failing Windows run | 1 | 13,975.94 ms | Bun test timeout at 5,000 ms |

The optimized single-file run passed (8 tests), the full `bun test packages/memory-core` suite passed (673 tests), and `bun run typecheck` exited 0.

## Mutation receipt
A temporary mutation added 500 sequential `git rev-parse HEAD` subprocesses before the assertion. It reliably went RED: `(fail) GitPathStateStore > rejects unmerged entries [5002.58ms]`, `this test timed out after 5000ms`, `1 fail`; the mutation was removed before commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows timeout in the `rejects unmerged entries` test in `packages/memory-core` by building the git conflict state without sequential subprocesses. The old test created a conflict through eight git subprocesses, which could exceed Bun's 5-second test timeout on a cold Windows runner. It now writes the stage 1/2/3 index entries in a single `update-index --index-info` call and keeps the same `GitPathStateError` assertion.

<sup>Written for commit 1943430b7f2e27da79e7d9e3d1e35a08c31cba04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

