### PR TITLE
docs: document local OpenCode plugin wiring

### DIFF
--- a/docs/superpowers/plans/2026-09-04-local-opencode-plugin.md
+++ b/docs/superpowers/plans/2026-09-04-local-opencode-plugin.md
@@ -1,0 +1,111 @@
+# Local OpenCode Plugin Wiring Implementation Plan
+
+> **For agentic workers:** Execute this plan task-by-task with the repository's required QA and evidence workflow.
+
+**Goal:** Configure the installed OpenCode 1.18.27 instance to load the cloned oh-my-openagent source entrypoint directly, so future `git pull` operations update the plugin without republishing or relinking a package.
+
+**Architecture:** Preserve the existing OpenCode JSONC configuration and its `model-watch` plugin/MCP entries. Remove any pre-existing package-style `oh-my-opencode` or `oh-my-openagent` plugin entry, then add one absolute `file://` plugin entry targeting `packages/omo-opencode/src/index.ts`; install the checkout's workspace dependencies so OpenCode can resolve the source tree at runtime. Verify the effective configuration with the plugin's doctor command and a real isolated OpenCode smoke test using a faithful copy of the edited config.
+
+**Tech Stack:** OpenCode 1.18.27, JSONC configuration, the repository's Bun workspace, and the `.agents/skills/opencode-qa` isolated harness.
+
+---
+
+### Task 1: Document the approved local-source design
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-09-04-local-opencode-plugin-design.md`
+
+- [x] **Step 1: Record the design and constraints**
+
+Document the absolute source entrypoint, the preserved existing configuration, removal of conflicting OMO package entries, the dependency-install prerequisite, the fact that `git pull` refreshes source code, and the residual requirement to reinstall dependencies when the lockfile changes.
+
+- [x] **Step 2: Self-review the design document**
+
+Check for placeholders, contradictions, ambiguous paths, and accidental secret-bearing configuration content.
+
+- [x] **Step 3: Commit the design document**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-09-04-local-opencode-plugin-design.md
+git commit -m "docs: define local OpenCode plugin wiring"
+```
+
+Expected: one commit containing only the design document.
+
+### Task 2: Install checkout dependencies without changing source
+
+**Files:**
+- Modify: ignored dependency/install outputs only (`node_modules/` and package-manager metadata as required by the repository tooling)
+
+- [ ] **Step 1: Confirm the checkout is clean and the source entrypoint exists**
+
+Run:
+
+```bash
+git status --short --branch
+test -f packages/omo-opencode/src/index.ts
+```
+
+Expected: the task branch is clean and the source entrypoint exists.
+
+- [ ] **Step 2: Install the repository's Bun workspace dependencies**
+
+Use the supported Bun package-manager path available in the environment (the environment may need a temporary `npm exec --package=bun@1.3.12 -- bun ...` launcher because `bun` is not necessarily installed on `PATH`). Do not run a global install and do not change tracked source/config files.
+
+- [ ] **Step 3: Verify dependency installation**
+
+Run the repository's focused OpenCode adapter typecheck or equivalent dependency-resolution check. Expected: exit code 0, or record the exact environment limitation if the checkout cannot be built in this environment.
+
+### Task 3: Wire the live OpenCode configuration to the checkout
+
+**Files:**
+- Modify: `~/.config/opencode/opencode.jsonc` (outside the repository; preserve existing entries)
+
+- [ ] **Step 1: Snapshot the active config without printing secrets**
+
+Record a redacted copy/digest and the existing plugin/MCP keys in the evidence directory. Do not include authentication values or environment dumps.
+
+- [ ] **Step 2: Add the source plugin entry**
+
+Remove any existing `oh-my-opencode`, `oh-my-openagent`, `npm:oh-my-opencode`, `npm:oh-my-openagent`, and versioned/package-qualified variants from the plugin array, then ensure it contains exactly this OMO source entry while retaining `file:///home/heki/.config/opencode/model-watch.js` and the existing `ouroboros` MCP:
+
+```json
+"file:///home/heki/workspace/oh-my-openagent/packages/omo-opencode/src/index.ts"
+```
+
+- [ ] **Step 3: Verify JSONC and idempotency**
+
+Parse the active config, assert the source entry is present once, assert no OMO package-style entry remains, assert the existing plugin/MCP remain, and run the wiring operation a second time to confirm no duplicate entry.
+
+### Task 4: Prove the live plugin wiring
+
+**Files:**
+- Create: `.omo/evidence/20260904-local-opencode-plugin/what-was-tested.md`
+- Create: `.omo/evidence/20260904-local-opencode-plugin/config-before-after.txt`
+- Create: `.omo/evidence/20260904-local-opencode-plugin/doctor.txt`
+- Create: `.omo/evidence/20260904-local-opencode-plugin/opencode-qa.txt`
+
+- [ ] **Step 1: Run the plugin doctor against the live installation**
+
+Run the doctor in JSON or text mode and capture sanitized output proving the source entry resolves and OpenCode 1.18.27 is supported. Record that the doctor applies a minimum-version floor, so its pinned SDK version need not exactly equal the installed CLI version.
+
+- [ ] **Step 2: Run the mandatory isolated OpenCode QA**
+
+Run the relevant `.agents/skills/opencode-qa` self-check plus a source-plugin smoke case with isolated XDG directories. Seed the isolated config from a faithful, sanitized copy of the edited live config so it includes `model-watch`, `ouroboros`, and the OMO source entry. Record before/after real session counts and the exact observed event/output. Never use the real OpenCode database for spawned QA.
+
+- [ ] **Step 3: Write reviewer-readable evidence**
+
+Explain what was tested, what was observed, why it covers source loading/config preservation, and what was omitted or remains environment-dependent. Redact credentials, auth headers, and private environment values.
+
+- [ ] **Step 4: Run final repository checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Expected: no whitespace errors; only the documented design/evidence changes are present in the task branch.

