### PR TITLE
fix(lazycodex): repair published skill sync smoke

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1448,35 +1448,89 @@ jobs:
               expected_doctor_output_prefix="codex exec "
               expected_doctor_hint="Use \$omo:lcx-doctor"
 
-              if npx_install_output=$(npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous 2>&1) &&
-                 npx_doctor_output=$(npx -y "$package_spec" --dry-run doctor 2>&1) &&
-                 [ "$npx_install_output" = "$expected_install_output" ] &&
-                 case "$npx_doctor_output" in "$expected_doctor_output_prefix"*) true ;; *) false ;; esac &&
-                 case "$npx_doctor_output" in *"--sandbox danger-full-access"*) true ;; *) false ;; esac &&
-                 case "$npx_doctor_output" in *"$expected_doctor_hint"*) true ;; *) false ;; esac &&
-                 case "$npx_doctor_output" in *"--model"*|*"gpt-5.5-codex-mini"*) false ;; *) true ;; esac &&
-                 npx -y "$package_spec" install --no-tui --codex-autonomous &&
-                 [ -x "$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ] &&
-                 [ ! -e "$CODEX_LOCAL_BIN_DIR/omo" ] &&
-                 omo_agent_toolkit_version_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" --version 2>&1) &&
-                 [ "$omo_agent_toolkit_version_output" = "$OMO_VERSION" ] &&
-                 ulw_loop_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ulw-loop --help 2>&1) &&
-                 printf "%s" "$ulw_loop_output" | grep -q "ulw-loop" &&
-                 simulate_legacy_omo_upgrade "$package_spec" "$SMOKE_DIR/upgrade-marked" marked &&
-                 simulate_legacy_omo_upgrade "$package_spec" "$SMOKE_DIR/upgrade-unmarked" unmarked; then
-                echo "$npx_install_output"
-                echo "$npx_doctor_output"
-                echo "omo-agent-toolkit --version: $omo_agent_toolkit_version_output"
-                echo "omo-agent-toolkit ulw-loop: $ulw_loop_output"
+              if ! registry_version=$(npm view "$package_spec" version --silent 2>"$SMOKE_DIR/registry-error"); then
+                echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/12)"
                 cd "$GITHUB_WORKSPACE"
                 rm -rf "$SMOKE_DIR"
-                return 0
+                sleep 10
+                continue
               fi
 
