### PR TITLE
refactor: consolidate memory tool surface

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -607,7 +607,6 @@ Configured under `memory` in `omo.json`, with per-agent overrides under `memory.
   "memory": {
     "enabled": true,
     "agent": "auto",
-    "tool_exposure": "direct",
     "reflection": { "trigger": { "step_count": 25 } },
     "nudge": { "every_user_turns": 10 },
     "dream": { "idle_minutes": 30 },
@@ -622,13 +621,8 @@ Configured under `memory` in `omo.json`, with per-agent overrides under `memory.
 | -------------------- | ---------- | ------------------------------------------------------------------------------- |
 | `enabled`            | `true`     | Master switch for the whole memory component                                     |
 | `agent`              | `"auto"`   | Which agent identity owns the memory repository                                  |
-| `tool_exposure`      | `"direct"` | `direct` registers the memory tools always-on; `search` opts into the MCP server |
 | `compile_warn_tokens`| `30000`    | Warn when the compiled memory block exceeds this many tokens                     |
 | `agents`             | `{}`       | Per-agent overrides; any block below may be overridden field by field            |
-
-`tool_exposure` defaults to `direct` deliberately. The `search` value moves the tools behind
-senpi's `tool_search` catalog through an extension-declared MCP server, which keeps the tool list
-smaller but removes memory entirely if that server fails to start.
 
 #### Reflection
 

--- a/docs/reference/omo-json.md
+++ b/docs/reference/omo-json.md
@@ -138,7 +138,7 @@ The block may also appear at the shared top level or in profile layers and follo
 
 ### `memory` (Senpi harness)
 
-The optional `memory` block configures the Senpi memory subsystem (`schema/memory.ts` `OmoMemorySettingsSchema`). Keys: `enabled` (default `true`), `agent` (default `"auto"`), `tool_exposure` (`"direct"` or `"search"`, default `"direct"`), the sub-blocks `reflection`, `nudge`, `facts`, `dream`, `people`, `soul`, `write_notice`, `sync`, `search`, plus `compile_warn_tokens` and per-agent overrides under `agents`.
+The optional `memory` block configures the Senpi memory subsystem (`schema/memory.ts` `OmoMemorySettingsSchema`). Keys: `enabled` (default `true`), `agent` (default `"auto"`), the sub-blocks `reflection`, `nudge`, `facts`, `dream`, `people`, `soul`, `write_notice`, `sync`, `search`, plus `compile_warn_tokens` and per-agent overrides under `agents`.
 
 ### `git_master` (Senpi harness)
 

--- a/packages/memory-core/src/identity/layout.test.ts
+++ b/packages/memory-core/src/identity/layout.test.ts
@@ -30,7 +30,6 @@ describe("memory identity layout constants", () => {
       "facts-queue",
       "facts",
       "notices",
-      "tool-receipts",
       "recall",
     ])
   })
