### PR TITLE
fix(publish): wait for npm propagation as long as npm says it can take

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1272,25 +1272,32 @@ jobs:
         run: |
           set -euo pipefail
 
-          for attempt in $(seq 1 5); do
-            IMMUTABLE_VERSION=$(npm view omo-ai@$OMO_AI_VERSION version 2>/dev/null || true)
+          # npm publish returns before the registry serves the new version: its own output says
+          # "Your package is being processed and may take a few minutes to become available", and
+          # omo-ai 5.0.0-0.beta.42 (2026-09-04) took ~5 minutes. The previous 5 x 15 s = 60 s budget
+          # therefore failed the run AFTER a successful publish. Size the wait to the registry's stated
+          # contract and read with --prefer-online so a cached "not found" cannot mask a landed version.
+          READINESS_INTERVAL_SECONDS=15
+          READINESS_ATTEMPTS=60   # 60 x 15 s = 15 minutes
+          for attempt in $(seq 1 "$READINESS_ATTEMPTS"); do
+            IMMUTABLE_VERSION=$(npm view --prefer-online "omo-ai@$OMO_AI_VERSION" version 2>/dev/null || true)
             BETA_READY=true
             if [ "$ALREADY_PUBLISHED" != "true" ]; then
-              BETA_VERSION=$(npm view omo-ai dist-tags.beta 2>/dev/null || true)
+              BETA_VERSION=$(npm view --prefer-online omo-ai dist-tags.beta 2>/dev/null || true)
               [ "$BETA_VERSION" = "$OMO_AI_VERSION" ] || BETA_READY=false
             fi
 
             if [ "$IMMUTABLE_VERSION" = "$OMO_AI_VERSION" ] && [ "$BETA_READY" = "true" ]; then
-              echo "omo-ai@$OMO_AI_VERSION is ready"
+              echo "omo-ai@$OMO_AI_VERSION is ready (attempt ${attempt}/${READINESS_ATTEMPTS})"
               break
             fi
 
-            if [ "$attempt" = "5" ]; then
-              echo "::error::omo-ai@$OMO_AI_VERSION was not ready after 5 attempts"
+            if [ "$attempt" = "$READINESS_ATTEMPTS" ]; then
+              echo "::error::omo-ai@$OMO_AI_VERSION did not become visible within $((READINESS_ATTEMPTS * READINESS_INTERVAL_SECONDS)) s. The publish-main job already reported '+ omo-ai@$OMO_AI_VERSION', so this is a registry propagation timeout, not a publish failure: check 'npm view omo-ai@$OMO_AI_VERSION version' before re-running anything."
               exit 1
             fi
-            echo "Waiting for omo-ai@$OMO_AI_VERSION registry propagation (attempt ${attempt}/5)"
-            sleep 15
+            echo "Waiting for omo-ai@$OMO_AI_VERSION registry propagation (attempt ${attempt}/${READINESS_ATTEMPTS}, ${READINESS_INTERVAL_SECONDS}s)"
+            sleep "$READINESS_INTERVAL_SECONDS"
           done
 
       - name: Guard omo-ai dist-tags