+              if [[ "$package_spec" != *"@latest" && "$registry_version" != "${package_spec##*@}" ]]; then
+                echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/12; visible=${registry_version})"
+                cd "$GITHUB_WORKSPACE"
+                rm -rf "$SMOKE_DIR"
+                sleep 10
+                continue
+              fi
+
+              if ! npx_install_output=$(npx -y "$package_spec" --dry-run install --no-tui --codex-autonomous 2>&1); then
+                echo "::error::Published LazyCodex install dry-run failed after ${package_spec} became visible (registry=${registry_version})"
+                echo "$npx_install_output" >&2
+                cd "$GITHUB_WORKSPACE"
+                rm -rf "$SMOKE_DIR"
+                return 1
+              fi
+              if ! npx_doctor_output=$(npx -y "$package_spec" --dry-run doctor 2>&1); then
+                echo "::error::Published LazyCodex doctor dry-run failed for visible ${package_spec} (registry=${registry_version})"
+                echo "$npx_doctor_output" >&2
+                cd "$GITHUB_WORKSPACE"
+                rm -rf "$SMOKE_DIR"
+                return 1
+              fi
+              doctor_prefix_ok=false
+              doctor_sandbox_ok=false
+              doctor_hint_ok=false
+              doctor_model_ok=true
+              case "$npx_doctor_output" in "$expected_doctor_output_prefix"*) doctor_prefix_ok=true ;; esac
+              case "$npx_doctor_output" in *"--sandbox danger-full-access"*) doctor_sandbox_ok=true ;; esac
+              case "$npx_doctor_output" in *"$expected_doctor_hint"*) doctor_hint_ok=true ;; esac
+              case "$npx_doctor_output" in *"--model"*|*"gpt-5.5-codex-mini"*) doctor_model_ok=false ;; esac
+              if [ "$npx_install_output" != "$expected_install_output" ] ||
+                 [ "$doctor_prefix_ok" != true ] ||
+                 [ "$doctor_sandbox_ok" != true ] ||
+                 [ "$doctor_hint_ok" != true ] ||
+                 [ "$doctor_model_ok" != true ]; then
+                echo "::error::Published LazyCodex dry-run behavior failed for visible ${package_spec} (registry=${registry_version})"
+                echo "$npx_install_output" >&2
+                echo "$npx_doctor_output" >&2
+                cd "$GITHUB_WORKSPACE"
+                rm -rf "$SMOKE_DIR"
+                return 1
+              fi
+              if ! npx -y "$package_spec" install --no-tui --codex-autonomous; then
+                echo "::error::Published LazyCodex install failed for visible ${package_spec} (registry=${registry_version}); this is not registry propagation"
+                cd "$GITHUB_WORKSPACE"
+                rm -rf "$SMOKE_DIR"
+                return 1
+              fi
+              if ! [ -x "$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ] ||
+                 [ -e "$CODEX_LOCAL_BIN_DIR/omo" ] ||
+                 ! omo_agent_toolkit_version_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" --version 2>&1) ||
+                 [ "$omo_agent_toolkit_version_output" != "$OMO_VERSION" ] ||
+                 ! ulw_loop_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ulw-loop --help 2>&1) ||
+                 ! printf "%s" "$ulw_loop_output" | grep -q "ulw-loop"; then
+                echo "::error::Published LazyCodex installed but runtime verification failed for visible ${package_spec}"
+                echo "version output: ${omo_agent_toolkit_version_output:-<missing>}" >&2
+                echo "$ulw_loop_output" >&2
+                cd "$GITHUB_WORKSPACE"
+                rm -rf "$SMOKE_DIR"
+                return 1
+              fi
+              if ! simulate_legacy_omo_upgrade "$package_spec" "$SMOKE_DIR/upgrade-marked" marked ||
+                 ! simulate_legacy_omo_upgrade "$package_spec" "$SMOKE_DIR/upgrade-unmarked" unmarked; then
+                echo "::error::Published LazyCodex legacy-wrapper upgrade verification failed for visible ${package_spec}"
+                cd "$GITHUB_WORKSPACE"
+                rm -rf "$SMOKE_DIR"
+                return 1
+              fi
+              echo "$npx_install_output"
+              echo "$npx_doctor_output"
+              echo "omo-agent-toolkit --version: $omo_agent_toolkit_version_output"
+              echo "omo-agent-toolkit ulw-loop: $ulw_loop_output"
               cd "$GITHUB_WORKSPACE"
               rm -rf "$SMOKE_DIR"
-              echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/12)"
-              sleep 10
+              return 0
             done
             echo "::error::Published LazyCodex smoke failed for ${package_spec}"
             return 1

--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -5,8 +5,8 @@ import { fileURLToPath } from "node:url";
 
 import { resolveCanonicalUltraworkDirectivePath } from "./canonical-ultrawork-directive.mjs";
 import { isCliEntry } from "./entry-guard.mjs";
-import { sharedSkillsRootPath } from "@oh-my-opencode/shared-skills";
-import { createSkillSourceCopyFilter } from "@oh-my-opencode/shared-skills/skill-source-filter";
+import { sharedSkillsRootPath } from "../../../shared-skills/index.mjs";
+import { createSkillSourceCopyFilter } from "../../../shared-skills/skill-source-filter.mjs";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = join(root, "..", "..", "..");

--- a/packages/omo-codex/plugin/test/sync-skills-codex-compatibility.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-codex-compatibility.test.mjs
@@ -99,3 +99,11 @@ test("#given the aggregate sync implementation #when its skill adaptation pipeli
 	);
 	assert.match(script, /await adaptSkillForCodex\(skillName\)/);
 });
