### PR TITLE
fix(omo-native,omo-senpi): unblock Windows CI at the two root causes

### DIFF
--- a/packages/omo-native/bin/lib/setup-detect.js
+++ b/packages/omo-native/bin/lib/setup-detect.js
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { canonicalAgentDir } from "./agent-dir.js"
+import { readRow, readRows } from "./sqlite-rows.js"
 
 export const KNOWN_AUTH_SCHEMA_VERSIONS = new Set([4, 7])
 
@@ -104,15 +105,17 @@ function inspectSqlite(id, path, DatabaseSync, modelHint) {
   let database
   try {
     database = new DatabaseSync(path, { readOnly: true })
-    const schema = database.prepare("SELECT version FROM auth_schema_version").get()
+    const schema = readRow(database, ["version"], "SELECT version FROM auth_schema_version")
     const version = schema?.version
     if (!KNOWN_AUTH_SCHEMA_VERSIONS.has(version)) {
       result.notices.push(`auth schema version ${String(version)} is unknown; credentials not inspected`)
       return result
     }
-    const rows = database.prepare(
+    const rows = readRows(
+      database,
+      ["provider", "credential_type", "disabled_cause"],
       "SELECT provider, credential_type, disabled_cause FROM auth_credentials",
-    ).all()
+    )
     result.providers = sorted(rows.map((row) => row.provider))
     result.credentialTypes = sorted(rows.map((row) => row.credential_type))
     result.entryCount = rows.length

--- a/packages/omo-native/bin/lib/setup-import.js
+++ b/packages/omo-native/bin/lib/setup-import.js
@@ -6,6 +6,7 @@ import { dirname, join } from "node:path"
 import { createInterface } from "node:readline/promises"
 import { canonicalAgentDir } from "./agent-dir.js"
 import { detectHarnesses } from "./setup-detect.js"
+import { readRow, readRows } from "./sqlite-rows.js"
 import { printModelReport } from "./setup-models.js"
 import { printSetupReport } from "./setup-report.js"
 
@@ -57,14 +58,16 @@ function readSqliteStore(id, path, expectedVersion, DatabaseSync, providerMap, p
   let database
   try {
     database = new DatabaseSync(path, { readOnly: true })
-    const version = database.prepare("SELECT version FROM auth_schema_version").get()?.version
+    const version = readRow(database, ["version"], "SELECT version FROM auth_schema_version")?.version
     if (version !== expectedVersion) {
       plan.notices.push(`NOTICE ${id}: auth schema version ${String(version)} is unknown; credentials not imported`)
       return
     }
-    const rows = database.prepare(
+    const rows = readRows(
+      database,
+      ["provider", "credential_type", "data"],
       "SELECT provider, credential_type, data FROM auth_credentials WHERE disabled_cause IS NULL ORDER BY id ASC",
-    ).all()
+    )
     for (const row of rows) {
       if (row.credential_type === "oauth") {
         plan.oauth.push(row.provider)

--- a/packages/omo-native/bin/lib/sqlite-rows.js
+++ b/packages/omo-native/bin/lib/sqlite-rows.js
@@ -1,0 +1,32 @@
+/**
+ * Read rows from a SQLite database without creating a prepared statement.
+ *
+ * Bun 1.4's `node:sqlite` does not finalize outstanding `StatementSync` objects when
+ * `DatabaseSync.close()` runs (oven-sh/bun#40001), so `sqlite3_close()` returns SQLITE_BUSY
+ * and the file handle is retained until the statement object is garbage collected. On POSIX an
+ * open handle does not block `unlink`, so this is invisible; on Windows it keeps the database
+ * file locked, which makes the next open of the same file block and the temp root fail teardown
+ * with EBUSY. `StatementSync` exposes no `finalize()`, so the only deterministic release is to
+ * never create one: `exec()` with a user-defined SQL function as the row sink delivers every
+ * row to JavaScript with zero statement objects, and `close()` then releases the handle.
+ *
+ * `columns` is the exact projection order; each row comes back as a plain object keyed by those
+ * names. `sql` must be a complete SELECT whose projection matches `columns` in order.
+ */
+export function readRows(database, columns, sql) {
+  const rows = []
+  const sink = `omo_sink_${Math.random().toString(36).slice(2, 10)}`
+  database.function(sink, { varargs: true, deterministic: false }, (...values) => {
+    const row = {}
+    columns.forEach((column, index) => { row[column] = values[index] })
+    rows.push(row)
+    return null
+  })
+  database.exec(`SELECT ${sink}(${columns.join(", ")}) FROM (${sql})`)
+  return rows
+}
+
+/** First row of `readRows`, or undefined. */
+export function readRow(database, columns, sql) {
+  return readRows(database, columns, sql)[0]
+}

--- a/packages/omo-native/test/setup-detect.test.ts
+++ b/packages/omo-native/test/setup-detect.test.ts
@@ -7,6 +7,10 @@ import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { detectHarnesses, needsSetupSuggestion } from "../bin/lib/setup-detect.js"
 import { formatSetupReport } from "../bin/lib/setup-report.js"
+
+function sqlLiteral(value: string | null): string {
+  return value === null ? "NULL" : `'${value.replace(/'/g, "''")}'`
+}
 import { teardownRoots, withDatabase } from "./teardown.test-support"
 
 // Older Bun runtimes ship no node:sqlite at all, so the module loads lazily and the fixtures that
@@ -54,8 +58,12 @@ async function createDatabase(path: string, version: number, rows: Array<[string
         data TEXT NOT NULL, disabled_cause TEXT DEFAULT NULL
       );
     `)
-    const insert = db.prepare("INSERT INTO auth_credentials (provider, credential_type, data, disabled_cause) VALUES (?, ?, ?, ?)")
-    for (const [provider, type, disabled] of rows) insert.run(provider, type, "SQLITE-SECRET", disabled)
+    // exec() with literal values: a prepared INSERT would leave this writer's handle open past
+    // close() under Bun 1.4 (oven-sh/bun#40001), and the reader that opens the same file next
+    // would then block on the Windows file lock.
+    for (const [provider, type, disabled] of rows) {
+      db.exec(`INSERT INTO auth_credentials (provider, credential_type, data, disabled_cause) VALUES (${sqlLiteral(provider)}, ${sqlLiteral(type)}, 'SQLITE-SECRET', ${sqlLiteral(disabled)})`)
+    }
   })
 }
 

--- a/packages/omo-native/test/setup-import.test.ts
+++ b/packages/omo-native/test/setup-import.test.ts
@@ -10,6 +10,10 @@ import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { teardownRoots, withDatabase } from "./teardown.test-support"
 
+function sqlLiteral(value: string | null): string {
+  return value === null ? "NULL" : `'${value.replace(/'/g, "''")}'`
+}
+
 // Older Bun runtimes ship no node:sqlite at all, so the module loads lazily and the fixtures that
 // need a real database skip there. Production degrades the same way: setup-import.js reports the
 // database credentials as not imported when the import throws. The pinned CI runtime is now Bun
@@ -64,9 +68,11 @@ async function database(path: string, version: number, rows: Array<[string, stri
         data TEXT NOT NULL, disabled_cause TEXT DEFAULT NULL
       );
     `)
-    const insert = database.prepare("INSERT INTO auth_credentials (provider, credential_type, data, disabled_cause) VALUES (?, ?, ?, ?)")
+    // exec() with literal values: a prepared INSERT would leave this writer's handle open past
+    // close() under Bun 1.4 (oven-sh/bun#40001), and the reader that opens the same file next
+    // would then block on the Windows file lock.
     for (const [provider, type, key, disabled] of rows) {
-      insert.run(provider, type, JSON.stringify({ key }), disabled)
+      database.exec(`INSERT INTO auth_credentials (provider, credential_type, data, disabled_cause) VALUES (${sqlLiteral(provider)}, ${sqlLiteral(type)}, ${sqlLiteral(JSON.stringify({ key }))}, ${sqlLiteral(disabled)})`)
     }
   })
 }

--- a/packages/omo-native/test/sqlite-rows.test.ts
+++ b/packages/omo-native/test/sqlite-rows.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, readdirSync, readlinkSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { readRow, readRows } from "../bin/lib/sqlite-rows.js"
+
+const SQLITE_AVAILABLE = await (async () => {
+  try { await import("node:sqlite"); return true } catch { return false }
+})()
+
+async function loadDatabaseSync() {
+  const sqlite = await import("node:sqlite")
+  return sqlite.DatabaseSync
+}
+
+/** Open handles on `needle` in this process. Linux only; other hosts return undefined. */
+function openHandlesOn(needle: string): number | undefined {
+  if (process.platform !== "linux") return undefined
+  return readdirSync("/proc/self/fd")
+    .map((fd) => { try { return readlinkSync(join("/proc/self/fd", fd)) } catch { return "" } })
+    .filter((target) => target.includes(needle)).length
+}
+
+async function seededDatabase(): Promise<{ root: string; path: string }> {
+  const root = mkdtempSync(join(tmpdir(), "omo-sqlite-rows-"))
+  const path = join(root, "agent.db")
+  const DatabaseSync = await loadDatabaseSync()
+  const db = new DatabaseSync(path)
+  db.exec(`
+    CREATE TABLE auth_schema_version (id INTEGER PRIMARY KEY, version INTEGER NOT NULL);
+    INSERT INTO auth_schema_version VALUES (1, 7);
+    CREATE TABLE auth_credentials (
+      id INTEGER PRIMARY KEY, provider TEXT NOT NULL, credential_type TEXT NOT NULL,
+      data TEXT NOT NULL, disabled_cause TEXT DEFAULT NULL
+    );
+    INSERT INTO auth_credentials (provider, credential_type, data, disabled_cause) VALUES
+      ('omp-api', 'api_key', '{"key":"SECRET"}', NULL),
+      ('omp-disabled', 'oauth', '{}', 'expired');
+  `)
+  db.close()
+  return { root, path }
+}
+
+describe("sqlite-rows", () => {
+  test.skipIf(!SQLITE_AVAILABLE)("#given a seeded store #when rows are read #then every projected column comes back keyed by name, in order", async () => {
+    const { root, path } = await seededDatabase()
+    try {
+      const DatabaseSync = await loadDatabaseSync()
+      const db = new DatabaseSync(path, { readOnly: true })
+      const version = readRow(db, ["version"], "SELECT version FROM auth_schema_version")
+      const rows = readRows(db, ["provider", "credential_type", "disabled_cause"],
+        "SELECT provider, credential_type, disabled_cause FROM auth_credentials ORDER BY id ASC")
+      db.close()
+      expect(version).toEqual({ version: 7 })
+      expect(rows).toEqual([
+        { provider: "omp-api", credential_type: "api_key", disabled_cause: null },
+        { provider: "omp-disabled", credential_type: "oauth", disabled_cause: "expired" },
+      ])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test.skipIf(!SQLITE_AVAILABLE)("#given rows were read #when the database is closed #then no file handle survives close()", async () => {
+    // The defect this module exists to avoid: a prepared statement keeps the SQLite file handle
+    // alive past close(). Reading through exec() + a sink function must leave nothing behind.
+    const { root, path } = await seededDatabase()
+    try {
+      const DatabaseSync = await loadDatabaseSync()
+      const db = new DatabaseSync(path, { readOnly: true })
+      readRow(db, ["version"], "SELECT version FROM auth_schema_version")
+      readRows(db, ["provider"], "SELECT provider FROM auth_credentials")
+      db.close()
+      const handles = openHandlesOn("agent.db")
+      if (handles !== undefined) expect(handles).toBe(0)
+      // Every host: the directory must be removable right now. On Windows a retained handle
+      // makes this throw EBUSY, which is exactly the teardown failure seen in CI.
+      rmSync(root, { recursive: true, force: true })
+      expect(existsSync(root)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test.skipIf(!SQLITE_AVAILABLE)("#given an empty result #when rows are read #then an empty array and undefined row come back", async () => {
+    const { root, path } = await seededDatabase()
+    try {
+      const DatabaseSync = await loadDatabaseSync()
+      const db = new DatabaseSync(path, { readOnly: true })
+      const none = readRows(db, ["provider"], "SELECT provider FROM auth_credentials WHERE 1 = 0")
+      const first = readRow(db, ["provider"], "SELECT provider FROM auth_credentials WHERE 1 = 0")
+      db.close()
+      expect(none).toEqual([])
+      expect(first).toBeUndefined()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/omo-senpi/scripts/qa/isolation-review-blockers.test.mjs
+++ b/packages/omo-senpi/scripts/qa/isolation-review-blockers.test.mjs
@@ -344,15 +344,20 @@ test("#given a non-directory root component #when snapshotDirectory runs #then t
 
 		// Then
 		expect(result.complete).toBe(false);
-		expect(result.errors).toEqual([
-			{
-				path: ".",
-				code:
-					process.platform === "linux"
-						? "ENOTDIR"
-						: "DIRECTORY_IDENTITY_UNAVAILABLE",
-			},
-		]);
+		// The root stat fails BEFORE directory identity binding is attempted, so the platform's own
+		// errno wins on every host. Linux reports ENOTDIR for a file used as a path component;
+		// macOS also reports ENOTDIR, which isolation-state.mjs remaps to
+		// DIRECTORY_IDENTITY_UNAVAILABLE (darwin only); Windows has no ENOTDIR for this case and
+		// reports ENOENT - the same absence mapping the digestDirectory case below pins. A
+		// two-way linux/other split collapsed macOS and Windows together and was only ever
+		// validated on macOS.
+		const platformRootError =
+			process.platform === "win32"
+				? "ENOENT"
+				: process.platform === "darwin"
+					? "DIRECTORY_IDENTITY_UNAVAILABLE"
+					: "ENOTDIR";
+		expect(result.errors).toEqual([{ path: ".", code: platformRootError }]);
 	} finally {
 		rmSync(parent, { recursive: true, force: true });
 	}

--- a/packages/omo-senpi/scripts/qa/isolation-state-races.test.mjs
+++ b/packages/omo-senpi/scripts/qa/isolation-state-races.test.mjs
@@ -23,6 +23,36 @@ import * as isolationState from "./isolation-state.mjs";
 const { changedSnapshotPaths, snapshotDirectory, snapshotProtectedState } =
 	isolationState;
 
+// These scenarios exercise RACE semantics (same-size overwrites, ENOENT-then-open, close-failure
+// precedence), not no-follow capability. The production reader fails closed with
+// NO_FOLLOW_UNAVAILABLE wherever O_NOFOLLOW is absent (Windows) - that contract is pinned in
+// isolation-platform-capabilities.test.mjs - and doing so here would stop every race before it
+// starts, so the fixture supplies a read flag the host can honour. None of these fixtures use
+// symlinks, so O_RDONLY is byte-equivalent to the production flags for the files they read.
+const RACE_READ_FLAGS = constants.O_RDONLY;
+function raceIo(overrides = {}) {
+	return { noFollowReadFlags: RACE_READ_FLAGS, ...overrides };
+}
+function raceReader(readFile) {
+	readFile.noFollowReadFlags = RACE_READ_FLAGS;
+	return readFile;
+}
+
+// Directory traversal binds identity with O_DIRECTORY | O_NOFOLLOW (isolation-state.mjs). Where
+// either constant is absent (Windows), snapshotDirectory fails closed BEFORE traversal with
+// DIRECTORY_IDENTITY_UNAVAILABLE at ".", so no directory race can be observed there. Each race
+// below keeps its setup and injection on every host and asserts the verdict the host can
+// produce: the specific race code where identity binding exists, the fail-closed capability
+// error where it does not. Both uphold the invariant that a mutation never looks unchanged.
+const DIRECTORY_IDENTITY =
+	constants.O_DIRECTORY !== undefined && constants.O_NOFOLLOW !== undefined;
+function expectDirectoryIdentityUnavailable(scan) {
+	expect(scan.complete).toBe(false);
+	expect(scan.errors).toEqual([{ path: ".", code: "DIRECTORY_IDENTITY_UNAVAILABLE" }]);
+	expect([...scan.snapshot.keys()]).toEqual([]);
+	expect(scan.bytesRead).toBe(0);
+}
+
 test("#given a same-size in-place overwrite after an observation read #when metadata is verified #then the snapshot fails closed", () => {
 	const root = mkdtempSync(join(tmpdir(), "omo-senpi-same-size-observation-"));
 	try {
@@ -55,8 +85,12 @@ test("#given a same-size in-place overwrite after an observation read #when meta
 		const scan = snapshotDirectory(
 			root,
 			{ maxFiles: 10, maxBytes: 4, maxEntries: 10 },
-			io,
+			raceIo(io),
 		);
+		if (!DIRECTORY_IDENTITY) {
+			expectDirectoryIdentityUnavailable(scan);
+			return;
+		}
 		expect(scan.bytesRead).toBe(4);
 		expect(scan.complete).toBe(false);
 		expect(scan.errors).toEqual([{ path: "state.json", code: "FILE_CHANGED" }]);
@@ -91,7 +125,7 @@ test("#given a same-size in-place overwrite after a protected read #when metadat
 				? { ...metadata, mtimeNs: metadata.mtimeNs + 1n }
 				: metadata;
 		};
-		const snapshot = snapshotProtectedState(root, readFile);
+		const snapshot = snapshotProtectedState(root, raceReader(readFile));
 		expect(snapshot.complete).toBe(false);
 		expect(snapshot.errors).toEqual([
 			{ path: "auth.json", code: "FILE_CHANGED" },
@@ -117,7 +151,7 @@ test("#given an existence probe would hide inaccessible protected state #when op
 			if (file === join(root, "auth.json")) return deniedRead();
 			return openSync(file, flags);
 		};
-		const snapshot = snapshotProtectedState(root, deniedRead);
+		const snapshot = snapshotProtectedState(root, raceReader(deniedRead));
 		expect(snapshot.complete).toBe(false);
 		expect(snapshot.errors).toEqual([{ path: "auth.json", code: "EACCES" }]);
 		expect(snapshot.snapshot.has("auth.json")).toBe(false);
@@ -142,7 +176,7 @@ test("#given only volatile settings stamps change #when bounded complete-tree sn
 				modelLastOnThinkingLevels: { model: "low" },
 			}),
 		);
-		const before = snapshotDirectory(root);
+		const before = snapshotDirectory(root, undefined, raceIo());
 		writeFileSync(
 			path,
 			JSON.stringify({
@@ -152,7 +186,13 @@ test("#given only volatile settings stamps change #when bounded complete-tree sn
 				modelLastOnThinkingLevels: { model: "high" },
 			}),
 		);
-		const after = snapshotDirectory(root);
+		const after = snapshotDirectory(root, undefined, raceIo());
+		if (!DIRECTORY_IDENTITY) {
+			expectDirectoryIdentityUnavailable(before);
+			expectDirectoryIdentityUnavailable(after);
+			expect(changedSnapshotPaths(before.snapshot, after.snapshot)).toEqual([]);
+			return;
+		}
 		expect(before.complete).toBe(true);
 		expect(after.complete).toBe(true);
 		expect(changedSnapshotPaths(before.snapshot, after.snapshot)).toEqual([]);
@@ -210,8 +250,12 @@ test("#given an enumerated entry vanishes before stat #when final directory meta
 		const scan = snapshotDirectory(
 			root,
 			{ maxFiles: 10, maxBytes: 1024, maxEntries: 10 },
-			io,
+			raceIo(io),
 		);
+		if (!DIRECTORY_IDENTITY) {
+			expectDirectoryIdentityUnavailable(scan);
+			return;
+		}
 		expect(scan.complete).toBe(false);
 		expect(scan.truncated).toBe(false);
 		expect(scan.errors).toEqual([{ path: ".", code: "FILE_CHANGED" }]);
@@ -244,10 +288,14 @@ test("#given replacement between initial stat and open #when snapshotted #then p
 					? snapshotDirectory(
 							root,
 							{ maxFiles: 10, maxBytes: 1024, maxEntries: 10 },
-							io,
+							raceIo(io),
 						)
-					: snapshotProtectedState(root, io);
+					: snapshotProtectedState(root, raceIo(io));
 			expect(result.complete).toBe(false);
+			if (kind === "observed" && !DIRECTORY_IDENTITY) {
+				expectDirectoryIdentityUnavailable(result);
+				continue;
+			}
 			expect(result.errors).toEqual([{ path: name, code: "FILE_REPLACED" }]);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
@@ -266,9 +314,17 @@ test("#given success or primary failure plus close failure #when reading #then p
 					? snapshotDirectory(
 							root,
 							{ maxFiles: 10, maxBytes: 1024, maxEntries: 10 },
-							io,
+							raceIo(io),
 						)
-					: snapshotProtectedState(root, io);
+					: snapshotProtectedState(root, raceIo(io));
+			if (kind === "observed" && !DIRECTORY_IDENTITY) {
+				expectDirectoryIdentityUnavailable(run({
+					closeSync() {
+						throw codedError("ECLOSE");
+					},
+				}));
+				continue;
+			}
 			expect(
 				run({
 					closeSync() {
@@ -306,7 +362,7 @@ test("#given ENOENT stat then open success and close failure #when absence races
 	try {
 		const path = join(root, "auth.json");
 		let firstStat = true;
-		const snapshot = snapshotProtectedState(root, {
+		const snapshot = snapshotProtectedState(root, raceIo({
 			lstatSync(file, options) {
 				if (file === path && firstStat) {
 					firstStat = false;
@@ -318,7 +374,7 @@ test("#given ENOENT stat then open success and close failure #when absence races
 			closeSync() {
 				throw codedError("ECLOSE");
 			},
-		});
+		}));
 		expect(snapshot.errors).toEqual([
 			{ path: "auth.json", code: "FILE_REPLACED" },
 		]);
@@ -333,14 +389,18 @@ test("#given the root vanishes after its initial identity check #when directory 
 		const scan = snapshotDirectory(
 			root,
 			{ maxFiles: 10, maxBytes: 1024, maxEntries: 10 },
-			{
+			raceIo({
 				opendirSync() {
 					throw codedError("ENOENT");
 				},
-			},
+			}),
 		);
 
 		expect(scan.complete).toBe(false);
+		if (!DIRECTORY_IDENTITY) {
+			expectDirectoryIdentityUnavailable(scan);
+			return;
+		}
 		expect(scan.errors).toEqual([{ path: ".", code: "FILE_REPLACED" }]);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
@@ -364,7 +424,7 @@ test("#given directory open returns a stale external descriptor #when traversal 
 		const scan = snapshotDirectory(
 			root,
 			{ maxFiles: 10, maxBytes: 1024, maxEntries: 10 },
-			{
+			raceIo({
 				openDirectorySync(path, flags) {
 					if (
 						(path === state || path.endsWith("/state")) &&
@@ -375,11 +435,15 @@ test("#given directory open returns a stale external descriptor #when traversal 
 					}
 					return openSync(path, flags);
 				},
-			},
+			}),
 		);
 		if (!suppliedExternalFd) closeSync(externalFd);
 
 		expect(scan.complete).toBe(false);
+		if (!DIRECTORY_IDENTITY) {
+			expectDirectoryIdentityUnavailable(scan);
+			return;
+		}
 		expect(scan.errors).toContainEqual({
 			path: "state",
 			code: "FILE_REPLACED",
@@ -402,7 +466,7 @@ test("#given an opened directory is replaced after its identity check #when trav
 		const scan = snapshotDirectory(
 			root,
 			{ maxFiles: 10, maxBytes: 1024, maxEntries: 10 },
-			{
+			raceIo({
 				opendirSync(path) {
 					directoryOpens += 1;
 					const directory = opendirSync(path);
@@ -422,10 +486,14 @@ test("#given an opened directory is replaced after its identity check #when trav
 						},
 					};
 				},
-			},
+			}),
 		);
 
 		expect(scan.complete).toBe(false);
+		if (!DIRECTORY_IDENTITY) {
+			expectDirectoryIdentityUnavailable(scan);
+			return;
+		}
 		expect(scan.errors).toContainEqual({
 			path: "state",
 			code: "FILE_REPLACED",
@@ -443,13 +511,17 @@ test("#given non-ASCII canonical paths #when snapshots and errors are ordered #t
 		const scan = snapshotDirectory(
 			root,
 			{ maxFiles: 10, maxBytes: 1024, maxEntries: 10 },
-			{
+			raceIo({
 				openSync() {
 					throw codedError("EIO");
 				},
-			},
+			}),
 		);
 
+		if (!DIRECTORY_IDENTITY) {
+			expectDirectoryIdentityUnavailable(scan);
+			return;
+		}
 		expect(scan.errors).toEqual([
 			{ path: "z", code: "EIO" },
 			{ path: "ä", code: "EIO" },


### PR DESCRIPTION
## Summary

Fixes the two Windows-only failure groups on `dev` (run [33879345538](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/33879345538), head `724ad6f91`) that gate the beta publish. Neither is a Windows flake; both have a concrete cause in code, fixed at that cause. Nothing is skipped or gated off Windows.

### 1. `test (windows-latest, 2/2)` — setup-detect "all four harness stores" timing out

Both tests timed out at 30s (35.8s / 38.8s) with `EBUSY` teardown leaks. They took 4.7s / 4.6s on the last green `dev` run, no commit in between touched this code, and the *other* SQLite tests in the same file barely moved — only the two that open the same `agent.db` 4–6 times hung. That rules out runner load and points at a file lock.

**Root cause:** Bun 1.4.0 `node:sqlite` does not finalize outstanding `StatementSync` objects in `DatabaseSync.close()` ([oven-sh/bun#40001](https://github.com/oven-sh/bun/issues/40001)). `prepare()` alone triggers it; `sqlite3_close()` returns `SQLITE_BUSY` and the handle survives until the statement is garbage-collected. POSIX never notices; on Windows the db file stays **locked**, so the next open blocks and teardown fails `EBUSY`. This is also why it was intermittent — GC timing decided pass vs hang.

Reproduced on Linux via `/proc/self/fd` (handles on the db after `close()`): `exec` only → 0, `prepare+run` → 1 (compounding), `prepare+run` then GC → 0. `StatementSync` exposes no `finalize()`/`close()`/`Symbol.dispose` in Bun 1.4.0, so "finalize before close" is not available.

**Fix:** `packages/omo-native/bin/lib/sqlite-rows.js` reads rows with `exec()` + a user-defined SQL function as the row sink — zero statement objects, `close()` releases the handle deterministically (0 handles measured). Both production readers (`setup-detect.js`, `setup-import.js`) and both test writers (whose prepared `INSERT`s leaked the *writer's* handle the reader then collided with) use it. All six `prepare()` sites are gone.

### 2. `senpi-compatibility (windows-latest)` — `isolation-state-races.test.mjs` 13/13

Every test in the file failed, including ones unrelated to overwrites. The production reader fails closed where `O_NOFOLLOW`/`O_DIRECTORY` are absent (#7769, correct). It has two gates: the **file** gate reads `io.noFollowReadFlags` (injectable by design); the **directory** gate reads the fs constants directly. The race fixtures inherited `noFollowReadFlags: undefined` from `FILE_IO`, so on Windows every read failed closed *before the race under test could occur*. Real Windows CI reports `DIRECTORY_IDENTITY_UNAVAILABLE` 16× — the directory gate genuinely fires there.

**Fix, file gate:** fixtures supply a read flag the host can honour (`O_RDONLY`; no fixture uses symlinks, so it is byte-equivalent for the files read) via `raceIo()`/`raceReader()` at all 17 call sites.

**Fix, directory gate:** it cannot be injected and Windows genuinely lacks the primitive, so the nine `snapshotDirectory` races branch on the reader's own predicate (`O_DIRECTORY && O_NOFOLLOW`): where identity binding exists they assert the specific race code; where it does not, the fail-closed `DIRECTORY_IDENTITY_UNAVAILABLE` verdict with an empty snapshot and `bytesRead 0`. **Setup and race injection are identical on every host — only the verdict that counts as correct differs**, and both uphold the invariant that a mutation never looks unchanged. The capability contract itself stays pinned in `isolation-platform-capabilities.test.mjs`.

## Test plan

All on a bunshin Linux box (npm 11 shim so the vendored lsp-daemon test-setup hook runs; node 20 / bun 1.4.0). Windows capability reproduced by deleting `constants.O_NOFOLLOW` via `--preload` before any module loads.

| Check | Result |
| --- | --- |
| **RED** dev's races file, Windows sim | 1 pass / **12 fail** (matches CI) |
| **GREEN** branch, Windows sim | **13 pass / 0 fail** |
| **GREEN** branch, normal POSIX + capabilities suite | 18 pass / 0 fail |
| **GREEN** sqlite-rows + setup-detect + setup-import | 22 pass / 0 fail |
| Mutant: sqlite helper reverts to `prepare()` | leak test **fails**, 2 others pass |
| Mutant A: race flags removed (file gate) | **5 fail** under Windows sim |
| Mutant B: fail-closed helper asserts `FILE_REPLACED` | **9 fail** under Windows sim |
| Mutant C: capability predicate inverted | **9 fail** under normal POSIX |
| Blast radius: `packages/omo-senpi/scripts/qa` + touched omo-native suites | 172 pass / 0 fail |

Mutants B and C are the important ones: they prove the capability branch asserts the real verdict rather than waving Windows through.

> **Windows jobs only run with the `ci:full-matrix` label** — applied here, since both fixes are Windows-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the two non-flaky Windows-only CI failures on `dev` that gate the beta publish: SQLite file handles leak past `close()` under Bun 1.4, and the state-race tests fail closed before the race runs on Windows. No tests are skipped or gated off Windows.

**Bug Fixes**
- Replaces all prepared statements in the `packages/omo-native` SQLite readers and test writers with `exec()` plus a row-sink function, so `DatabaseSync.close()` deterministically releases the database file on Windows.
- Gives the `isolation-state-races` fixtures `O_RDONLY` instead of inherited `noFollowReadFlags: undefined`, so file reads no longer fail closed before exercising the race.
- Branches the nine directory-snapshot races on the reader's own `O_DIRECTORY`/`O_NOFOLLOW` predicate, asserting the race code where available and `DIRECTORY_IDENTITY_UNAVAILABLE` on Windows.
- Updates the `isolation-review-blockers` non-directory-root expectation to the platform's own errno (`ENOENT` on Windows, `DIRECTORY_IDENTITY_UNAVAILABLE` on macOS, `ENOTDIR` on Linux), since the root stat fails before identity binding and the old linux/other split only held on macOS.
- Keeps race setup and injection identical across hosts; the no-follow capability contract stays pinned in `isolation-platform-capabilities.test.mjs`.

<sup>Written for commit 8177f0338b7d69a80cc3a225614b9292a3ecc729. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

