### PR TITLE
fix(lsp-core): synchronize push diagnostics fallback tests

### DIFF
--- a/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
+++ b/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
@@ -9,6 +9,7 @@ import {
 	diagnostic,
 	readEvents,
 	waitForEventCount,
+	waitForEventCountBySubscription,
 } from "./workspace-apply-edit-test-support.js";
 
 const harness = createWorkspaceEditTestHarness();
@@ -249,7 +250,7 @@ describe("LspClient diagnostics freshness", () => {
 		);
 
 		const pending = context.client.diagnostics(context.source);
-		const [delivery] = await waitForEventCount(
+		const [delivery] = await waitForEventCountBySubscription(
 			context.events,
 			(event) => event.type === "clientResponse" && event.method === "workspace/configuration",
 			1,

--- a/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
+++ b/packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
@@ -240,6 +240,7 @@ describe("LspClient diagnostics freshness", () => {
 						trigger: "didOpen",
 						version: 1,
 						diagnostics: [diagnostic("push-fallback")],
+						awaitClientDelivery: true,
 					},
 				],
 				diagnosticResponses: [{ error: { code: -32601, message: "Method not found" } }],
@@ -247,7 +248,14 @@ describe("LspClient diagnostics freshness", () => {
 			{ diagnosticsFreshnessTimeoutMs: 500, versionlessPublishQuiescenceMs: 5 },
 		);
 
-		const result = await context.client.diagnostics(context.source);
+		const pending = context.client.diagnostics(context.source);
+		const [delivery] = await waitForEventCount(
+			context.events,
+			(event) => event.type === "clientResponse" && event.method === "workspace/configuration",
+			1,
+		);
+		expect(delivery).toBeDefined();
+		const result = await pending;
 
 		expect(result.items).toEqual([diagnostic("push-fallback")]);
 	});

--- a/packages/lsp-core/src/lsp/workspace-apply-edit-test-support.ts
+++ b/packages/lsp-core/src/lsp/workspace-apply-edit-test-support.ts
@@ -149,22 +149,40 @@ export async function waitForEventCount(
 	predicate: (event: RecordedEvent) => boolean,
 	count: number,
 ): Promise<readonly RecordedEvent[]> {
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		const matches = readEvents(path).filter(predicate);
+		if (matches.length >= count) return matches;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	return readEvents(path).filter(predicate);
+}
+
+export async function waitForEventCountBySubscription(
+	path: string,
+	predicate: (event: RecordedEvent) => boolean,
+	count: number,
+): Promise<readonly RecordedEvent[]> {
+	const initial = readEvents(path).filter(predicate);
+	if (initial.length >= count) return initial;
 	return new Promise((resolve) => {
+		let watcher: ReturnType<typeof watch> | undefined;
+		let timeout: ReturnType<typeof setTimeout> | undefined;
 		let settled = false;
-		const watcher = watch(path, { persistent: false }, () => {
-			const matches = readEvents(path).filter(predicate);
-			if (matches.length >= count) finish(matches);
-		});
-		const timeout = setTimeout(() => finish(readEvents(path).filter(predicate)), 2_000);
 		const finish = (matches: readonly RecordedEvent[]): void => {
 			if (settled) return;
 			settled = true;
-			clearTimeout(timeout);
-			watcher.close();
+			if (timeout !== undefined) clearTimeout(timeout);
+			watcher?.close();
 			resolve(matches);
 		};
-		const initial = readEvents(path).filter(predicate);
-		if (initial.length >= count) finish(initial);
+		const check = (): void => {
+			const matches = readEvents(path).filter(predicate);
+			if (matches.length >= count) finish(matches);
+		};
+		watcher = watch(path, { persistent: false }, check);
+		timeout = setTimeout(() => finish(readEvents(path).filter(predicate)), 2_000);
+		check();
 	});
 }
 

--- a/packages/lsp-core/src/lsp/workspace-apply-edit-test-support.ts
+++ b/packages/lsp-core/src/lsp/workspace-apply-edit-test-support.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, watch, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -149,13 +149,23 @@ export async function waitForEventCount(
 	predicate: (event: RecordedEvent) => boolean,
 	count: number,
 ): Promise<readonly RecordedEvent[]> {
-	const deadline = Date.now() + 2_000;
-	while (Date.now() < deadline) {
-		const matches = readEvents(path).filter(predicate);
-		if (matches.length >= count) return matches;
-		await new Promise((resolve) => setTimeout(resolve, 10));
-	}
-	return readEvents(path).filter(predicate);
+	return new Promise((resolve) => {
+		let settled = false;
+		const watcher = watch(path, { persistent: false }, () => {
+			const matches = readEvents(path).filter(predicate);
+			if (matches.length >= count) finish(matches);
+		});
+		const timeout = setTimeout(() => finish(readEvents(path).filter(predicate)), 2_000);
+		const finish = (matches: readonly RecordedEvent[]): void => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			watcher.close();
+			resolve(matches);
+		};
+		const initial = readEvents(path).filter(predicate);
+		if (initial.length >= count) finish(initial);
+	});
 }
 
 function isRecordedEvent(value: unknown): value is RecordedEvent {


### PR DESCRIPTION
# LSP diagnostics push-fallback race

## Red evidence

Release-state PR #7810 on Windows failed
`packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts:252`:
expected the `push-fallback` diagnostic and received `[]`.

The same source tree passed the corresponding dev Windows test, proving the
failure was nondeterministic. The test started diagnostics immediately after
`didOpen` without waiting for the fixture's push-diagnostics delivery.

## Fix

- The fixture now requests a `workspace/configuration` delivery barrier after
  `publishDiagnostics`.
- The test subscribes to that exact client-response event before awaiting the
  diagnostics result.
- `waitForEventCount` now uses `fs.watch` plus a bounded timeout instead of a
  fixed-sleep polling loop.

This preserves the real contract: the push diagnostic must be observed by the
client before the fallback assertion is evaluated.

## Green evidence

On mengmotaMac, five consecutive runs of:

```text
bun test packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts
```

completed with `11 pass`, `0 fail`, and `32 expect() calls` on every run.

## Cleanup

The verification worktree and remote test artifacts are disposable. No server,
port, or browser process was left running.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky LSP push-diagnostics fallback test so the fallback assertion only runs after the client receives the pushed diagnostic. Replaces the polling loop in `waitForEventCount` with a `fs.watch`-based watcher and a bounded timeout, scoped to the fallback test.

<sup>Written for commit 8812fb862eab633aa9973bfd4d7098fb1498292d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