--- a/docs/superpowers/plans/2026-09-04-local-opencode-plugin.md
+++ b/docs/superpowers/plans/2026-09-04-local-opencode-plugin.md
@@ -39,7 +39,7 @@ Expected: one commit containing only the design document.
 **Files:**
 - Modify: ignored dependency/install outputs only (`node_modules/` and package-manager metadata as required by the repository tooling)
 
-- [ ] **Step 1: Confirm the checkout is clean and the source entrypoint exists**
+- [x] **Step 1: Confirm the checkout is clean and the source entrypoint exists**
 
 Run:
 
@@ -50,11 +50,11 @@ test -f packages/omo-opencode/src/index.ts
 
 Expected: the task branch is clean and the source entrypoint exists.
 
-- [ ] **Step 2: Install the repository's Bun workspace dependencies**
+- [x] **Step 2: Install the repository's Bun workspace dependencies**
 
 Use the supported Bun package-manager path available in the environment (the environment may need a temporary `npm exec --package=bun@1.3.12 -- bun ...` launcher because `bun` is not necessarily installed on `PATH`). Do not run a global install and do not change tracked source/config files.
 
-- [ ] **Step 3: Verify dependency installation**
+- [x] **Step 3: Verify dependency installation**
 
 Run the repository's focused OpenCode adapter typecheck or equivalent dependency-resolution check. Expected: exit code 0, or record the exact environment limitation if the checkout cannot be built in this environment.
 
@@ -63,11 +63,11 @@ Run the repository's focused OpenCode adapter typecheck or equivalent dependency
 **Files:**
 - Modify: `~/.config/opencode/opencode.jsonc` (outside the repository; preserve existing entries)
 
-- [ ] **Step 1: Snapshot the active config without printing secrets**
+- [x] **Step 1: Snapshot the active config without printing secrets**
 
 Record a redacted copy/digest and the existing plugin/MCP keys in the evidence directory. Do not include authentication values or environment dumps.
 
-- [ ] **Step 2: Add the source plugin entry**
+- [x] **Step 2: Add the source plugin entry**
 
 Remove any existing `oh-my-opencode`, `oh-my-openagent`, `npm:oh-my-opencode`, `npm:oh-my-openagent`, and versioned/package-qualified variants from the plugin array, then ensure it contains exactly this OMO source entry while retaining `file:///home/heki/.config/opencode/model-watch.js` and the existing `ouroboros` MCP:
 
@@ -75,7 +75,7 @@ Remove any existing `oh-my-opencode`, `oh-my-openagent`, `npm:oh-my-opencode`, `
 "file:///home/heki/workspace/oh-my-openagent/packages/omo-opencode/src/index.ts"
 ```
 
-- [ ] **Step 3: Verify JSONC and idempotency**
+- [x] **Step 3: Verify JSONC and idempotency**
 
 Parse the active config, assert the source entry is present once, assert no OMO package-style entry remains, assert the existing plugin/MCP remain, and run the wiring operation a second time to confirm no duplicate entry.
 
@@ -87,19 +87,19 @@ Parse the active config, assert the source entry is present once, assert no OMO 
 - Create: `.omo/evidence/20260904-local-opencode-plugin/doctor.txt`
 - Create: `.omo/evidence/20260904-local-opencode-plugin/opencode-qa.txt`
 
-- [ ] **Step 1: Run the plugin doctor against the live installation**
+- [x] **Step 1: Run the plugin doctor against the live installation**
 
 Run the doctor in JSON or text mode and capture sanitized output proving the source entry resolves and OpenCode 1.18.27 is supported. Record that the doctor applies a minimum-version floor, so its pinned SDK version need not exactly equal the installed CLI version.
 
-- [ ] **Step 2: Run the mandatory isolated OpenCode QA**
+- [x] **Step 2: Run the mandatory isolated OpenCode QA**
 
 Run the relevant `.agents/skills/opencode-qa` self-check plus a source-plugin smoke case with isolated XDG directories. Seed the isolated config from a faithful, sanitized copy of the edited live config so it includes `model-watch`, `ouroboros`, and the OMO source entry. Record before/after real session counts and the exact observed event/output. Never use the real OpenCode database for spawned QA.
 
