### PR TITLE
fix(publish): require the canonical Codex prompt in npm payload verification

### DIFF
--- a/.omo/evidence/20260906-npm-payload-codex-prompt-gate/README.md
+++ b/.omo/evidence/20260906-npm-payload-codex-prompt-gate/README.md
@@ -1,0 +1,40 @@
+# The npm payload verifier does not require the prompt the Codex installer reads
+
+## What was tested
+
+`script/verify-npm-payload.mjs`, the gate the publish workflow runs before every `npm publish`
+(base package, `oh-my-openagent` alias, and `lazycodex-ai`), against the real `npm pack --dry-run`
+path list of this branch's base commit.
+
+- Probe: `gate-probe.mjs` computes what the shipped gate requires (shared-skills export targets only)
+  and what the added Codex-install requirement resolves to, both against the same packed path list.
+- Unit: `bun test script/npm-payload-required-paths.test.ts`.
+
+## What was observed
+
+```
+packed paths: 1222
+shipped gate (shared-skills only) missing: []
+new gate required: ["packages/prompts-core/prompts/ultrawork/codex.md"]
+new gate missing: ["packages/prompts-core/prompts/ultrawork/codex.md"]
+```
+
+| Input | Before | After |
+| --- | --- | --- |
+| real packed path list of `dev` (payload that shipped as 5.0.0-beta.43) | gate reports nothing missing | gate reports the canonical Codex prompt missing |
+| `bun test script/npm-payload-required-paths.test.ts` | file did not exist | 3 pass / 0 fail |
+| mutation: `requiredCodexInstallPaths()` returns `[]` | - | 2 of 3 tests fail, then pass again once reverted |
+
+## Why it is enough
+
+The gate ran in the 5.0.0-beta.43 publish and printed containment OK for a payload whose Codex
+install cannot run, which is the exact miss this change closes. The probe reproduces that verdict on
+the same packed path list, and the mutation shows the new assertions fail when the requirement is
+removed.
+
+## What was omitted
+
+The verifier is not executed end to end here because npm 12 changed `npm pack --json` from an array
+to an object keyed by package name, which the existing `packedPaths()` reader does not handle; CI and
+the publish workflow pin Node 24 (npm 11), where the shipped reader is correct. The probe therefore
+feeds the same real packed list into the required-path check directly instead of shimming npm.

--- a/.omo/evidence/20260906-npm-payload-codex-prompt-gate/gate-probe-output.txt
+++ b/.omo/evidence/20260906-npm-payload-codex-prompt-gate/gate-probe-output.txt
@@ -1,0 +1,4 @@
+packed paths: 1222
+shipped gate (shared-skills only) missing: []
+new gate required: ["packages/prompts-core/prompts/ultrawork/codex.md"]
+new gate missing: ["packages/prompts-core/prompts/ultrawork/codex.md"]

--- a/.omo/evidence/20260906-npm-payload-codex-prompt-gate/gate-probe.mjs
+++ b/.omo/evidence/20260906-npm-payload-codex-prompt-gate/gate-probe.mjs
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+
+import { findMissingPayloadPaths, requiredCodexInstallPaths } from "./script/npm-payload-required-paths.mjs";
+
+const raw = JSON.parse(readFileSync("pack.json", "utf8"));
+const entry = Array.isArray(raw) ? raw[0] : Object.values(raw)[0];
+const packed = entry.files.map((file) => file.path);
+
+const manifest = JSON.parse(readFileSync("packages/shared-skills/package.json", "utf8"));
+const sharedTargets = Object.values(manifest.exports ?? {}).flatMap((exportEntry) =>
+  typeof exportEntry === "string"
+    ? [exportEntry]
+    : [exportEntry?.import, exportEntry?.default].filter((target) => typeof target === "string"),
+);
+const sharedRequired = [...new Set(sharedTargets.map((target) => `packages/shared-skills/${target.replace(/^\.\//, "")}`))];
+
+console.log("packed paths:", packed.length);
+console.log("shipped gate (shared-skills only) missing:", JSON.stringify(findMissingPayloadPaths(packed, sharedRequired)));
+console.log("new gate required:", JSON.stringify(requiredCodexInstallPaths()));
+console.log("new gate missing:", JSON.stringify(findMissingPayloadPaths(packed, requiredCodexInstallPaths())));