--- a/script/publish-readiness-budget.test.ts
+++ b/script/publish-readiness-budget.test.ts
@@ -1,0 +1,86 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+/**
+ * Executes the "Wait for omo-ai registry readiness" step of publish.yml with `npm` and `sleep`
+ * stubbed on PATH, so the loop's budget is asserted rather than assumed.
+ *
+ * Regression pinned (2026-09-04, beta.42): `npm publish` printed "+ omo-ai@5.0.0-0.beta.42" and
+ * "Your package is being processed and may take a few minutes to become available", yet the verify
+ * step gave up after 5 x 15 s = 60 s and failed the release run - a false failure of a successful
+ * publish (the same shape that bit lazycodex-ai in beta.31 and beta.34). The registry showed the
+ * version roughly five minutes after publish.
+ */
+
+const workflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
+const workflowText = readFileSync(workflowPath, "utf8").replace(/\r\n/g, "\n")
+const workflow = Bun.YAML.parse(workflowText) as { jobs: Record<string, { steps: Array<{ name?: string; run?: string }> }> }
+
+function readinessRunBlock(): string {
+  const step = workflow.jobs["post-publish-verify"].steps.find((s) => s.name === "Wait for omo-ai registry readiness")
+  if (!step?.run) throw new Error("post-publish-verify has no 'Wait for omo-ai registry readiness' run block")
+  return step.run
+}
+
+interface Outcome { readonly status: number; readonly stdout: string; readonly stderr: string; readonly npmCalls: number; readonly sleeps: number }
+
+/**
+ * npm stub: reports the version/dist-tag as absent for the first `readyAfterViews` `npm view`
+ * calls, then as present. sleep stub: records the call and returns immediately.
+ */
+function runReadiness(readyAfterViews: number): Outcome {
+  const root = mkdtempSync(join(tmpdir(), "publish-readiness-"))
+  try {
+    const bin = join(root, "bin")
+    const counter = join(root, "npm-views")
+    const sleeps = join(root, "sleeps")
+    Bun.spawnSync(["mkdir", "-p", bin])
+    writeFileSync(counter, "0")
+    writeFileSync(sleeps, "")
+    writeFileSync(join(bin, "npm"), [
+      "#!/usr/bin/env bash",
+      'n=$(cat "$COUNTER"); n=$((n+1)); echo "$n" > "$COUNTER"',
+      'if [ "$n" -gt "$READY_AFTER" ]; then echo "$OMO_AI_VERSION"; fi',
+      "exit 0",
+      "",
+    ].join("\n"))
+    writeFileSync(join(bin, "sleep"), ["#!/usr/bin/env bash", 'echo "$1" >> "$SLEEPS"', ""].join("\n"))
+    chmodSync(join(bin, "npm"), 0o755)
+    chmodSync(join(bin, "sleep"), 0o755)
+    const script = join(root, "readiness.sh")
+    writeFileSync(script, readinessRunBlock())
+    const result = spawnSync("bash", [script], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}`, COUNTER: counter, SLEEPS: sleeps, READY_AFTER: String(readyAfterViews), OMO_AI_VERSION: "5.0.0-0.beta.42", ALREADY_PUBLISHED: "false" },
+    })
+    return {
+      status: result.status ?? -1,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      npmCalls: Number(readFileSync(counter, "utf8").trim()),
+      sleeps: readFileSync(sleeps, "utf8").split("\n").filter(Boolean).length,
+    }
+  } finally { rmSync(root, { recursive: true, force: true }) }
+}
+
+describe("publish.yml post-publish-verify registry readiness", () => {
+  test("#given the registry needs ~5 minutes to expose the version #when readiness polls #then it keeps waiting instead of failing a successful publish", () => {
+    // 5 minutes at the loop's own interval, expressed in npm view calls (2 views per attempt).
+    const outcome = runReadiness(2 * 20)
+    expect(outcome.status).toBe(0)
+    expect(outcome.stdout).toContain("is ready")
+  })
+
+  test("#given the registry never exposes the version #when the budget is exhausted #then it fails and names the publish-vs-propagation distinction", () => {
+    const outcome = runReadiness(Number.MAX_SAFE_INTEGER)
+    expect(outcome.status).not.toBe(0)
+    expect(outcome.stdout + outcome.stderr).toContain("propagat")
+    // Budget is wall-clock shaped, not "5 tries": sleeps x interval must cover several minutes.
+    expect(outcome.sleeps).toBeGreaterThanOrEqual(20)
+  })
+})


### PR DESCRIPTION
## Problem

`post-publish-verify` → "Wait for omo-ai registry readiness" polled **5 × 15 s = 60 s** and then failed the run. npm's own publish output says *"Your package is being processed and may take a few minutes to become available"*, and `omo-ai@5.0.0-0.beta.42` (run 33896927928, 2026-09-04) took ~5 minutes to appear on the registry. `publish-main` had already printed `+ omo-ai@5.0.0-0.beta.42` with a signed provenance statement — the publish **succeeded**, and the release run still ended red. Same shape as the lazycodex-ai propagation false-failures in beta.31 and beta.34.

## Fix

- Budget sized to the registry's stated contract: `READINESS_ATTEMPTS=60` × `READINESS_INTERVAL_SECONDS=15` (15 min), named constants instead of a magic `seq 1 5`.
- `npm view --prefer-online` for both reads, so a cached "not found" cannot mask a version that has landed.
- The timeout error says what actually happened: publish-main already reported the version, so this is a propagation timeout — check `npm view` before re-running anything.

## Proof

`script/publish-readiness-budget.test.ts` extracts the step's own `run` block from `publish.yml` and executes it with `npm` and `sleep` stubbed on `PATH` (npm reports the version absent for N views, then present; sleep records and returns).

- **RED** (original block): registry needs ~5 min → exit 1 after **4 sleeps**; never-visible case gives up after 4 sleeps.
- **GREEN** (this PR): same ~5 min scenario → waits and prints `is ready`; never-visible case fails only after ≥20 sleeps with a message containing `propagat`.
- All 7 workflow-pinning suites: 27/27. `actionlint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the post-publish registry readiness check so a successful `npm publish` no longer fails the release run when the registry takes a few minutes to serve the new version. The poll budget grows from 5 × 15 s to 60 × 15 s (15 minutes), matching npm's stated propagation window, and `npm view` now reads with `--prefer-online` so a cached "not found" can't mask a landed version.

- The timeout error now states that publish-main already reported the version and points the operator to `npm view` instead of re-running.
- Adds a test that executes the workflow's own readiness step with `npm` and `sleep` stubbed on `PATH`, covering both the ~5-minute propagation and never-visible cases.

<sup>Written for commit 2d3eca4c2ad8e7850398ffd246e006bd7f158035. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