-- [ ] **Step 3: Write reviewer-readable evidence**
+- [x] **Step 3: Write reviewer-readable evidence**
 
 Explain what was tested, what was observed, why it covers source loading/config preservation, and what was omitted or remains environment-dependent. Redact credentials, auth headers, and private environment values.
 
-- [ ] **Step 4: Run final repository checks**
+- [x] **Step 4: Run final repository checks**
 
 Run:
 

--- a/docs/superpowers/specs/2026-09-04-local-opencode-plugin-design.md
+++ b/docs/superpowers/specs/2026-09-04-local-opencode-plugin-design.md
@@ -1,0 +1,32 @@
+# Local OpenCode Plugin Wiring Design
+
+## Goal
+
+Configure the installed OpenCode 1.18.27 instance to load the oh-my-openagent source from the cloned checkout at:
+
+```text
+file:///home/heki/workspace/oh-my-openagent/packages/omo-opencode/src/index.ts
+```
+
+After this change, pulling new commits into the checkout updates the code OpenCode loads without republishing or relinking the package.
+
+## Configuration behavior
+
+The existing OpenCode configuration remains intact. Its `model-watch` plugin entry and `ouroboros` MCP definition are preserved. Before adding the source entry, any existing package-style `oh-my-opencode` or `oh-my-openagent` plugin entry is removed so the runtime duplicate-OMO guard cannot disable startup. The OMO source entry is then added to the active OpenCode JSONC plugin array and is kept idempotent, meaning repeated setup does not create duplicates.
+
+The checkout's workspace dependencies must be installed for the source entry to resolve. If a future pull changes dependency manifests or the lockfile, the dependency install step must be repeated; source-only pulls are picked up immediately.
+
+## Verification
+
+Verification covers four boundaries:
+
+1. The OpenCode config parses, contains the source entry exactly once, and contains no OMO package-style plugin entry.
+2. Existing plugin and MCP entries remain present.
+3. The OMO doctor recognizes the local source plugin and the installed OpenCode version.
+4. A real OpenCode smoke run loads a faithful copy of the edited configuration — including `model-watch`, `ouroboros`, and the OMO source entry — in an isolated XDG sandbox, while the real OpenCode session database remains unchanged.
+
+Secrets, authentication values, and private environment data are not copied into repository evidence.
+
+## Residual risk
+
+The source path is machine-specific and therefore intentionally local to this checkout. Moving the clone requires updating the plugin entry. Dependency changes after a pull still require the repository's package-manager install command.


### PR DESCRIPTION
## Summary

- Document the supported local `file://` source-plugin setup for OpenCode.
- Incorporate review feedback for duplicate OMO package entries and faithful-config verification.
- Record the completed local verification plan and evidence boundaries.

The live wiring is intentionally outside this repository in `~/.config/opencode/opencode.jsonc`; it is not included in this PR. The active source entry is:

`file:///home/heki/workspace/oh-my-openagent/packages/omo-opencode/src/index.ts`

Existing `model-watch` and `ouroboros` entries were preserved, and the configuration operation was verified idempotently.

## Review response

- The design now explicitly removes existing `oh-my-opencode` / `oh-my-openagent` package-style entries before adding the source entry, preventing the runtime duplicate-plugin guard from disabling startup.
- Verification asserts exactly one source entry and zero OMO package-style entries.
- The isolated smoke case uses a faithful copy of the edited configuration, including `model-watch`, `ouroboros`, and the source plugin.
- The OpenCode doctor version check is documented as a minimum-version check; the installed CLI version need not equal the SDK pin.

## Verification

- `bun install --frozen-lockfile` completed, including repository prepare/build steps.
- `bun run --cwd packages/omo-opencode typecheck` passed.
- `bun run typecheck` passed.
- OpenCode doctor passed for OpenCode 1.18.27 and recognized the local-dev configuration.
- Isolated OpenCode QA loaded the faithful configuration, exposed 16 OMO agents, and kept the real session database unchanged: 194 before / 194 after.
- tmux TUI smoke passed with the real database unchanged.
- Evidence: `.omo/evidence/20260904-local-opencode-plugin/` in the local checkout.

The repository-wide `bun test` command was not a clean pass in this environment: it encountered unrelated Bun asset-support, native Bun shim, Senpi RPC, LSP subprocess, and OpenCode source-audit timeout failures. This is recorded as a limitation in `repository-checks.txt`, not represented as a passing gate.

## Residual risk

The source path is machine-specific. `git pull` updates source-only changes immediately; dependency or lockfile changes still require rerunning the repository install command.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds design and implementation docs for wiring the OpenCode plugin to the local oh-my-openagent source checkout.

- Docs specify a `file://` source entry and removal of package-style OMO entries to avoid the duplicate-plugin guard.
- Verification covers config idempotency, doctor checks, and an isolated QA run with evidence boundaries.

<sup>Written for commit 92979428a973b892a34cffbfbb469ffff28a63c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