--- a/script/npm-payload-required-paths.d.mts
+++ b/script/npm-payload-required-paths.d.mts
@@ -1,0 +1,6 @@
+export declare function requiredCodexInstallPaths(): readonly string[]
+
+export declare function findMissingPayloadPaths(
+  packedPaths: readonly string[],
+  requiredPaths: readonly string[],
+): string[]

--- a/script/npm-payload-required-paths.mjs
+++ b/script/npm-payload-required-paths.mjs
@@ -1,0 +1,16 @@
+import { sep } from "node:path"
+
+import { canonicalUltraworkDirectiveRelativePath } from "../packages/omo-codex/plugin/scripts/canonical-ultrawork-directive.mjs"
+
+// The cache installer materializes the canonical ultrawork directive into the plugin root only when
+// the published payload carries it, and sync-skills.mjs then reads it. lazycodex-ai@5.0.0-beta.43
+// shipped that path while oh-my-openagent@5.0.0-beta.43 did not, so the second payload died at
+// `npm run sync:skills` with ENOENT while passing this verifier.
+export function requiredCodexInstallPaths() {
+  return [canonicalUltraworkDirectiveRelativePath.split(sep).join("/")]
+}
+
+export function findMissingPayloadPaths(packedPaths, requiredPaths) {
+  const packed = new Set(packedPaths)
+  return requiredPaths.filter((requiredPath) => !packed.has(requiredPath))
+}

--- a/script/npm-payload-required-paths.test.ts
+++ b/script/npm-payload-required-paths.test.ts
@@ -1,0 +1,38 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { findMissingPayloadPaths, requiredCodexInstallPaths } from "./npm-payload-required-paths.mjs"
+
+const canonicalCodexPromptPath = "packages/prompts-core/prompts/ultrawork/codex.md"
+
+describe("npm payload required paths", () => {
+  test("#given the Codex install requirements #when they are resolved #then the canonical prompt is required with posix separators", () => {
+    // given / when
+    const required = requiredCodexInstallPaths()
+
+    // then
+    expect(required).toContain(canonicalCodexPromptPath)
+  })
+
+  test("#given a payload without the canonical prompt #when it is checked #then the missing path is reported", () => {
+    // given
+    const packedPaths = ["package.json", "packages/shared-skills/index.mjs"]
+
+    // when
+    const missing = findMissingPayloadPaths(packedPaths, requiredCodexInstallPaths())
+
+    // then
+    expect(missing).toEqual([canonicalCodexPromptPath])
+  })
+
+  test("#given a payload carrying the canonical prompt #when it is checked #then nothing is reported", () => {
+    // given
+    const packedPaths = ["package.json", canonicalCodexPromptPath]
+
+    // when
+    const missing = findMissingPayloadPaths(packedPaths, requiredCodexInstallPaths())
+
+    // then
+    expect(missing).toEqual([])
+  })
+})

--- a/script/verify-npm-payload.mjs
+++ b/script/verify-npm-payload.mjs
@@ -3,6 +3,8 @@
 import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 
