### PR TITLE
docs: present eval examples with JavaScript first

### DIFF
--- a/packages/omo-senpi/skills/init-deep/SKILL.md
+++ b/packages/omo-senpi/skills/init-deep/SKILL.md
@@ -36,7 +36,7 @@ Generate hierarchical AGENTS.md files: root + complexity-scored subdirectories, 
 
 Measure and compute in ONE eval cell - code, not mental arithmetic:
 
-```python
+```js
 # Measure (tracked files minus vendored/generated: node_modules, .git, dist,
 # build, out, vendor, target, coverage, lockfiles, minified and binary files)
 S        = total source bytes after exclusions


### PR DESCRIPTION
Make the init-deep eval example use the JavaScript language label first, matching the repository default and sibling skill guidance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `init-deep` skill docs so the eval example uses the `js` language label instead of `python`, aligning with the repository default and sibling skill guidance. No behavior change.

<sup>Written for commit 8b8b1743c8ad43fbf171d23dbe34bd6aeccdc648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

