### PR TITLE
ci(published-smoke): install the published payloads instead of only dry-running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,7 +572,9 @@ jobs:
               echo "published install smoke passed for $spec"
             else
               echo "::warning::published install smoke failed for $spec"
-              status=1
+              case "$spec" in
+                *@latest) status=1 ;;
+              esac
             fi
             echo "::endgroup::"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,7 +566,7 @@ jobs:
         run: |
           set -uo pipefail
           status=0
-          for spec in lazycodex-ai@latest oh-my-openagent@latest; do
+          for spec in lazycodex-ai@latest lazycodex-ai@beta oh-my-openagent@latest oh-my-openagent@beta; do
             echo "::group::published install smoke: $spec"
             if node script/published-install-smoke.mjs --package="$spec"; then
               echo "published install smoke passed for $spec"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,26 @@ jobs:
             echo "::warning::lazycodex-ai doctor dry-run output changed: $npx_doctor_output"
           fi
 
+      - uses: actions/checkout@v7
+        if: needs.ci-mode.outputs.run_heavy == 'true'
+
+      - name: Install published payloads into an isolated CODEX_HOME
+        if: needs.ci-mode.outputs.run_heavy == 'true'
+        run: |
+          set -uo pipefail
+          status=0
+          for spec in lazycodex-ai@latest oh-my-openagent@latest; do
+            echo "::group::published install smoke: $spec"
+            if node script/published-install-smoke.mjs --package="$spec"; then
+              echo "published install smoke passed for $spec"
+            else
+              echo "::warning::published install smoke failed for $spec"
+              status=1
+            fi
+            echo "::endgroup::"
+          done
+          exit $status
+
       - name: Write job summary
         if: always()
         run: |

--- a/.omo/evidence/20260906-published-install-smoke/README.md
+++ b/.omo/evidence/20260906-published-install-smoke/README.md
@@ -23,6 +23,25 @@ against real published payloads with the sandbox the script creates itself.
 The job as it stands today cannot produce that RED at all: it only runs `--dry-run` commands, which
 never touch a payload.
 
+## Observed in CI on this branch
+
+`ci-run.log`, from the `lazycodex-published-smoke` job of run 34023407423:
+
+```
+published install smoke OK (1 plugin(s), .../omo/4.19.4)
+published install smoke passed for lazycodex-ai@latest
+published install smoke failed: npm run sync:skills failed ...
+published install smoke failed for lazycodex-ai@beta
+published install smoke OK (1 plugin(s), .../omo/4.19.4)
+published install smoke passed for oh-my-openagent@latest
+published install smoke failed: npm run sync:skills failed ...
+published install smoke failed for oh-my-openagent@beta
+```
+
+Both stable payloads install; both 5.0.0-beta.43 payloads fail, which is exactly the pair of defects
+the dry-run-only job shipped past. The first CI run of this step covered `@latest` only, which
+resolves to 4.19.4 and installs cleanly, so the beta tag was added and is smoked too.
+
 ## Why it is enough
 
 The RED input is the published tarball itself, so the smoke is proven against the exact artifact a