+import { findMissingPayloadPaths, requiredCodexInstallPaths } from "./npm-payload-required-paths.mjs"
+
 const FORBIDDEN_RULES = [
   { name: "nested node_modules", matches: (path) => path.includes("node_modules/") },
   { name: "senpi payload", matches: (path) => path.startsWith("packages/omo-senpi/") },
@@ -40,10 +42,12 @@ const offenders = paths.flatMap((path) => {
   return rule ? [`${rule.name}: ${path}`] : []
 })
 
-const packed = new Set(paths)
-const missing = requiredSharedSkillsPaths().filter((path) => !packed.has(path))
+const missing = [
+  ...findMissingPayloadPaths(paths, requiredSharedSkillsPaths()),
+  ...findMissingPayloadPaths(paths, requiredCodexInstallPaths()),
+]
 if (missing.length > 0) {
-  console.error(`npm payload is missing shared-skills export targets the plugin imports (${missing.length}):`)
+  console.error(`npm payload is missing runtime paths the Codex plugin install reads (${missing.length}):`)
   for (const line of missing) console.error(`  ${line}`)
   process.exit(1)
 }


### PR DESCRIPTION
## What breaks

`script/verify-npm-payload.mjs` is the gate the publish workflow runs before every `npm publish`.
It ran during the 5.0.0-beta.43 release and printed `npm payload containment OK`, and the payload it
approved cannot install: `bunx oh-my-openagent@5.0.0-beta.43 install` dies at `npm run sync:skills`
with `ENOENT ... packages/prompts-core/prompts/ultrawork/codex.md`. The gate has no opinion about the
one file the Codex cache install has to read, so nothing stopped the release.

## Failing input

dev's own `npm pack --dry-run --json` path list, fed to the two required-path sources the verifier
has today and to the one this PR adds:

```
packed paths: 1222
shipped gate (shared-skills only) missing: []
new gate required: ["packages/prompts-core/prompts/ultrawork/codex.md"]
new gate missing: ["packages/prompts-core/prompts/ultrawork/codex.md"]
```

## Root cause

`requiredSharedSkillsPaths()` was added (#7813) after `lazycodex-ai@5.0.0-beta.43` shipped without
`skill-source-filter.mjs`, and it covers exactly the shared-skills export targets. The canonical
ultrawork directive is a second runtime input of the same install step — `copyCanonicalPromptSources`
materializes it into the plugin cache and `sync-skills.mjs` reads it — but it is not derived from any
manifest, so no required-path rule covers it.

## RED / GREEN

| Input | Before | After |
| --- | --- | --- |
| dev's real packed path list | gate reports nothing missing (exit 0) | gate reports the canonical prompt missing (exit 1) |
| `bun test script/npm-payload-required-paths.test.ts` | file did not exist | 3 pass / 0 fail |
| mutation: `requiredCodexInstallPaths()` returns `[]` | - | 2 of 3 new tests fail, green again on revert |
| `bun test script/npm-payload-containment.test.ts` | 5 pass / 0 fail | 5 pass / 0 fail (control) |

Evidence: `.omo/evidence/20260906-npm-payload-codex-prompt-gate/`.

## The fix

The required path is read from `plugin/scripts/canonical-ultrawork-directive.mjs`, the module the
installer itself uses, so the gate cannot drift from the installer, and it is normalized to posix
separators because `npm pack` reports posix paths. The existing shared-skills requirement is
untouched; both feed the same `missing` report.

## Ordering

This gate is intentionally strict: on current `dev` it fails, because the base payload really is
missing that path. #7835 adds the path to the root `files` allowlist. Merging #7835 first (or both)
keeps `publish.yml` green; merging this one alone turns the next base publish into a loud, correct
failure instead of a broken tarball.

## Scope deliberately not touched

- No change to the forbidden-path rules, the shared-skills requirement, or the workflow.
- `packedPaths()` still assumes npm's array-shaped `npm pack --json`; that is correct for the pinned
  Node 24 (npm 11) used by CI and publish, and npm 12's object shape is out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the npm publish gate so it requires the canonical Codex prompt, which the Codex installer reads at `npm run sync:skills`. The gate previously approved payloads missing `packages/prompts-core/prompts/ultrawork/codex.md`, so 5.0.0-beta.43 published broken.

- The required path is read from the installer's own `canonical-ultrawork-directive.mjs` module and normalized to posix separators, so the gate and installer cannot drift.
- The gate now fails on current `dev` because the base payload is missing that path; merge the companion PR that adds the path to the `files` allowlist to keep `publish.yml` green.

<sup>Written for commit d510125f8defb070f35ffb728bcb1776dcf827f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

