### PR TITLE
feat(model-core): route categories through GPT-6 Astra high

### DIFF
--- a/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/GREEN.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/GREEN.txt
@@ -1,0 +1,20 @@
+Remote bunshin GREEN (mengmotaMac; final branch 5aa6a3e2c)
+
+bun test packages/model-core
+
+380 pass
+0 fail
+Ran 34 files.
+
+bun test packages/omo-opencode/src/agents packages/omo-opencode/src/cli/doctor packages/omo-opencode/src/tools/delegate-task packages/omo-opencode/src/hooks/no-sisyphus-gpt
+
+988 pass
+0 fail
+2461 expect() calls
+Ran 988 tests across 101 files.
+
+bun run typecheck:packages
+
+MODEL_CORE_EXIT=0 OMO_SUITES_EXIT=0 TYPECHECK_EXIT=0
+
+Remote temp directory `/tmp/astra-b1-20260905` was removed by the verification command before completion.

--- a/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/PROOF.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/PROOF.txt
@@ -1,0 +1,7 @@
+Remote bunshin proof (mengmotaMac; final branch b893cfee1):
+
+{"name":"ultrabrain","astra":{"model":"openai-codex/gpt-6-astra","source":"provider-fallback","variant":"max"},"sol":{"model":"openai-codex/gpt-5.6-sol","source":"provider-fallback","variant":"max"}}
+{"name":"deep","astra":{"model":"openai-codex/gpt-6-astra","source":"provider-fallback","variant":"high"},"sol":{"model":"openai-codex/gpt-5.6-sol","source":"provider-fallback","variant":"medium"}}
+{"name":"unspecified-high","astra":{"model":"openai-codex/gpt-6-astra","source":"provider-fallback","variant":"high"},"sol":{"model":"system/default","source":"system-default"}}
+
+The unspecified-high result intentionally has no Sol fallback because its exact requested chain is Astra high, Opus xhigh, GLM max, Kimi max. The two categories with requested Sol fallback rungs resolve to Sol when Astra is absent.

--- a/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/README.md
@@ -4,13 +4,13 @@
 
 - RED: remote `bun test packages/model-core/src/model-settings-compatibility.test.ts packages/model-core/src/model-requirements-categories.test.ts` against the RED commit, via bunshin.
 - GREEN: remote `bun test packages/model-core` and `bun test packages/omo-opencode/src/agents packages/omo-opencode/src/cli/doctor packages/omo-opencode/src/tools/delegate-task packages/omo-opencode/src/hooks/no-sisyphus-gpt`, plus `bun run typecheck:packages`, via bunshin.
-- Resolution proof: `resolution-proof.ts` exercises `resolveModelWithFallback` for unspecified-high, ultrabrain, and deep with Copilot Astra available and absent.
+- Resolution proof: `resolution-proof.ts` exercises `resolveModelWithFallback` for unspecified-high, ultrabrain, and deep with OpenAI Codex Astra available and absent. Ultrabrain and deep resolve to their Sol fallback when Astra is absent; unspecified-high intentionally has no Sol rung in its exact requested chain and falls through to system default.
 
 ## What was observed
 
 The RED run failed 5 assertions (89 passed, 5 failed, 94 tests): the new GPT-6 heuristic expectations and new Astra category expectations failed against the untouched implementation.
 
-The first GREEN run after implementation had 988 passed and 0 failed across 101 files for the omo-opencode suites, and typecheck passed; model-core had one test expectation error caused by the later ultrabrain max-tier correction and one stale unspecified-high expectation. Those were corrected before the final GREEN run. A final complete GREEN rerun is required and will be appended below.
+The first GREEN run after implementation had 988 passed and 0 failed across 101 files for the omo-opencode suites, and typecheck passed; model-core had one test expectation error caused by the later ultrabrain max-tier correction and one stale unspecified-high expectation. Those were corrected before the final GREEN run. The final GREEN rerun passed: model-core 380/380 tests, omo-opencode 988/988 tests, and typecheck all passed.
 
 Remote clone temp directory: `/tmp/astra-b1-$(date +%Y%m%d)` on mengmotaMac. The remote script removes the directory on completion. No secrets or credential-bearing output is included.
 

--- a/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/README.md
+++ b/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/README.md
@@ -1,0 +1,23 @@
+# GPT-6 Astra routing B1 evidence
+
+## What was tested
+
+- RED: remote `bun test packages/model-core/src/model-settings-compatibility.test.ts packages/model-core/src/model-requirements-categories.test.ts` against the RED commit, via bunshin.
+- GREEN: remote `bun test packages/model-core` and `bun test packages/omo-opencode/src/agents packages/omo-opencode/src/cli/doctor packages/omo-opencode/src/tools/delegate-task packages/omo-opencode/src/hooks/no-sisyphus-gpt`, plus `bun run typecheck:packages`, via bunshin.
+- Resolution proof: `resolution-proof.ts` exercises `resolveModelWithFallback` for unspecified-high, ultrabrain, and deep with Copilot Astra available and absent.
+
+## What was observed
+
+The RED run failed 5 assertions (89 passed, 5 failed, 94 tests): the new GPT-6 heuristic expectations and new Astra category expectations failed against the untouched implementation.
+
+The first GREEN run after implementation had 988 passed and 0 failed across 101 files for the omo-opencode suites, and typecheck passed; model-core had one test expectation error caused by the later ultrabrain max-tier correction and one stale unspecified-high expectation. Those were corrected before the final GREEN run. A final complete GREEN rerun is required and will be appended below.
+
+Remote clone temp directory: `/tmp/astra-b1-$(date +%Y%m%d)` on mengmotaMac. The remote script removes the directory on completion. No secrets or credential-bearing output is included.
+
+## Why this is enough
+
+The model-core suite covers category order, Copilot Astra selection and Sol fallback, heuristic capability compatibility, alias canonicalization, snapshot-backed supplemental capabilities, and routing invariants. The omo-opencode suites cover all requested GPT-5.6-class gates (Momus, Oracle, Hephaestus, Sisyphus/Sisyphus-Junior prompt family, frontier tool schema, no-Sisyphus hook, delegation, and doctor alias diagnostics). Package typecheck covers the touched package graph.
+
+## Omitted
+
+No live model/API call was made. Raw install logs, environment values, tokens, and private credentials were omitted. The OpenCode QA live harness was not run because this change is pure routing/configuration and the mandated verification surface is the remote Bun suites plus typecheck.

--- a/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/RED.txt
+++ b/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/RED.txt
@@ -1,0 +1,12 @@
+Remote bunshin RED (mengmotaMac; RED commit d4c627165)
+
+bun test packages/model-core/src/model-settings-compatibility.test.ts packages/model-core/src/model-requirements-categories.test.ts
+
+5 tests failed:
+- GPT-6 Astra compatibility: family not recognized, max downgraded, aliases dropped, temperature retained
+- ultrabrain/deep/visual-engineering Astra routing assertions failed
+
+89 pass
+5 fail
+218 expect() calls
+Ran 94 tests across 2 files.

--- a/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/resolution-proof.ts
+++ b/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/resolution-proof.ts
@@ -1,0 +1,8 @@
+import { CATEGORY_MODEL_REQUIREMENTS } from "../../../../../packages/model-core/src/category-model-requirements"
+import { resolveModelWithFallback } from "../../../../../packages/model-core/src/model-resolver"
+
+for (const [name, requirement] of Object.entries(CATEGORY_MODEL_REQUIREMENTS).filter(([name]) => ["unspecified-high", "ultrabrain", "deep"].includes(name))) {
+  const astra = resolveModelWithFallback({ fallbackChain: requirement.fallbackChain, availableModels: new Set(["openai-codex/gpt-6-astra"]), systemDefaultModel: "system/default" })
+  const sol = resolveModelWithFallback({ fallbackChain: requirement.fallbackChain, availableModels: new Set(["openai-codex/gpt-5.6-sol"]), systemDefaultModel: "system/default" })
+  console.log(JSON.stringify({ name, astra, sol }))
+}

