### PR TITLE
fix(model-core,telemetry): register claude-fable-5-1 everywhere the Fable 5.1 routing needs it

### DIFF
--- a/docs/reference/senpi-telemetry.md
+++ b/docs/reference/senpi-telemetry.md
@@ -19,7 +19,7 @@ The payloads carry only booleans, buckets, counters, and allowlisted enum values
 | `session_started` | `$os_version` | `string` | - |
 | `session_started` | `arch` | `string` | - |
 | `session_started` | `cpu_count` | `number` | - |
-| `session_started` | `default_model` | `string` | `qwen3.6-flash`, `qwen3.8-max-preview`, `claude-fable-5`, `claude-haiku-4-5`, `claude-opus-5`, `claude-sonnet-5`, `deepseek-v4-flash`, `deepseek-v4-pro`, `gemini-3.1-pro`, `gemini-3.6-flash`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-6-astra`, `grok-4.6`, `k3`, `kimi-for-coding-highspeed`, `kimi-k3`, `gpt-5.6-luna-fast`, `glm-5.2`, `glm-5.3`, `mimo-v2.5-pro`, `minimax-m2.7`, `minimax-m3`, `grok-4.20-0309-non-reasoning`, `custom` |
+| `session_started` | `default_model` | `string` | `qwen3.6-flash`, `qwen3.8-max-preview`, `claude-fable-5`, `claude-fable-5-1`, `claude-haiku-4-5`, `claude-opus-5`, `claude-sonnet-5`, `deepseek-v4-flash`, `deepseek-v4-pro`, `gemini-3.1-pro`, `gemini-3.6-flash`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-6-astra`, `grok-4.6`, `k3`, `kimi-for-coding-highspeed`, `kimi-k3`, `gpt-5.6-luna-fast`, `glm-5.2`, `glm-5.3`, `mimo-v2.5-pro`, `minimax-m2.7`, `minimax-m3`, `grok-4.20-0309-non-reasoning`, `custom` |
 | `session_started` | `default_provider` | `string` | `alibaba-token-plan`, `alibaba-token-plan-cn`, `anthropic`, `anthropic-api`, `bailian-coding-plan`, `deepseek`, `google`, `github-copilot`, `kimi-coding`, `kimi-for-coding`, `moonshotai`, `openai`, `openai-codex`, `opencode`, `opencode-go`, `qwen-token-plan`, `qwen-token-plan-cn`, `vercel`, `xai`, `xiaomi`, `zai-coding-plan`, `custom` |
 | `session_started` | `memory_bucket` | `string` | `lt_8_gb`, `8_15_gb`, `16_31_gb`, `32_63_gb`, `64_plus_gb` |
 | `session_started` | `model_count` | `number` | - |
@@ -47,7 +47,7 @@ The payloads carry only booleans, buckets, counters, and allowlisted enum values
 | `turn_completed` | `cache_write_tokens` | `number` | - |
 | `turn_completed` | `cost_usd` | `number` | - |
 | `turn_completed` | `input_tokens` | `number` | - |
-| `turn_completed` | `model_id` | `string` | `qwen3.6-flash`, `qwen3.8-max-preview`, `claude-fable-5`, `claude-haiku-4-5`, `claude-opus-5`, `claude-sonnet-5`, `deepseek-v4-flash`, `deepseek-v4-pro`, `gemini-3.1-pro`, `gemini-3.6-flash`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-6-astra`, `grok-4.6`, `k3`, `kimi-for-coding-highspeed`, `kimi-k3`, `gpt-5.6-luna-fast`, `glm-5.2`, `glm-5.3`, `mimo-v2.5-pro`, `minimax-m2.7`, `minimax-m3`, `grok-4.20-0309-non-reasoning`, `custom` |
+| `turn_completed` | `model_id` | `string` | `qwen3.6-flash`, `qwen3.8-max-preview`, `claude-fable-5`, `claude-fable-5-1`, `claude-haiku-4-5`, `claude-opus-5`, `claude-sonnet-5`, `deepseek-v4-flash`, `deepseek-v4-pro`, `gemini-3.1-pro`, `gemini-3.6-flash`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-6-astra`, `grok-4.6`, `k3`, `kimi-for-coding-highspeed`, `kimi-k3`, `gpt-5.6-luna-fast`, `glm-5.2`, `glm-5.3`, `mimo-v2.5-pro`, `minimax-m2.7`, `minimax-m3`, `grok-4.20-0309-non-reasoning`, `custom` |
 | `turn_completed` | `output_tokens` | `number` | - |
 | `turn_completed` | `provider` | `string` | `alibaba-token-plan`, `alibaba-token-plan-cn`, `anthropic`, `anthropic-api`, `bailian-coding-plan`, `deepseek`, `google`, `github-copilot`, `kimi-coding`, `kimi-for-coding`, `moonshotai`, `openai`, `openai-codex`, `opencode`, `opencode-go`, `qwen-token-plan`, `qwen-token-plan-cn`, `vercel`, `xai`, `xiaomi`, `zai-coding-plan`, `custom` |
 | `turn_completed` | `reasoning_tokens` | `number` | - |