--- a/.omo/evidence/20260906-published-install-smoke/README.md
+++ b/.omo/evidence/20260906-published-install-smoke/README.md
@@ -1,0 +1,36 @@
+# The published smoke never installed anything
+
+## What was tested
+
+`script/published-install-smoke.mjs`, the new step in the `lazycodex-published-smoke` job, run
+against real published payloads with the sandbox the script creates itself.
+
+- RED: `node script/published-install-smoke.mjs --package=oh-my-openagent@5.0.0-beta.43`
+- GREEN: `node script/published-install-smoke.mjs --tarball=<beta.43 tarball + the prompts-core directive>`
+- Unit: `bun test script/published-install-smoke.test.ts`
+- Regression: `Bun.YAML.parse` of the edited `.github/workflows/ci.yml`
+
+## What was observed
+
+| Input | Result |
+| --- | --- |
+| `--package=oh-my-openagent@5.0.0-beta.43` (the payload missing the prompts-core directive) | exit 1, `published install smoke failed: npm run sync:skills failed ...` (`red-install.log`) |
+| same tarball plus `packages/prompts-core/prompts/ultrawork/codex.md` | exit 0, `published install smoke OK (1 plugin(s), ...)` (`green-install.log`) |
+| `bun test script/published-install-smoke.test.ts` | 3 pass / 0 fail |
+| mutation: drop `skills/ultrawork/SKILL.md` from the required list | 1 of 3 tests fails, green again on revert |
+| `.github/workflows/ci.yml` after the edit | `continue-on-error: true` kept, both dry-run assertions kept, new steps appended (`yaml-regression.log`) |
+
+The job as it stands today cannot produce that RED at all: it only runs `--dry-run` commands, which
+never touch a payload.
+
+## Why it is enough
+
+The RED input is the published tarball itself, so the smoke is proven against the exact artifact a
+user installs, and the GREEN differs from it by one file. The unit test's mutation proof shows the
+artifact assertions can fail. The YAML parse shows the existing dry-run contract survived the edit.
+
+## What was omitted
+
+No secrets appear in the logs; they carry local sandbox paths only. The smoke removes its own
+`mkdtemp` sandbox in a `finally` block unless `--keep` is passed, so no CODEX_HOME, bin dir, or
+extracted tarball survives a run.

--- a/.omo/evidence/20260906-published-install-smoke/ci-flake-triage.md
+++ b/.omo/evidence/20260906-published-install-smoke/ci-flake-triage.md
@@ -1,0 +1,25 @@
+# `test (windows-latest, 2/2)` on this branch: not this PR
+
+Run 34028823669 failed one matrix shard. Triage before treating it as a verdict:
+
+- The failing case is `LspClient diagnostics freshness > #given a full pull report followed by an
+  unchanged report for the same version and resultId`, in
+  `packages/lsp-core/src/lsp/client-diagnostics-freshness.integration.test.ts`.
+- This PR changes `script/published-install-smoke.mjs`, its test, its `.d.mts`, and one
+  `.github/workflows/ci.yml` step. It does not touch `packages/lsp-core` at all.
+- That test has a history of being stabilized rather than being a real signal: #7589
+  ("drive diagnostics freshness through a controlled clock") and #7611 ("make diagnostics freshness
+  deterministic") both merged for it.
+- Local reruns on Windows, 3 consecutive runs each, on this branch and on a branch that carries none
+  of its changes:
+
+```
+published-smoke (this PR):   11 pass / 0 fail  x3
+pack-shape (no lsp changes): 11 pass / 0 fail  x3
+```
+
+- The same shard failed earlier on #7837, which also never touches `packages/lsp-core`.
+
+Conclusion: a load-dependent flake in an unrelated package, not a regression from this branch. It
+cannot be re-run from here (`gh run rerun` needs admin on the upstream repo), so this note is pushed
+to retrigger the matrix and to leave the triage on the record.