+
+test("#given the published package layout #when sync-skills resolves shared skill helpers #then it uses files shipped beside the package instead of a workspace-only dependency", async () => {
+	const script = await readFile(join(pluginRoot, "scripts", "sync-skills.mjs"), "utf8");
+
+	assert.match(script, /from "\.\.\/\.\.\/\.\.\/shared-skills\/index\.mjs"/);
+	assert.match(script, /from "\.\.\/\.\.\/\.\.\/shared-skills\/skill-source-filter\.mjs"/);
+	assert.doesNotMatch(script, /from "@oh-my-opencode\/shared-skills/);
+});

--- a/packages/omo-codex/plugin/test/sync-skills.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills.test.mjs
@@ -93,7 +93,9 @@ test("#given aggregate Codex skills #when source wiring is inspected #then share
 	assert.equal(rootPackageFiles.includes("packages/shared-skills/index.mjs"), true);
 	assert.equal(rootPackageFiles.includes("packages/shared-skills/skills"), true);
 	assert.equal(sharedSkillDependency, "file:../../shared-skills");
-	assert.match(syncScript, /from "@oh-my-opencode\/shared-skills"/);
+	assert.match(syncScript, /from "\.\.\/\.\.\/\.\.\/shared-skills\/index\.mjs"/);
+	assert.match(syncScript, /from "\.\.\/\.\.\/\.\.\/shared-skills\/skill-source-filter\.mjs"/);
+	assert.doesNotMatch(syncScript, /from "@oh-my-opencode\/shared-skills/);
 	assert.doesNotMatch(syncScript, /shared-skills",\s*"skills"/);
 });
 

--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -315,6 +315,10 @@ describe("LazyCodex publish workflow", () => {
       smokeStep.includes('smoke_lazycodex_package "lazycodex-ai@latest"')
     const retriesRegistryPropagation = smokeStep.includes("for attempt in $(seq 1 12)") &&
       smokeStep.includes("registry propagation")
+    const distinguishesVisibleInstallFailure =
+      smokeStep.includes('npm view "$package_spec" version --silent') &&
+      smokeStep.includes("install dry-run failed after") &&
+      smokeStep.includes("this is not registry propagation")
     const isolatesCodexState = smokeStep.includes('export HOME="$SMOKE_DIR/home"') &&
       smokeStep.includes('export CODEX_HOME="$SMOKE_DIR/codex"') &&
       smokeStep.includes('export CODEX_LOCAL_BIN_DIR="$SMOKE_DIR/bin"')
@@ -323,11 +327,15 @@ describe("LazyCodex publish workflow", () => {
       smokeStep.includes('expected_install_output="npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous"') &&
       smokeStep.includes('expected_doctor_output_prefix="codex exec ') &&
       smokeStep.includes("npx --yes oh-my-openagent@latest install --platform=codex --no-tui --codex-autonomous") &&
-      smokeStep.includes('case "$npx_doctor_output" in "$expected_doctor_output_prefix"*) true ;; *) false ;; esac') &&
-      smokeStep.includes('case "$npx_doctor_output" in *"--sandbox danger-full-access"*) true ;; *) false ;; esac') &&
       smokeStep.includes('expected_doctor_hint="Use \\$omo:lcx-doctor"') &&
-      smokeStep.includes('case "$npx_doctor_output" in *"$expected_doctor_hint"*) true ;; *) false ;; esac') &&
-      smokeStep.includes('case "$npx_doctor_output" in *"--model"*|*"gpt-5.5-codex-mini"*) false ;; *) true ;; esac') &&
+      smokeStep.includes("doctor_prefix_ok=false") &&
+      smokeStep.includes("doctor_sandbox_ok=false") &&
+      smokeStep.includes("doctor_hint_ok=false") &&
+      smokeStep.includes("doctor_model_ok=true") &&
+      smokeStep.includes('[ "$doctor_prefix_ok" != true ]') &&
+      smokeStep.includes('[ "$doctor_sandbox_ok" != true ]') &&
+      smokeStep.includes('[ "$doctor_hint_ok" != true ]') &&
+      smokeStep.includes('[ "$doctor_model_ok" != true ]') &&
       !smokeStep.includes("npx --yes --package oh-my-openagent omo install") &&
       !smokeStep.includes("--platform=claude-code") &&
       !smokeStep.includes("--platform=gemini")
@@ -335,11 +343,12 @@ describe("LazyCodex publish workflow", () => {
       smokeStep.includes('npx -y "$package_spec" install --no-tui --codex-autonomous') &&
       smokeStep.includes('[ -x "$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ]') &&
       smokeStep.includes('omo_agent_toolkit_version_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" --version 2>&1)') &&
-      smokeStep.includes('[ "$omo_agent_toolkit_version_output" = "$OMO_VERSION" ]') &&
+      smokeStep.includes('[ "$omo_agent_toolkit_version_output" != "$OMO_VERSION" ]') &&
       smokeStep.includes('ulw_loop_output=$("$CODEX_LOCAL_BIN_DIR/omo-agent-toolkit" ulw-loop --help 2>&1)') &&
       smokeStep.includes('printf "%s" "$ulw_loop_output" | grep -q "ulw-loop"')
     const assertsLegacyOmoBinIsRemoved =
-      smokeStep.includes('[ ! -e "$CODEX_LOCAL_BIN_DIR/omo" ]') &&
+      smokeStep.includes('[ -e "$CODEX_LOCAL_BIN_DIR/omo" ]') &&
+      smokeStep.includes("runtime verification failed") &&
       !smokeStep.includes('[ -x "$CODEX_LOCAL_BIN_DIR/omo" ]') &&
       !smokeStep.includes('"$CODEX_LOCAL_BIN_DIR/omo" --version') &&
       !smokeStep.includes('"$CODEX_LOCAL_BIN_DIR/omo" ulw-loop --help')
@@ -358,6 +367,10 @@ describe("LazyCodex publish workflow", () => {
     expect(smokesReleaseVersion, "post-publish smoke must verify the exact release version").toBe(true)
     expect(smokesStableLatestOnly, "post-publish smoke must verify latest only for stable releases").toBe(true)
     expect(retriesRegistryPropagation, "post-publish smoke must tolerate npm registry propagation").toBe(true)
+    expect(
+      distinguishesVisibleInstallFailure,
+      "post-publish smoke must stop and report install failures once the package is registry-visible",
+    ).toBe(true)
     expect(isolatesCodexState, "post-publish smoke must isolate HOME and Codex paths").toBe(true)
     expect(assertsDryRunRouting, "post-publish smoke must assert the expected dry-run routing output").toBe(true)
     expect(


### PR DESCRIPTION
# lazycodex-ai beta.43 published-install fix

## RED

On mengmotaMac, a clean isolated install of the published package reproduced
the user-facing failure:

```text
npx -y lazycodex-ai@5.0.0-beta.43 install --no-tui --codex-autonomous
```

The package was visible in npm, but `npm run sync:skills` exited 1 because
`sync-skills.mjs` imported the workspace-only
`@oh-my-opencode/shared-skills/skill-source-filter` path from the flattened
published cache.

## Root fix

- `packages/omo-codex/plugin/scripts/sync-skills.mjs` now imports the shipped
  sibling files under `../../../shared-skills/`.
- The publish workflow already includes the canonical
  `packages/prompts-core/prompts/ultrawork/codex.md` file in the lazycodex
  tarball; the packed-layout verification confirms both that file and the
  shared-skills helper are present.
- `publish.yml` now probes npm visibility first. Once a version is visible,
  dry-run/install/runtime failures fail immediately with an install-specific
  error instead of being mislabeled as registry propagation.

## GREEN

Workflow contract tests on mengmotaMac:

```text
script/lazycodex-published-smoke-workflow.test.ts
script/publish-lazycodex-workflow.test.ts
7 pass, 0 fail
```

Codex sync contract tests:

```text
packages/omo-codex/plugin/test/sync-skills-codex-compatibility.test.mjs
8 pass, 0 fail
```

Published-layout tarball probe on mengmotaMac:

```text
npm pack --ignore-scripts
cd packages/omo-codex/plugin
npm run sync:skills
EXIT=0
SHARED_FILE=0
PROMPT_FILE=0
```

The probe uses the same lazycodex `files` override as `publish.yml`, so it
exercises the flattened npm payload rather than the workspace symlink layout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the published `lazycodex-ai` install so `npm run sync:skills` no longer fails on a workspace-only import path. The publish smoke now checks npm visibility first, so install or runtime failures surface as errors rather than being retried as registry propagation, and contract tests now assert the shipped sibling imports.

<sup>Written for commit 482641346156fd399799cd03bc94a008338bce9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

