### PR TITLE
fix(omo-senpi): restore dev CI after Fable 5.1 transition

### DIFF
--- a/packages/omo-senpi/src/components/fallback-architect/architect-gate.test.ts
+++ b/packages/omo-senpi/src/components/fallback-architect/architect-gate.test.ts
@@ -83,7 +83,7 @@ describe("architect gate", () => {
     describe("#when the gate is evaluated with that registry", () => {
       it("#then the builtin architect category counts as active", () => {
         withFixture({ categories: { quick: { model: "some/model" } } }, (cwd, env) => {
-          const registry = fakeRegistry([{ provider: "anthropic", id: "claude-fable-5" }])
+          const registry = fakeRegistry([{ provider: "anthropic", id: "claude-fable-5-1" }])
           expect(hasActiveArchitectCategory(cwd, { env, registry })).toBe(true)
         })
       })

--- a/packages/omo-senpi/src/components/memory/facts-payload-oversize.test.ts
+++ b/packages/omo-senpi/src/components/memory/facts-payload-oversize.test.ts
@@ -60,7 +60,11 @@ function warnCollector() {
 async function queueFileNames(identity: MemoryIdentity): Promise<string[]> {
   const layout = factsQueuePaths(identity.paths)
   return (await readdir(layout.queueDir).catch(() => []))
-    .filter((name) => name.endsWith(".json") && name !== "consumed.json" && name !== "failures.json")
+    .filter((name) =>
+      name.endsWith(".json") &&
+      name !== "consumed.json" &&
+      name !== "failures.json" &&
+      name !== "claims.json")
     .sort()
 }
 

--- a/packages/omo-senpi/src/components/memory/facts-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/facts-wiring.test.ts
@@ -53,7 +53,7 @@ async function seedJournal(paths: MemoryIdentityPaths, count: number): Promise<v
 
 async function queueFileCount(paths: MemoryIdentityPaths): Promise<number> {
   const names = await readdir(paths.factsQueue).catch(() => [] as string[])
-  return names.filter((name) => name.endsWith(".json") && name !== "consumed.json").length
+  return names.filter((name) => name.endsWith(".json") && name !== "consumed.json" && name !== "claims.json").length
 }
 
 function wiringFor(paths: MemoryIdentityPaths, enabled: boolean) {

--- a/packages/omo-senpi/src/components/memory/sandbox.test.ts
+++ b/packages/omo-senpi/src/components/memory/sandbox.test.ts
@@ -108,7 +108,7 @@ describe("reflection worker OS sandbox", () => {
     const realAgentDir = realpathSync(agentDir)
     expect(profile).toContain(`(allow file-write* (subpath ${JSON.stringify(realAgentDir)}))`)
     for (const lock of ["settings.json.lock", "auth.json.lock", "hooks-state.json.lock"]) {
-      expect(join(realAgentDir, lock).startsWith(`${realAgentDir}/`)).toBe(true)
+      expect(dirname(join(realAgentDir, lock))).toBe(realAgentDir)
     }
   }, 30_000)
 

--- a/packages/omo-senpi/src/components/task/planner.test.ts
+++ b/packages/omo-senpi/src/components/task/planner.test.ts
@@ -68,7 +68,10 @@ describe("createTaskChildPlanner", () => {
     const planner = createTaskChildPlanner(
       {},
       {},
-      () => registry([model("zai-coding-plan", "glm-5.2")]),
+      () => registry([
+        model("anthropic", "claude-fable-5-1"),
+        model("google", "gemini-3.1-pro"),
+      ]),
     )
 
     // when
@@ -83,9 +86,9 @@ describe("createTaskChildPlanner", () => {
     const resolved = expectResolved(result)
     expect(resolved.plan.resolved_model).toMatchObject({
       source: "category",
-      provider: "zai-coding-plan",
-      model_id: "glm-5.2",
-      display: "zai-coding-plan/glm-5.2",
+      provider: "anthropic",
+      model_id: "claude-fable-5-1",
+      display: "anthropic/claude-fable-5-1",
       variant: "max",
     })
   })
@@ -103,7 +106,7 @@ describe("createTaskChildPlanner", () => {
         },
       },
       {},
-      () => registry([model("google", "gemini-3.1-pro")]),
+      () => registry([model("anthropic", "claude-fable-5-1")]),
     )
 
     // when
@@ -225,7 +228,7 @@ describe("createTaskChildPlanner", () => {
     const planner = createTaskChildPlanner(
       {},
       BUILTIN_AGENTS,
-      () => registry([model("zai-coding-plan", "glm-5.2")]),
+      () => registry([model("anthropic", "claude-fable-5-1")]),
     )
 
     // when
@@ -238,7 +241,7 @@ describe("createTaskChildPlanner", () => {
 
     // then
     const resolved = expectResolved(result)
-    expect(resolved.plan.resolved_model).toMatchObject({ source: "category", provider: "zai-coding-plan" })
+    expect(resolved.plan.resolved_model).toMatchObject({ source: "category", provider: "anthropic" })
     expect(resolved.plan.category).toBe("visual-engineering")
   })
 
@@ -248,7 +251,10 @@ describe("createTaskChildPlanner", () => {
     const planner = createTaskChildPlanner(
       { categories: { explore: { model: "google/gemini-3.1-pro" } } },
       agents,
-      () => registry([model("google", "gemini-3.1-pro")]),
+      () => registry([
+        model("anthropic", "claude-fable-5-1"),
+        model("google", "gemini-3.1-pro"),
+      ]),
     )
 
     // when
@@ -298,7 +304,7 @@ describe("createTaskChildPlanner", () => {
     const planner = createTaskChildPlanner(
       {},
       BUILTIN_AGENTS,
-      () => registry([model("google", "gemini-3.1-pro")]),
+      () => registry([model("anthropic", "claude-fable-5-1")]),
     )
 
     // when
@@ -321,8 +327,8 @@ describe("createTaskChildPlanner", () => {
       "omo-senpi-gate-reviewer",
       "omo-senpi-qa-executor",
     ])
-    // writing survives on a gemini-only registry (its gemini-3.1-pro rung resolves); ultrabrain's
-    // sol-only chain is dead, so the dead-chain gate excludes it.
+    // writing survives when its Fable 5.1 rung resolves; ultrabrain's
+    // Astra-only chain is dead, so the dead-chain gate excludes it.
     expect(result.error.availableCategories).toContain("writing")
     expect(result.error.availableCategories).not.toContain("ultrabrain")
   })
@@ -449,7 +455,7 @@ describe("createTaskChildPlanner plan variant", () => {
     const planner = createTaskChildPlanner(
       {},
       {},
-      () => registry([model("zai-coding-plan", "glm-5.2")]),
+      () => registry([model("anthropic", "claude-fable-5-1")]),
     )
 
     // when
@@ -489,7 +495,7 @@ describe("createTaskChildPlanner plan variant", () => {
     const planner = createTaskChildPlanner(
       {},
       BUILTIN_AGENTS,
-      () => registry([model("openai", "gpt-5.6-sol")]),
+      () => registry([model("openai", "gpt-6-astra")]),
     )
 
     // when
@@ -502,7 +508,7 @@ describe("createTaskChildPlanner plan variant", () => {
 
     // then
     const resolved = expectResolved(result)
-    expect(resolved.plan.model).toBe("openai/gpt-5.6-sol")
+    expect(resolved.plan.model).toBe("openai/gpt-6-astra")
     expect(resolved.plan.variant).toBe("xhigh")
   })
 })

--- a/packages/senpi-task/src/category/available-categories.test.ts
+++ b/packages/senpi-task/src/category/available-categories.test.ts
@@ -19,7 +19,7 @@ describe("resolveAvailableCategoryNames", () => {
   describe("#given no user categories and a registry exposing the architect gate model", () => {
     describe("#when the runtime category list is resolved", () => {
       it("#then the builtin architect category is exposed", () => {
-        const names = resolveAvailableCategoryNames({}, fakeRegistry([{ provider: "anthropic", id: "claude-fable-5" }]))
+        const names = resolveAvailableCategoryNames({}, fakeRegistry([{ provider: "anthropic", id: "claude-fable-5-1" }]))
         expect(names).toContain("architect")
       })
     })
@@ -39,7 +39,7 @@ describe("resolveAvailableCategoryNames", () => {
     describe("#when the registry lacks the gate model", () => {
       it("#then the explicit declaration still exposes architect", () => {
         const names = resolveAvailableCategoryNames(
-          { categories: { architect: { model: "anthropic/claude-fable-5" } } },
+          { categories: { architect: { model: "anthropic/claude-fable-5-1" } } },
           fakeRegistry([{ provider: "omo-mock", id: "mock-weak" }]),
         )
         expect(names).toContain("architect")


### PR DESCRIPTION
## Summary

Restores the Senpi adapter and task-category test contracts after the Fable
5.1 routing transition, fixes the Memorian cancellation double-abort path, and
refreshes the committed Senpi extension bundle from the current dev tree.

## Changes

- Update architect, available-category, planner, facts, and sandbox fixtures
  to use the current Fable 5.1 and cross-platform path contracts.
- Make Memorian cancellation signal the in-process child and let the child own
  its single abort/dispose path.
- Exclude durable `claims.json` state from queue-file assertions.
- Refresh `packages/omo-senpi/plugin/extensions/*` from Linux after rebasing
  onto `2bf127dd`.

## QA and evidence

- `bun test` on mengmotaMac for the six named/affected test files:
  `51 pass`, `0 fail`, `130 expect() calls`.
- Linux gorky `bun packages/omo-senpi/plugin/scripts/build-extension.mjs
  --check`: exit 0, current bundle.
- Linux gorky `bun run build:omo-native` plus
  `node script/verify-omo-ai-payload.mjs`: `378 packed paths`, `0 offenders`,
  `5618885 bytes`.
- `bunx tsgo --noEmit -p packages/omo-senpi/tsconfig.json`: exit 0.
- Evidence: `.omo/evidence/20260905-omo-dev-green/README.md`

## Risks and residuals

The historical CI run also contained a non-fatal `node:net` EPIPE emitted by
the LSP daemon Vitest process; the test files completed successfully. The
Linux bundle check is authoritative and was run after rebasing onto current
dev.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores dev CI for `omo-senpi` after the Fable 5.1 routing transition.

- Updates test fixtures to Fable 5.1 model identifiers across architect, planner, facts, and sandbox tests.
- Excludes durable `claims.json` state from queue-file assertions.
- Makes path assertions cross-platform with `dirname`.

<sup>Written for commit 01a4a4858c458bcdfdd9b3e6ee88523731b507ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

