### PR TITLE
fix(publish): refuse to reuse a release commit that is not the base head

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -417,20 +417,33 @@ jobs:
 
           git fetch origin "${BASE_REF}" --tags
 
+          BASE_HEAD="$(git rev-parse "origin/${BASE_REF}")"
+
+          # A release commit may only be REUSED when it is the current base head. A stamp that
+          # sits behind the head belongs to an earlier, abandoned attempt: its tree predates every
+          # merge since, so publishing it would ship a version whose contents nobody reviewed under
+          # that number (2026-09-04: a beta.41 retry re-selected the first attempt's stamp, whose
+          # tree lacked the senpi engine bump; only gate-reuse's CI check kept it off npm). Fail
+          # closed and ask for a fresh version number instead of restamping over a live one.
+          reuse_or_refuse() {
+            local candidate="$1" origin_desc="$2"
+            if [ "$candidate" = "$BASE_HEAD" ]; then
+              echo "release_sha=${candidate}" >> "$GITHUB_OUTPUT"
+              echo "needs_push=false" >> "$GITHUB_OUTPUT"
+              echo "${origin_desc} is the current origin/${BASE_REF} head: ${candidate}"
+              exit 0
+            fi
+            echo "::error::${origin_desc} (${candidate}) is stale: origin/${BASE_REF} has moved to ${BASE_HEAD}. Refusing to publish a tree that predates the base head. Bump to an unused version so a fresh release commit is stamped on the current head."
+            exit 1
+          }
+
           if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
-            RELEASE_SHA="$(git rev-list --max-count=1 "refs/tags/v${VERSION}")"
-            echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
-            echo "needs_push=false" >> "$GITHUB_OUTPUT"
-            echo "Release tag v${VERSION} already exists locally at ${RELEASE_SHA}"
-            exit 0
+            reuse_or_refuse "$(git rev-list --max-count=1 "refs/tags/v${VERSION}")" "Release tag v${VERSION}"
           fi
 
           RELEASE_SHA="$(git rev-list --max-count=1 --grep="^release: v${VERSION}$" "origin/${BASE_REF}" 2>/dev/null || true)"
           if [ -n "$RELEASE_SHA" ]; then
-            echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
-            echo "needs_push=false" >> "$GITHUB_OUTPUT"
-            echo "Release commit already exists on origin/${BASE_REF}: ${RELEASE_SHA}"
-            exit 0
+            reuse_or_refuse "$RELEASE_SHA" "Release commit for v${VERSION}"
           fi
 
           git checkout -B "$RELEASE_BRANCH" "origin/${BASE_REF}"