@@ -106,7 +106,7 @@ The payloads carry only booleans, buckets, counters, and allowlisted enum values
 | `delegation_completed` | `execution_mode` | `string` | `in-process`, `process` |
 | `delegation_completed` | `fallback_attempts` | `number` | - |
 | `delegation_completed` | `input_tokens` | `number` | - |
-| `delegation_completed` | `model_id` | `string` | `qwen3.6-flash`, `qwen3.8-max-preview`, `claude-fable-5`, `claude-haiku-4-5`, `claude-opus-5`, `claude-sonnet-5`, `deepseek-v4-flash`, `deepseek-v4-pro`, `gemini-3.1-pro`, `gemini-3.6-flash`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-6-astra`, `grok-4.6`, `k3`, `kimi-for-coding-highspeed`, `kimi-k3`, `gpt-5.6-luna-fast`, `glm-5.2`, `glm-5.3`, `mimo-v2.5-pro`, `minimax-m2.7`, `minimax-m3`, `grok-4.20-0309-non-reasoning`, `custom` |
+| `delegation_completed` | `model_id` | `string` | `qwen3.6-flash`, `qwen3.8-max-preview`, `claude-fable-5`, `claude-fable-5-1`, `claude-haiku-4-5`, `claude-opus-5`, `claude-sonnet-5`, `deepseek-v4-flash`, `deepseek-v4-pro`, `gemini-3.1-pro`, `gemini-3.6-flash`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-6-astra`, `grok-4.6`, `k3`, `kimi-for-coding-highspeed`, `kimi-k3`, `gpt-5.6-luna-fast`, `glm-5.2`, `glm-5.3`, `mimo-v2.5-pro`, `minimax-m2.7`, `minimax-m3`, `grok-4.20-0309-non-reasoning`, `custom` |
 | `delegation_completed` | `model_source` | `string` | `category`, `explicit`, `agent`, `none` |
 | `delegation_completed` | `output_tokens` | `number` | - |
 | `delegation_completed` | `owner_kind` | `string` | `plain_child`, `dag_node`, `team_member`, `unknown` |

--- a/packages/model-core/src/model-capabilities/supplemental-entries.ts
+++ b/packages/model-core/src/model-capabilities/supplemental-entries.ts
@@ -31,6 +31,21 @@ export const SUPPLEMENTAL_MODEL_CAPABILITIES: Record<string, ModelCapabilitiesSn
 			output: 262144,
 		},
 	},
+	"claude-fable-5-1": {
+		id: "claude-fable-5-1",
+		family: "claude-fable",
+		reasoning: true,
+		temperature: false,
+		toolCall: true,
+		modalities: {
+			input: ["text", "image", "pdf"],
+			output: ["text"],
+		},
+		limit: {
+			context: 1000000,
+			output: 128000,
+		},
+	},
 	"gpt-6-astra": {
 		id: "gpt-6-astra",
 		family: "gpt",

--- a/packages/model-core/src/model-requirements-agents.test.ts
+++ b/packages/model-core/src/model-requirements-agents.test.ts
@@ -149,7 +149,7 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
         })
   })
 