@@ -98,7 +97,6 @@ describe("buildIdentityPaths", () => {
     expect(paths.factsQueue).toBe(join(runtime, "facts-queue"))
     expect(paths.facts).toBe(join(runtime, "facts"))
     expect(paths.notices).toBe(join(runtime, "notices"))
-    expect(paths.toolReceipts).toBe(join(runtime, "tool-receipts"))
     expect(paths.recall).toBe(join(runtime, "recall"))
     expect(paths.recallLedger).toBe(join(runtime, "recall", "ledger"))
     expect(paths.recallPending).toBe(join(runtime, "recall", "pending"))

--- a/packages/memory-core/src/identity/layout.ts
+++ b/packages/memory-core/src/identity/layout.ts
@@ -20,7 +20,6 @@ export const RUNTIME_SUBDIRNAMES = [
   "facts-queue",
   "facts",
   "notices",
-  "tool-receipts",
   "recall",
 ] as const
 export type RuntimeSubdirname = (typeof RUNTIME_SUBDIRNAMES)[number]
@@ -39,7 +38,6 @@ export interface MemoryIdentityPaths {
   factsQueue: string
   facts: string
   notices: string
-  toolReceipts: string
   /** Recall runtime tree: per-session surfaced-path ledgers and pending gate nudges. */
   recall: string
   recallLedger: string
@@ -75,7 +73,6 @@ export function buildIdentityPaths(memoryRoot: string, id: string): MemoryIdenti
     factsQueue: join(runtime, "facts-queue"),
     facts: join(runtime, "facts"),
     notices: join(runtime, "notices"),
-    toolReceipts: join(runtime, "tool-receipts"),
     recall: join(runtime, "recall"),
     recallLedger: join(runtime, "recall", "ledger"),
     recallPending: join(runtime, "recall", "pending"),

--- a/packages/memory-core/src/memfs/frontmatter.ts
+++ b/packages/memory-core/src/memfs/frontmatter.ts
@@ -16,7 +16,7 @@
  *
  * Dual-copy verdict: memory.ts:472-553 and memory-apply-patch.ts:644-714
  * are BEHAVIORALLY IDENTICAL. The only divergence is error-message prefix
- * ("memory:" vs "memory_apply_patch:"). This module uses a neutral prefix
+ * ("memory:" vs "memory apply_patch:"). This module uses a neutral prefix
  * since tool-level distinction is the caller's responsibility (todo 9/10).
  */
 

--- a/packages/memory-core/src/memfs/paths.ts
+++ b/packages/memory-core/src/memfs/paths.ts
@@ -11,7 +11,7 @@ import {
  * Confined memory path validation.
  *
  * Dual-copy verdict: Letta's memory.ts:346-454 and
- * memory-apply-patch.ts:509-643 implementations are behaviorally identical.
+ * Both memory write paths use this shared validation.
  * They differ only in tool-name error prefixes, comments, and formatting.
  */
 export class MemoryPathError extends Error {

--- a/packages/memory-core/src/tools/commit-write.ts
+++ b/packages/memory-core/src/tools/commit-write.ts
@@ -1,0 +1,75 @@
+import { readFile } from "../fs/resilient"
+import { join } from "node:path"
+
+import { NoEffectiveChangesError, type GitCommitAuthor, type GitMemoryRepo } from "../git"
+import { SOUL_EDIT_RESULT_LINE, touchesSoulPath } from "../soul"
+import type { LockDomain } from "../locks"
+import type { MemoryToolProvenance } from "./memory"
+import { MemoryToolError } from "./tool-errors"
+
+export interface CommitMemoryWriteOptions {
+  readonly repo: GitMemoryRepo
+  readonly lock: MemoryWriteLock
+  readonly apply: () => Promise<readonly string[]>
+  readonly reason: string
+  readonly author: GitCommitAuthor
+  readonly provenance?: MemoryToolProvenance
+  readonly successLabel: string
+  readonly noChangesMessage?: string
+}
+
+export interface MemoryWriteLock {
+  <T>(domain: LockDomain, operation: () => Promise<T>): Promise<T>
+}
+
+export interface MemoryWriteCommit {
+  readonly message: string
+  readonly sha: string
+  readonly subject: string
+  readonly affectedPaths: readonly string[]
+}
+
+export async function commitMemoryWrite(options: CommitMemoryWriteOptions): Promise<MemoryWriteCommit> {
+  const { repo, lock, reason, author, provenance, successLabel, noChangesMessage } = options
+  return lock("memory-write", async () => {
+    await repo.cleanCheck()
+    const paths = await options.apply()
+    if (paths.length === 0) throw new MemoryToolError(noChangesMessage ?? "made no changes")
+    let result
+    try {
+      result = await repo.commitWrite(paths, memoryCommitMessage(reason, provenance), author)
+    } catch (error) {
+      if (error instanceof NoEffectiveChangesError) {
+        throw new MemoryToolError(noChangesMessage ?? "made no effective changes", { cause: error })
+      }
+      throw error
+    }
+    const shortSha = result.sha.slice(0, 7)
+    const local = !(await hasConfiguredRemote(repo))
+    const summary = local
+      ? `${successLabel} committed locally (${shortSha}).`
+      : `${successLabel} committed (${shortSha}); harness will sync after the turn.`
+    return {
+      message: touchesSoulPath(paths) ? `${summary}\n${SOUL_EDIT_RESULT_LINE}` : summary,
+      sha: result.sha,
+      subject: reason.split(/\r?\n/, 1)[0] ?? reason,
+      affectedPaths: paths,
+    }
+  })
+}
+
+async function hasConfiguredRemote(repo: GitMemoryRepo): Promise<boolean> {
+  const gitConfig = await readFile(join(repo.dir, ".git", "config"), "utf8").catch(() => "")
+  return /^\s*\[remote\s+"[^"]+"\]/m.test(gitConfig)
+}
+
+function memoryCommitMessage(reason: string, provenance: MemoryToolProvenance | undefined): string {
+  if (provenance === undefined) return reason
+  return [
+    reason,
+    "",
+    "Omo-Writer: memory-tool",
+    `Omo-Session: ${provenance.sessionId}`,
+    `Omo-Turn: ${provenance.userTurns}`,
+  ].join("\n")
+}

--- a/packages/memory-core/src/tools/index.ts
+++ b/packages/memory-core/src/tools/index.ts
@@ -1,5 +1,6 @@
 // Barrel exports only.
 export * from "./memory"
-export * from "./memory-apply-patch"
+export * from "./commit-write"
+export * from "./patch-apply"
 export * from "./patch-parser"
 export * from "./tool-errors"

--- a/packages/memory-core/src/tools/memory-apply-patch-validation.test.ts
+++ b/packages/memory-core/src/tools/memory-apply-patch-validation.test.ts
@@ -95,7 +95,7 @@ describe("memoryApplyPatch validation failures", () => {
 
     // #then
     expect(error.message).toBe([
-      "memory_apply_patch: failed to apply hunk to system/fenced.md: context not found",
+      "memory apply_patch: failed to apply hunk to system/fenced.md: context not found",
       "",
       "The patch old/context lines did not match the current memory file exactly.",
       "Read the current memory file and retry with exact context.",

--- a/packages/memory-core/src/tools/memory-validation.test.ts
+++ b/packages/memory-core/src/tools/memory-validation.test.ts
@@ -163,7 +163,7 @@ describe("runMemoryTool", () => {
       const setup = await fixture()
       await seed(setup, "note.md", "same")
       const head = await setup.repo.head()
-      await expect(run(setup, params)).rejects.toThrow(`memory: ${params.command} made no effective changes`)
+      await expect(run(setup, params)).rejects.toThrow(`memory: ${params.command} made no changes`)
       expect(await setup.repo.head()).toBe(head)
       expect(await setup.repo.status()).toBe("")
     }

--- a/packages/memory-core/src/tools/memory.test.ts
+++ b/packages/memory-core/src/tools/memory.test.ts
@@ -71,6 +71,27 @@ async function git(repo: GitMemoryRepo, args: string[]): Promise<string> {
 setDefaultTimeout(process.platform === "win32" ? 30000 : 5000)
 
 describe("runMemoryTool", () => {
+  it("#given a codex patch #when apply_patch runs #then it applies and commits through the memory tool", async () => {
+    const setup = await fixture()
+    const result = await run(setup, {
+      command: "apply_patch",
+      reason: "add patch note",
+      input: [
+        "*** Begin Patch",
+        "*** Add File: reference/patch.md",
+        "+---",
+        "+description: Patch note",
+        "+---",
+        "+written through memory",
+        "*** End Patch",
+      ].join("\n"),
+    })
+
+    expect(result.message).toMatch(/^Memory apply_patch committed locally \([0-9a-f]{7}\)\.$/)
+    expect(await body(setup.repo, "reference/patch.md")).toBe("written through memory")
+    expect(setup.domains).toEqual(["memory-write"])
+  })
+
   it("#given create params #when run #then it renders frontmatter, commits under the writer lock, and reports local", async () => {
     const setup = await fixture()
     const result = await run(setup, {

--- a/packages/memory-core/src/tools/memory.ts
+++ b/packages/memory-core/src/tools/memory.ts
@@ -1,11 +1,11 @@
 import { existsSync } from "../fs/resilient"
 import { mkdir, readdir, readFile, rename, rm, stat, unlink, writeFile } from "../fs/resilient"
 import { dirname, join, relative } from "node:path"
-import { NoEffectiveChangesError, type GitCommitAuthor, type GitMemoryRepo } from "../git"
+import type { GitCommitAuthor, GitMemoryRepo } from "../git"
 import { parseMemoryFile, renderMemoryFile, type ParsedMemoryFile } from "../memfs/frontmatter"
 import { validateMemoryPath, validateRepositoryPath } from "../memfs/paths"
-import type { LockDomain } from "../locks"
-import { SOUL_EDIT_RESULT_LINE, touchesSoulPath } from "../soul"
+import { MemoryPatchHunkError, MemoryPatchParseError, applyMemoryPatch } from "./patch-apply"
+import { commitMemoryWrite, type MemoryWriteLock } from "./commit-write"
 import { MemoryToolError } from "./tool-errors"
 
 export type MemoryCommand =
@@ -15,6 +15,7 @@ export type MemoryCommand =
   | "delete"
   | "rename"
   | "update_description"
+  | "apply_patch"
 
 export interface MemoryToolProvenance {
   readonly sessionId: string
@@ -35,6 +36,7 @@ export interface MemoryToolParams {
   insert_text?: string
   description?: string
   file_text?: string
+  input?: string
 }
 
 /** Post-commit metadata carried to the notice channel (plan IC-4); subject is the message's first line. */
@@ -49,9 +51,7 @@ export interface MemoryToolResult {
   readonly commit?: MemoryToolCommit
 }
 
-export interface MemoryToolLock {
-  <T>(domain: LockDomain, operation: () => Promise<T>): Promise<T>
-}
+export type MemoryToolLock = MemoryWriteLock
 
 export interface RunMemoryToolOptions {
   repo: GitMemoryRepo
@@ -65,37 +65,24 @@ export async function runMemoryTool(options: RunMemoryToolOptions): Promise<Memo
   const { repo, lock, params } = options
   try {
     const reason = required(params.reason, "reason").trim()
-    return await lock("memory-write", async () => {
-      await repo.cleanCheck()
-      const { affectedPaths } = await applyCommand(repo.dir, params)
-      if (affectedPaths.length === 0) {
-        throw toolError(`${params.command} made no changes`)
-      }
-
-      let result
-      try {
-        result = await repo.commitWrite(affectedPaths, memoryCommitMessage(reason, params.provenance), params.author)
-      } catch (error) {
-        if (error instanceof NoEffectiveChangesError) {
-          throw toolError(`${params.command} made no effective changes`, error)
-        }
-        throw error
-      }
-
-      const local = !(await hasConfiguredRemote(repo))
-      const summary = local
-        ? `Memory ${params.command} committed locally (${result.sha.slice(0, 7)}).`
-        : `Memory ${params.command} committed (${result.sha.slice(0, 7)}); harness will sync after the turn.`
-      return {
-        message: touchesSoulPath(affectedPaths) ? `${summary}\n${SOUL_EDIT_RESULT_LINE}` : summary,
-        commit: {
-          sha: result.sha,
-          subject: reason.split(/\r?\n/, 1)[0] ?? reason,
-          affectedPaths,
-        },
-      }
+    const result = await commitMemoryWrite({
+      repo,
+      lock,
+      reason,
+      author: params.author,
+      ...(params.provenance === undefined ? {} : { provenance: params.provenance }),
+      successLabel: `Memory ${params.command}`,
+      noChangesMessage: `${params.command} made no changes`,
+      apply: async () => (await applyCommand(repo.dir, params)).affectedPaths,
     })
+    return {
+      message: result.message,
+      commit: { sha: result.sha, subject: result.subject, affectedPaths: result.affectedPaths },
+    }
   } catch (error) {
+    if (error instanceof MemoryPatchParseError || error instanceof MemoryPatchHunkError) {
+      throw toolError(error.message)
+    }
     if (error instanceof MemoryToolError) throw error
     throw toolError(errorMessage(error), error)
   }
@@ -109,6 +96,10 @@ async function applyCommand(root: string, params: MemoryToolParams): Promise<App
     case "delete": return remove(root, params)
     case "rename": return move(root, params)
     case "update_description": return updateDescription(root, params)
+    case "apply_patch": {
+      const input = required(params.input, "input", "apply_patch")
+      return { affectedPaths: await applyMemoryPatch(root, input) }
+    }
   }
 }
 
@@ -245,24 +236,8 @@ function required(value: string | undefined, field: string, command?: MemoryComm
   return value
 }
 
-async function hasConfiguredRemote(repo: GitMemoryRepo): Promise<boolean> {
-  const gitConfig = await readFile(join(repo.dir, ".git", "config"), "utf8").catch(() => "")
-  return /^\s*\[remote\s+"[^"]+"\]/m.test(gitConfig)
-}
-
 function toolError(message: string, cause?: unknown): MemoryToolError {
   return new MemoryToolError(message, cause === undefined ? undefined : { cause })
-}
-
-function memoryCommitMessage(reason: string, provenance: MemoryToolProvenance | undefined): string {
-  if (provenance === undefined) return reason
-  return [
-    reason,
-    "",
-    "Omo-Writer: memory-tool",
-    `Omo-Session: ${provenance.sessionId}`,
-    `Omo-Turn: ${provenance.userTurns}`,
-  ].join("\n")
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/memory-core/src/tools/patch-apply.ts
+++ b/packages/memory-core/src/tools/patch-apply.ts
@@ -1,0 +1,150 @@
+import { access, mkdir, readFile, unlink, writeFile } from "../fs/resilient"
+import { dirname, relative } from "node:path"
+
+import { parseMemoryFile, renderMemoryFile } from "../memfs/frontmatter"
+import { MemoryPathError, validateMemoryPath } from "../memfs/paths"
+import {
+  applyMemoryPatchHunk,
+  MemoryPatchHunkError,
+  MemoryPatchParseError,
+  parseMemoryPatch,
+  type PatchOperation,
+} from "./patch-parser"
+
+export { MemoryPatchHunkError, MemoryPatchParseError }
+
+export async function applyMemoryPatch(root: string, input: string): Promise<string[]> {
+  return applyOperations(root, parseMemoryPatch(input))
+}
+
+async function applyOperations(root: string, operations: readonly PatchOperation[]): Promise<string[]> {
+  const pendingWrites = new Map<string, string>()
+  const pendingDeletes = new Set<string>()
+  const affectedPaths = new Set<string>()
+
+  const resolvePath = (input: string, fieldName: string): { absolute: string; relative: string } => {
+    try {
+      const absolute = validateMemoryPath(root, input, { fieldName })
+      return { absolute, relative: relative(root, absolute).replace(/\\/g, "/") }
+    } catch (error) {
+      if (!(error instanceof MemoryPathError)) throw error
+      const detail = error.message.replace(/^memory path: /, "")
+      throw new Error(`memory apply_patch: ${detail}`)
+    }
+  }
+
+  const loadCurrent = async (path: { absolute: string; relative: string }): Promise<string> => {
+    if (pendingDeletes.has(path.absolute) && !pendingWrites.has(path.absolute)) {
+      throw new Error(`memory apply_patch: file not found for update: ${path.relative}`)
+    }
+    const pending = pendingWrites.get(path.absolute)
+    if (pending !== undefined) return pending
+    try {
+      return (await readUtf8TextStrict(path.absolute)).replace(/\r\n/g, "\n")
+    } catch (error) {
+      throw new Error(`memory apply_patch: failed to read ${path.relative}: ${errorMessage(error)}`)
+    }
+  }
+
+  for (const operation of operations) {
+    if (operation.kind === "add") {
+      const target = resolvePath(operation.targetPath, "Add File path")
+      if (pendingWrites.has(target.absolute)) {
+        throw new Error(`memory apply_patch: duplicate add/update target in patch: ${target.relative}`)
+      }
+      if (await exists(target.absolute)) {
+        throw new Error(`memory apply_patch: cannot add existing memory file: ${target.relative}`)
+      }
+      pendingWrites.set(target.absolute, normalizeAddedContent(target.relative.slice(0, -3), operation.contentLines.join("\n")))
+      pendingDeletes.delete(target.absolute)
+      affectedPaths.add(target.relative)
+      continue
+    }
+
+    if (operation.kind === "delete") {
+      const target = resolvePath(operation.targetPath, "Delete File path")
+      const parsed = parseForTool(await loadCurrent(target))
+      assertEditable(parsed.frontmatter.read_only, target.relative)
+      pendingWrites.delete(target.absolute)
+      pendingDeletes.add(target.absolute)
+      affectedPaths.add(target.relative)
+      continue
+    }
+
+    const source = resolvePath(operation.sourcePath, "Update File path")
+    const target = resolvePath(operation.targetPath, "Move to path")
+    const current = await loadCurrent(source)
+    assertEditable(parseForTool(current).frontmatter.read_only, source.relative)
+    let next = current
+    for (const hunk of operation.hunks) next = applyMemoryPatchHunk(next, hunk, source.relative)
+    if (parseForTool(next).frontmatter.read_only === "true") {
+      throw new Error(`memory apply_patch: ${target.relative} cannot be written with read_only=true`)
+    }
+    pendingWrites.set(target.absolute, next)
+    pendingDeletes.delete(target.absolute)
+    affectedPaths.add(target.relative)
+    if (source.absolute !== target.absolute) {
+      pendingWrites.delete(source.absolute)
+      pendingDeletes.add(source.absolute)
+      affectedPaths.add(source.relative)
+    }
+  }
+
+  for (const [path, content] of pendingWrites) {
+    await mkdir(dirname(path), { recursive: true })
+    await writeFile(path, Buffer.from(content, "utf8"))
+  }
+  for (const path of pendingDeletes) {
+    if (!pendingWrites.has(path) && await exists(path)) await unlink(path)
+  }
+  return [...affectedPaths]
+}
+
+function parseForTool(content: string): ReturnType<typeof parseMemoryFile> {
+  try {
+    return parseMemoryFile(content)
+  } catch (error) {
+    throw new Error(`memory apply_patch: ${errorMessage(error).replace(/^frontmatter: /, "")}`)
+  }
+}
+
+function normalizeAddedContent(label: string, rawContent: string): string {
+  try {
+    const parsed = parseMemoryFile(rawContent)
+    return renderMemoryFile(parsed.frontmatter, parsed.body)
+  } catch {
+    return renderMemoryFile({ description: `Memory block ${label}` }, rawContent)
+  }
+}
+
+function assertEditable(readOnly: string | undefined, path: string): void {
+  if (readOnly === "true") throw new Error(`memory apply_patch: ${path} is read_only and cannot be modified`)
+}
+
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+
+async function readUtf8TextStrict(path: string): Promise<string> {
+  const bytes = await readFile(path)
+  const bom = bytes[0] === 0xff && bytes[1] === 0xfe
+    ? "UTF-16LE"
+    : bytes[0] === 0xfe && bytes[1] === 0xff ? "UTF-16BE" : null
+  if (bom !== null) throw new Error(`File is not valid UTF-8 text: ${path}. Detected ${bom} BOM; convert it to UTF-8 and retry.`)
+  try {
+    return utf8Decoder.decode(bytes)
+  } catch {
+    throw new Error(`File is not valid UTF-8 text: ${path}. The file contains bytes that cannot be decoded as UTF-8.`)
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/memory-core/src/tools/patch-parser.test.ts
+++ b/packages/memory-core/src/tools/patch-parser.test.ts
@@ -18,7 +18,7 @@ describe("memory patch parser", () => {
 
       // #then
       expect(parse).toThrow(MemoryPatchParseError)
-      expect(parse).toThrow(`memory_apply_patch: ${message}`)
+      expect(parse).toThrow(`memory apply_patch: ${message}`)
     })
   }
 

--- a/packages/memory-core/src/tools/patch-parser.ts
+++ b/packages/memory-core/src/tools/patch-parser.ts
@@ -33,7 +33,7 @@ const MAX_FAILED_HUNK_PREVIEW_CHARS = 2_000
 const MAX_CURRENT_FILE_PREVIEW_CHARS = 4_000
 
 function failure(message: string): MemoryPatchParseError {
-  return new MemoryPatchParseError(`memory_apply_patch: ${message}`)
+  return new MemoryPatchParseError(`memory apply_patch: ${message}`)
 }
 
 function directivePath(line: string, directive: string, lineNumber: number): string {
@@ -142,7 +142,7 @@ export function parseMemoryPatch(input: string): PatchOperation[] {
 export function applyMemoryPatchHunk(content: string, hunk: PatchHunk, filePath: string): string {
   const { oldChunk, newChunk } = buildOldNewChunks(hunk.lines)
   if (oldChunk.length === 0) {
-    throw new Error(`memory_apply_patch: failed to apply hunk to ${filePath}: hunk has no anchor/context`)
+    throw new Error(`memory apply_patch: failed to apply hunk to ${filePath}: hunk has no anchor/context`)
   }
   const exactIndex = content.indexOf(oldChunk)
   if (exactIndex !== -1) return replaceAt(content, exactIndex, oldChunk.length, newChunk)
@@ -186,7 +186,7 @@ function formatHunkContextNotFoundError(filePath: string, oldChunk: string, cont
   const current = truncateForDiagnostic(content, MAX_CURRENT_FILE_PREVIEW_CHARS)
   const fence = markdownFenceFor(failed, current)
   return [
-    `memory_apply_patch: failed to apply hunk to ${filePath}: context not found`,
+    `memory apply_patch: failed to apply hunk to ${filePath}: context not found`,
     "",
     "The patch old/context lines did not match the current memory file exactly.",
     "Read the current memory file and retry with exact context.",

--- a/packages/memory-core/src/tools/soul-edit.test.ts
+++ b/packages/memory-core/src/tools/soul-edit.test.ts
@@ -6,7 +6,6 @@ import { dirname, join } from "node:path"
 import { GitMemoryRepo, type GitCommitAuthor } from "../git"
 import { renderMemoryFile } from "../memfs/frontmatter"
 import { MEMORY_SOUL_EDIT_RESULT_TOKEN } from "../soul"
-import { runMemoryApplyPatch } from "./memory-apply-patch"
 import { runMemoryTool, type MemoryToolLock } from "./memory"
 import { realpathSync } from "node:fs"
 
@@ -21,7 +20,6 @@ const WINDOWS_INTEGRATION_TEST_TIMEOUT = process.platform === "win32" ? 20_000 :
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
-
 async function fixture(): Promise<{ repo: GitMemoryRepo; lock: MemoryToolLock }> {
   const root = realpathSync.native(await mkdtemp(join(tmpdir(), "omo-memory-soul-edit-")))
   roots.push(root)
@@ -138,65 +136,5 @@ describe("runMemoryTool soul-edit result", () => {
     expect(result.message).not.toContain(MEMORY_SOUL_EDIT_RESULT_TOKEN)
     expect(result.commit?.affectedPaths).toEqual(["notes/facts/2026-08.md"])
     expect(result.commit?.subject).toBe("record a fact")
-  }, WINDOWS_INTEGRATION_TEST_TIMEOUT)
-})
-
-describe("runMemoryApplyPatch soul-edit result", () => {
-  it("#given a patch updating system/persona.md #when applied #then the result carries the soul-edit directive and commit metadata", async () => {
-    // given
-    const setup = await fixture()
-    await seed(setup, "system/persona.md", "version one\n")
-
-    // when
-    const result = await runMemoryApplyPatch({
-      repo: setup.repo,
-      lock: setup.lock,
-      params: {
-        reason: "evolve persona",
-        input: [
-          "*** Begin Patch",
-          "*** Update File: system/persona.md",
-          "@@",
-          "-version one",
-          "+version two",
-          "*** End Patch",
-        ].join("\n"),
-        author: AUTHOR,
-      },
-    })
-
-    // then
-    expect(result.message).toContain(MEMORY_SOUL_EDIT_RESULT_TOKEN)
-    expect(result.commit?.affectedPaths).toEqual(["system/persona.md"])
-    expect(result.commit?.subject).toBe("evolve persona")
-    expect(result.commit?.sha).toBe((await setup.repo.head()) ?? undefined)
-  }, WINDOWS_INTEGRATION_TEST_TIMEOUT)
-
-  it("#given a patch adding a non-soul file #when applied #then no soul-edit directive appears", async () => {
-    // given
-    const setup = await fixture()
-
-    // when
-    const result = await runMemoryApplyPatch({
-      repo: setup.repo,
-      lock: setup.lock,
-      params: {
-        reason: "add reference note",
-        input: [
-          "*** Begin Patch",
-          "*** Add File: reference/note.md",
-          "+---",
-          "+description: Note",
-          "+---",
-          "+plain note",
-          "*** End Patch",
-        ].join("\n"),
-        author: AUTHOR,
-      },
-    })
-
-    // then
-    expect(result.message).not.toContain(MEMORY_SOUL_EDIT_RESULT_TOKEN)
-    expect(result.commit?.affectedPaths).toEqual(["reference/note.md"])
   }, WINDOWS_INTEGRATION_TEST_TIMEOUT)
 })

--- a/packages/omo-config-core/src/schema/memory.test.ts
+++ b/packages/omo-config-core/src/schema/memory.test.ts
@@ -9,7 +9,6 @@ import {
 const FULL_DEFAULTS: OmoMemorySettings = {
   enabled: true,
   agent: "auto",
-  tool_exposure: "direct",
   reflection: {
     enabled: true,
     trigger: { step_count: 25, on_compaction: true },
@@ -58,7 +57,6 @@ describe("OmoMemorySettingsSchema defaults", () => {
     const input: OmoMemorySettings = {
       enabled: false,
       agent: "backend-lead",
-      tool_exposure: "search",
       reflection: {
         enabled: false,
         trigger: { step_count: 25, on_compaction: false },

--- a/packages/omo-config-core/src/schema/memory.ts
+++ b/packages/omo-config-core/src/schema/memory.ts
@@ -90,7 +90,7 @@ export const OmoMemorySoulSchema = z.object({
 }).strict()
 
 // ---------------------------------------------------------------------------
-// Write notice (memory / memory_apply_patch tool-result row)
+// Write notice (memory tool-result row)
 // ---------------------------------------------------------------------------
 
 export const OmoMemoryWriteNoticeSchema = z.object({
@@ -191,7 +191,6 @@ export const OmoMemorySettingsSchema = z.object({
   agent: z.string().min(1).default("auto"),
   // "direct" registers the memory tools as always-on ToolDefinitions; "search" opts in to the
   // extension-declared MCP server surfaced through senpi's tool_search catalog.
-  tool_exposure: z.enum(["direct", "search"]).default("direct"),
   reflection: OmoMemoryReflectionSchema.default({
     enabled: true,
     trigger: { step_count: 25, on_compaction: true },
@@ -223,7 +222,6 @@ export const OmoMemorySettingsSchema = z.object({
 export const OmoMemorySettingsLayerSchema = z.object({
   enabled: z.boolean().optional(),
   agent: z.string().min(1).optional(),
-  tool_exposure: z.enum(["direct", "search"]).optional(),
   reflection: OmoMemoryReflectionLayerSchema.optional(),
   nudge: OmoMemoryNudgeLayerSchema.optional(),
   facts: OmoMemoryFactsLayerSchema.optional(),

--- a/packages/omo-senpi/plugin/scripts/build-extension.mjs
+++ b/packages/omo-senpi/plugin/scripts/build-extension.mjs
@@ -56,8 +56,6 @@ const taskEntryPath = join(packageRoot, "src", "extension", "omo-task.ts")
 const taskOutputPath = process.env.OMO_SENPI_PLUGIN_OUTPUT === undefined ? join(pluginRoot, "extensions", "omo-task.js") : join(process.env.OMO_SENPI_PLUGIN_OUTPUT, "extensions", "omo-task.js")
 const memberEntryPath = join(repoRoot, "packages", "senpi-task", "src", "team", "member-extension", "index.ts")
 const memberOutputPath = process.env.OMO_SENPI_PLUGIN_OUTPUT === undefined ? join(pluginRoot, "extensions", "omo-member.js") : join(process.env.OMO_SENPI_PLUGIN_OUTPUT, "extensions", "omo-member.js")
-const memoryMcpEntryPath = join(packageRoot, "src", "mcp", "memory-server.ts")
-const memoryMcpOutputPath = process.env.OMO_SENPI_PLUGIN_OUTPUT === undefined ? join(pluginRoot, "extensions", "omo-memory-mcp.js") : join(process.env.OMO_SENPI_PLUGIN_OUTPUT, "extensions", "omo-memory-mcp.js")
 const supervisorEntryPath = join(packageRoot, "src", "components", "memory", "worker", "memory-run-supervisor.ts")
 const supervisorOutputPath = process.env.OMO_SENPI_PLUGIN_OUTPUT === undefined ? join(pluginRoot, "extensions", "memory-run-supervisor.mjs") : join(process.env.OMO_SENPI_PLUGIN_OUTPUT, "extensions", "memory-run-supervisor.mjs")
 const advisorRuntimeEntryPath = join(packageRoot, "src", "components", "init-deep-advisor", "runtime.ts")
@@ -97,9 +95,6 @@ export async function buildExtension(options = {}) {
   const memberOutput = options.memberOutputPath ?? (options.outputPath === undefined
     ? memberOutputPath
     : join(dirname(output), "omo-member.js"))
-  const memoryMcpOutput = options.memoryMcpOutputPath ?? (options.outputPath === undefined
-    ? memoryMcpOutputPath
-    : join(dirname(output), "omo-memory-mcp.js"))
   const supervisorOutput = options.supervisorOutputPath ?? (options.outputPath === undefined
     ? supervisorOutputPath
     : join(dirname(output), "memory-run-supervisor.mjs"))
@@ -109,7 +104,6 @@ export async function buildExtension(options = {}) {
   const mainInputs = await buildEntry(entryPath, output, buildDefines)
   const taskInputs = await buildEntry(taskEntryPath, taskOutput, buildDefines)
   const memberInputs = await buildEntry(memberEntryPath, memberOutput, buildDefines)
-  const memoryMcpInputs = await buildEntry(memoryMcpEntryPath, memoryMcpOutput, buildDefines)
   const supervisorInputs = await buildEntry(supervisorEntryPath, supervisorOutput, buildDefines)
   const advisorRuntimeInputs = await buildEntry(advisorRuntimeEntryPath, advisorRuntimeOutput, buildDefines)
   // Bundling inlines assets.ts but its markdown is read from disk at runtime next to the bundle,
@@ -117,7 +111,7 @@ export async function buildExtension(options = {}) {
   await Promise.all([
     stageRuntimePersonas(repoRoot, dirname(output)),
   ])
-  return { mainInputs, taskInputs, memberInputs, memoryMcpInputs, supervisorInputs, advisorRuntimeInputs }
+  return { mainInputs, taskInputs, memberInputs, supervisorInputs, advisorRuntimeInputs }
 }
 
 async function buildEntry(entry, output, buildDefines) {
@@ -154,9 +148,6 @@ export async function checkExtensionCurrent(options = {}) {
   const memberOutput = options.memberOutputPath ?? (options.outputPath === undefined
     ? memberOutputPath
     : join(dirname(output), "omo-member.js"))
-  const memoryMcpOutput = options.memoryMcpOutputPath ?? (options.outputPath === undefined
-    ? memoryMcpOutputPath
-    : join(dirname(output), "omo-memory-mcp.js"))
   const supervisorOutput = options.supervisorOutputPath ?? (options.outputPath === undefined
     ? supervisorOutputPath
     : join(dirname(output), "memory-run-supervisor.mjs"))
@@ -169,8 +160,6 @@ export async function checkExtensionCurrent(options = {}) {
   if (currentTask === undefined) return { ok: false, reason: "missing-output", output: taskOutput }
   const currentMember = await readBuiltEntry(memberOutput)
   if (currentMember === undefined) return { ok: false, reason: "missing-output", output: memberOutput }
-  const currentMemoryMcp = await readBuiltEntry(memoryMcpOutput)
-  if (currentMemoryMcp === undefined) return { ok: false, reason: "missing-output", output: memoryMcpOutput }
   const currentSupervisor = await readBuiltEntry(supervisorOutput)
   if (currentSupervisor === undefined) return { ok: false, reason: "missing-output", output: supervisorOutput }
   const currentAdvisorRuntime = await readBuiltEntry(advisorRuntimeOutput)
@@ -186,7 +175,6 @@ export async function checkExtensionCurrent(options = {}) {
   const expectedOutput = join(tempRoot, "omo.js")
   const expectedTaskOutput = join(tempRoot, "omo-task.js")
   const expectedMemberOutput = join(tempRoot, "omo-member.js")
-  const expectedMemoryMcpOutput = join(tempRoot, "omo-memory-mcp.js")
   const expectedSupervisorOutput = join(tempRoot, "memory-run-supervisor.mjs")
   const expectedAdvisorRuntimeOutput = join(tempRoot, "omo-init-deep-advisor.js")
   try {
@@ -194,7 +182,6 @@ export async function checkExtensionCurrent(options = {}) {
       outputPath: expectedOutput,
       taskOutputPath: expectedTaskOutput,
       memberOutputPath: expectedMemberOutput,
-      memoryMcpOutputPath: expectedMemoryMcpOutput,
       supervisorOutputPath: expectedSupervisorOutput,
       advisorRuntimeOutputPath: expectedAdvisorRuntimeOutput,
     })
@@ -206,9 +193,6 @@ export async function checkExtensionCurrent(options = {}) {
     }
     if (!artifactsMatch(currentMember, await readFile(expectedMemberOutput, "utf8"))) {
       return { ok: false, reason: "stale-output", output: memberOutput }
-    }
-    if (!artifactsMatch(currentMemoryMcp, await readFile(expectedMemoryMcpOutput, "utf8"))) {
-      return { ok: false, reason: "stale-output", output: memoryMcpOutput }
     }
     if (!artifactsMatch(currentSupervisor, await readFile(expectedSupervisorOutput, "utf8"))) {
       return { ok: false, reason: "stale-output", output: supervisorOutput }
@@ -276,8 +260,6 @@ if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.a
     console.log(`omo-senpi extension build is current: ${result.output}`)
   } else {
     await buildExtension()
-    console.log(
-      `Built omo-senpi extensions: ${outputPath}, ${taskOutputPath}, ${memberOutputPath}, ${memoryMcpOutputPath}, ${supervisorOutputPath}, ${advisorRuntimeOutputPath}`,
-    )
+    console.log(`Built omo-senpi extensions: ${outputPath}, ${taskOutputPath}, ${memberOutputPath}, ${supervisorOutputPath}, ${advisorRuntimeOutputPath}`)
   }
 }

--- a/packages/omo-senpi/plugin/scripts/build-extension.test.mjs
+++ b/packages/omo-senpi/plugin/scripts/build-extension.test.mjs
@@ -37,7 +37,6 @@ function outputPathsIn(root) {
     outputPath: join(root, "omo.js"),
     taskOutputPath: join(root, "omo-task.js"),
     memberOutputPath: join(root, "omo-member.js"),
-    memoryMcpOutputPath: join(root, "omo-memory-mcp.js"),
     supervisorOutputPath: join(root, "memory-run-supervisor.mjs"),
     advisorRuntimeOutputPath: join(root, "omo-init-deep-advisor.js"),
   }
@@ -78,11 +77,10 @@ describe("checkExtensionCurrent", () => {
     const outputs = await sharedOutputs()
 
     // when
-    const mcp = await readFile(outputs.memoryMcpOutputPath, "utf8")
     const supervisor = await readFile(outputs.supervisorOutputPath, "utf8")
 
     // then (Node's ESM loader strips a shebang only at byte 0; a marker above it breaks startup)
-    for (const text of [mcp, supervisor]) {
+    for (const text of [supervisor]) {
       expect(text.startsWith("#!/usr/bin/env node\n")).toBe(true)
       expect(text.indexOf("\n// omo:")).toBeGreaterThan(0)
     }
@@ -90,7 +88,6 @@ describe("checkExtensionCurrent", () => {
     const check = await checkExtensionCurrent({
       outputPath: outputs.outputPath,
       memberOutputPath: outputs.memberOutputPath,
-      memoryMcpOutputPath: outputs.memoryMcpOutputPath,
       supervisorOutputPath: outputs.supervisorOutputPath,
     })
     // Compare the whole result so a failure names the stale artifact instead of printing "false".

--- a/packages/omo-senpi/src/bundle-size.test.ts
+++ b/packages/omo-senpi/src/bundle-size.test.ts
@@ -32,7 +32,7 @@ const builtExtensionPath = join(packageRoot, "plugin", "extensions", "omo.js")
 // 1,000,377 bytes; 1,050,000 preserves explicit headroom per this comment's own rule (never the failing
 // value). Still no new third-party dependency - bundle-purity green against the merged manifest.
 // Raised 710,000 -> 880,000 for plan letta-memory-parity-port: the new `memory` component ports the
-// full Letta-Code local memory engine (git-backed MemFS, memory/memory_apply_patch tools, prompt
+// full Letta-Code local memory engine (git-backed MemFS, memory tool, prompt
 // compiler, reflection/dreaming worker + state machine, palace viewer, transcript search, git sync
 // mirror) plus the harness-neutral `@oh-my-opencode/memory-core` package. It is a single self-contained
 // user feature wired into the extension entry; the imports span the whole engine (nothing accidental

--- a/packages/omo-senpi/src/components/memory/context.ts
+++ b/packages/omo-senpi/src/components/memory/context.ts
@@ -60,6 +60,5 @@ export async function ensureIdentityRuntimeDirs(paths: MemoryIdentityPaths): Pro
     paths.factsQueue,
     paths.facts,
     paths.notices,
-    paths.toolReceipts,
   ].map((path) => mkdir(path, { recursive: true })))
 }

--- a/packages/omo-senpi/src/components/memory/index.test.ts
+++ b/packages/omo-senpi/src/components/memory/index.test.ts
@@ -155,7 +155,7 @@ describe("createMemoryComponent", () => {
     ])
     // Direct registration is the default surface so memory always works; the exposure-search MCP
     // variant is an explicit opt-in asserted in tool-surface.test.ts.
-    expect(pi.tools.map((tool) => tool.name)).toEqual(["memory", "memory_apply_patch"])
+    expect(pi.tools.map((tool) => tool.name)).toEqual(["memory"])
     expect(pi.mcpServers.map((server) => server.name)).toEqual([])
     expect(pi.entries).toEqual([{
       customType: MEMORY_BINDING_CUSTOM_TYPE,

--- a/packages/omo-senpi/src/components/memory/index.ts
+++ b/packages/omo-senpi/src/components/memory/index.ts
@@ -84,7 +84,6 @@ export function createMemoryComponent(options: MemoryComponentOptions = {}): Omo
         ...(options.refreshStatus === undefined ? {} : { refreshStatus: options.refreshStatus }),
         // Reuse the boot snapshot: registration must not add a loadConfig() call, because the
         // enablement latch depends on the ORDER of reads across boot -> session_start -> reload.
-        toolExposure: bootConfig.tool_exposure,
       })
       wiring.registerStatic(pi, ctx)
       pi.registerEntryRenderer(MEMORY_BINDING_CUSTOM_TYPE, renderMemoryBindingEntry)

--- a/packages/omo-senpi/src/components/memory/memory-notice-wiring.ts
+++ b/packages/omo-senpi/src/components/memory/memory-notice-wiring.ts
@@ -1,16 +1,3 @@
-// Shared consumer for the MCP memory tool surface (memory.tool_exposure: "search").
-//
-// The MCP server process has no senpi session state, so commit metadata reaches the extension
-// through an out-of-band receipt file (tool-receipts.ts) that is READ-AND-DELETED. That makes the
-// read a one-shot: every visible notice derived from a commit has to come from the SAME read, or
-// the second consumer silently finds nothing. This module owns that single read per memory
-// tool_result and fans it out to both notices - soul-updated (soul.edit_notice) and write-updated
-// (write_notice.enabled) - so neither gate can starve the other.
-//
-// The DIRECT tool surface deliberately emits no write-updated entry: there the tool's own
-// renderResult (memory-write-render.ts) already draws the same notice on the tool row, and a
-// second transcript entry would double-notify.
-
 import type { EntryRenderer } from "@code-yeongyu/senpi"
 import { touchesSoulPath, type MemoryToolCommit } from "@oh-my-opencode/memory-core"
 
@@ -18,36 +5,17 @@ import type { MemoryExtensionAPI } from "./capabilities"
 import type { MemoryIdentityContext } from "./context"
 import { renderMemoryWriteNotice } from "./memory-write-render"
 import { SOUL_UPDATED_ENTRY_TYPE, renderSoulUpdatedEntry, type SoulUpdatedRecord } from "./soul-notice"
-import { MEMORY_MCP_APPLY_PATCH_TOOL_NAME, MEMORY_MCP_TOOL_NAME } from "./tool-metadata"
-import { consumeToolReceipt, type MemoryToolReceipt } from "./tool-receipts"
-import { gatherMemoryWriteNotice, type MemoryWriteNotice } from "./tools"
+import type { MemoryWriteNotice } from "./tools"
 
 export const MEMORY_WRITE_UPDATED_ENTRY_TYPE = "omo-memory:write-updated"
 
-/** The write notice as a transcript entry; identical payload and rendering to the direct tool row. */
 export const renderMemoryWriteUpdatedEntry: EntryRenderer<MemoryWriteNotice> = (entry, options, theme) => {
   const record = entry.data
-  if (record === undefined) return undefined
-  return renderMemoryWriteNotice(record, options, theme, Date.now())
+  return record === undefined ? undefined : renderMemoryWriteNotice(record, options, theme, Date.now())
 }
-
 export interface MemoryNoticeWiringOptions {
   readonly resolveContext: (sessionId: string) => MemoryIdentityContext | undefined
-  /** memory.soul.edit_notice for the identity behind the commit. */
   readonly resolveEditNotice: (identity: string) => boolean
-  /** memory.write_notice.enabled for the identity behind the commit. */
-  readonly resolveWriteNotice: (identity: string) => boolean
-  /** Gather seam; production reuses the direct surface's own best-effort gather. */
-  readonly gatherWriteNotice?: (
-    context: MemoryIdentityContext,
-    commit: MemoryToolCommit,
-    sessionId: string,
-  ) => Promise<MemoryWriteNotice | undefined>
-  /** Receipt seam; production read-and-deletes the on-disk receipt exactly once per tool_result. */
-  readonly consumeReceipt?: (
-    receiptsDir: string,
-    toolCallId: string,
-  ) => Promise<MemoryToolReceipt | undefined>
 }
 
 export interface MemoryNoticeWiring {
@@ -58,106 +26,20 @@ export interface MemoryNoticeWiring {
 export function createMemoryNoticeWiring(options: MemoryNoticeWiringOptions): MemoryNoticeWiring {
   let api: MemoryExtensionAPI | undefined
 
-  /**
-   * The write notice is DECORATION: gathering probes git and the filesystem, so a failure or a
-   * degraded gather drops this one entry and never disturbs the soul notice or the tool result.
-   */
-  async function emitWrite(
-    context: MemoryIdentityContext,
-    commit: MemoryToolCommit,
-    sessionId: string,
-  ): Promise<void> {
-    if (api === undefined) return
-    if (!options.resolveWriteNotice(context.identity)) return
-    const gather = options.gatherWriteNotice ?? defaultGatherWriteNotice
-    let notice: MemoryWriteNotice | undefined
-    try {
-      notice = await gather(context, commit, sessionId)
-    } catch {
-      return
-    }
-    if (notice === undefined) return
-    api.appendEntry(MEMORY_WRITE_UPDATED_ENTRY_TYPE, notice)
-  }
-
-  function emitSoul(identity: string, commit: MemoryToolCommit): void {
-    if (api === undefined) return
-    if (!touchesSoulPath(commit.affectedPaths)) return
-    if (!options.resolveEditNotice(identity)) return
-    api.appendEntry(SOUL_UPDATED_ENTRY_TYPE, {
-      sha: commit.sha,
-      subject: commit.subject,
-      affectedPaths: commit.affectedPaths,
-    } satisfies SoulUpdatedRecord)
-  }
-
   return {
     register(pi): void {
       api = pi
       pi.registerEntryRenderer(SOUL_UPDATED_ENTRY_TYPE, renderSoulUpdatedEntry)
-      pi.registerEntryRenderer(MEMORY_WRITE_UPDATED_ENTRY_TYPE, renderMemoryWriteUpdatedEntry)
-      pi.on("tool_result", async (payload, eventCtx) => {
-        if (!isRecord(payload) || payload.type !== "tool_result") return
-        if (!isMemoryMcpToolName(payload.toolName)) return
-        if (typeof payload.toolCallId !== "string" || payload.toolCallId.length === 0) return
-        const sessionId = readSessionId(eventCtx)
-        if (sessionId === undefined) return
-        const context = options.resolveContext(sessionId)
-        if (context === undefined) return
-        const consume = options.consumeReceipt ?? consumeToolReceipt
-        // ONE read per tool_result: the receipt is read-and-deleted, so every notice below is
-        // derived from this single commit record.
-        const receipt = await consume(context.identityPaths.toolReceipts, payload.toolCallId)
-        if (receipt === undefined) return
-        const commit: MemoryToolCommit = {
-          sha: receipt.sha,
-          subject: receipt.subject,
-          affectedPaths: receipt.affectedPaths,
-        }
-        emitSoul(context.identity, commit)
-        await emitWrite(context, commit, sessionId)
-      })
     },
-
-    // Direct surface only: the tool's own renderResult already draws the write notice on the tool
-    // row, so emitting a write-updated entry here would notify twice for one commit.
     onCommit(context, commit): void {
-      emitSoul(context.identity, commit)
+      if (api === undefined) return
+      if (touchesSoulPath(commit.affectedPaths) && options.resolveEditNotice(context.identity)) {
+        api.appendEntry(SOUL_UPDATED_ENTRY_TYPE, {
+          sha: commit.sha,
+          subject: commit.subject,
+          affectedPaths: commit.affectedPaths,
+        } satisfies SoulUpdatedRecord)
+      }
     },
   }
-}
-
-async function defaultGatherWriteNotice(
-  context: MemoryIdentityContext,
-  commit: MemoryToolCommit,
-  sessionId: string,
-): Promise<MemoryWriteNotice | undefined> {
-  // Bounded: a wedged git or filesystem probe degrades the entry, it never stalls the event loop
-  // handler the host awaits.
-  return await Promise.race([
-    gatherMemoryWriteNotice(context, commit, { sessionId }),
-    new Promise<undefined>((resolve) => {
-      setTimeout(resolve, WRITE_NOTICE_BUDGET_MS).unref?.()
-    }),
-  ])
-}
-
-/** Same budget the direct surface gives its own gather; the entry is decoration, not the write. */
-const WRITE_NOTICE_BUDGET_MS = 3_000
-
-function isMemoryMcpToolName(value: unknown): boolean {
-  return value === MEMORY_MCP_TOOL_NAME || value === MEMORY_MCP_APPLY_PATCH_TOOL_NAME
-}
-
-function readSessionId(eventCtx: unknown): string | undefined {
-  if (!isRecord(eventCtx) || !isRecord(eventCtx.sessionManager)) return undefined
-  const manager = eventCtx.sessionManager
-  const getter = manager.getSessionId
-  if (typeof getter !== "function") return undefined
-  const value = Reflect.apply(getter, manager, [])
-  return typeof value === "string" && value.length > 0 ? value : undefined
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
 }

--- a/packages/omo-senpi/src/components/memory/memory-write-render.test.ts
+++ b/packages/omo-senpi/src/components/memory/memory-write-render.test.ts
@@ -1,4 +1,4 @@
-// Presentation tests for the memory write notice (the row a memory/memory_apply_patch
+// Presentation tests for the memory write notice (the row a memory
 // tool result draws in the transcript).
 //
 // The contract is senpi's own notice family (notice/box.ts + cache-warm-renderer.ts):

--- a/packages/omo-senpi/src/components/memory/memory-write-render.ts
+++ b/packages/omo-senpi/src/components/memory/memory-write-render.ts
@@ -1,4 +1,4 @@
-// Tool-result row for the memory / memory_apply_patch writes.
+// Tool-result row for memory writes.
 //
 // The model still receives the plain "Memory <command> committed locally (<sha7>)." string; this
 // module only replaces what the HUMAN sees with the house notice contract (noticeComponent, the

--- a/packages/omo-senpi/src/components/memory/memory.test-support.ts
+++ b/packages/omo-senpi/src/components/memory/memory.test-support.ts
@@ -27,7 +27,6 @@ export function memorySettings(overrides: Partial<OmoMemorySettings> = {}): OmoM
   return {
     enabled: true,
     agent: "auto",
-    tool_exposure: "direct",
     reflection: {
       enabled: true,
       trigger: { step_count: 25, on_compaction: true },

--- a/packages/omo-senpi/src/components/memory/nudge-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/nudge-wiring.test.ts
@@ -256,7 +256,7 @@ describe("createMemoryNudgeWiring", () => {
       toolCallId: string
       toolName: string
       input: Record<string, unknown>
-    } = { type: "tool_call", toolCallId: "call-mcp-1", toolName: "mcp_omo-memory_memory_apply_patch", input: { reason: "save" } }
+    } = { type: "tool_call", toolCallId: "call-memory-1", toolName: "memory", input: { reason: "save" } }
 
     // when
     await pi.dispatch("tool_call", call, ctx)
@@ -267,7 +267,7 @@ describe("createMemoryNudgeWiring", () => {
       userTurns: 4,
       identityId: context.identity,
       repoPath: context.identityPaths.repo,
-      toolCallId: "call-mcp-1",
+      toolCallId: "call-memory-1",
     })
   }, 30_000)
 })

--- a/packages/omo-senpi/src/components/memory/nudge-wiring.ts
+++ b/packages/omo-senpi/src/components/memory/nudge-wiring.ts
@@ -4,9 +4,6 @@ import type { GitMemoryRepo, MemoryToolProvenance } from "@oh-my-opencode/memory
 import type { MemoryExtensionAPI } from "./capabilities"
 import type { MemoryIdentityContext } from "./context"
 import {
-  MEMORY_APPLY_PATCH_TOOL_NAME,
-  MEMORY_MCP_APPLY_PATCH_TOOL_NAME,
-  MEMORY_MCP_TOOL_NAME,
   MEMORY_TOOL_NAME,
 } from "./tool-metadata"
 import { joinFields, noticeComponent } from "./worker/entry-renderers"
@@ -211,9 +208,6 @@ function isMemoryToolName(value: unknown): boolean {
   // The MCP surface exposes the same tools under senpi's catalog names (mcp_<server>_<tool>);
   // matching only the bare names would skip provenance injection on the search exposure.
   return value === MEMORY_TOOL_NAME
-    || value === MEMORY_APPLY_PATCH_TOOL_NAME
-    || value === MEMORY_MCP_TOOL_NAME
-    || value === MEMORY_MCP_APPLY_PATCH_TOOL_NAME
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/omo-senpi/src/components/memory/prompt.ts
+++ b/packages/omo-senpi/src/components/memory/prompt.ts
@@ -15,11 +15,6 @@ export const MEMORY_NUDGE_METADATA_TOKEN = "user turns since your last memory sa
 export const MEMORY_PRESSURE_METADATA_TOKEN = "memory pressure:"
 export const MEMORY_SOUL_METADATA_TOKEN = "Soul updated by"
 
-// Injected ONLY under the opt-in search exposure: pointing the agent at tool_search while the tools
-// are directly registered sent it hunting for a tool that does not exist (session 019fe95c-09d2).
-const MEMORY_TOOL_DISCOVERY_NOTE =
-  'The memory tools are discoverable through tool_search: run `tool_search("memory")` once to activate them, then use them for every save.'
-
 export interface MemoryPromptSession {
   readonly id: string
   readonly priorMessageCount: number
@@ -29,7 +24,6 @@ export interface MemoryPromptInjectionOptions {
   readonly resolveContext: (sessionId: string) => MemoryIdentityContext | undefined
   readonly createRepo?: (context: MemoryIdentityContext) => GitMemoryRepo
   readonly cache?: MemoryBlockCache
-  readonly searchExposure?: () => boolean
   readonly resolveCompileWarnTokens?: (identity: string) => number
   readonly resolveNudgeTurns?: (
     repo: GitMemoryRepo,
@@ -72,9 +66,8 @@ export function createMemoryPromptHandler(
       repo,
       options.resolveCompileWarnTokens?.(context.identity),
     )
-    const composed = options.searchExposure?.() === true ? `${pressureBlock}\n\n${MEMORY_TOOL_DISCOVERY_NOTE}` : pressureBlock
     return {
-      systemPrompt: replaceMemoryBlock(systemPrompt, markMemoryBlock(context.identity, composed)),
+      systemPrompt: replaceMemoryBlock(systemPrompt, markMemoryBlock(context.identity, pressureBlock)),
       message: {
         customType: MEMORY_NOTICE_CUSTOM_TYPE,
         content: renderMemoryNotice(session.priorMessageCount, nudgeTurns, soulNotice),

--- a/packages/omo-senpi/src/components/memory/tool-metadata.ts
+++ b/packages/omo-senpi/src/components/memory/tool-metadata.ts
@@ -1,76 +1,11 @@
-// Shared memory tool identity + description metadata. The senpi ToolDefinition layer (tools.ts) and the
-// standalone MCP server (src/mcp/memory-server.ts) both consume this module, so it must stay free of
-// TypeBox and harness imports: the MCP bundle runs under plain Node with no senpi runtime present.
-
 export const MEMORY_TOOL_NAME = "memory"
-export const MEMORY_APPLY_PATCH_TOOL_NAME = "memory_apply_patch"
-
-// MCP surface identity. senpi names catalog tools `mcp_<server>_<tool>` with non-alphanumerics
-// (except dash/underscore) sanitized, so the omo-memory server exposes these exact tool names in
-// tool_call/tool_result events (senpi builtin mcp expose/naming.ts).
-export const MEMORY_MCP_SERVER_NAME = "omo-memory"
-export const MEMORY_MCP_TOOL_NAME = `mcp_${MEMORY_MCP_SERVER_NAME}_${MEMORY_TOOL_NAME}`
-export const MEMORY_MCP_APPLY_PATCH_TOOL_NAME = `mcp_${MEMORY_MCP_SERVER_NAME}_${MEMORY_APPLY_PATCH_TOOL_NAME}`
 
 export const MEMORY_TOOL_DESCRIPTION = [
-  "A convenience tool for memories stored in the omo memory repo that automatically commits changes. The harness syncs clean committed memory changes after the turn.",
+  "A convenience tool for memories stored in the omo memory repo that automatically commits changes.",
   "",
-  "Memory files are markdown documents with YAML frontmatter. Frontmatter carries a `description` (required on create; it is what the memory index shows) and may set `read_only: \"true\"` to block modification. Edits preserve existing frontmatter.",
+  "Supported operations: create, str_replace, insert, delete, rename, update_description, and apply_patch.",
+  "apply_patch accepts Codex-style multi-file or multi-hunk patches through the input field.",
   "",
-  "Supported operations on memory files:",
-  "- `str_replace`",
-  "- `insert`",
-  "- `delete` (files, or directories recursively)",
-  "- `rename` (path rename only)",
-  "- `update_description`",
-  "- `create`",
-  "For larger reorganizations, use memory_apply_patch instead.",
-  "",
-  "Path formats accepted:",
-  "- relative memory file paths (e.g. `system/contacts.md`, `reference/project/team.md`)",
-  "- absolute paths only when they are inside the memory repo",
-  "",
-  "Note: absolute paths outside the memory repo are rejected.",
-  "",
-  "When creating or deleting files, check for `[[path]]` references in other memory files that may need to be added or updated. Keeping references consistent ensures future discoverability.",
-  "",
-  "On success the tool returns `Memory <command> committed locally (<sha>).`, or `Memory <command> committed (<sha>); harness will sync after the turn.` when a remote is configured. Commits are authored with the bound omo memory identity.",
-].join("\n")
-
-export const MEMORY_APPLY_PATCH_DESCRIPTION = [
-  "Apply a codex-style patch to memory files in the omo memory repo, then automatically commit the change. The harness syncs clean committed memory changes after the turn.",
-  "",
-  "This is similar to `apply_patch`, but scoped to the memory repo and with memory-aware guardrails. `input` is patch text in the standard apply_patch format (`*** Begin Patch` ... `*** Add/Update/Delete File` ... `*** End Patch`); `reason` is the git commit message.",
-  "",
-  "Path rules:",
-
-  "- Relative paths are interpreted inside the memory repo",
-  "- Absolute paths are allowed only when under the memory repo",
-  "- Paths outside the memory repo are rejected",
-  "",
-  "Memory rules:",
-  "- Operates on markdown memory files (`.md`) with YAML frontmatter",
-  "- Updated/deleted files must be valid memory files with frontmatter",
-  "- `read_only: \"true\"` files cannot be modified",
-  "- If adding a file without frontmatter, frontmatter is created automatically",
-  "",
-  "Git behavior:",
-  "- Stages changed memory paths",
-  "- Commits with `reason`, authored by the bound omo memory identity (`<identity>@omo.local`)",
-  "- Sync to a configured remote is handled by the harness after the turn",
-  "",
-  "On success the tool returns `memory_apply_patch committed locally (<sha>).`, or `memory_apply_patch committed (<sha>); harness will sync after the turn.` when a remote is configured.",
-  "",
-  "Example:",
-  "```python",
-  "memory_apply_patch(",
-  '  reason="Refine coding preferences",',
-  '  input="""*** Begin Patch',
-  "*** Update File: system/human/prefs/coding.md",
-  "@@",
-  "-Use broad abstractions",
-  "+Prefer small focused helpers",
-  '*** End Patch"""',
-  ")",
-  "```",
+  "Memory files are markdown documents with YAML frontmatter. Paths must remain inside the memory repo.",
+  "read_only blocks cannot be modified. Commits are authored with the bound omo memory identity; the harness will sync after the turn.",
 ].join("\n")

--- a/packages/omo-senpi/src/components/memory/tools-apply-patch.test.ts
+++ b/packages/omo-senpi/src/components/memory/tools-apply-patch.test.ts
@@ -17,7 +17,7 @@ describe("memory tool execution", () => {
     // given
     const fixture = await boundFixture()
     await seedFile(fixture, "system/human/prefs/coding.md", "Use broad abstractions")
-    const [, applyPatchTool] = createMemoryTools(() => fixture.context)
+    const [applyPatchTool] = createMemoryTools(() => fixture.context)
     const input = [
       "*** Begin Patch",
       "*** Update File: system/human/prefs/coding.md",
@@ -28,11 +28,11 @@ describe("memory tool execution", () => {
     ].join("\n")
 
     // when
-    const result = await applyPatchTool.execute("call-1", { reason: "Refine coding preferences", input })
+    const result = await applyPatchTool.execute("call-1", { command: "apply_patch", reason: "Refine coding preferences", input })
 
     // then
     expect(result.isError).toBeUndefined()
-    expect(textOf(result)).toMatch(/^memory_apply_patch committed locally \([0-9a-f]{7}\)\.$/)
+    expect(textOf(result)).toMatch(/^Memory apply_patch committed locally \([0-9a-f]{7}\)\.$/)
     const written = parseMemoryFile(await readFile(join(fixture.repo.dir, "system/human/prefs/coding.md"), "utf8"))
     expect(written.body).toContain("Prefer small focused helpers")
     expect(await git(fixture.repo, ["log", "-1", "--format=%s"])).toBe("Refine coding preferences")
@@ -40,14 +40,14 @@ describe("memory tool execution", () => {
   test("#given a bound identity #when memory_apply_patch receives a malformed patch #then the parse error maps to an error result", async () => {
     // given
     const fixture = await boundFixture()
-    const [, applyPatchTool] = createMemoryTools(() => fixture.context)
+    const [applyPatchTool] = createMemoryTools(() => fixture.context)
 
     // when
-    const result = await applyPatchTool.execute("call-1", { reason: "Broken", input: "definitely not a patch" })
+    const result = await applyPatchTool.execute("call-1", { command: "apply_patch", reason: "Broken", input: "definitely not a patch" })
 
     // then
     expect(result.isError).toBe(true)
-    expect(textOf(result)).toContain("memory_apply_patch:")
+    expect(textOf(result)).toContain("memory: memory apply_patch:")
   })
 })
 
@@ -57,7 +57,7 @@ describe("memory tool onCommit seam", () => {
     const fixture = await boundFixture()
     await seedFile(fixture, "system/identity.md", "- Name: Ada")
     const commits: Array<{ sha: string; subject: string; affectedPaths: readonly string[] }> = []
-    const [, applyPatchTool] = createMemoryTools(() => fixture.context, {
+    const [applyPatchTool] = createMemoryTools(() => fixture.context, {
       onCommit: (commit) => commits.push(commit),
     })
     const input = [
@@ -70,7 +70,7 @@ describe("memory tool onCommit seam", () => {
     ].join("\n")
 
     // when
-    const result = await applyPatchTool.execute("call-2", { reason: "rename", input })
+    const result = await applyPatchTool.execute("call-2", { command: "apply_patch", reason: "rename", input })
 
     // then
     expect(result.isError).toBeUndefined()

--- a/packages/omo-senpi/src/components/memory/tools-write-notice.test.ts
+++ b/packages/omo-senpi/src/components/memory/tools-write-notice.test.ts
@@ -213,13 +213,14 @@ describe("memory write notice gathering", () => {
     expect(result.details.writeNotice).toBeUndefined()
   }, 60_000)
 
-  test("#given memory_apply_patch commits #when the result is built #then it carries the same notice payload shape", async () => {
+  test("#given memory apply_patch commits #when the result is built #then it carries the same notice payload shape", async () => {
     // given
     const fixture = await boundFixture()
-    const [, applyPatchTool] = toolsFor(fixture)
+    const [applyPatchTool] = toolsFor(fixture)
 
     // when
     const result = await applyPatchTool.execute("call-1", {
+      command: "apply_patch",
       reason: "Patch a new block",
       input: [
         "*** Begin Patch",

--- a/packages/omo-senpi/src/components/memory/tools.test.ts
+++ b/packages/omo-senpi/src/components/memory/tools.test.ts
@@ -2,12 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import { FakeExtensionAPI } from "../../../test-support/fake-extension-api"
 import type { MemoryIdentityContext } from "./context"
-import {
-  MEMORY_APPLY_PATCH_TOOL_NAME,
-  MEMORY_TOOL_NAME,
-  createMemoryTools,
-  registerMemoryTools,
-} from "./tools"
+import { MEMORY_TOOL_NAME, createMemoryTools, registerMemoryTools } from "./tools"
 import { boundFixture, textOf } from "./tools.test-support"
 
 describe("memory tool registration", () => {
@@ -20,7 +15,7 @@ describe("memory tool registration", () => {
 
     // then
     const names = pi.tools.map((tool) => tool["name"])
-    expect(names).toEqual([MEMORY_TOOL_NAME, MEMORY_APPLY_PATCH_TOOL_NAME])
+    expect(names).toEqual([MEMORY_TOOL_NAME])
     for (const tool of pi.tools) {
       expect(tool["executionMode"]).toBe("sequential")
       expect(typeof tool["label"]).toBe("string")
@@ -51,20 +46,17 @@ describe("memory tool registration", () => {
 })
 
 describe("memory tool activation", () => {
-  test("#given no bound identity #when either tool executes #then an actionable initialization error is returned", async () => {
+  test("#given no bound identity #when the memory tool executes #then an actionable initialization error is returned", async () => {
     // given
-    const [memoryTool, applyPatchTool] = createMemoryTools(() => undefined)
+    const [memoryTool] = createMemoryTools(() => undefined)
 
     // when
     const memoryResult = await memoryTool.execute("call-1", { command: "create", reason: "x", file_path: "a.md", description: "d" })
-    const patchResult = await applyPatchTool.execute("call-2", { reason: "x", input: "*** Begin Patch\n*** End Patch" })
 
     // then
     expect(memoryResult.isError).toBe(true)
     expect(textOf(memoryResult)).toContain("no memory identity bound")
     expect(textOf(memoryResult)).toContain("restart")
-    expect(patchResult.isError).toBe(true)
-    expect(textOf(patchResult)).toContain("no memory identity bound")
   })
 
   test("#given a resolver that binds after registration #when the tool executes #then activation follows binding", async () => {

--- a/packages/omo-senpi/src/components/memory/tools.ts
+++ b/packages/omo-senpi/src/components/memory/tools.ts
@@ -1,14 +1,7 @@
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-
 import type { AgentToolResult, ToolDefinition } from "@code-yeongyu/senpi"
 import {
-  MemoryApplyPatchError,
-  MemoryPatchHunkError,
-  MemoryPatchParseError,
   MemoryToolError,
   createNodeGitExec,
-  runMemoryApplyPatch,
   runMemoryTool,
   type MemoryToolCommit,
   type MemoryToolProvenance,
@@ -24,14 +17,11 @@ import type { SenpiExtensionAPI } from "../../extension/types"
 import type { MemoryIdentityContext } from "./context"
 
 import {
-  MEMORY_APPLY_PATCH_DESCRIPTION,
-  MEMORY_APPLY_PATCH_TOOL_NAME,
-  MEMORY_MCP_SERVER_NAME,
   MEMORY_TOOL_DESCRIPTION,
   MEMORY_TOOL_NAME,
 } from "./tool-metadata"
 
-export { MEMORY_APPLY_PATCH_TOOL_NAME, MEMORY_MCP_SERVER_NAME, MEMORY_TOOL_NAME }
+export { MEMORY_TOOL_NAME }
 
 const UNBOUND_IDENTITY_MESSAGE =
   "no memory identity bound to this session; enable omo memory and restart the session so the memory tools can initialize"
@@ -44,6 +34,7 @@ export const MemoryToolParams = Type.Object({
     Type.Literal("delete"),
     Type.Literal("rename"),
     Type.Literal("update_description"),
+    Type.Literal("apply_patch"),
   ], { description: "The memory operation to perform." }),
   reason: Type.String({ description: "Git commit message recorded for this memory change." }),
   file_path: Type.Optional(Type.String({ description: "Target memory file: relative to the memory repo, or absolute inside it. Required by create, str_replace, insert, delete, and update_description." })),
@@ -55,11 +46,7 @@ export const MemoryToolParams = Type.Object({
   insert_text: Type.Optional(Type.String({ description: "Text to insert. Required by insert." })),
   description: Type.Optional(Type.String({ description: "Frontmatter description of the memory block. Required by create and update_description." })),
   file_text: Type.Optional(Type.String({ description: "Initial body text for create." })),
-})
-
-export const MemoryApplyPatchParams = Type.Object({
-  reason: Type.String({ description: "Git commit message recorded for this memory change." }),
-  input: Type.String({ description: "Patch text in the standard apply_patch format (*** Begin Patch ... *** End Patch)." }),
+  input: Type.Optional(Type.String({ description: "Codex-style patch text for apply_patch." })),
 })
 
 /** One path touched by the commit, with the line counts `git show --numstat` reported for it. */
@@ -129,8 +116,8 @@ export type MemoryContextResolver = () => MemoryIdentityContext | undefined
 export function createMemoryTools(
   resolveContext: MemoryContextResolver,
   options: MemoryToolsOptions = {},
-): readonly [MemoryToolDefinition<typeof MemoryToolParams>, MemoryToolDefinition<typeof MemoryApplyPatchParams>] {
-  return [createMemoryTool(resolveContext, options), createMemoryApplyPatchTool(resolveContext, options)]
+): readonly [MemoryToolDefinition<typeof MemoryToolParams>] {
+  return [createMemoryTool(resolveContext, options)]
 }
 
 // Registration is cheap and always available; ACTIVATION is gated at execute time through the
@@ -144,29 +131,11 @@ export function registerMemoryTools(
   for (const tool of createMemoryTools(resolveContext, options)) pi.registerTool({ ...tool })
 }
 
-export interface MemoryToolSurfaceOptions extends MemoryToolsOptions {
-  readonly exposure?: "direct" | "search"
-}
-
-// Direct registration is the DEFAULT surface: an extension-declared MCP server that fails to start
-// (as shipped in 5.0.0-beta.3, where the declaration missing `enabled: true` resolved as state
-// "disabled") removes memory entirely. The search exposure stays available as an explicit opt-in
-// (memory.tool_exposure: "search") and must declare enabled: true so senpi actually starts it;
-// hosts without registerMcpServer fall back to direct registration even when opted in.
 export function registerMemoryToolSurface(
   pi: SenpiExtensionAPI,
   resolveContext: MemoryContextResolver,
-  options: MemoryToolSurfaceOptions = {},
+  options: MemoryToolsOptions = {},
 ): void {
-  if (options.exposure === "search" && typeof pi.registerMcpServer === "function") {
-    pi.registerMcpServer(MEMORY_MCP_SERVER_NAME, {
-      command: process.execPath,
-      args: [join(dirname(fileURLToPath(import.meta.url)), "omo-memory-mcp.js")],
-      exposure: "search",
-      enabled: true,
-    })
-    return
-  }
   registerMemoryTools(pi, resolveContext, options)
 }
 
@@ -178,7 +147,7 @@ function createMemoryTool(
     name: MEMORY_TOOL_NAME,
     label: "Memory",
     description: MEMORY_TOOL_DESCRIPTION,
-    promptSnippet: "memory - edit omo memory blocks (create/str_replace/insert/delete/rename/update_description); auto-commits each change",
+    promptSnippet: "memory - edit omo memory blocks (create/str_replace/insert/delete/rename/update_description/apply_patch); auto-commits each change",
     promptGuidelines: [
       "Record durable facts, preferences, and decisions with the memory tool as you learn them; every change is committed with the reason you provide.",
       "Memory files are markdown with YAML frontmatter; keep each block's description accurate because the memory index surfaces it.",
@@ -201,49 +170,6 @@ function createMemoryTool(
         return okResult(result.message, await writeNoticeFor(context, result.commit, options))
       } catch (error) {
         if (error instanceof MemoryToolError) return errorResult(error.message)
-        throw error
-      }
-    },
-    renderResult: renderResultFor(options),
-  }
-}
-
-function createMemoryApplyPatchTool(
-  resolveContext: MemoryContextResolver,
-  options: MemoryToolsOptions,
-): MemoryToolDefinition<typeof MemoryApplyPatchParams> {
-  return {
-    name: MEMORY_APPLY_PATCH_TOOL_NAME,
-    label: "Memory Apply Patch",
-    description: MEMORY_APPLY_PATCH_DESCRIPTION,
-    promptSnippet: "memory_apply_patch - apply a codex-style patch to omo memory files; auto-commits the change",
-    promptGuidelines: [
-      "Use memory_apply_patch for multi-file or multi-hunk memory edits; prefer the memory tool for single-block changes.",
-      "Patches may only target paths inside the memory repo, and read_only memory files cannot be modified.",
-    ],
-    parameters: MemoryApplyPatchParams,
-    executionMode: "sequential",
-    execute: async (_toolCallId, params) => {
-      const context = resolveContext()
-      if (context === undefined) return errorResult(`${MEMORY_APPLY_PATCH_TOOL_NAME}: ${UNBOUND_IDENTITY_MESSAGE}`)
-      try {
-        const { repo, lock, author } = await prepareEngine(context, options)
-        const provenance = readToolProvenance(params)
-        const result = await runMemoryApplyPatch({
-          repo,
-          lock,
-          params: { ...params, author, ...(provenance === undefined ? {} : { provenance }) },
-        })
-        if (result.commit !== undefined) options.onCommit?.(result.commit)
-        return okResult(result.message, await writeNoticeFor(context, result.commit, options))
-      } catch (error) {
-        if (
-          error instanceof MemoryApplyPatchError
-          || error instanceof MemoryPatchParseError
-          || error instanceof MemoryPatchHunkError
-        ) {
-          return errorResult(error.message)
-        }
         throw error
       }
     },

--- a/packages/omo-senpi/src/components/memory/wiring-memory-write.ts
+++ b/packages/omo-senpi/src/components/memory/wiring-memory-write.ts
@@ -2,7 +2,7 @@ import type { SenpiExtensionAPI } from "../../extension/types"
 import { refreshMemoryStatus } from "./status"
 import { isRecord, readUi, sessionIdFrom } from "./wiring-context"
 import type { MemoryWiringOptions } from "./wiring-types"
-import { MEMORY_APPLY_PATCH_TOOL_NAME, MEMORY_TOOL_NAME } from "./tools"
+import { MEMORY_TOOL_NAME } from "./tools"
 
 export function registerMemoryWriteListener(
   pi: SenpiExtensionAPI,
@@ -49,7 +49,7 @@ function isMemoryToolResult(value: unknown): boolean {
     || typeof value.toolName !== "string"
   ) return false
   return matchesToolName(value.toolName, MEMORY_TOOL_NAME)
-    || matchesToolName(value.toolName, MEMORY_APPLY_PATCH_TOOL_NAME)
+    || matchesToolName(value.toolName, MEMORY_TOOL_NAME)
 }
 
 function matchesToolName(toolName: string, expected: string): boolean {

--- a/packages/omo-senpi/src/components/memory/wiring-types.ts
+++ b/packages/omo-senpi/src/components/memory/wiring-types.ts
@@ -25,8 +25,6 @@ export interface MemoryWiringOptions {
   readonly createFactsExtractor?: (options: FactsExtractorRunnerOptions) => FactsExtractorPort
   /** Memorian gate runner seam; the live QA driver substitutes a scripted child here. */
   readonly createMemorianRunner?: (identity: MemoryIdentityContext) => MemorianGatePort
-  /** Boot-snapshot tool exposure; registration must not re-read config (latch order is observable). */
-  readonly toolExposure?: "direct" | "search"
   readonly now?: () => number
   readonly refreshStatus?: typeof refreshMemoryStatus
   /** Injectable animation timers; tests drive frames without touching the wall clock. */

--- a/packages/omo-senpi/src/components/memory/wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/wiring.test.ts
@@ -241,7 +241,6 @@ describe("memory footer wiring", () => {
 
     const toolContext = sessionContext(fixture.sessionId, statusCalls)
     await pi.dispatch("tool_result", memoryResult("mcp_omo-memory_memory"), toolContext)
-    await pi.dispatch("tool_result", memoryResult("mcp_omo-memory_memory_apply_patch"), toolContext)
     await pi.dispatch("tool_result", memoryResult("read"), toolContext)
 
     expect(statusCalls).toHaveLength(1)

--- a/packages/omo-senpi/src/components/memory/wiring.ts
+++ b/packages/omo-senpi/src/components/memory/wiring.ts
@@ -61,17 +61,6 @@ export function createMemoryWiring(options: MemoryWiringOptions): MemoryWiring {
       const override = settings.agents[identity]?.soul
       return override?.edit_notice ?? settings.soul.edit_notice
     },
-    resolveWriteNotice: (identity) => {
-      // Presentation must never depend on config health, matching the direct surface's gate:
-      // an unreadable config keeps the default on.
-      try {
-        const settings = resolveMemorySettings(options.loadConfig({ cwd: options.cwd() }).config.memory)
-        const override = settings.agents[identity]?.write_notice
-        return override?.enabled ?? settings.write_notice.enabled
-      } catch {
-        return true
-      }
-    },
   })
 
   // Late-bound because the two wirings are mutually dependent by design: recall's drain needs the

--- a/packages/omo-senpi/src/components/task/engine-runners.test.ts
+++ b/packages/omo-senpi/src/components/task/engine-runners.test.ts
@@ -81,7 +81,6 @@ describe("task child memory tool exclusion", () => {
   test("#given the ui-only tool names passed to the in-process runner #when inspected #then both memory tools are listed", () => {
     // given / when / then
     expect(TASK_CHILD_UI_ONLY_TOOL_NAMES).toContain("memory")
-    expect(TASK_CHILD_UI_ONLY_TOOL_NAMES).toContain("memory_apply_patch")
   })
 
   test("#given shared parent tools including memory tools #when an in-process child starts #then the child tool set excludes them", async () => {
@@ -89,7 +88,7 @@ describe("task child memory tool exclusion", () => {
     let captured: CreateAgentSessionOptions | undefined
     const fake = createFakeSession()
     const runner = new InProcessRunner({
-      sharedParentTools: [makeTool("grep"), makeTool("memory"), makeTool("memory_apply_patch")],
+      sharedParentTools: [makeTool("grep"), makeTool("memory")],
       uiOnlyToolNames: TASK_CHILD_UI_ONLY_TOOL_NAMES,
       createSession: async (options) => {
         captured = options
@@ -106,7 +105,6 @@ describe("task child memory tool exclusion", () => {
     const names = (captured?.customTools ?? []).map((tool) => tool.name)
     expect(names).toEqual(["grep"])
     expect(names).not.toContain("memory")
-    expect(names).not.toContain("memory_apply_patch")
   })
 
   test("#given the default runner factories #when the in-process runner is built #then construction succeeds with the ui-only names wired", () => {

--- a/packages/omo-senpi/src/components/task/engine-runners.ts
+++ b/packages/omo-senpi/src/components/task/engine-runners.ts
@@ -15,12 +15,12 @@ import {
   type ManagedRunner,
 } from "@oh-my-opencode/senpi-task"
 
-import { MEMORY_APPLY_PATCH_TOOL_NAME, MEMORY_TOOL_NAME } from "../memory/tools"
+import { MEMORY_TOOL_NAME } from "../memory/tools"
 import type { TaskRuntimeContext } from "./runtime-context"
 
 // Memory tools are bound to the parent session's identity (repo commits + writer lock); a task
 // child must never inherit them, so they ride the same ui-only exclusion as render-only tools.
-export const TASK_CHILD_UI_ONLY_TOOL_NAMES: readonly string[] = [MEMORY_TOOL_NAME, MEMORY_APPLY_PATCH_TOOL_NAME]
+export const TASK_CHILD_UI_ONLY_TOOL_NAMES: readonly string[] = [MEMORY_TOOL_NAME]
 
 export interface RunnerBuildContext {
   readonly runtime: TaskRuntimeContext

--- a/packages/omo-senpi/src/components/telemetry/omo-native-tools.test.ts
+++ b/packages/omo-senpi/src/components/telemetry/omo-native-tools.test.ts
@@ -165,7 +165,7 @@ describe("OmO Native tool telemetry", () => {
 
   test("#given feature tools across two sessions #when repeated #then each feature emits once per session", async () => {
     const { pi, events } = fixture()
-    const tools = ["create_goal", "team_create", "memory", "memory_apply_patch"]
+    const tools = ["create_goal", "team_create", "memory"]
 
     for (const toolName of tools) await pi.dispatch("tool_result", result(toolName, {}), context("session-a"))
     for (const toolName of tools) await pi.dispatch("tool_result", result(toolName, {}), context("session-a"))

--- a/packages/omo-senpi/src/components/telemetry/omo-native-tools.ts
+++ b/packages/omo-senpi/src/components/telemetry/omo-native-tools.ts
@@ -162,7 +162,7 @@ function spawnTarget(item: Record<string, unknown>, parent: Record<string, unkno
 function featureForTool(toolName: string): "goal_tool" | "team_create" | "memory_tool" | undefined {
   if (matchesToolName(toolName, "create_goal")) return "goal_tool"
   if (matchesToolName(toolName, "team_create")) return "team_create"
-  if (matchesToolName(toolName, "memory_apply_patch") || matchesToolName(toolName, "memory")) return "memory_tool"
+  if (matchesToolName(toolName, "memory")) return "memory_tool"
   return undefined
 }
 


### PR DESCRIPTION
Consolidates memory writes under one memory tool with apply_patch, removes memory MCP exposure, and shares the lock/commit pipeline. Remote Bunshin evidence: .omo/evidence/20260905-memory-tool-consolidation/remote-scoped-final.log (82 pass, 0 fail).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates memory writes into a single `memory` tool: `apply_patch` is now a command on it, the separate `memory_apply_patch` tool is gone, and all writes share the same lock/commit pipeline.

- Removes the MCP search exposure and the `tool_exposure` config option; the tool is always registered directly and the memory MCP extension bundle is no longer built.
- Error messages now use `memory:` and `memory apply_patch:` prefixes; the `tool-receipts` runtime directory is removed.

**Migration**
- Remove `tool_exposure` from `memory` config blocks; it's no longer accepted.

<sup>Written for commit 6fd53f2cfd5f8dc61d2ae0f5a4f6ba45a4178847. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

