### PR TITLE
fix(categories): restore the root-cause clause in the deep Astra prompt append

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -8,7 +8,7 @@ rather than a restatement of it: ultrabrain states the success criteria of a max
 answer (evidence cited from this turn, executable claims executed, a self-falsification pass, rejected
 alternatives and open assumptions named, one decision-complete recommendation); deep keeps one goal and
 one deliverable with a generous exploration budget, the goal as authorization, numbered steps as one
-atomic task, and the harness fact that a question ends the turn unfinished; unspecified-high asks for a
+atomic task, fixes trace at least two levels above the symptom to the root cause, and the harness fact that a question ends the turn unfinished; unspecified-high asks for a
 survey of the whole affected surface (callers, sibling modules, tests, docs, schemas, config, CI, git
 history), at least two weighed approaches, and delivery across every surface found. The previous
 ultrabrain append prescribed a "Bottom line" response format that the Astra preset bans as a stock

--- a/packages/omo-opencode/src/tools/delegate-task/openai-categories.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/openai-categories.ts
@@ -23,7 +23,7 @@ The orchestrator routed this task here for depth: one goal, one deliverable, and
 
 The goal is the authorization. Choose how to reach it yourself, and when it lists numbered steps or phases, deliver all of them in this turn as one task; a proposal, a plan awaiting approval, a simplified version, or a proof of concept is unfinished work. When the steps turn out to be independent problems sharing no reasoning, do the one the goal centers on and return the others as separately delegable items with what you learned. A question ends your turn and hands the task back unfinished, so decide from context, record each assumption in the final message, and stop early only for a blocker you cannot route around: a missing secret, a decision only the user can make, or three materially different attempts that all failed.
 
-Depth means understanding the mechanism, so the diff stays as small as the fix allows; on greenfield work choose strong defaults and finish something you would hand to a senior engineer. Close with the delivered change, the evidence that it works, and the assumptions you made.
+Fix the cause: trace at least two levels above the symptom before settling, and prefer the change that makes the failure impossible over the guard that hides it. Depth means understanding the mechanism, so the diff stays as small as the fix allows; on greenfield work choose strong defaults and finish something you would hand to a senior engineer. Close with the delivered change, the evidence that it works, and the assumptions you made.
 </Category_Context>`
 
 export const UNSPECIFIED_HIGH_CATEGORY_PROMPT_APPEND_GPT_6_ASTRA = `<Category_Context name="unspecified-high">

--- a/packages/senpi-task/src/category/openai-categories.ts
+++ b/packages/senpi-task/src/category/openai-categories.ts
@@ -31,7 +31,7 @@ The orchestrator routed this task here for depth: one goal, one deliverable, and
 
 The goal is the authorization. Choose how to reach it yourself, and when it lists numbered steps or phases, deliver all of them in this turn as one task; a proposal, a plan awaiting approval, a simplified version, or a proof of concept is unfinished work. When the steps turn out to be independent problems sharing no reasoning, do the one the goal centers on and return the others as separately delegable items with what you learned. A question ends your turn and hands the task back unfinished, so decide from context, record each assumption in the final message, and stop early only for a blocker you cannot route around: a missing secret, a decision only the user can make, or three materially different attempts that all failed.
 
-Depth means understanding the mechanism, so the diff stays as small as the fix allows; on greenfield work choose strong defaults and finish something you would hand to a senior engineer. Close with the delivered change, the evidence that it works, and the assumptions you made.
+Fix the cause: trace at least two levels above the symptom before settling, and prefer the change that makes the failure impossible over the guard that hides it. Depth means understanding the mechanism, so the diff stays as small as the fix allows; on greenfield work choose strong defaults and finish something you would hand to a senior engineer. Close with the delivered change, the evidence that it works, and the assumptions you made.
 </Category_Context>`
 
 export const UNSPECIFIED_HIGH_CATEGORY_PROMPT_APPEND_GPT_6_ASTRA = `<Category_Context name="unspecified-high">


### PR DESCRIPTION
## Summary

- Restores the root-cause clause in the deep GPT-6 Astra prompt append (`packages/senpi-task` and `packages/omo-opencode`, byte-identical): "Fix the cause: trace at least two levels above the symptom before settling, and prefer the change that makes the failure impossible over the guard that hides it." The 2026-09-05 changes.md entry is updated to match.

## QA & Evidence

- **What was tested:** `packages/senpi-task` category suite + resolve-agent-categories, omo-opencode delegate-task/plugin-handlers/utils tests, root `tsgo --noEmit` + senpi-task typecheck, on mengmotaMac via bunshin.
  **Observed result:** 110 pass / 0 fail; 800 pass / 0 fail; typechecks exit 0.
  **Artifact:** remote run `/tmp/astra-deep-rc-20260905` (removed after verification).
  **Why sufficient:** prose-only change to a prompt constant; dispatch tests assert placement, not wording.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the root-cause clause in the deep GPT-6 Astra prompt append across `packages/senpi-task` and `packages/omo-opencode`, and updates the corresponding `changes.md` entry to match.

- The clause instructs the model to trace at least two levels above the symptom and prefer fixes that make the failure impossible over guards that hide it.
- The change is prose-only; dispatch tests assert prompt placement, not wording.

<sup>Written for commit 273880b26345394b72f9f54cd2bcb0e4ddf2bc9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