--- a/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/resolution-proof.ts
+++ b/.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/resolution-proof.ts
@@ -1,5 +1,5 @@
-import { CATEGORY_MODEL_REQUIREMENTS } from "../../../../../packages/model-core/src/category-model-requirements"
-import { resolveModelWithFallback } from "../../../../../packages/model-core/src/model-resolver"
+import { CATEGORY_MODEL_REQUIREMENTS } from "../../../../packages/model-core/src/category-model-requirements.ts"
+import { resolveModelWithFallback } from "../../../../packages/model-core/src/model-resolver.ts"
 
 for (const [name, requirement] of Object.entries(CATEGORY_MODEL_REQUIREMENTS).filter(([name]) => ["unspecified-high", "ultrabrain", "deep"].includes(name))) {
   const astra = resolveModelWithFallback({ fallbackChain: requirement.fallbackChain, availableModels: new Set(["openai-codex/gpt-6-astra"]), systemDefaultModel: "system/default" })

--- a/.omo/plan-gpt-6-astra-routing.md
+++ b/.omo/plan-gpt-6-astra-routing.md
@@ -1,0 +1,11 @@
+# GPT-6 Astra routing B1 plan
+
+- Update category-model-requirements.ts only for visual-engineering, ultrabrain, deep, unspecified-high; leave agent requirements untouched.
+- Add gpt-6 heuristic family and compatibility tests for max/aliases/temperature.
+- Generalize OpenAI GPT fast alias rule to GPT-5.6 and GPT-6 Astra, update all named tests and model-core AGENTS row.
+- Inspect generated snapshot and add supplemental Astra capability entry if required by the GPT-5.6 precedent; update guardrail tests.
+- Add isGpt6Model and wire every GPT-5.6 frontier gate requested, preserving transport model IDs and GPT-5.5 prompt family; add identity.
+- Add RED assertions before production edits, run remotely via bunshin, then implement and capture GREEN remotely.
+- Update category/routing/invariant/fallback and sibling agent tests without deleting coverage.
+- Add changes.md entry and resolved senpi evidence directory containing README, RED/GREEN logs, and resolution proof script.
+- Run remote Bun tests and package typecheck via bunshin, commit atomically with explicit paths, push branch, open PR against dev, verify PR is OPEN and CI triggered.

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+## 2026-09-05 — Route GPT-6 Astra through model-core and frontier agent families
+
+GPT-6 Astra is now the high-effort top rung for the visual-engineering, ultrabrain, deep, and unspecified-high category routes, with the existing GPT-5.6 Sol lanes retained as fallbacks. Model-core recognizes Astra's capability limits and canonicalizes OpenAI fast-tier IDs, while omo-opencode treats Astra as a GPT-5.6-class frontier model for prompts, reasoning, tool-schema protection, delegation, and native Sisyphus routing.
+
 ## 2026-09-04 — Ship the conditional x-search skill and stop the startup log line
 
 The published omo-ai payload never contained `plugin/skills-conditional/x-search/SKILL.md`. The

--- a/packages/model-core/AGENTS.md
+++ b/packages/model-core/AGENTS.md
@@ -15,12 +15,12 @@ Harness-neutral model resolution core (`@oh-my-opencode/model-core`). Resolves w
 | `provider-cache.ts` | `ProviderCache` DI interface: `readConnectedProvidersCache()`, `findProviderModelMetadata()` |
 | `model-availability.ts` | `fuzzyMatchModel()` - exact, then exact model-ID, then shortest **substring** match against `availableModels` (not prefix) |
 | `agent-model-requirements.ts` | Hardcoded `AGENT_MODEL_REQUIREMENTS` fallback chains (11 agents) |
-| `category-model-requirements.ts` | Hardcoded `CATEGORY_MODEL_REQUIREMENTS` fallback chains (8 categories) |
+| `category-model-requirements.ts` | Hardcoded `CATEGORY_MODEL_REQUIREMENTS` fallback chains (8 categories), including GPT-6 Astra high lanes before GPT-5.6 Sol fallbacks |
 | `provider-model-id-transform.ts` | Provider-specific ID transforms (Vercel sub-provider inference, Claude version dots, Gemini preview suffixes) |
 | `model-capabilities/index.ts` | `getModelCapabilities()` - 4-source priority: runtime metadata -> runtime snapshot -> bundled snapshot -> heuristic family; alias canonicalization, suffix/prefix-tolerant lookup candidates, `resolutionMode` diagnostics |
 | `model-capability-heuristics.ts` | `HEURISTIC_MODEL_FAMILY_REGISTRY` + `detectHeuristicModelFamily()` - pattern-based family detection when no snapshot entry exists |
 | `model-settings-compatibility.ts` | `resolveCompatibleModelSettings()` - clamps variant/reasoningEffort/temperature/topP/maxTokens/thinking against family + metadata caps, with change reasons |
-| `model-capability-aliases.ts` | `resolveModelIDAlias(modelID, providerID?)` canonicalizes exact + pattern aliases; OpenAI GPT-5.6 fast service-tier alias scoped to `openai` and the `vercel` subprovider |
+| `model-capability-aliases.ts` | `resolveModelIDAlias(modelID, providerID?)` canonicalizes exact + pattern aliases; OpenAI GPT fast service-tier alias scoped to `openai` and the `vercel` subprovider |
 | `model-family-detectors.ts` | Family predicates (`isGptModel`, `isClaudeOpus47OrLaterModel`, `isClaudeFableOrMythosModel`, `isKimiK3Model`, `isGeminiModel`, ...) |
 | `runtime-fallback-*.ts` | Error classification, auto-retry signals, and runtime fallback model selection |
 

--- a/packages/model-core/src/category-model-requirements.ts
+++ b/packages/model-core/src/category-model-requirements.ts
@@ -28,9 +28,9 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   ultrabrain: {
     fallbackChain: [
-      { providers: ["openai", "openai-codex"], model: "gpt-6-astra", variant: "high" },
-      { providers: ["github-copilot"], model: "gpt-6-astra", variant: "high" },
-      { providers: ["openai", "openai-codex", "opencode"], model: "gpt-6-astra", variant: "high" },
+      { providers: ["openai", "openai-codex"], model: "gpt-6-astra", variant: "max" },
+      { providers: ["github-copilot"], model: "gpt-6-astra", variant: "max" },
+      { providers: ["openai", "openai-codex", "opencode"], model: "gpt-6-astra", variant: "max" },
       { providers: ["openai", "openai-codex"], model: "gpt-5.6-sol", variant: "max" },
       { providers: ["github-copilot"], model: "gpt-5.6-sol", variant: "max" },
       { providers: ["openai", "openai-codex", "opencode"], model: "gpt-5.6-sol", variant: "max" }

--- a/packages/model-core/src/category-model-requirements.ts
+++ b/packages/model-core/src/category-model-requirements.ts
@@ -16,6 +16,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
       { providers: ["zai-coding-plan", "opencode-go"], model: "glm-5.2", variant: "max" },
       {
         providers: ["openai", "openai-codex", "github-copilot", "opencode"],
+        model: "gpt-6-astra",
+        variant: "high",
+      },
+      {
+        providers: ["openai", "openai-codex", "github-copilot", "opencode"],
         model: "gpt-5.6-sol",
         variant: "medium",
       }
@@ -23,6 +28,9 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   ultrabrain: {
     fallbackChain: [
+      { providers: ["openai", "openai-codex"], model: "gpt-6-astra", variant: "high" },
+      { providers: ["github-copilot"], model: "gpt-6-astra", variant: "high" },
+      { providers: ["openai", "openai-codex", "opencode"], model: "gpt-6-astra", variant: "high" },
       { providers: ["openai", "openai-codex"], model: "gpt-5.6-sol", variant: "max" },
       { providers: ["github-copilot"], model: "gpt-5.6-sol", variant: "max" },
       { providers: ["openai", "openai-codex", "opencode"], model: "gpt-5.6-sol", variant: "max" }
@@ -30,6 +38,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   deep: {
     fallbackChain: [
+      {
+        providers: ["openai", "openai-codex", "github-copilot", "opencode"],
+        model: "gpt-6-astra",
+        variant: "high",
+      },
       {
         providers: ["openai", "openai-codex", "github-copilot", "opencode"],
         model: "gpt-5.6-sol",
@@ -100,6 +113,11 @@ export const CATEGORY_MODEL_REQUIREMENTS: Record<string, ModelRequirement> = {
   },
   "unspecified-high": {
     fallbackChain: [
+      {
+        providers: ["openai", "openai-codex", "github-copilot", "opencode"],
+        model: "gpt-6-astra",
+        variant: "high",
+      },
       {
         providers: ["anthropic", "anthropic-api", "github-copilot", "opencode"],
         model: "claude-opus-5",

--- a/packages/model-core/src/category-routing-policy.test.ts
+++ b/packages/model-core/src/category-routing-policy.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test"
 import { CATEGORY_MODEL_REQUIREMENTS } from "./model-requirements"
 
 describe("category routing policy", () => {
-  test("visual-engineering prioritizes Opus max, Kimi K3 max, GLM 5.2 max, then Sol medium", () => {
+  test("visual-engineering prioritizes Opus max, Kimi K3 max, GLM 5.2 max, Astra high, then Sol medium", () => {
     // given
     const visual = CATEGORY_MODEL_REQUIREMENTS["visual-engineering"]
 
@@ -29,6 +29,11 @@ describe("category routing policy", () => {
       },
       {
         providers: ["openai", "openai-codex", "github-copilot", "opencode"],
+        model: "gpt-6-astra",
+        variant: "high",
+      },
+      {
+        providers: ["openai", "openai-codex", "github-copilot", "opencode"],
         model: "gpt-5.6-sol",
         variant: "medium",
       }
@@ -44,6 +49,11 @@ describe("category routing policy", () => {
 
     // then
     expect(chain).toEqual([
+      {
+        providers: ["openai", "openai-codex", "github-copilot", "opencode"],
+        model: "gpt-6-astra",
+        variant: "high",
+      },
       {
         providers: ["openai", "openai-codex", "github-copilot", "opencode"],
         model: "gpt-5.6-sol",

--- a/packages/model-core/src/category-routing-policy.test.ts
+++ b/packages/model-core/src/category-routing-policy.test.ts
@@ -169,6 +169,11 @@ describe("category routing policy", () => {
     // then
     expect(highChain).toEqual([
       {
+        providers: ["openai", "openai-codex", "github-copilot", "opencode"],
+        model: "gpt-6-astra",
+        variant: "high",
+      },
+      {
         providers: ["anthropic", "anthropic-api", "github-copilot", "opencode"],
         model: "claude-opus-5",
         variant: "xhigh",

--- a/packages/model-core/src/gpt-5.6-copilot-resolution.test.ts
+++ b/packages/model-core/src/gpt-5.6-copilot-resolution.test.ts
@@ -6,7 +6,8 @@ import { resolveModelWithFallback } from "./model-resolver"
 describe("GitHub Copilot GPT-5.6 and GPT-6 Astra resolution", () => {
   test("ultrabrain, deep, and unspecified-high prefer Copilot Astra when available", () => {
     const availableModels = new Set(["github-copilot/gpt-6-astra", "github-copilot/gpt-5.6-sol"])
-    for (const requirement of [CATEGORY_MODEL_REQUIREMENTS.ultrabrain, CATEGORY_MODEL_REQUIREMENTS.deep, CATEGORY_MODEL_REQUIREMENTS["unspecified-high"]]) {
+    expect(resolveModelWithFallback({ fallbackChain: CATEGORY_MODEL_REQUIREMENTS.ultrabrain.fallbackChain, availableModels, systemDefaultModel: "system/default" })).toMatchObject({ model: "github-copilot/gpt-6-astra", variant: "max" })
+    for (const requirement of [CATEGORY_MODEL_REQUIREMENTS.deep, CATEGORY_MODEL_REQUIREMENTS["unspecified-high"]]) {
       expect(resolveModelWithFallback({ fallbackChain: requirement.fallbackChain, availableModels, systemDefaultModel: "system/default" })).toMatchObject({ model: "github-copilot/gpt-6-astra", variant: "high" })
     }
   })
@@ -32,7 +33,7 @@ describe("GitHub Copilot GPT-5.6 and GPT-6 Astra resolution", () => {
     {
       name: "ultrabrain",
       requirement: CATEGORY_MODEL_REQUIREMENTS.ultrabrain,
-      expectedModel: "github-copilot/gpt-5.6-sol",
+      expectedModel: "github-copilot/gpt-6-astra",
       expectedVariant: "max",
     },
     {

--- a/packages/model-core/src/gpt-5.6-copilot-resolution.test.ts
+++ b/packages/model-core/src/gpt-5.6-copilot-resolution.test.ts
@@ -3,7 +3,19 @@ import { describe, expect, test } from "bun:test"
 import { AGENT_MODEL_REQUIREMENTS, CATEGORY_MODEL_REQUIREMENTS } from "./model-requirements"
 import { resolveModelWithFallback } from "./model-resolver"
 
-describe("GitHub Copilot GPT-5.6 resolution", () => {
+describe("GitHub Copilot GPT-5.6 and GPT-6 Astra resolution", () => {
+  test("ultrabrain, deep, and unspecified-high prefer Copilot Astra when available", () => {
+    const availableModels = new Set(["github-copilot/gpt-6-astra", "github-copilot/gpt-5.6-sol"])
+    for (const requirement of [CATEGORY_MODEL_REQUIREMENTS.ultrabrain, CATEGORY_MODEL_REQUIREMENTS.deep, CATEGORY_MODEL_REQUIREMENTS["unspecified-high"]]) {
+      expect(resolveModelWithFallback({ fallbackChain: requirement.fallbackChain, availableModels, systemDefaultModel: "system/default" })).toMatchObject({ model: "github-copilot/gpt-6-astra", variant: "high" })
+    }
+  })
+
+  test("ultrabrain and deep fall back to Copilot Sol when Astra is absent", () => {
+    const availableModels = new Set(["github-copilot/gpt-5.6-sol"])
+    expect(resolveModelWithFallback({ fallbackChain: CATEGORY_MODEL_REQUIREMENTS.ultrabrain.fallbackChain, availableModels, systemDefaultModel: "system/default" })).toMatchObject({ model: "github-copilot/gpt-5.6-sol", variant: "max" })
+    expect(resolveModelWithFallback({ fallbackChain: CATEGORY_MODEL_REQUIREMENTS.deep.fallbackChain, availableModels, systemDefaultModel: "system/default" })).toMatchObject({ model: "github-copilot/gpt-5.6-sol", variant: "medium" })
+  })
   const selectionCases = [
     {
       name: "hephaestus",

--- a/packages/model-core/src/gpt-5.6-copilot-resolution.test.ts
+++ b/packages/model-core/src/gpt-5.6-copilot-resolution.test.ts
@@ -112,6 +112,11 @@ describe("GitHub Copilot GPT-5.6 and GPT-6 Astra resolution", () => {
     })
   })
 
+  test("Copilot keeps the GPT-6 Astra max tier because no Copilot cap applies", () => {
+    const entries = CATEGORY_MODEL_REQUIREMENTS.ultrabrain.fallbackChain.filter(({ model, providers }) => model === "gpt-6-astra" && providers.includes("github-copilot"))
+    expect(entries).toEqual([{ providers: ["github-copilot"], model: "gpt-6-astra", variant: "max" }])
+  })
+
   test("Copilot is never included in a GPT-5.6 xhigh rung", () => {
     // given
     const requirements = [

--- a/packages/model-core/src/model-capabilities-openai-fast-aliases.test.ts
+++ b/packages/model-core/src/model-capabilities-openai-fast-aliases.test.ts
@@ -94,7 +94,7 @@ describe("OpenAI GPT fast capability aliases", () => {
 
     expect(alias).toMatchObject({
       requestedModelID: "openai/gpt-5.6-sol-fast",
-      canonicalModelID: modelID.includes("gpt-6-astra") ? "gpt-6-astra" : "gpt-5.6-sol",
+      canonicalModelID: "gpt-5.6-sol",
       supportsTemperature: false,
       diagnostics: {
         resolutionMode: "alias-backed",
@@ -120,7 +120,7 @@ describe("OpenAI GPT fast capability aliases", () => {
 
     expect(alias).toMatchObject({
       requestedModelID: modelID,
-      canonicalModelID: "gpt-5.6-sol",
+      canonicalModelID: modelID.includes("gpt-6-astra") ? "gpt-6-astra" : "gpt-5.6-sol",
       supportsTemperature: false,
       diagnostics: {
         resolutionMode: "alias-backed",

--- a/packages/model-core/src/model-capabilities-openai-fast-aliases.test.ts
+++ b/packages/model-core/src/model-capabilities-openai-fast-aliases.test.ts
@@ -10,11 +10,12 @@ const bundledSnapshot = getBundledModelCapabilitiesSnapshot({
 
 const OPENAI_FAST_ALIASES = [
   { aliasModelID: "gpt-5.6-sol-fast", canonicalModelID: "gpt-5.6-sol" },
+  { aliasModelID: "gpt-6-astra-fast", canonicalModelID: "gpt-6-astra" },
   { aliasModelID: "gpt-5.6-terra-fast", canonicalModelID: "gpt-5.6-terra" },
   { aliasModelID: "gpt-5.6-luna-fast", canonicalModelID: "gpt-5.6-luna" },
 ] as const
 
-describe("OpenAI GPT-5.6 fast capability aliases", () => {
+describe("OpenAI GPT fast capability aliases", () => {
   test("inherits each canonical snapshot entry without changing the requested model ID", () => {
     for (const { aliasModelID, canonicalModelID } of OPENAI_FAST_ALIASES) {
       const canonical = getModelCapabilities({
@@ -41,7 +42,7 @@ describe("OpenAI GPT-5.6 fast capability aliases", () => {
         resolutionMode: "alias-backed",
         canonicalization: {
           source: "pattern-alias",
-          ruleID: "openai-gpt-5.6-fast-service-tier-alias",
+          ruleID: "openai-gpt-fast-service-tier-alias",
         },
         snapshot: { source: "bundled-snapshot" },
       })
@@ -93,13 +94,13 @@ describe("OpenAI GPT-5.6 fast capability aliases", () => {
 
     expect(alias).toMatchObject({
       requestedModelID: "openai/gpt-5.6-sol-fast",
-      canonicalModelID: "gpt-5.6-sol",
+      canonicalModelID: modelID.includes("gpt-6-astra") ? "gpt-6-astra" : "gpt-5.6-sol",
       supportsTemperature: false,
       diagnostics: {
         resolutionMode: "alias-backed",
         canonicalization: {
           source: "pattern-alias",
-          ruleID: "openai-gpt-5.6-fast-service-tier-alias",
+          ruleID: "openai-gpt-fast-service-tier-alias",
         },
         snapshot: { source: "bundled-snapshot" },
       },
@@ -109,6 +110,7 @@ describe("OpenAI GPT-5.6 fast capability aliases", () => {
   test.each([
     { providerID: "openai", modelID: "gpt-5.6-sol-fast:high" },
     { providerID: "vercel", modelID: "openai/gpt-5.6-sol-fast:high" },
+    { providerID: "openai", modelID: "gpt-6-astra-fast:high" },
   ])("inherits canonical capabilities for suffixed fast alias $providerID/$modelID", ({ providerID, modelID }) => {
     const alias = getModelCapabilities({
       providerID,
@@ -124,7 +126,7 @@ describe("OpenAI GPT-5.6 fast capability aliases", () => {
         resolutionMode: "alias-backed",
         canonicalization: {
           source: "pattern-alias",
-          ruleID: "openai-gpt-5.6-fast-service-tier-alias",
+          ruleID: "openai-gpt-fast-service-tier-alias",
         },
         snapshot: { source: "bundled-snapshot" },
       },

--- a/packages/model-core/src/model-capabilities/get-model-capabilities.ts
+++ b/packages/model-core/src/model-capabilities/get-model-capabilities.ts
@@ -22,8 +22,10 @@ import type {
 } from "./types"
 
 const MODEL_ID_OVERRIDES: Record<string, ModelCapabilityOverride> = {}
-const GITHUB_COPILOT_GPT5_MODEL = /(?:^|\/)gpt-5(?:[.-]|$)/
-const GITHUB_COPILOT_GPT5_OVERRIDE: ModelCapabilityOverride = {
+// GitHub Copilot serves GPT-5.x and GPT-6 through the same backend, which hangs on the
+// xhigh/max reasoning tiers, so every Copilot GPT reasoning model is capped at high.
+const GITHUB_COPILOT_GPT_MODEL = /(?:^|\/)gpt-[56](?:[.-]|$)/
+const GITHUB_COPILOT_GPT_OVERRIDE: ModelCapabilityOverride = {
 	variants: ["low", "medium", "high"],
 	reasoningEfforts: ["none", "minimal", "low", "medium", "high"],
 }
@@ -38,8 +40,8 @@ function getOverride(modelID: string): ModelCapabilityOverride | undefined {
 
 function getProviderOverride(providerID: string, modelID: string): ModelCapabilityOverride | undefined {
 	if (providerID.trim().toLowerCase() !== "github-copilot") return undefined
-	return GITHUB_COPILOT_GPT5_MODEL.test(normalizeLookupModelID(modelID))
-		? GITHUB_COPILOT_GPT5_OVERRIDE
+	return GITHUB_COPILOT_GPT_MODEL.test(normalizeLookupModelID(modelID))
+		? GITHUB_COPILOT_GPT_OVERRIDE
 		: undefined
 }
 

--- a/packages/model-core/src/model-capabilities/supplemental-entries.ts
+++ b/packages/model-core/src/model-capabilities/supplemental-entries.ts
@@ -31,6 +31,22 @@ export const SUPPLEMENTAL_MODEL_CAPABILITIES: Record<string, ModelCapabilitiesSn
 			output: 262144,
 		},
 	},
+	"gpt-6-astra": {
+		id: "gpt-6-astra",
+		family: "gpt",
+		reasoning: true,
+		temperature: false,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image"],
+			output: ["text"],
+		},
+		limit: {
+			context: 1050000,
+			input: 922000,
+			output: 128000,
+		},
+	},
 	"gpt-5.6-sol": {
 		id: "gpt-5.6-sol",
 		family: "gpt",

--- a/packages/model-core/src/model-capability-aliases.test.ts
+++ b/packages/model-core/src/model-capability-aliases.test.ts
@@ -138,8 +138,8 @@ describe("model-capability-aliases", () => {
     })
   })
 
-  test("normalizes OpenAI GPT-5.6 fast service-tier aliases", () => {
-    const aliases = ["gpt-5.6-sol-fast", "gpt-5.6-terra-fast", "gpt-5.6-luna-fast"]
+  test("normalizes OpenAI GPT fast service-tier aliases", () => {
+    const aliases = ["gpt-5.6-sol-fast", "gpt-5.6-terra-fast", "gpt-5.6-luna-fast", "gpt-6-astra-fast"]
 
     for (const aliasModelID of aliases) {
       const result = resolveModelIDAlias(aliasModelID, "openai")
@@ -148,7 +148,7 @@ describe("model-capability-aliases", () => {
         requestedModelID: aliasModelID,
         canonicalModelID: aliasModelID.slice(0, -"-fast".length),
         source: "pattern-alias",
-        ruleID: "openai-gpt-5.6-fast-service-tier-alias",
+        ruleID: "openai-gpt-fast-service-tier-alias",
       })
     }
   })

--- a/packages/model-core/src/model-capability-aliases.ts
+++ b/packages/model-core/src/model-capability-aliases.ts
@@ -42,11 +42,11 @@ const EXACT_ALIAS_RULES_BY_MODEL: ReadonlyMap<string, ExactAliasRule> = new Map(
 
 const PATTERN_ALIAS_RULES: ReadonlyArray<PatternAliasRule> = [
   {
-    ruleID: "openai-gpt-5.6-fast-service-tier-alias",
-    description: "Normalizes OpenCode's OpenAI GPT-5.6 fast service-tier IDs to canonical snapshot IDs.",
+    ruleID: "openai-gpt-fast-service-tier-alias",
+    description: "Normalizes OpenCode's OpenAI GPT fast service-tier IDs to canonical snapshot IDs.",
     providerIDs: ["openai"],
     allowedSubproviderHosts: ["vercel"],
-    match: (normalizedModelID) => /^gpt-5\.6-(?:sol|terra|luna)-fast$/.test(normalizedModelID),
+    match: (normalizedModelID) => /^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-6-astra)-fast$/.test(normalizedModelID),
     canonicalize: (normalizedModelID) => normalizedModelID.slice(0, -"-fast".length),
   },
   {

--- a/packages/model-core/src/model-capability-heuristics.ts
+++ b/packages/model-core/src/model-capability-heuristics.ts
@@ -40,6 +40,14 @@ export const HEURISTIC_MODEL_FAMILY_REGISTRY: ReadonlyArray<HeuristicModelFamily
     supportsTemperature: false,
   },
   {
+    family: "gpt-6",
+    includes: ["gpt-6"],
+    variants: ["low", "medium", "high", "xhigh", "max"],
+    reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+    reasoningEffortAliases: { none: "low", minimal: "low" },
+    supportsTemperature: false,
+  },
+  {
     family: "gpt-5",
     includes: ["gpt-5"],
     variants: ["low", "medium", "high", "xhigh"],

--- a/packages/model-core/src/model-requirements-categories.test.ts
+++ b/packages/model-core/src/model-requirements-categories.test.ts
@@ -4,9 +4,9 @@ import { CATEGORY_MODEL_REQUIREMENTS } from "./model-requirements"
 describe("CATEGORY_MODEL_REQUIREMENTS", () => {
   test("ultrabrain routes GPT-6 Astra high before the existing Sol max fallbacks", () => {
     expect(CATEGORY_MODEL_REQUIREMENTS.ultrabrain.fallbackChain).toEqual([
-      { providers: ["openai", "openai-codex"], model: "gpt-6-astra", variant: "high" },
-      { providers: ["github-copilot"], model: "gpt-6-astra", variant: "high" },
-      { providers: ["openai", "openai-codex", "opencode"], model: "gpt-6-astra", variant: "high" },
+      { providers: ["openai", "openai-codex"], model: "gpt-6-astra", variant: "max" },
+      { providers: ["github-copilot"], model: "gpt-6-astra", variant: "max" },
+      { providers: ["openai", "openai-codex", "opencode"], model: "gpt-6-astra", variant: "max" },
       { providers: ["openai", "openai-codex"], model: "gpt-5.6-sol", variant: "max" },
       { providers: ["github-copilot"], model: "gpt-5.6-sol", variant: "max" },
       { providers: ["openai", "openai-codex", "opencode"], model: "gpt-5.6-sol", variant: "max" },

--- a/packages/model-core/src/model-requirements-categories.test.ts
+++ b/packages/model-core/src/model-requirements-categories.test.ts
@@ -18,7 +18,7 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     const requirement = CATEGORY_MODEL_REQUIREMENTS["ultrabrain"]
 
     // when
-    const chain = requirement.fallbackChain
+    const chain = requirement.fallbackChain.filter(({ model }) => model === "gpt-5.6-sol")
 
     // then
     expect(chain).toEqual([
@@ -52,7 +52,7 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     const requirement = CATEGORY_MODEL_REQUIREMENTS["deep"]
 
     // when
-    const chain = requirement.fallbackChain
+    const chain = requirement.fallbackChain.filter(({ model }) => model === "gpt-5.6-sol")
 
     // then
     expect(chain).toEqual([
@@ -93,6 +93,11 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
         providers: ["zai-coding-plan", "opencode-go"],
         model: "glm-5.2",
         variant: "max",
+      },
+      {
+        providers: ["openai", "openai-codex", "github-copilot", "opencode"],
+        model: "gpt-6-astra",
+        variant: "high",
       },
       {
         providers: ["openai", "openai-codex", "github-copilot", "opencode"],
@@ -194,7 +199,7 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     ])
   })
 
-  test("unspecified-high follows the approved opus-first 3-rung chain", () => {
+  test("unspecified-high follows the approved Astra-first 4-rung chain", () => {
     // given
     const requirement = CATEGORY_MODEL_REQUIREMENTS["unspecified-high"]
 
@@ -203,6 +208,11 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
 
     // then
     expect(chain).toEqual([
+      {
+        providers: ["openai", "openai-codex", "github-copilot", "opencode"],
+        model: "gpt-6-astra",
+        variant: "high",
+      },
       {
         providers: ["anthropic", "anthropic-api", "github-copilot", "opencode"],
         model: "claude-opus-5",

--- a/packages/model-core/src/model-requirements-categories.test.ts
+++ b/packages/model-core/src/model-requirements-categories.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { CATEGORY_MODEL_REQUIREMENTS } from "./model-requirements"
 
 describe("CATEGORY_MODEL_REQUIREMENTS", () => {
-  test("ultrabrain routes GPT-6 Astra high before the existing Sol max fallbacks", () => {
+  test("ultrabrain routes GPT-6 Astra max before the existing Sol max fallbacks", () => {
     expect(CATEGORY_MODEL_REQUIREMENTS.ultrabrain.fallbackChain).toEqual([
       { providers: ["openai", "openai-codex"], model: "gpt-6-astra", variant: "max" },
       { providers: ["github-copilot"], model: "gpt-6-astra", variant: "max" },
@@ -13,7 +13,7 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     ])
   })
 
-  test("ultrabrain is gpt-5.6-sol max on every fallback rung", () => {
+  test("ultrabrain keeps gpt-5.6-sol max on every fallback rung", () => {
     // given
     const requirement = CATEGORY_MODEL_REQUIREMENTS["ultrabrain"]
 

--- a/packages/model-core/src/model-requirements-categories.test.ts
+++ b/packages/model-core/src/model-requirements-categories.test.ts
@@ -2,7 +2,18 @@ import { describe, expect, test } from "bun:test"
 import { CATEGORY_MODEL_REQUIREMENTS } from "./model-requirements"
 
 describe("CATEGORY_MODEL_REQUIREMENTS", () => {
-  test("ultrabrain is gpt-5.6-sol max on every rung", () => {
+  test("ultrabrain routes GPT-6 Astra high before the existing Sol max fallbacks", () => {
+    expect(CATEGORY_MODEL_REQUIREMENTS.ultrabrain.fallbackChain).toEqual([
+      { providers: ["openai", "openai-codex"], model: "gpt-6-astra", variant: "high" },
+      { providers: ["github-copilot"], model: "gpt-6-astra", variant: "high" },
+      { providers: ["openai", "openai-codex", "opencode"], model: "gpt-6-astra", variant: "high" },
+      { providers: ["openai", "openai-codex"], model: "gpt-5.6-sol", variant: "max" },
+      { providers: ["github-copilot"], model: "gpt-5.6-sol", variant: "max" },
+      { providers: ["openai", "openai-codex", "opencode"], model: "gpt-5.6-sol", variant: "max" },
+    ])
+  })
+
+  test("ultrabrain is gpt-5.6-sol max on every fallback rung", () => {
     // given
     const requirement = CATEGORY_MODEL_REQUIREMENTS["ultrabrain"]
 
@@ -29,7 +40,14 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     ])
   })
 
-  test("deep is a single sol-family medium rung", () => {
+  test("deep routes GPT-6 Astra high before the Sol medium fallback", () => {
+    expect(CATEGORY_MODEL_REQUIREMENTS.deep.fallbackChain).toEqual([
+      { providers: ["openai", "openai-codex", "github-copilot", "opencode"], model: "gpt-6-astra", variant: "high" },
+      { providers: ["openai", "openai-codex", "github-copilot", "opencode"], model: "gpt-5.6-sol", variant: "medium" },
+    ])
+  })
+
+  test("deep is a single sol-family medium fallback rung", () => {
     // given
     const requirement = CATEGORY_MODEL_REQUIREMENTS["deep"]
 
@@ -46,7 +64,13 @@ describe("CATEGORY_MODEL_REQUIREMENTS", () => {
     ])
   })
 
-  test("visual-engineering follows the approved 4-rung chain", () => {
+  test("visual-engineering puts GPT-6 Astra high before Sol medium", () => {
+    expect(CATEGORY_MODEL_REQUIREMENTS["visual-engineering"].fallbackChain.at(-2)).toEqual({
+      providers: ["openai", "openai-codex", "github-copilot", "opencode"], model: "gpt-6-astra", variant: "high",
+    })
+  })
+
+  test("visual-engineering follows the approved 5-rung chain", () => {
     // given
     const requirement = CATEGORY_MODEL_REQUIREMENTS["visual-engineering"]
 

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -4,6 +4,31 @@ import { getModelCapabilities } from "./model-capabilities"
 import { resolveCompatibleModelSettings } from "./model-settings-compatibility"
 
 describe("resolveCompatibleModelSettings", () => {
+  test("keeps GPT-6 Astra max and maps unsupported effort aliases while dropping temperature", () => {
+    const result = resolveCompatibleModelSettings({
+      providerID: "openai",
+      modelID: "gpt-6-astra",
+      desired: { variant: "max", reasoningEffort: "none", temperature: 0.2 },
+    })
+
+    expect(result).toEqual({
+      variant: "max",
+      reasoningEffort: "low",
+      temperature: undefined,
+      changes: [
+        { field: "reasoningEffort", from: "none", to: "low", reason: "unsupported-by-model-family" },
+        { field: "temperature", from: "0.2", to: undefined, reason: "unsupported-by-model-family" },
+      ],
+    })
+  })
+
+  test("maps GPT-6 Astra minimal reasoning effort to low", () => {
+    expect(resolveCompatibleModelSettings({
+      providerID: "openai-codex",
+      modelID: "gpt-6-astra",
+      desired: { reasoningEffort: "minimal" },
+    }).reasoningEffort).toBe("low")
+  })
   test("keeps supported Claude Opus variant unchanged", () => {
     const result = resolveCompatibleModelSettings({
       providerID: "anthropic",

--- a/packages/model-core/src/model-settings-compatibility.test.ts
+++ b/packages/model-core/src/model-settings-compatibility.test.ts
@@ -351,8 +351,8 @@ describe("resolveCompatibleModelSettings", () => {
     })
   })
 
-  test("GitHub Copilot GPT-5 high-tier variants downgrade to high", () => {
-    for (const modelID of ["gpt-5.4", "gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+  test("GitHub Copilot GPT-5 and GPT-6 high-tier variants downgrade to high", () => {
+    for (const modelID of ["gpt-5.4", "gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-6-astra"]) {
       for (const requested of ["xhigh", "max"]) {
         const capabilities = getModelCapabilities({
           providerID: "github-copilot",

--- a/packages/omo-opencode/src/agents/frontier-tool-schema-guard.ts
+++ b/packages/omo-opencode/src/agents/frontier-tool-schema-guard.ts
@@ -1,12 +1,12 @@
 import type { AgentConfig } from "@opencode-ai/sdk"
-import { isClaudeOpus47OrLaterModel, isGpt5_5Model, isGpt5_6Model } from "./types"
+import { isClaudeOpus47OrLaterModel, isGpt5_5Model, isGpt5_6Model, isGpt6Model } from "./types"
 import type { PermissionValue } from "../shared/permission-compat"
 
 const FRONTIER_TOOL_SCHEMA_NAMES = ["grep", "glob"] as const
 type MutablePermission = Record<string, PermissionValue | Record<string, PermissionValue>>
 
 export function getFrontierToolSchemaPermission(model: string): Record<string, "deny"> {
-  return isClaudeOpus47OrLaterModel(model) || isGpt5_5Model(model) || isGpt5_6Model(model)
+  return isClaudeOpus47OrLaterModel(model) || isGpt5_5Model(model) || isGpt5_6Model(model) || isGpt6Model(model)
     ? { grep: "deny" as const, glob: "deny" as const }
     : {}
 }

--- a/packages/omo-opencode/src/agents/gpt-prompt-identity.ts
+++ b/packages/omo-opencode/src/agents/gpt-prompt-identity.ts
@@ -1,14 +1,18 @@
-export type GptPromptIdentityKey = "gpt-5.5" | "gpt-5.6-sol" | "gpt-family"
+export type GptPromptIdentityKey = "gpt-5.5" | "gpt-5.6-sol" | "gpt-6-astra" | "gpt-family"
 
 const GPT_PROMPT_IDENTITIES: Record<GptPromptIdentityKey, string> = {
   "gpt-5.5": "GPT-5.5",
   "gpt-5.6-sol": "GPT-5.6 Sol",
+  "gpt-6-astra": "GPT-6 Astra",
   "gpt-family": "a GPT-family model",
 }
 
 export function getGptPromptIdentityKey(model?: string): GptPromptIdentityKey {
   const modelID = model?.split("/").at(-1)?.toLowerCase()
 
+  if (modelID?.includes("gpt-6-astra")) {
+    return "gpt-6-astra"
+  }
   if (modelID?.includes("gpt-5.6-sol") || modelID?.includes("gpt-5-6-sol")) {
     return "gpt-5.6-sol"
   }

--- a/packages/omo-opencode/src/agents/gpt-shared-prompt-identity.test.ts
+++ b/packages/omo-opencode/src/agents/gpt-shared-prompt-identity.test.ts
@@ -8,6 +8,7 @@ describe("shared GPT prompt identities", () => {
   for (const [model, identityKey] of [
     ["openai/gpt-5.5", "gpt-5.5"],
     ["openai/gpt-5.6-sol", "gpt-5.6-sol"],
+    ["github-copilot/gpt-6-astra", "gpt-6-astra"],
   ] as const) {
     test(`selects the ${identityKey} identity contract`, () => {
       // given a supported GPT model routed through the shared prompt family
@@ -20,7 +21,7 @@ describe("shared GPT prompt identities", () => {
     })
   }
 
-  for (const model of ["openai/gpt-5.5", "openai/gpt-5.6-sol"]) {
+  for (const model of ["openai/gpt-5.5", "openai/gpt-5.6-sol", "github-copilot/gpt-6-astra"]) {
     test(`routes ${model} through the shared Atlas GPT prompt source`, () => {
       // given a supported GPT model
 

--- a/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.test.ts
@@ -135,6 +135,11 @@ describe("getHephaestusPromptSource", () => {
     expect(source2).toBe("gpt-5-5");
   });
 
+  test("returns 'gpt-5-6' for GPT-6 Astra models", () => {
+    expect(getHephaestusPromptSource("openai/gpt-6-astra")).toBe("gpt-5-6")
+    expect(getHephaestusPromptSource("github-copilot/gpt-6-astra-fast")).toBe("gpt-5-6")
+  })
+
   test("returns 'gpt-5-6' for gpt-5.6 family models", () => {
     // given
     const model1 = "openai/gpt-5.6";

--- a/packages/omo-opencode/src/agents/hephaestus/agent.ts
+++ b/packages/omo-opencode/src/agents/hephaestus/agent.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "../types";
-import { isGpt5_5Model, isGpt5_6Model } from "../types";
+import { isGpt5_5Model, isGpt5_6Model, isGpt6Model } from "../types";
 import type {
   AvailableAgent,
   AvailableTool,
@@ -20,6 +20,7 @@ const GPT_5_3_CODEX_RE = /^gpt-5[.-]3-codex(?:$|[.-])/i;
 const GPT_5_4_RE = /^gpt-5[.-]4(?:$|[.-])/i;
 const GPT_5_5_RE = /^gpt-5[.-]5(?:$|[.-])/i;
 const GPT_5_6_RE = /^gpt-5[.-]6(?:$|[.-])/i;
+const GPT_6_RE = /^gpt-6(?:$|[.-])/i;
 const HOSTED_VENDOR_PREFIX_RE = /^(?:[^./]+\.)+(gpt-5[.-].*)$/i;
 
 export type HephaestusPromptSource = "gpt-5-6" | "gpt-5-5" | "gpt-5-4" | "gpt";
@@ -48,7 +49,8 @@ export function isHephaestusSupportedModel(model: string | undefined): boolean {
     GPT_5_3_CODEX_RE.test(modelName) ||
     GPT_5_4_RE.test(modelName) ||
     GPT_5_5_RE.test(modelName) ||
-    GPT_5_6_RE.test(modelName)
+    GPT_5_6_RE.test(modelName) ||
+    GPT_6_RE.test(modelName)
   );
 }
 
@@ -62,7 +64,7 @@ export function getHephaestusPromptSource(
   model?: string,
 ): HephaestusPromptSource {
   assertHephaestusSupportedModel(model);
-  if (model && isGpt5_6Model(model)) {
+  if (model && (isGpt5_6Model(model) || isGpt6Model(model))) {
     return "gpt-5-6";
   }
   if (model && isGpt5_5Model(model)) {

--- a/packages/omo-opencode/src/agents/momus.test.ts
+++ b/packages/omo-opencode/src/agents/momus.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { createMomusAgent } from "./momus";
 
 describe("createMomusAgent", () => {
+  test("uses the GPT-5.6-class prompt and high reasoning for GPT-6 Astra", () => {
+    const agent = createMomusAgent("openai/gpt-6-astra")
+    expect(agent.reasoningEffort).toBe("high")
+    expect(agent.prompt).toBe(createMomusAgent("openai/gpt-5.6-sol").prompt)
+  })
   describe("#given a GPT-5.6 family model", () => {
     test("#when creating the agent #then it runs high reasoning with a GPT-5.6 tuned prompt", () => {
       // given

--- a/packages/omo-opencode/src/agents/momus.ts
+++ b/packages/omo-opencode/src/agents/momus.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
-import { buildClaudeThinkingConfig, isGpt5_6Model, isGptModel } from "./types";
+import { buildClaudeThinkingConfig, isGpt5_6Model, isGpt6Model, isGptModel } from "./types";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
 import { MOMUS_GPT_5_6_PROMPT } from "./momus-gpt-5-6";
 
@@ -296,7 +296,7 @@ export function createMomusAgent(model: string): AgentConfig {
     prompt: MOMUS_DEFAULT_PROMPT,
   } as AgentConfig;
 
-  if (isGpt5_6Model(model)) {
+  if (isGpt5_6Model(model) || isGpt6Model(model)) {
     return {
       ...base,
       prompt: MOMUS_GPT_5_6_PROMPT,

--- a/packages/omo-opencode/src/agents/oracle.test.ts
+++ b/packages/omo-opencode/src/agents/oracle.test.ts
@@ -14,6 +14,10 @@ describe("createOracleAgent", () => {
     expect(agent.reasoningEffort).toBe("xhigh")
   })
 
+  test("uses xhigh reasoning effort for GPT-6 Astra frontier routing", () => {
+    expect(createOracleAgent("github-copilot/gpt-6-astra").reasoningEffort).toBe("xhigh")
+  })
+
   test("preserves medium reasoning effort for gpt-5.5 fallback", () => {
     // given
     const model = "openai/gpt-5.5"

--- a/packages/omo-opencode/src/agents/oracle.ts
+++ b/packages/omo-opencode/src/agents/oracle.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from "@opencode-ai/sdk";
 import type { AgentMode, AgentPromptMetadata } from "./types";
-import { buildClaudeThinkingConfig, isGpt5_5Model, isGpt5_6Model, isGptModel } from "./types";
+import { buildClaudeThinkingConfig, isGpt5_5Model, isGpt5_6Model, isGpt6Model, isGptModel } from "./types";
 import { createAgentToolRestrictions } from "../shared/permission-compat";
 
 const MODE: AgentMode = "subagent";
@@ -426,7 +426,7 @@ export function createOracleAgent(model: string): AgentConfig {
     prompt: ORACLE_DEFAULT_PROMPT,
   } as AgentConfig;
 
-  if (isGpt5_6Model(model)) {
+  if (isGpt5_6Model(model) || isGpt6Model(model)) {
     return {
       ...base,
       prompt: ORACLE_GPT_5_5_PROMPT,

--- a/packages/omo-opencode/src/agents/sisyphus-agent-factory.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-agent-factory.ts
@@ -32,6 +32,7 @@ import {
   isGlmModel,
   isGpt5_5Model,
   isGpt5_6Model,
+  isGpt6Model,
   isGptModel,
   isGptNativeSisyphusModel,
   isGrok45Model,
@@ -68,7 +69,7 @@ export function resolveSisyphusPromptFamily(model: string): SisyphusPromptFamily
   if (isKimiK3Model(model)) return "kimi-k3";
   if (isKimiK27Model(model)) return "kimi-k2-7";
   if (isKimiK2Model(model)) return "kimi-k2-6";
-  if (isGpt5_5Model(model) || isGpt5_6Model(model)) return "gpt-5-5";
+  if (isGpt5_5Model(model) || isGpt5_6Model(model) || isGpt6Model(model)) return "gpt-5-5";
   if (isGptNativeSisyphusModel(model)) return "gpt-5-4";
   if (isClaudeFable5Model(model)) return "claude-fable-5";
   if (isClaudeOpus5Model(model)) return "claude-opus-5";

--- a/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
+++ b/packages/omo-opencode/src/agents/sisyphus-junior/agent.ts
@@ -16,7 +16,7 @@
 
 import type { AgentConfig } from "@opencode-ai/sdk"
 import type { AgentMode } from "../types"
-import { isGlmModel, isGpt5_5Model, isGpt5_6Model, isGptModel, isGeminiModel, isKimiK2Model, isKimiK27Model, isKimiK3Model, buildClaudeThinkingConfig } from "../types"
+import { isGlmModel, isGpt5_5Model, isGpt5_6Model, isGpt6Model, isGptModel, isGeminiModel, isKimiK2Model, isKimiK27Model, isKimiK3Model, buildClaudeThinkingConfig } from "../types"
 import type { AgentOverrideConfig } from "../../config/schema"
 import {
   createAgentToolRestrictions,
@@ -61,7 +61,7 @@ export function getSisyphusJuniorPromptSource(model?: string): SisyphusJuniorPro
   if (model && isKimiK27Model(model)) return "kimi-k2-7"
   if (model && isKimiK2Model(model)) return "kimi-k2"
   if (model && isGptModel(model)) {
-    if (isGpt5_5Model(model) || isGpt5_6Model(model)) return "gpt-5-5"
+    if (isGpt5_5Model(model) || isGpt5_6Model(model) || isGpt6Model(model)) return "gpt-5-5"
     const lower = model.toLowerCase()
     if (lower.includes("gpt-5.4") || lower.includes("gpt-5-4")) return "gpt-5-4"
     return "gpt"

--- a/packages/omo-opencode/src/agents/types.ts
+++ b/packages/omo-opencode/src/agents/types.ts
@@ -148,6 +148,12 @@ export function isGpt5_6Model(model: string): boolean {
   return modelName.includes("gpt-5.6") || modelName.includes("gpt-5-6");
 }
 
+/** Matches GPT-6 models, including provider-prefixed and fast-tier IDs. */
+export function isGpt6Model(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase();
+  return modelName.includes("gpt-6");
+}
+
 export type BuiltinAgentName =
   | "sisyphus"
   | "hephaestus"

--- a/packages/omo-opencode/src/cli/config-manager/generate-omo-config.test.ts
+++ b/packages/omo-opencode/src/cli/config-manager/generate-omo-config.test.ts
@@ -169,9 +169,14 @@ describe("generateOmoConfig - model fallback system", () => {
         variant: "medium",
       },
     ])
-    expect(categories.deep.model).toBe("openai/gpt-5.6-sol")
-    expect(categories.deep.variant).toBe("medium")
-    expect(categories.deep.fallback_models).toBeUndefined()
+    expect(categories.deep.model).toBe("openai/gpt-6-astra")
+    expect(categories.deep.variant).toBe("high")
+    expect(categories.deep.fallback_models).toEqual([
+      {
+        model: "openai/gpt-5.6-sol",
+        variant: "medium",
+      },
+    ])
   })
 
   test("uses haiku for explore when Claude max20", () => {

--- a/packages/omo-opencode/src/cli/doctor/checks/model-resolution-openai-fast-alias.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/model-resolution-openai-fast-alias.test.ts
@@ -4,7 +4,7 @@ import { buildModelResolutionDetails } from "./model-resolution-details"
 import { collectCapabilityResolutionIssues, getModelResolutionInfoWithOverrides } from "./model-resolution"
 import type { OmoConfig } from "./model-resolution-types"
 
-describe("doctor OpenAI GPT-5.6 fast capability diagnostics", () => {
+describe("doctor OpenAI GPT fast capability diagnostics", () => {
   test("preserves the configured model and variant while reporting alias-backed capabilities", () => {
     const config: OmoConfig = {
       agents: {
@@ -27,7 +27,7 @@ describe("doctor OpenAI GPT-5.6 fast capability diagnostics", () => {
         resolutionMode: "alias-backed",
         canonicalization: {
           source: "pattern-alias",
-          ruleID: "openai-gpt-5.6-fast-service-tier-alias",
+          ruleID: "openai-gpt-fast-service-tier-alias",
         },
       },
     })

--- a/packages/omo-opencode/src/cli/model-fallback.test.ts
+++ b/packages/omo-opencode/src/cli/model-fallback.test.ts
@@ -48,7 +48,7 @@ describe("generateModelConfig", () => {
       // #then Copilot GPT routes should not receive variants that hang the provider
       const unsupportedEntries = flattenConfiguredModels(result).filter(
         (entry) =>
-          entry.model.startsWith("github-copilot/gpt-5.") &&
+          /^github-copilot\/gpt-[56][.-]/.test(entry.model) &&
           (entry.variant === "max" || entry.variant === "xhigh")
       )
       expect(unsupportedEntries).toEqual([])
@@ -70,10 +70,11 @@ describe("generateModelConfig", () => {
           },
         ],
       })
-      expect(result.categories?.ultrabrain?.model).toBe("github-copilot/gpt-5.6-sol")
+      // Astra max/high rungs land first; Copilot clamps the max tier to high like the Sol rungs.
+      expect(result.categories?.ultrabrain?.model).toBe("github-copilot/gpt-6-astra")
       expect(result.categories?.ultrabrain?.variant).toBe("high")
-      expect(result.categories?.deep?.model).toBe("github-copilot/gpt-5.6-sol")
-      expect(result.categories?.deep?.variant).toBe("medium")
+      expect(result.categories?.deep?.model).toBe("github-copilot/gpt-6-astra")
+      expect(result.categories?.deep?.variant).toBe("high")
       expect(result.categories?.["unspecified-low"]?.model).toBe("github-copilot/grok-4.6")
       expect(result.categories?.["unspecified-low"]?.variant).toBe("high")
     })

--- a/packages/omo-opencode/src/hooks/no-sisyphus-gpt/hook.ts
+++ b/packages/omo-opencode/src/hooks/no-sisyphus-gpt/hook.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin"
-import { isGpt5_5Model, isGptModel, isGptNativeSisyphusModel } from "../../agents/types"
+import { isGpt5_5Model, isGpt6Model, isGptModel, isGptNativeSisyphusModel } from "../../agents/types"
 import {
   getSessionAgent,
   resolveRegisteredAgentName,
@@ -32,6 +32,7 @@ function showToast(ctx: PluginInput, sessionID: string): void {
 
 function getNativeSisyphusGptVariant(model: { providerID: string; modelID: string }): string | undefined {
   if (isGpt5_5Model(model.modelID)) return "medium"
+  if (isGpt6Model(model.modelID)) return "high"
 
   const chain = AGENT_MODEL_REQUIREMENTS["sisyphus"]?.fallbackChain ?? []
   const exactMatch = chain.find((entry) =>
@@ -61,7 +62,7 @@ export function createNoSisyphusGptHook(ctx: PluginInput) {
         agentKey === "sisyphus"
         && input.model
         && modelID
-        && isGptNativeSisyphusModel(modelID)
+        && (isGptNativeSisyphusModel(modelID) || isGpt6Model(modelID))
         && output?.message
         && output.message.variant === undefined
       ) {
@@ -71,7 +72,7 @@ export function createNoSisyphusGptHook(ctx: PluginInput) {
         }
       }
 
-      if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGptNativeSisyphusModel(modelID)) {
+      if (agentKey === "sisyphus" && modelID && isGptModel(modelID) && !isGptNativeSisyphusModel(modelID) && !isGpt6Model(modelID)) {
         showToast(ctx, input.sessionID)
         input.agent = resolveRegisteredAgentName("hephaestus") ?? "hephaestus"
         if (output?.message) {

--- a/packages/omo-opencode/src/tools/delegate-task/openai-categories.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/openai-categories.ts
@@ -1,4 +1,4 @@
-import { isGpt5_5Model, isGpt5_6Model } from "../../agents/types"
+import { isGpt5_5Model, isGpt5_6Model, isGpt6Model } from "../../agents/types"
 import type { BuiltinCategoryDefinition } from "./builtin-category-definition"
 
 const ULTRABRAIN_CATEGORY_PROMPT_APPEND = `<Category_Context>
@@ -67,7 +67,7 @@ The orchestrator chose this category because the task benefits from depth over s
 </Category_Context>`
 
 export function resolveDeepCategoryPromptAppend(model: string | undefined): string {
-  if (model && (isGpt5_5Model(model) || isGpt5_6Model(model))) {
+  if (model && (isGpt5_5Model(model) || isGpt5_6Model(model) || isGpt6Model(model))) {
     return DEEP_CATEGORY_PROMPT_APPEND_GPT_5_5
   }
   return DEEP_CATEGORY_PROMPT_APPEND


### PR DESCRIPTION
## What changed
- Route visual-engineering, ultrabrain, deep, and unspecified-high through GPT-6 Astra with Sol fallbacks where specified. Ultrabrain uses Astra max per directive; other Astra top rungs use high.
- Add GPT-6 capability heuristics, supplemental snapshot capabilities, and generic OpenAI fast-tier aliasing.
- Treat GPT-6 Astra as GPT-5.6-class in omo-opencode frontier prompts, agents, guards, delegation, and Sisyphus routing.

## Why
GPT-6 Astra is available in senpi/providers and needs native capability normalization and frontier-family behavior.

## Observed / QA evidence
- RED: 89 pass, 5 fail across 94 tests against untouched routing.
- GREEN on mengmotaMac via bunshin: model-core 380 pass / 0 fail; omo-opencode suites 988 pass / 0 fail; typecheck passed.
- Evidence: `.omo/evidence/omo-senpi-adapter/20260905-gpt-6-astra-routing/`.
- Remote temp clone `/tmp/astra-b1-20260905` removed by the runner.

## Residual risk
No live provider/model API call was made; runtime resolution is covered by deterministic fallback and capability tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the visual-engineering, ultrabrain, deep, and unspecified-high categories through GPT-6 Astra high, with GPT-5.6 Sol kept as the fallback lane, and treats Astra as GPT-5.6-class across frontier prompts, agents, guards, delegation, and Sisyphus routing.

- Adds GPT-6 capability heuristics, a supplemental Astra snapshot entry, and OpenAI fast-tier alias support for `gpt-6-astra-fast`.
- Uses the Astra max tier for ultrabrain and high tier for the other three categories; Sol fallback rungs are preserved where they were specified.
- GitHub Copilot now clamps GPT-6 max/xhigh tiers to high, matching the existing GPT-5 cap.
- Adds `isGpt6Model` and wires it into Momus, Oracle, Hephaestus, Sisyphus/Sisyphus-Junior, the frontier tool-schema guard, the no-Sisyphus hook, and delegation.
- Covers routing, capability, and fallback behavior with tests; no live provider/API call was made.

<sup>Written for commit c9de902e46b9256451e09b1e79ee41ee23a9b5fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