-  test("prometheus uses Fable 5 xhigh before Kimi K3 max", () => {
+  test("prometheus uses Fable 5.1 xhigh before Kimi K3 max", () => {
     // given
     const prometheus = AGENT_MODEL_REQUIREMENTS["prometheus"]
 
@@ -160,7 +160,7 @@ describe("AGENT_MODEL_REQUIREMENTS", () => {
     expect(prometheus.fallbackChain).toHaveLength(2)
     expect(primary).toEqual({
           providers: ["anthropic", "github-copilot", "opencode"],
-          model: "claude-fable-5",
+          model: "claude-fable-5-1",
           variant: "xhigh",
         })
     expect(kimiFallback).toEqual({

--- a/packages/omo-senpi/src/components/telemetry/model-vocabulary.ts
+++ b/packages/omo-senpi/src/components/telemetry/model-vocabulary.ts
@@ -15,13 +15,13 @@
 export const KNOWN_MODELS = Object.freeze({
   "alibaba-token-plan": Object.freeze(["qwen3.6-flash", "qwen3.8-max-preview"]),
   "alibaba-token-plan-cn": Object.freeze(["qwen3.8-max-preview"]),
-  anthropic: Object.freeze(["claude-fable-5", "claude-haiku-4-5", "claude-opus-5", "claude-sonnet-5"]),
-  "anthropic-api": Object.freeze(["claude-fable-5", "claude-haiku-4-5", "claude-opus-5", "claude-sonnet-5"]),
+  anthropic: Object.freeze(["claude-fable-5", "claude-fable-5-1", "claude-haiku-4-5", "claude-opus-5", "claude-sonnet-5"]),
+  "anthropic-api": Object.freeze(["claude-fable-5", "claude-fable-5-1", "claude-haiku-4-5", "claude-opus-5", "claude-sonnet-5"]),
   "bailian-coding-plan": Object.freeze(["qwen3.6-flash"]),
   deepseek: Object.freeze(["deepseek-v4-flash", "deepseek-v4-pro"]),
   google: Object.freeze(["gemini-3.1-pro", "gemini-3.6-flash"]),
   "github-copilot": Object.freeze([
-    "claude-fable-5", "claude-haiku-4-5", "claude-opus-5", "claude-sonnet-5", "gemini-3.1-pro",
+    "claude-fable-5", "claude-fable-5-1", "claude-haiku-4-5", "claude-opus-5", "claude-sonnet-5", "gemini-3.1-pro",
     "gpt-5.6-sol", "gpt-5.6-terra", "gpt-6-astra", "grok-4.6",
   ]),
   "kimi-coding": Object.freeze(["k3", "kimi-for-coding-highspeed", "kimi-k3"]),
@@ -30,7 +30,7 @@ export const KNOWN_MODELS = Object.freeze({
   openai: Object.freeze(["gpt-5.6-luna-fast", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-6-astra"]),
   "openai-codex": Object.freeze(["gpt-5.6-luna-fast", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-6-astra"]),
   opencode: Object.freeze([
-    "claude-fable-5", "claude-opus-5", "claude-sonnet-5", "gemini-3.1-pro", "gpt-5.6-sol",
+    "claude-fable-5", "claude-fable-5-1", "claude-opus-5", "claude-sonnet-5", "gemini-3.1-pro", "gpt-5.6-sol",
     "gpt-5.6-terra", "gpt-6-astra", "grok-4.6", "kimi-k3",
   ]),
   "opencode-go": Object.freeze([
@@ -39,7 +39,7 @@ export const KNOWN_MODELS = Object.freeze({
   "qwen-token-plan": Object.freeze(["qwen3.6-flash", "qwen3.8-max-preview"]),
   "qwen-token-plan-cn": Object.freeze(["qwen3.8-max-preview"]),
   vercel: Object.freeze([
-    "claude-fable-5", "claude-haiku-4-5", "claude-opus-5", "claude-sonnet-5", "deepseek-v4-flash",
+    "claude-fable-5", "claude-fable-5-1", "claude-haiku-4-5", "claude-opus-5", "claude-sonnet-5", "deepseek-v4-flash",
     "deepseek-v4-pro", "gemini-3.1-pro", "gemini-3.6-flash", "glm-5.2", "gpt-5.6-sol",
     "gpt-5.6-terra", "gpt-6-astra", "grok-4.6", "kimi-k3", "mimo-v2.5-pro", "minimax-m2.7",
     "minimax-m3", "qwen3.6-flash",

--- a/packages/senpi-task/src/category/category-routing-policy.test.ts
+++ b/packages/senpi-task/src/category/category-routing-policy.test.ts
@@ -15,7 +15,7 @@ describe("Senpi category routing policy", () => {
 
     // then
     expect(routing).toEqual({
-      visualEngineering: { model: "anthropic/claude-opus-5", variant: "max" },
+      visualEngineering: { model: "anthropic/claude-fable-5-1", variant: "max" },
       quick: { model: "kimi-coding/kimi-for-coding-highspeed" },
       unspecifiedHigh: { model: "openai/gpt-6-astra", variant: "high" },
       unspecifiedLow: { model: "xai/grok-4.6", variant: "xhigh" },


### PR DESCRIPTION
## What changed
`2d03a69b3` routed prometheus and the visual/writing categories through `claude-fable-5-1` but shipped without the registrations the requirement chains are contract-tested against, leaving dev CI red on every OS. This PR adds them and moves two stale expectations to the shipped contract:

- **`packages/model-core/src/model-capabilities/supplemental-entries.ts`** — new `claude-fable-5-1` entry cloned from the generated snapshot's `claude-fable-5` shape (claude-fable family, reasoning, no temperature, tool calls, text/image/pdf, 1M context, 128k output). Fixes `getModelCapabilities > keeps every built-in OmO requirement model snapshot-backed` (was `heuristic-backed`).
- **`packages/omo-senpi/src/components/telemetry/model-vocabulary.ts`** + **`docs/reference/senpi-telemetry.md`** — `claude-fable-5-1` added beside `claude-fable-5` on anthropic, anthropic-api, github-copilot, opencode, vercel (every provider that ships a fable-5-1 rung) and in the disclosure lists. Fixes `product-identity > no shipped rung collapses to custom` — the guard (no executable rung exports as custom/custom; user-named models still mask to custom) is unchanged.
- **`packages/model-core/src/model-requirements-agents.test.ts`** — prometheus primary is `claude-fable-5-1` xhigh; the ordering guard (Fable before Kimi K3 max, chain length 2) is kept.
- **`packages/senpi-task/src/category/category-routing-policy.test.ts`** — visual-engineering default is `anthropic/claude-fable-5-1` max (the shipped primary rung), other categories unchanged.

## Verification (fleet, gorky, never local)
RED on dev a722ee320: 4 fail / 46 pass across the 5 files (`evidence/model-core-red-dev-gorky.txt`).
GREEN on this branch: targeted 5 files **50/50**; `packages/model-core` + `omo-senpi/src/components/telemetry` + `senpi-task/src/category` **668 pass / 1 fail** — the one remaining failure is `resolveAvailableCategoryNames … architect gate` (owned by the CI lane w33:p36, not touched here). `tsgo --noEmit` exit 0 for model-core and omo-senpi.

## Residual risk
Capability numbers for fable-5-1 mirror fable-5 until the generated snapshot picks the model up from models.dev; the supplemental entry is the same mechanism used for gpt-6-astra.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `claude-fable-5-1` in model capabilities and telemetry vocabulary so the Fable 5.1 routing no longer breaks dev CI.

- Adds a supplemental capability entry for `claude-fable-5-1` mirroring `claude-fable-5` until the generated snapshot picks it up.
- Adds `claude-fable-5-1` to `KNOWN_MODELS` on anthropic, anthropic-api, github-copilot, opencode, and vercel, and to the telemetry docs disclosure.
- Updates prometheus and visual-engineering tests to expect `claude-fable-5-1` while keeping the ordering and variant guards.

<sup>Written for commit 8181c28f3b6acb1f624956ec1f64667d095e70c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