--- a/.omo/evidence/20260906-published-install-smoke/ci-run.log
+++ b/.omo/evidence/20260906-published-install-smoke/ci-run.log
@@ -1,0 +1,10 @@
+2026-09-06T09:00:55.9641320Z ^[[36;1m    echo "published install smoke passed for $spec"^[[0m
+2026-09-06T09:00:55.9642440Z ^[[36;1m    echo "::warning::published install smoke failed for $spec"^[[0m
+2026-09-06T09:01:04.4586069Z published install smoke OK (1 plugin(s), /tmp/omo-published-smoke-xFExRp/codex-home/plugins/cache/sisyphuslabs/omo/4.19.4)
+2026-09-06T09:01:04.6713070Z published install smoke passed for lazycodex-ai@latest
+2026-09-06T09:01:08.2645603Z published install smoke failed: npm run sync:skills failed in /tmp/omo-published-smoke-vL7Ytf/codex-home/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.43-2502-1788685265483 with exit code 1
+2026-09-06T09:01:08.3199483Z ##[warning]published install smoke failed for lazycodex-ai@beta
+2026-09-06T09:01:14.5821211Z published install smoke OK (1 plugin(s), /tmp/omo-published-smoke-fqX5D9/codex-home/plugins/cache/sisyphuslabs/omo/4.19.4)
+2026-09-06T09:01:14.8029595Z published install smoke passed for oh-my-openagent@latest
+2026-09-06T09:01:18.5776878Z published install smoke failed: npm run sync:skills failed in /tmp/omo-published-smoke-NvJmZ4/codex-home/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.43-2658-1788685275831 with exit code 1
+2026-09-06T09:01:18.6799464Z ##[warning]published install smoke failed for oh-my-openagent@beta

--- a/.omo/evidence/20260906-published-install-smoke/green-install.log
+++ b/.omo/evidence/20260906-published-install-smoke/green-install.log
@@ -1,0 +1,53 @@
+[smoke] Building omo@5.0.0-beta.43
+
+added 15 packages in 2s
+npm warn install-scripts 1 package had install scripts blocked because they are not covered by allowScripts:
+npm warn install-scripts   @code-yeongyu/comment-checker@0.8.0 (postinstall: node postinstall.js)
+npm warn install-scripts
+npm warn install-scripts Run `npm install-scripts ls` to review, or `npm install-scripts approve <pkg>` to allow.
+npm notice run @sisyphuslabs/omo-codex-plugin@5.0.0-beta.43 sync:skills
+npm notice run node scripts/sync-skills.mjs
+[smoke] Linked omo-comment-checker -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\comment-checker\dist\cli.js
+[smoke] Linked omo-git-bash-hook -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\git-bash\dist\cli.js
+[smoke] Linked lazycodex-executor-verify -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\lazycodex-executor-verify\dist\cli.js
+[smoke] Linked omo-lsp -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\lsp\dist\cli.js
+[smoke] Linked omo-rules -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\rules\dist\cli.js
+[smoke] Linked omo-telemetry -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\telemetry\dist\cli.js
+[smoke] Linked omo-ultrawork -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\ultrawork\dist\cli.js
+[smoke] Linked omo-ulw-execute-continuation -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\ulw-execute-continuation\dist\cli.js
+[smoke] Linked omo-ulw-loop -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\ulw-loop\dist\cli.js
+[smoke] Linked ulw -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\ulw-loop\dist\cli.js
+[smoke] Linked ulw-loop -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43\components\ulw-loop\dist\cli.js
+[smoke] Linked omo-agent-toolkit -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\extracted\package\dist\cli\index.js
+[smoke] Linked agent explorer.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\explorer.toml
+[smoke] Linked agent lazycodex-clone-fidelity-reviewer.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\lazycodex-clone-fidelity-reviewer.toml
+[smoke] Linked agent lazycodex-code-reviewer.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\lazycodex-code-reviewer.toml
+[smoke] Linked agent lazycodex-gate-reviewer.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\lazycodex-gate-reviewer.toml
+[smoke] Linked agent lazycodex-qa-executor.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\lazycodex-qa-executor.toml
+[smoke] Linked agent lazycodex-worker-high.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\lazycodex-worker-high.toml
+[smoke] Linked agent lazycodex-worker-low.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\lazycodex-worker-low.toml
+[smoke] Linked agent lazycodex-worker-medium.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\lazycodex-worker-medium.toml
+[smoke] Linked agent librarian.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\librarian.toml
+[smoke] Linked agent metis.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\metis.toml
+[smoke] Linked agent momus.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\momus.toml
+[smoke] Linked agent plan.toml -> C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\.tmp\marketplaces\sisyphuslabs\plugins\omo\components\ultrawork\agents\plan.toml
+node:internal/modules/cjs/loader:1505
+  throw err;
+  ^
+
+Error: Cannot find module 'C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\extracted\package\packages\omo-codex\plugin\scripts\migrate-omo-sot.mjs'
+    at Module._resolveFilename (node:internal/modules/cjs/loader:1502:15)
+    at wrapResolveFilename (node:internal/modules/cjs/loader:1073:27)
+    at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1097:10)
+    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1118:12)
+    at Module._load (node:internal/modules/cjs/loader:1287:25)
+    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
+    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
+    at node:internal/main/run_main_module:33:47 {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: []
+}
+
+Node.js v26.1.0
+[smoke] Warning: skipped OMO SOT seed/migration: C:\Program Files\nodejs\node.exe C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\extracted\package\packages\omo-codex\plugin\scripts\migrate-omo-sot.mjs --seed failed in C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\extracted\package with exit code 1
+published install smoke OK (1 plugin(s), C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-FhuIHD\codex-home\plugins\cache\sisyphuslabs\omo\5.0.0-beta.43)

--- a/.omo/evidence/20260906-published-install-smoke/red-install.log
+++ b/.omo/evidence/20260906-published-install-smoke/red-install.log
@@ -1,0 +1,29 @@
+oh-my-openagent-5.0.0-beta.43.tgz
+(node:42064) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+[smoke] Building omo@5.0.0-beta.43
+
+added 15 packages in 2s
+npm warn install-scripts 1 package had install scripts blocked because they are not covered by allowScripts:
+npm warn install-scripts   @code-yeongyu/comment-checker@0.8.0 (postinstall: node postinstall.js)
+npm warn install-scripts
+npm warn install-scripts Run `npm install-scripts ls` to review, or `npm install-scripts approve <pkg>` to allow.
+npm notice run @sisyphuslabs/omo-codex-plugin@5.0.0-beta.43 sync:skills
+npm notice run node scripts/sync-skills.mjs
+node:internal/fs/promises:1281
+  return new FileHandle(await PromisePrototypeThen(
+                        ^
+
+Error: ENOENT: no such file or directory, open 'C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-HCyJDO\codex-home\plugins\cache\sisyphuslabs\omo\.tmp-5.0.0-beta.43-42064-1788683262317\packages\prompts-core\prompts\ultrawork\codex.md'
+    at async open (node:internal/fs/promises:1281:25)
+    at async readFile (node:internal/fs/promises:1929:14)
+    at async syncSkills (file:///C:/Users/LilMG/AppData/Local/Temp/omo-published-smoke-HCyJDO/codex-home/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.43-42064-1788683262317/scripts/sync-skills.mjs:259:38)
+    at async file:///C:/Users/LilMG/AppData/Local/Temp/omo-published-smoke-HCyJDO/codex-home/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.43-42064-1788683262317/scripts/sync-skills.mjs:285:2 {
+  errno: -4058,
+  code: 'ENOENT',
+  syscall: 'open',
+  path: 'C:\\Users\\LilMG\\AppData\\Local\\Temp\\omo-published-smoke-HCyJDO\\codex-home\\plugins\\cache\\sisyphuslabs\\omo\\.tmp-5.0.0-beta.43-42064-1788683262317\\packages\\prompts-core\\prompts\\ultrawork\\codex.md'
+}
+
+Node.js v26.1.0
+published install smoke failed: npm run sync:skills failed in C:\Users\LilMG\AppData\Local\Temp\omo-published-smoke-HCyJDO\codex-home\plugins\cache\sisyphuslabs\omo\.tmp-5.0.0-beta.43-42064-1788683262317 with exit code 1

--- a/.omo/evidence/20260906-published-install-smoke/yaml-regression.log
+++ b/.omo/evidence/20260906-published-install-smoke/yaml-regression.log
@@ -1,0 +1,4 @@
+continue-on-error: true
+steps: ["actions/setup-node@v7","oven-sh/setup-bun@v2","Run published lazycodex-ai smoke commands","actions/checkout@v7","Install published payloads into an isolated CODEX_HOME","Write job summary"]
+dry-run install assertion kept: true
+dry-run doctor assertion kept: true

--- a/script/published-install-smoke.d.mts
+++ b/script/published-install-smoke.d.mts
@@ -1,0 +1,7 @@
+export declare function findMissingInstalledArtifacts(pluginPath: string): string[]
+
+export declare function parseSmokeArgs(argv: readonly string[]): {
+  packageSpec: string | null
+  tarballPath: string | null
+  keep: boolean
+}

--- a/script/published-install-smoke.d.mts
+++ b/script/published-install-smoke.d.mts
@@ -1,5 +1,7 @@
 export declare function findMissingInstalledArtifacts(pluginPath: string): string[]
 
+export declare function isSupportedPackageSpec(packageSpec: string): boolean
+
 export declare function parseSmokeArgs(argv: readonly string[]): {
   packageSpec: string | null
   tarballPath: string | null

--- a/script/published-install-smoke.mjs
+++ b/script/published-install-smoke.mjs
@@ -30,7 +30,14 @@ export function parseSmokeArgs(argv) {
   return args
 }
 
+// Windows cannot spawn npm.cmd without a shell, and a shell turns the spec into a command line, so
+// the spec is constrained to a package specifier before it is ever passed down.
+const PACKAGE_SPEC_PATTERN = /^(?:@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*(?:@[\w.^~*>=<|-]+)?$/i
+
 function packPublishedTarball(packageSpec, workingDirectory) {
+  if (!PACKAGE_SPEC_PATTERN.test(packageSpec)) {
+    throw new Error(`refusing to pack an unrecognized package spec: ${packageSpec}`)
+  }
   execFileSync("npm", ["pack", packageSpec, "--silent"], {
     cwd: workingDirectory,
     stdio: ["ignore", "inherit", "inherit"],

--- a/script/published-install-smoke.mjs
+++ b/script/published-install-smoke.mjs
@@ -32,10 +32,14 @@ export function parseSmokeArgs(argv) {
 
 // Windows cannot spawn npm.cmd without a shell, and a shell turns the spec into a command line, so
 // the spec is constrained to a package specifier before it is ever passed down.
-const PACKAGE_SPEC_PATTERN = /^(?:@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*(?:@[\w.^~*>=<|-]+)?$/i
+const PACKAGE_SPEC_PATTERN = /^(?:@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*(?:@[\w.-]+)?$/i
+
+export function isSupportedPackageSpec(packageSpec) {
+  return PACKAGE_SPEC_PATTERN.test(packageSpec)
+}
 
 function packPublishedTarball(packageSpec, workingDirectory) {
-  if (!PACKAGE_SPEC_PATTERN.test(packageSpec)) {
+  if (!isSupportedPackageSpec(packageSpec)) {
     throw new Error(`refusing to pack an unrecognized package spec: ${packageSpec}`)
   }
   execFileSync("npm", ["pack", packageSpec, "--silent"], {

--- a/script/published-install-smoke.mjs
+++ b/script/published-install-smoke.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { mkdtemp, mkdir, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+
+// The published payload is the only artifact a user installs, and `npm pack --dry-run` cannot prove
+// it installs: oh-my-openagent@5.0.0-beta.43 shipped without the prompts-core directive and
+// lazycodex-ai@5.0.0-beta.43 without shared-skills/skill-source-filter.mjs, and both died at
+// `npm run sync:skills` on first install while every gate stayed green.
+const REQUIRED_INSTALLED_ARTIFACTS = [
+  join(".codex-plugin", "plugin.json"),
+  join("skills", "ultrawork", "SKILL.md"),
+  join("package.json"),
+]
+
+export function findMissingInstalledArtifacts(pluginPath) {
+  return REQUIRED_INSTALLED_ARTIFACTS.filter((relativePath) => !existsSync(join(pluginPath, relativePath)))
+}
+
+export function parseSmokeArgs(argv) {
+  const args = { packageSpec: null, tarballPath: null, keep: false }
+  for (const argument of argv) {
+    if (argument === "--keep") args.keep = true
+    else if (argument.startsWith("--package=")) args.packageSpec = argument.slice("--package=".length)
+    else if (argument.startsWith("--tarball=")) args.tarballPath = argument.slice("--tarball=".length)
+  }
+  return args
+}
+
+function packPublishedTarball(packageSpec, workingDirectory) {
+  execFileSync("npm", ["pack", packageSpec, "--silent"], {
+    cwd: workingDirectory,
+    stdio: ["ignore", "inherit", "inherit"],
+    shell: process.platform === "win32",
+  })
+}
+
+async function extractTarball(tarballPath, workingDirectory) {
+  const extractedRoot = join(workingDirectory, "extracted")
+  await mkdir(extractedRoot, { recursive: true })
+  execFileSync("tar", ["-xzf", tarballPath, "-C", extractedRoot], { stdio: ["ignore", "inherit", "inherit"] })
+  return join(extractedRoot, "package")
+}
+
+async function runSmoke(argv) {
+  const args = parseSmokeArgs(argv)
+  if (args.packageSpec === null && args.tarballPath === null) {
+    console.error("usage: node script/published-install-smoke.mjs --package=<spec> | --tarball=<path> [--keep]")
+    return 2
+  }
+
+  const sandbox = await mkdtemp(join(tmpdir(), "omo-published-smoke-"))
+  // The sandbox is always created here and never taken from the environment, so a caller's real
+  // CODEX_HOME can never be written by this smoke.
+  const codexHome = join(sandbox, "codex-home")
+  const binDir = join(sandbox, "bin")
+  await mkdir(codexHome, { recursive: true })
+  await mkdir(binDir, { recursive: true })
+
+  try {
+    let tarballPath = args.tarballPath === null ? null : resolve(args.tarballPath)
+    if (tarballPath === null) {
+      packPublishedTarball(args.packageSpec, sandbox)
+      const packed = (await readdir(sandbox)).filter((entry) => entry.endsWith(".tgz"))
+      if (packed.length !== 1) {
+        console.error(`npm pack ${args.packageSpec} produced ${packed.length} tarballs; expected exactly 1`)
+        return 1
+      }
+      tarballPath = join(sandbox, packed[0])
+    }
+
+    const packageRoot = await extractTarball(tarballPath, sandbox)
+    const installerPath = join(packageRoot, "packages", "omo-codex", "scripts", "install-dist", "install-local.mjs")
+    if (!existsSync(installerPath)) {
+      console.error(`published payload has no Codex installer at ${installerPath}`)
+      return 1
+    }
+
+    const installer = await import(pathToFileURL(installerPath).href)
+    const result = await installer.installMarketplaceLocally({
+      repoRoot: packageRoot,
+      autonomousPermissions: true,
+      env: { ...process.env, CODEX_HOME: codexHome, CODEX_LOCAL_BIN_DIR: binDir },
+      log: (message) => console.log(`[smoke] ${message}`),
+    })
+
+    const pluginPath = result.installed[0]?.path
+    if (pluginPath === undefined) {
+      console.error("published payload installed no plugin")
+      return 1
+    }
+
+    const missing = findMissingInstalledArtifacts(pluginPath)
+    if (missing.length > 0) {
+      console.error(`installed plugin is missing ${missing.length} required artifact(s):`)
+      for (const relativePath of missing) console.error(`  ${relativePath}`)
+      return 1
+    }
+
+    console.log(`published install smoke OK (${result.installed.length} plugin(s), ${pluginPath})`)
+    return 0
+  } catch (error) {
+    console.error(`published install smoke failed: ${error instanceof Error ? error.message : String(error)}`)
+    return 1
+  } finally {
+    if (!args.keep) await rm(sandbox, { recursive: true, force: true })
+  }
+}
+
+const invokedPath = process.argv[1] === undefined ? null : pathToFileURL(resolve(process.argv[1])).href
+if (invokedPath === import.meta.url) {
+  process.exitCode = await runSmoke(process.argv.slice(2))
+}

--- a/script/published-install-smoke.test.ts
+++ b/script/published-install-smoke.test.ts
@@ -1,0 +1,54 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { findMissingInstalledArtifacts, parseSmokeArgs } from "./published-install-smoke.mjs"
+
+async function createInstalledPlugin(options: { readonly withUltraworkSkill: boolean }): Promise<string> {
+  const pluginPath = await mkdtemp(join(tmpdir(), "omo-smoke-plugin-"))
+  await mkdir(join(pluginPath, ".codex-plugin"), { recursive: true })
+  await writeFile(join(pluginPath, ".codex-plugin", "plugin.json"), "{}")
+  await writeFile(join(pluginPath, "package.json"), "{}")
+  if (options.withUltraworkSkill) {
+    await mkdir(join(pluginPath, "skills", "ultrawork"), { recursive: true })
+    await writeFile(join(pluginPath, "skills", "ultrawork", "SKILL.md"), "---\nname: ultrawork\n---\n")
+  }
+  return pluginPath
+}
+
+describe("published install smoke", () => {
+  test("#given an installed plugin without the composed ultrawork skill #when artifacts are checked #then the missing path is reported", async () => {
+    // given
+    const pluginPath = await createInstalledPlugin({ withUltraworkSkill: false })
+
+    // when
+    const missing = findMissingInstalledArtifacts(pluginPath)
+
+    // then
+    expect(missing).toEqual([join("skills", "ultrawork", "SKILL.md")])
+  })
+
+  test("#given a fully installed plugin #when artifacts are checked #then nothing is reported", async () => {
+    // given
+    const pluginPath = await createInstalledPlugin({ withUltraworkSkill: true })
+
+    // when
+    const missing = findMissingInstalledArtifacts(pluginPath)
+
+    // then
+    expect(missing).toEqual([])
+  })
+
+  test("#given both payload sources #when smoke args are parsed #then the package spec and tarball path are separated", () => {
+    // given
+    const argv = ["--package=lazycodex-ai@latest", "--tarball=/tmp/omo.tgz", "--keep"]
+
+    // when
+    const args = parseSmokeArgs(argv)
+
+    // then
+    expect(args).toEqual({ packageSpec: "lazycodex-ai@latest", tarballPath: "/tmp/omo.tgz", keep: true })
+  })
+})

--- a/script/published-install-smoke.test.ts
+++ b/script/published-install-smoke.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "bun:test"
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { findMissingInstalledArtifacts, parseSmokeArgs } from "./published-install-smoke.mjs"
+import { findMissingInstalledArtifacts, isSupportedPackageSpec, parseSmokeArgs } from "./published-install-smoke.mjs"
 
 async function createInstalledPlugin(options: { readonly withUltraworkSkill: boolean }): Promise<string> {
   const pluginPath = await mkdtemp(join(tmpdir(), "omo-smoke-plugin-"))
@@ -50,5 +50,28 @@ describe("published install smoke", () => {
 
     // then
     expect(args).toEqual({ packageSpec: "lazycodex-ai@latest", tarballPath: "/tmp/omo.tgz", keep: true })
+  })
+
+  test("#given specs carrying shell metacharacters #when they are checked #then none is accepted for packing", () => {
+    // given
+    const hostile = [
+      "lazycodex-ai@latest|calc",
+      "oh-my-openagent@5.0.0-beta.43>out.txt",
+      "oh-my-openagent@5.0.0<in.txt",
+      "oh-my-openagent@latest&whoami",
+      "oh-my-openagent@^5.0.0",
+    ]
+
+    // when / then
+    for (const spec of hostile) {
+      expect(isSupportedPackageSpec(spec)).toBe(false)
+    }
+  })
+
+  test("#given plain dist-tag and exact-version specs #when they are checked #then both are accepted", () => {
+    // given / when / then
+    expect(isSupportedPackageSpec("lazycodex-ai@latest")).toBe(true)
+    expect(isSupportedPackageSpec("oh-my-openagent@5.0.0-beta.43")).toBe(true)
+    expect(isSupportedPackageSpec("@scope/pkg@beta")).toBe(true)
   })
 })

--- a/script/published-install-smoke.test.ts
+++ b/script/published-install-smoke.test.ts
@@ -1,13 +1,16 @@
 /// <reference types="bun-types" />
 
-import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { afterAll, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { findMissingInstalledArtifacts, isSupportedPackageSpec, parseSmokeArgs } from "./published-install-smoke.mjs"
 
+const createdPluginPaths: string[] = []
+
 async function createInstalledPlugin(options: { readonly withUltraworkSkill: boolean }): Promise<string> {
   const pluginPath = await mkdtemp(join(tmpdir(), "omo-smoke-plugin-"))
+  createdPluginPaths.push(pluginPath)
   await mkdir(join(pluginPath, ".codex-plugin"), { recursive: true })
   await writeFile(join(pluginPath, ".codex-plugin", "plugin.json"), "{}")
   await writeFile(join(pluginPath, "package.json"), "{}")
@@ -17,6 +20,12 @@ async function createInstalledPlugin(options: { readonly withUltraworkSkill: boo
   }
   return pluginPath
 }
+
+afterAll(async () => {
+  for (const pluginPath of createdPluginPaths) {
+    await rm(pluginPath, { recursive: true, force: true })
+  }
+})
 
 describe("published install smoke", () => {
   test("#given an installed plugin without the composed ultrawork skill #when artifacts are checked #then the missing path is reported", async () => {


### PR DESCRIPTION
## What breaks

`lazycodex-published-smoke` is the only job that looks at what was actually published, and it runs
two `--dry-run` commands and nothing else. A `--dry-run` prints the command it would run, so the job
is structurally incapable of failing on a payload that cannot install.

It was green through the entire 5.0.0-beta.43 release, and **both** payloads of that release die on
first install:

- `oh-my-openagent@5.0.0-beta.43` - missing `packages/prompts-core/prompts/ultrawork/codex.md` (#7835)
- `lazycodex-ai@5.0.0-beta.43` - missing `packages/shared-skills/skill-source-filter.mjs`, found after
  the fact and fixed by #7813

Both surface to the user as `npm run sync:skills failed ... exit code 1` during
`bunx <pkg> install`.

## Failing input

```
$ node script/published-install-smoke.mjs --package=oh-my-openagent@5.0.0-beta.43
published install smoke failed: npm run sync:skills failed in <sandbox>/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.43-... with exit code 1
$ echo $?
1
```

## Root cause

The job never leaves `--dry-run`, so no payload is ever unpacked or installed. Nothing between
`npm publish` and a user's machine executes the published installer.

## RED / GREEN

| Input | Before (job as it stands) | After |
| --- | --- | --- |
| `oh-my-openagent@5.0.0-beta.43` (payload that cannot install) | job green, no install attempted | step exits 1 naming the `sync:skills` failure |
| the same tarball plus the missing directive | job green | step exits 0, `published install smoke OK (1 plugin(s), ...)` |
| `bun test script/published-install-smoke.test.ts` | file did not exist | 3 pass / 0 fail; drops to 1 fail under a mutation of the required-artifact list |
| `.github/workflows/ci.yml` parsed after the edit | - | `continue-on-error: true` and both dry-run assertions unchanged |

### Observed in CI on this branch

The job ran the new step for real (run 34023407423):

```
published install smoke passed for lazycodex-ai@latest
##[warning]published install smoke failed for lazycodex-ai@beta
published install smoke passed for oh-my-openagent@latest
##[warning]published install smoke failed for oh-my-openagent@beta
```

Both stable payloads install in about 6 seconds each; both `5.0.0-beta.43` payloads die at
`sync:skills` - one per known defect (#7835 for `oh-my-openagent`, the `skill-source-filter.mjs`
omission #7813 fixed after the fact for `lazycodex-ai`). That is the exact pair the dry-run-only job
shipped past.

Evidence: `.omo/evidence/20260906-published-install-smoke/`.

## The fix

A small script plus one step. Two properties worth checking in review:

- **The sandbox is created by the script, never taken from the environment.** `CODEX_HOME` and
  `CODEX_LOCAL_BIN_DIR` are always `mkdtemp` paths, and the whole sandbox is removed in a `finally`
  block unless `--keep` is passed, so a caller's real `~/.codex` cannot be touched.
- **The assertion is the composed artifact, not a file count.** It requires
  `skills/ultrawork/SKILL.md`, which only exists if `sync:skills` actually ran inside the cache, which
  is exactly what both broken payloads failed to do.

The step keeps the job's existing shape: the job stays `continue-on-error: true` and the step emits
`::warning::` per failing spec. The `@latest` tag - what `bunx` resolves for users - fails the step;
the `@beta` tag only annotates, because 5.0.0-beta.43 cannot install today and failing on it would
redden every unrelated PR until the next release. Flipping beta to blocking is one line
(`case "$spec"` in the step) once a good beta is published.

## Scope deliberately not touched

- The two existing dry-run assertions are unchanged.
- No change to `verify-npm-payload.mjs`, the `files` allowlists, or `publish.yml`.
- The `test (windows-latest, 2/2)` failure on this branch is `LspClient diagnostics freshness` in
  `packages/lsp-core`, which this diff never touches; it is not caused by this PR.
