### PR TITLE
fix(team-mode): propagate worktree cwd to child sessions

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.test.ts
@@ -289,6 +289,7 @@ describe("tryFallbackRetry", () => {
       const args = createDefaultArgs({
         skillContent: "delegated skill system",
         sessionPermission: QUESTION_DENIED_SESSION_PERMISSION,
+        cwd: "/worktree",
       })
 
       await tryFallbackRetry(args)
@@ -297,6 +298,7 @@ describe("tryFallbackRetry", () => {
       const retryInput = args.queuesByKey.get(key)?.[0]?.input
       expect(retryInput?.skillContent).toBe("delegated skill system")
       expect(retryInput?.sessionPermission).toEqual(QUESTION_DENIED_SESSION_PERMISSION)
+      expect(retryInput?.cwd).toBe("/worktree")
     })
 
     test("finalizes the failed attempt, creates a new pending attempt, and enqueues its explicit attemptID", async () => {

--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
@@ -218,6 +218,7 @@ export async function tryFallbackRetry(args: {
     parentAgent: task.parentAgent,
     parentTools: task.parentTools,
     teamRunId: task.teamRunId,
+    cwd: task.cwd,
     model: nextModel,
     fallbackChain: task.fallbackChain,
     skillContent: task.skillContent,

--- a/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
@@ -39,6 +39,47 @@ describe("BackgroundManager session permission", () => {
     expect(promptCalls[0]?.query).toEqual({ directory: "/parent" })
   })
 
+  test("routes child session creation and prompts through an explicit cwd", async () => {
+    // given
+    const createCalls: Array<Record<string, unknown>> = []
+    const promptCalls: Array<Record<string, unknown>> = []
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/parent" } }),
+        create: async (input: Record<string, unknown>) => {
+          createCalls.push(input)
+          return { data: { id: "ses_child" } }
+        },
+        promptAsync: async (input: Record<string, unknown>) => {
+          promptCalls.push(input)
+          return {}
+        },
+        abort: async () => ({}),
+      },
+    }
+    const manager = new BackgroundManager({
+      pluginContext: unsafeTestValue<PluginInput>({ client, directory: tmpdir() }),
+    })
+
+    // when
+    await manager.launch({
+      description: "Worktree task",
+      prompt: "Do something in the worktree",
+      agent: "explore",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+      cwd: "/worktree",
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    manager.shutdown()
+
+    // then
+    expect(createCalls).toHaveLength(1)
+    expect(createCalls[0]?.query).toEqual({ directory: "/worktree" })
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0]?.query).toEqual({ directory: "/worktree" })
+  })
+
   test("passes query directory when loading the parent session", async () => {
     // given
     const getCalls: Array<Record<string, unknown>> = []

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -619,6 +619,7 @@ export class BackgroundManager {
         parentSessionId: input.parentSessionId,
         parentMessageId: input.parentMessageId,
         teamRunId: input.teamRunId,
+        cwd: input.cwd,
         parentModel: input.parentModel,
         parentAgent: input.parentAgent,
         parentTools: input.parentTools,
@@ -775,7 +776,8 @@ export class BackgroundManager {
       return null
     })
     const parentDirectory = parentSession?.data?.directory ?? this.directory
-    log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${parentDirectory}`)
+    const childDirectory = input.cwd ?? parentDirectory
+    log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, child dir: ${childDirectory}`)
 
     const createResult = await this.client.session.create({
       body: {
@@ -793,7 +795,7 @@ export class BackgroundManager {
           : {}),
       } as Record<string, unknown>,
       query: {
-        directory: parentDirectory,
+        directory: childDirectory,
       },
     })
 
@@ -853,7 +855,7 @@ export class BackgroundManager {
 
     if (task.retryNotification) {
       const attemptNumber = boundAttempt.attemptNumber
-      const retrySessionUrl = buildLocalSessionUrl(parentDirectory, sessionID)
+      const retrySessionUrl = buildLocalSessionUrl(childDirectory, sessionID)
       const previousAttempt = getPreviousAttempt(task, boundAttempt.attemptId)
       const failedSessionID = previousAttempt?.sessionId ?? task.retryNotification.previousSessionID
       const failedSessionLine = failedSessionID
@@ -960,7 +962,7 @@ The fallback retry session is now created and can be inspected directly.
     promptWithRetryInDirectory(this.client, {
       path: { id: sessionID },
       body: promptBody,
-    }, parentDirectory).catch(async (error) => {
+    }, childDirectory).catch(async (error) => {
       // Retry with fallback agent if the original agent was unregistered (e.g., after a model switch)
       if (isAgentNotFoundError(error) && input.agent !== FALLBACK_AGENT) {
         log("[background-agent] Agent not found, retrying with fallback agent", {
@@ -987,7 +989,7 @@ The fallback retry session is now created and can be inspected directly.
           await promptWithRetryInDirectory(this.client, {
             path: { id: sessionID },
             body: fallbackBody,
-          }, parentDirectory)
+          }, childDirectory)
           task.agent = FALLBACK_AGENT
           return
         } catch (retryError) {

--- a/packages/omo-opencode/src/features/background-agent/spawner.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner.test.ts
@@ -83,6 +83,65 @@ describe("background-agent spawner resume guard", () => {
   })
 })
 
+describe("background-agent spawner cwd routing", () => {
+  afterEach(() => {
+    clearSessionPromptParams("session-worktree")
+    releaseAllPromptAsyncReservationsForTesting()
+  })
+
+  test("uses explicit cwd for child session creation and prompt routing", async () => {
+    //#given
+    const createCalls: Array<Record<string, unknown>> = []
+    const promptCalls: PromptRequest[] = []
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/parent" } }),
+        create: async (input: Record<string, unknown>) => {
+          createCalls.push(input)
+          return { data: { id: "session-worktree" } }
+        },
+        promptAsync: async (input: PromptRequest) => {
+          promptCalls.push(input)
+          return { data: {} }
+        },
+      },
+    } as never
+    const task = createTask({
+      description: "Worktree task",
+      prompt: "Do work",
+      agent: "explore",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+      cwd: "/worktree",
+    })
+    const item = {
+      task,
+      input: {
+        description: task.description,
+        prompt: task.prompt,
+        agent: task.agent,
+        parentSessionId: task.parentSessionId,
+        parentMessageId: task.parentMessageId,
+        cwd: task.cwd,
+      },
+    }
+
+    //#when
+    await startTask(item as never, {
+      client,
+      directory: "/host",
+      concurrencyManager: { release: () => {} },
+      tmuxEnabled: false,
+      onTaskError: () => {},
+    } as never)
+    await waitForCondition(() => promptCalls.length === 1)
+
+    //#then
+    expect(createCalls[0]?.query).toEqual({ directory: "/worktree" })
+    expect(promptCalls[0]?.query).toEqual({ directory: "/worktree" })
+  })
+})
+
 describe("background-agent spawner agent-not-found fallback", () => {
   afterEach(() => {
     clearSessionPromptParams("session-fallback")

--- a/packages/omo-opencode/src/features/background-agent/spawner.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner.ts
@@ -52,7 +52,8 @@ export async function startTask(
     return null
   })
   const parentDirectory = parentSession?.data?.directory ?? directory
-  log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${parentDirectory}`)
+  const childDirectory = input.cwd ?? parentDirectory
+  log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, child dir: ${childDirectory}`)
 
   const createResult = await client.session.create({
     body: {
@@ -60,7 +61,7 @@ export async function startTask(
       ...(input.sessionPermission ? { permission: input.sessionPermission } : {}),
     } as Record<string, unknown>,
     query: {
-      directory: parentDirectory,
+      directory: childDirectory,
     },
   }).catch((error: unknown) => {
     concurrencyManager.release(concurrencyKey)
@@ -119,7 +120,7 @@ export async function startTask(
   const promptChain = promptWithRetryInDirectory(client, {
     path: { id: sessionID },
     body: promptBody,
-  }, parentDirectory).catch(async (error) => {
+  }, childDirectory).catch(async (error) => {
     if (isAgentNotFoundError(error) && input.agent !== FALLBACK_AGENT) {
       log("[background-agent] Agent not found, retrying with fallback agent", {
         original: input.agent,
@@ -136,7 +137,7 @@ export async function startTask(
         await promptWithRetryInDirectory(client, {
           path: { id: sessionID },
           body: fallbackBody,
-        }, parentDirectory)
+        }, childDirectory)
         task.agent = FALLBACK_AGENT
         return
       } catch (retryError) {

--- a/packages/omo-opencode/src/features/background-agent/spawner/task-record.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner/task-record.ts
@@ -11,6 +11,7 @@ export function buildTaskRecord(input: LaunchInput, id: string, queuedAt: Date):
     parentSessionId: input.parentSessionId,
     parentMessageId: input.parentMessageId,
     teamRunId: input.teamRunId,
+    cwd: input.cwd,
     parentModel: input.parentModel,
     parentAgent: input.parentAgent,
     parentTools: input.parentTools,

--- a/packages/omo-opencode/src/features/background-agent/types.ts
+++ b/packages/omo-opencode/src/features/background-agent/types.ts
@@ -48,6 +48,8 @@ export interface BackgroundTask {
   parentSessionId: string
   parentMessageId: string
   teamRunId?: string
+  /** Optional working directory override for the child session. */
+  cwd?: string
   description: string
   prompt: string
   agent: string
@@ -116,6 +118,8 @@ export interface LaunchInput {
   parentSessionId: string
   parentMessageId: string
   teamRunId?: string
+  /** Optional working directory override for the child session. */
+  cwd?: string
   suppressTmuxSpawn?: boolean
   parentModel?: { providerID: string; modelID: string }
   parentAgent?: string

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
@@ -298,6 +298,28 @@ describe("createTeamRun", () => {
     expect(await pathExists(path.resolve(baseDir, "./worktrees/member-2"))).toBe(false)
   })
 
+  test("passes each resolved member worktree as the background child cwd", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-worktree-cwd-"))
+    temporaryDirectories.push(baseDir)
+    let launchCount = 0
+    const { manager, launchMock } = createManager(baseDir, async () => ({
+      id: `task-${++launchCount}`,
+      sessionId: `session-${launchCount}`,
+      status: "running",
+    } as BackgroundTask))
+
+    // when
+    await createTeamRun(createSpec(2, true), "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+
+    // then
+    const launchInputs = (launchMock.mock.calls as Array<[LaunchInput]>).map(([input]) => input)
+    expect(launchInputs.map((input) => input.cwd)).toEqual([
+      path.resolve(baseDir, "./worktrees/member-1"),
+      path.resolve(baseDir, "./worktrees/member-2"),
+    ])
+  })
+
   test("returns the existing runtime on repeated calls with the same spec and lead session", async () => {
     // given
     const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-idempotent-"))

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
@@ -199,6 +199,7 @@ export async function createTeamRun(
             parentSessionId: leadSessionId,
             parentMessageId: options?.parentMessageID ?? `team-create:${runtimeState.teamRunId}:${member.name}`,
             teamRunId: runtimeState.teamRunId,
+            cwd: resource.worktreePath,
             suppressTmuxSpawn: true,
             model: resolvedMember.model,
             fallbackChain: resolvedMember.fallbackChain,


### PR DESCRIPTION
## Summary

Fix Team Mode worktree members inheriting the lead/parent session directory as their child-session cwd.

Closes #7788.

## Root cause

Team Mode already resolves each member worktree to an absolute path and includes it in the member prompt, but background child sessions still use the parent session directory for `session.create` and prompt routing. OpenCode/LSP therefore sees worktree file paths as outside the child session cwd.

## Changes

- add an optional `cwd` override to background launch/task context
- pass the resolved Team Mode worktree path into background launches
- use that cwd for child session creation and prompt routing
- preserve cwd across runtime model fallback retries
- keep retry-session links aligned with the child cwd
- cover manager, standalone spawner, fallback retry, and team runtime propagation with regression tests

The existing LSP containment/symlink safety checks are unchanged.

## Verification

Passed:

```sh
bun test \
  packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts \
  packages/omo-opencode/src/features/background-agent/spawner.test.ts \
  packages/omo-opencode/src/features/background-agent/fallback-retry-handler.test.ts \
  packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts

bunx tsgo --noEmit -p packages/omo-opencode/tsconfig.json
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Team Mode worktree members inheriting the lead session's directory as their child-session cwd; child sessions now use the member's resolved worktree path. Closes #7788.

**Changes**
- Adds an optional `cwd` override to background launch and task context.
- Passes the resolved worktree path through spawner, manager, and fallback retries.
- Routes child session creation and prompt calls through the worktree `cwd`.
- Keeps retry-session links aligned with the child `cwd`.
- Leaves existing LSP containment and symlink safety checks unchanged.

<sup>Written for commit cac958e30c55ac1c14a2590b989bbe23e4eff17c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

