### PR TITLE
test(publish): stub npm and sleep as bash functions, not PATH executables

### DIFF
--- a/script/publish-readiness-budget.test.ts
+++ b/script/publish-readiness-budget.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -33,30 +33,38 @@ interface Outcome { readonly status: number; readonly stdout: string; readonly s
  * npm stub: reports the version/dist-tag as absent for the first `readyAfterViews` `npm view`
  * calls, then as present. sleep stub: records the call and returns immediately.
  */
+/**
+ * npm stub: reports the version/dist-tag as absent for the first `readyAfterViews` `npm view`
+ * calls, then as present. sleep stub: records the call and returns immediately.
+ *
+ * Both stubs are bash FUNCTIONS prepended to the extracted block, not executables on PATH. bash
+ * resolves a function before any PATH lookup on every OS, whereas a `#!/usr/bin/env bash` script
+ * on PATH is not executable on windows-latest (no shebang support, `;` PATH separator, `.cmd`
+ * shims) - the first version of this harness did that and both cases hung to the 30 s budget on
+ * Windows while passing on POSIX. The workflow text itself stays untouched.
+ */
 function runReadiness(readyAfterViews: number): Outcome {
   const root = mkdtempSync(join(tmpdir(), "publish-readiness-"))
   try {
-    const bin = join(root, "bin")
     const counter = join(root, "npm-views")
     const sleeps = join(root, "sleeps")
-    Bun.spawnSync(["mkdir", "-p", bin])
     writeFileSync(counter, "0")
     writeFileSync(sleeps, "")
-    writeFileSync(join(bin, "npm"), [
-      "#!/usr/bin/env bash",
-      'n=$(cat "$COUNTER"); n=$((n+1)); echo "$n" > "$COUNTER"',
-      'if [ "$n" -gt "$READY_AFTER" ]; then echo "$OMO_AI_VERSION"; fi',
-      "exit 0",
+    const preamble = [
+      "npm() {",
+      '  local n; n=$(cat "$COUNTER"); n=$((n+1)); printf "%s" "$n" > "$COUNTER"',
+      '  if [ "$n" -gt "$READY_AFTER" ]; then printf "%s\\n" "$OMO_AI_VERSION"; fi',
+      "  return 0",
+      "}",
+      'sleep() { printf "%s\\n" "$1" >> "$SLEEPS"; }',
+      "export -f npm sleep",
       "",
-    ].join("\n"))
-    writeFileSync(join(bin, "sleep"), ["#!/usr/bin/env bash", 'echo "$1" >> "$SLEEPS"', ""].join("\n"))
-    chmodSync(join(bin, "npm"), 0o755)
-    chmodSync(join(bin, "sleep"), 0o755)
+    ].join("\n")
     const script = join(root, "readiness.sh")
-    writeFileSync(script, readinessRunBlock())
+    writeFileSync(script, preamble + readinessRunBlock())
     const result = spawnSync("bash", [script], {
       encoding: "utf8",
-      env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}`, COUNTER: counter, SLEEPS: sleeps, READY_AFTER: String(readyAfterViews), OMO_AI_VERSION: "5.0.0-0.beta.42", ALREADY_PUBLISHED: "false" },
+      env: { ...process.env, COUNTER: counter, SLEEPS: sleeps, READY_AFTER: String(readyAfterViews), OMO_AI_VERSION: "5.0.0-0.beta.42", ALREADY_PUBLISHED: "false" },
     })
     return {
       status: result.status ?? -1,


### PR DESCRIPTION
## Problem

`script/publish-readiness-budget.test.ts` (#7781) stubbed `npm` and `sleep` as `#!/usr/bin/env bash` scripts placed on `PATH`. `windows-latest` cannot execute those (no shebang support, `;` PATH separator, `.cmd` shims), so the extracted readiness block never observed the stubbed version and **both cases hung to their 30 000 ms budget**. `dev` is red on `test (windows-latest, 2/2)` at `928aa8571` because of it; #7781's own CI did not run the Windows lane (no `ci:full-matrix`). Found by w33:p1W while proving #7782.

## Fix

The stubs are **bash functions prepended to the extracted run block**. bash resolves a function before any PATH lookup on every OS, so the harness drives the loop identically on Windows and POSIX. No `chmod`, no PATH edits, no executable files, and the workflow text under test is untouched. `skipIf(win32)` was rejected as a workaround.

## Proof

- Mutation: making the `npm` stub report the version immediately makes the never-visible case fail (`1 pass / 1 fail`); restored `2 pass / 0 fail` on POSIX — the assertions are driven by the stubs.
- RED (authoritative, real surface): dev `928aa8571` and #7782 head `f177b9a80` → `test (windows-latest, 2/2)` fails both cases at 30000 ms (p1W's run 33902474993).
- GREEN (authoritative): the same Windows lane on this PR, via `ci:full-matrix`.

A local "non-executable PATH stub" repro on macOS was attempted and discarded: it resolved the real `npm`, which now reports beta.42 as published, so it could not reproduce the hang honestly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the publish-readiness test harness so the Windows CI lane no longer hangs. The `npm` and `sleep` stubs are now bash functions prepended to the extracted run block instead of executable scripts on `PATH`, which Windows cannot run.

<sup>Written for commit 13e09782d3a04be9272569e0ca65067240625cc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