--- a/script/publish-resume-idempotency.test.ts
+++ b/script/publish-resume-idempotency.test.ts
@@ -8,6 +8,7 @@ const publishWorkflowPath = new URL("../.github/workflows/publish.yml", import.m
 export const resumeGuardFindings = {
   prepareExistingTagReuse: "prepare-release-state must reuse an existing release tag",
   prepareExistingCommitReuse: "prepare-release-state must reuse an existing release commit",
+  prepareStaleStampRefusal: "prepare-release-state must reuse a release commit only when it is the current base head and refuse a stale one",
   dispatchTagShaMismatchRefusal: "dispatch-provenance-safe-publish must reject an existing tag at a different SHA",
   ohMyOpencodePublishedProbe: "publish-main must skip an already-published oh-my-opencode version",
   ohMyOpenagentPublishedProbe: "publish-main must skip an already-published oh-my-openagent version",
@@ -56,20 +57,28 @@ export function assertResumeGuards(workflowText: string): string[] {
   const release = section(workflowText, "  release:")
   const marketplaceSync = section(release, "      - name: Sync LazyCodex Codex marketplace", "      - name: Resolve LazyCodex release payload")
 
+  // Both reuse paths must route through the head-equality guard: a stamp that IS the base head is
+  // reused without a push (resume), a stamp behind the head is refused (2026-09-04 beta.41 would
+  // otherwise have shipped a tree without its engine bump).
   if (!hasAll(prepareTagReuse, [
     'git rev-parse -q --verify "refs/tags/v${VERSION}"',
-    'RELEASE_SHA="$(git rev-list --max-count=1 "refs/tags/v${VERSION}")"',
-    'echo "release_sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"',
-    'echo "Release tag v${VERSION} already exists locally at ${RELEASE_SHA}"',
-    "exit 0",
+    'reuse_or_refuse "$(git rev-list --max-count=1 "refs/tags/v${VERSION}")" "Release tag v${VERSION}"',
   ])) findings.push(resumeGuardFindings.prepareExistingTagReuse)
 
   if (!hasAll(prepareCommitReuse, [
     'git rev-list --max-count=1 --grep="^release: v${VERSION}$" "origin/${BASE_REF}"',
-    'echo "Release commit already exists on origin/${BASE_REF}: ${RELEASE_SHA}"',
     "if [ -n \"$RELEASE_SHA\" ]; then",
-    "exit 0",
+    'reuse_or_refuse "$RELEASE_SHA" "Release commit for v${VERSION}"',
   ])) findings.push(resumeGuardFindings.prepareExistingCommitReuse)
+
+  if (!hasAll(prepareReleaseState, [
+    'BASE_HEAD="$(git rev-parse "origin/${BASE_REF}")"',
+    'if [ "$candidate" = "$BASE_HEAD" ]; then',
+    'echo "release_sha=${candidate}" >> "$GITHUB_OUTPUT"',
+    'echo "needs_push=false" >> "$GITHUB_OUTPUT"',
+    "is stale: origin/${BASE_REF} has moved to ${BASE_HEAD}",
+    "exit 1",
+  ])) findings.push(resumeGuardFindings.prepareStaleStampRefusal)
 
   if (!hasAll(dispatchExistingTag, [
     'if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then',
@@ -132,6 +141,19 @@ describe("publish resume idempotency", () => {
     expect(mutatedWorkflow).not.toBe(workflowText)
     expect(assertResumeGuards(mutatedWorkflow)).toEqual([
       resumeGuardFindings.dispatchTagShaMismatchRefusal,
+    ])
+  })
+
+  test("reports the stale-stamp refusal when the head-equality guard is neutralised", () => {
+    const workflowText = readFileSync(publishWorkflowPath, "utf8")
+    const mutatedWorkflow = workflowText.replace(
+      'if [ "$candidate" = "$BASE_HEAD" ]; then',
+      'if true; then # mutation: every stamp is reused, stale or not',
+    )
+
+    expect(mutatedWorkflow).not.toBe(workflowText)
+    expect(assertResumeGuards(mutatedWorkflow)).toEqual([
+      resumeGuardFindings.prepareStaleStampRefusal,
     ])
   })
 })

--- a/script/publish-stale-stamp-reuse.test.ts
+++ b/script/publish-stale-stamp-reuse.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+/**
+ * Executes the release-state reuse decision of publish.yml's "prepare" step against a real git
+ * history. The block is taken from the workflow text, not copied, so this test fails the moment the
+ * shipped shell drifts from what it asserts.
+ *
+ * Regression pinned (2026-09-04, beta.41): a retry after a failed publish found the FIRST attempt's
+ * `release: v5.0.0-beta.41` commit by message grep and handed that stale SHA to the publish child.
+ * That commit sat behind dev, so its tree lacked every fix merged since (the senpi 2026.9.4-3 pin
+ * among them). Only gate-reuse's "no successful CI on that SHA" refusal kept the wrong tree off npm.
+ */
+
+const workflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
+const workflowText = readFileSync(workflowPath, "utf8").replace(/\r\n/g, "\n")
+const workflow = Bun.YAML.parse(workflowText) as { jobs: Record<string, { steps: Array<{ id?: string; run?: string }> }> }
+
+function prepareRunBlock(): string {
+  const job = workflow.jobs["prepare-release-state"]
+  const step = job.steps.find((s) => s.id === "prepare")
+  if (!step?.run) throw new Error("publish.yml prepare-release-state has no step id=prepare with a run block")
+  // Stop before the stamping half: the fixture is a bare history with no package manifests.
+  const cut = step.run.indexOf('git checkout -B "$RELEASE_BRANCH"')
+  if (cut === -1) throw new Error("prepare run block no longer contains the checkout -B marker")
+  return step.run.slice(0, cut)
+}
+
+function git(cwd: string, args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8", env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" } })
+  if (result.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr}`)
+  return result.stdout.trim()
+}
+
+function commit(cwd: string, message: string): string {
+  writeFileSync(join(cwd, "file.txt"), message + "\n")
+  git(cwd, ["add", "file.txt"])
+  git(cwd, ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", message])
+  return git(cwd, ["rev-parse", "HEAD"])
+}
+
+interface Fixture { readonly work: string; readonly origin: string; readonly root: string }
+
+/** A bare origin with a `dev` branch and a clone that tracks it, mirroring the runner checkout. */
+function createFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "publish-stale-stamp-"))
+  const origin = join(root, "origin.git")
+  const seed = join(root, "seed")
+  git(root, ["init", "-q", "--bare", origin])
+  git(root, ["init", "-q", "-b", "dev", seed])
+  commit(seed, "initial")
+  git(seed, ["remote", "add", "origin", origin])
+  git(seed, ["push", "-q", "origin", "dev"])
+  const work = join(root, "work")
+  git(root, ["clone", "-q", origin, work])
+  return { work, origin, root }
+}
+
+function pushDev(seed: string): void { git(seed, ["push", "-q", "origin", "dev"]) }
+
+function runPrepare(fixture: Fixture, version: string): { status: number; stdout: string; stderr: string; outputs: Record<string, string> } {
+  const outputFile = join(fixture.root, "github_output")
+  writeFileSync(outputFile, "")
+  const script = join(fixture.root, "prepare.sh")
+  writeFileSync(script, prepareRunBlock())
+  const result = spawnSync("bash", [script], {
+    cwd: fixture.work,
+    encoding: "utf8",
+    env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null", VERSION: version, OMO_AI_VERSION: version, RELEASE_REF: "dev", PREPARED_RELEASE_SHA: "", GITHUB_SHA: "", GITHUB_OUTPUT: outputFile },
+  })
+  const outputs: Record<string, string> = {}
+  for (const line of readFileSync(outputFile, "utf8").split("\n")) { const i = line.indexOf("="); if (i > 0) outputs[line.slice(0, i)] = line.slice(i + 1) }
+  return { status: result.status ?? -1, stdout: result.stdout, stderr: result.stderr, outputs }
+}
+
+describe("publish.yml prepare-release-state reuse decision", () => {
+  test("#given a stale 'release: vX' commit behind the base head #when prepare runs for vX #then it refuses instead of handing the stale SHA to the publish child", () => {
+    const fixture = createFixture()
+    try {
+      const seed = join(fixture.root, "seed")
+      const stale = commit(seed, "release: v9.9.9-beta.1")
+      commit(seed, "fix: something merged after the failed first attempt")
+      pushDev(seed)
+
+      const result = runPrepare(fixture, "9.9.9-beta.1")
+
+      expect(result.outputs.release_sha).not.toBe(stale)
+      expect(result.status).not.toBe(0)
+      expect(result.stdout + result.stderr).toContain("stale")
+    } finally { rmSync(fixture.root, { recursive: true, force: true }) }
+  })
+
+  test("#given the 'release: vX' commit IS the base head #when prepare runs for vX #then it reuses that SHA without pushing", () => {
+    const fixture = createFixture()
+    try {
+      const seed = join(fixture.root, "seed")
+      const head = commit(seed, "release: v9.9.9-beta.2")
+      pushDev(seed)
+
+      const result = runPrepare(fixture, "9.9.9-beta.2")
+
+      expect(result.status).toBe(0)
+      expect(result.outputs.release_sha).toBe(head)
+      expect(result.outputs.needs_push).toBe("false")
+    } finally { rmSync(fixture.root, { recursive: true, force: true }) }
+  })
+})


### PR DESCRIPTION
## Problem

`prepare-release-state` treats **any** commit whose message matches `release: v<VERSION>` (and any existing `v<VERSION>` tag) as the prepared release SHA and hands it to the publish child:

```bash
RELEASE_SHA="$(git rev-list --max-count=1 --grep="^release: v${VERSION}$" "origin/${BASE_REF}")"
if [ -n "$RELEASE_SHA" ]; then ... needs_push=false; exit 0
```

On 2026-09-04 the first beta.41 attempt stamped `release: v5.0.0-beta.41` (commit `295bb1db5`, merge `75a632258`) and then failed its gate. Six fixes landed on `dev` afterwards — including the senpi `2026.9.4-3` engine pin (#7772) that the whole release existed to ship. The retry (run 33894739483) found the stale stamp by message grep and dispatched the publish child at `75a632258` (run 33894944582), whose tree still pinned senpi `2026.9.4-2`. **Only `gate-reuse`'s "no successful CI run for that SHA" refusal kept a beta.41 without its engine fix off npm.** Deleting the dangling tag beforehand did not help: the commit, not the tag, was the match.

## Fix

Both reuse paths (tag lookup and message grep) go through one guard: a candidate release commit is reused **only if it is the current `origin/<BASE_REF>` head**. A stamp behind the head belongs to an earlier, abandoned attempt — its tree predates every merge since — so the step now fails closed with an actionable `::error::` asking for an unused version number, which is exactly how beta.41 → beta.42 was recovered by hand. The already-stamped-at-head path is untouched.

## Proof

`script/publish-stale-stamp-reuse.test.ts` executes the **prepare step's own `run` block**, extracted from `publish.yml` at test time (so any drift between the shipped shell and the assertion fails the test), against a real git fixture with a bare `origin` and a `dev` branch.

- RED (unguarded block): a stale `release: v9.9.9-beta.1` commit behind `dev` → `release_sha` = that stale SHA, exit 0.
- GREEN (this PR): same fixture → non-zero exit, `release_sha` not emitted, stderr names it `stale`.
- Preserved: a `release: v9.9.9-beta.2` commit that **is** the head → reused, `needs_push=false`.
- Mutation: forcing the guard to always accept turns the stale case red again (1 pass / 1 fail), restored 2/2.

Also green: all five existing tests that pin `publish.yml` (25/25), `actionlint` clean, `bash -n` on the extracted block OK.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `prepare-release-state` so a retried publish can't reuse the first attempt's stale release commit. Previously any commit whose message matched `release: v<VERSION>` (or an existing same-version tag) was reused, which on 2026-09-04 would have shipped beta.41 without the senpi 2026.9.4-3 engine pin and four other fixes merged after the first attempt.

**What changed**
- Candidates are reused only when they are the current `origin/<BASE_REF>` head.
- Stale candidates fail closed with an error asking for an unused version.
- The already-stamped-at-head path is unchanged.

**Testing**
- The new test runs the prepare step's own `run` block against a real git fixture, so workflow drift fails the test.
- It verifies a stale commit behind `dev` is refused and a stamp at the head is reused without a push.
- The resume-idempotency contract test now pins the new guard, with a mutation case that neutralises it to confirm the finding.

<sup>Written for commit 481f32a44fa2a101c42baa5bac1c947742e7bd94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

