### PR TITLE
fix(publish): read both npm pack --json shapes in the payload verifier

### DIFF
--- a/.omo/evidence/20260906-npm-pack-json-shape/README.md
+++ b/.omo/evidence/20260906-npm-pack-json-shape/README.md
@@ -1,0 +1,40 @@
+# The payload verifier reads only npm 11's pack --json shape
+
+## What was tested
+
+`script/verify-npm-payload.mjs`, the gate `publish.yml` runs before every `npm publish`, against
+real `npm pack --dry-run --json` output produced by npm 12.0.2 on this machine (1222 packed paths).
+
+## What was observed
+
+`red-npm12.log`, both readers on the same real npm 12 payload:
+
+```
+old reader THROWS: TypeError: parsed is not iterable
+new reader -> 1222 paths
+new reader first path: .agents/command/get-unpublished-changes.md
+```
+
+| Input | Before | After |
+| --- | --- | --- |
+| real npm 12 `pack --json` output | `TypeError: parsed is not iterable` | 1222 paths, identical to the npm 11 shape |
+| npm 11 array output | 2 paths | 2 paths (unchanged) |
+| output of neither shape (`[]`, `{}`, `null`, a result without `files`) | read of undefined | `Error: npm pack --json returned no packed file list` |
+| whole verifier end to end on the npm 12 payload | could not reach the checks | `npm payload containment OK (1222 packed paths, 0 offenders)`, exit 0 |
+
+Unit run: `green-unit.log`, 3 pass / 0 fail. Verifier run: `green-verifier.log`.
+
+## Why it is enough
+
+The RED is real registry-tool output from this repository, not a synthetic fixture, and the GREEN
+run drives the actual script rather than the extracted helper. Severity is forward-looking: CI and
+`publish.yml` pin Node 24 (npm 11) today, so this is the gate breaking the day that pin moves, plus
+a named error instead of a read-of-undefined for any other shape.
+
+## What was omitted
+
+The end-to-end verifier run substitutes the `npm pack` spawn with the saved npm 12 payload for the
+duration of that one run, because `execFileSync("npm", ...)` cannot resolve `npm.cmd` on Windows
+without a shell (`spawnSync npm ENOENT`). That Windows spawn gap is a separate defect and is not
+fixed here. The substitution was reverted with `git checkout --` immediately after the capture; the
+committed script still spawns npm. No secrets appear in the logs.

--- a/.omo/evidence/20260906-npm-pack-json-shape/green-unit.log
+++ b/.omo/evidence/20260906-npm-pack-json-shape/green-unit.log
@@ -1,0 +1,11 @@
+bun test v1.3.14 (0d9b296a)
+
+script\npm-pack-paths.test.ts:
+(pass) npm pack path reader > #given npm 11 array output #when packed paths are read #then every packed path is returned [2.74ms]
+(pass) npm pack path reader > #given npm 12 object output keyed by package name #when packed paths are read #then the same paths are returned [1.02ms]
+(pass) npm pack path reader > #given output of neither shape #when packed paths are read #then it fails naming npm pack instead of throwing on undefined [9.17ms]
+
+ 3 pass
+ 0 fail
+ 6 expect() calls
+Ran 3 tests across 1 file. [1.66s]

--- a/.omo/evidence/20260906-npm-pack-json-shape/green-verifier.log
+++ b/.omo/evidence/20260906-npm-pack-json-shape/green-verifier.log
@@ -1,0 +1,1 @@
+npm payload containment OK (1222 packed paths, 0 offenders)

--- a/.omo/evidence/20260906-npm-pack-json-shape/red-npm12.log
+++ b/.omo/evidence/20260906-npm-pack-json-shape/red-npm12.log
@@ -1,0 +1,3 @@
+old reader THROWS: TypeError: parsed is not iterable
+new reader -> 1222 paths
+new reader first path: .agents/command/get-unpublished-changes.md

--- a/.omo/evidence/20260907-rebase-7840/combined-verifier.log
+++ b/.omo/evidence/20260907-rebase-7840/combined-verifier.log
@@ -1,0 +1,4 @@
+imports present: 2 of 2 (npm-pack-paths.mjs + npm-payload-required-paths.mjs)
+npm payload containment OK (1260 packed paths, 0 offenders)
+exit=0
+note: the npm spawn was temporarily substituted with saved npm 12.0.2 pack output for this capture because the Windows spawn fix lives in PR #7844; the substitution was reverted with git checkout -- and git status is clean.

--- a/.omo/evidence/20260907-rebase-7840/green-rebased.log
+++ b/.omo/evidence/20260907-rebase-7840/green-rebased.log
@@ -1,0 +1,21 @@
+bun test v1.3.14 (0d9b296a)
+
+script\npm-pack-paths.test.ts:
+(pass) npm pack path reader > #given npm 11 array output #when packed paths are read #then every packed path is returned [7.58ms]
+(pass) npm pack path reader > #given npm 12 object output keyed by package name #when packed paths are read #then the same paths are returned [2.88ms]
+(pass) npm pack path reader > #given output of neither shape #when packed paths are read #then it fails naming npm pack instead of throwing on undefined [4.99ms]
+(pass) npm pack path reader > #given output that is not JSON at all #when packed paths are read #then it fails naming npm pack rather than raising a bare SyntaxError [4.78ms]
+(pass) npm pack path reader > #given a packed entry without a string path #when packed paths are read #then it fails naming the entry [3.83ms]
+
+script\npm-payload-containment.test.ts:
+(pass) root npm payload containment > #given root files allowlist #when senpi containment is checked #then senpi plugin payload is not shipped [5.92ms]
+(pass) root npm payload containment > #given root files allowlist #when hygiene negations are checked #then nested node_modules and retired component residue are excluded [17.25ms]
+(pass) root npm payload containment > #given root files allowlist #when vendored MCP shipping is checked #then each ships its package.json alongside dist [2.36ms]
+(pass) root npm payload containment > #given root files allowlist #when the Codex plugin payload is checked #then the canonical prompts-core directive sync:skills reads is shipped [2.63ms]
+(pass) lazycodex-ai publish payload containment > #given publish workflow files override #when hygiene negations are checked #then the rewritten files list carries the same exclusions [12.87ms]
+(pass) lazycodex-ai publish payload containment > #given publish workflow #when payload guards are checked #then verify-npm-payload runs before both npm publish paths [3.10ms]
+
+ 11 pass
+ 0 fail
+ 27 expect() calls
+Ran 11 tests across 2 files. [12.99s]

--- a/script/npm-pack-paths.d.mts
+++ b/script/npm-pack-paths.d.mts
@@ -1,0 +1,1 @@
+export declare function parseNpmPackPaths(raw: string): string[]

--- a/script/npm-pack-paths.mjs
+++ b/script/npm-pack-paths.mjs
@@ -1,0 +1,13 @@
+// npm 11 prints `npm pack --json` as an array of package results; npm 12 (the npm bundled with
+// Node 26) prints an object keyed by package name. Reading only the array shape throws
+// "TypeError: parsed is not iterable" on npm 12, which reads as a broken script rather than a
+// version difference.
+export function parseNpmPackPaths(raw) {
+  const parsed = JSON.parse(raw)
+  const results = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {})
+  const [result] = results
+  if (result === null || typeof result !== "object" || !Array.isArray(result.files)) {
+    throw new Error("npm pack --json returned no packed file list; expected an array of results or an object keyed by package name")
+  }
+  return result.files.map((file) => file.path)
+}

--- a/script/npm-pack-paths.mjs
+++ b/script/npm-pack-paths.mjs
@@ -3,11 +3,21 @@
 // "TypeError: parsed is not iterable" on npm 12, which reads as a broken script rather than a
 // version difference.
 export function parseNpmPackPaths(raw) {
-  const parsed = JSON.parse(raw)
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    throw new Error(`npm pack --json did not return JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
   const results = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {})
   const [result] = results
   if (result === null || typeof result !== "object" || !Array.isArray(result.files)) {
     throw new Error("npm pack --json returned no packed file list; expected an array of results or an object keyed by package name")
   }
-  return result.files.map((file) => file.path)
+  return result.files.map((file) => {
+    if (file === null || typeof file !== "object" || typeof file.path !== "string") {
+      throw new Error("npm pack --json returned a packed entry without a string path")
+    }
+    return file.path
+  })
 }

--- a/script/npm-pack-paths.test.ts
+++ b/script/npm-pack-paths.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { parseNpmPackPaths } from "./npm-pack-paths.mjs"
+
+const npm11Output = JSON.stringify([{ id: "oh-my-opencode@5.0.0", files: [{ path: "package.json" }, { path: "bin/omo.js" }] }])
+const npm12Output = JSON.stringify({
+  "oh-my-opencode": { id: "oh-my-opencode@5.0.0", files: [{ path: "package.json" }, { path: "bin/omo.js" }] },
+})
+
+describe("npm pack path reader", () => {
+  test("#given npm 11 array output #when packed paths are read #then every packed path is returned", () => {
+    // given / when
+    const paths = parseNpmPackPaths(npm11Output)
+
+    // then
+    expect(paths).toEqual(["package.json", "bin/omo.js"])
+  })
+
+  test("#given npm 12 object output keyed by package name #when packed paths are read #then the same paths are returned", () => {
+    // given / when
+    const paths = parseNpmPackPaths(npm12Output)
+
+    // then
+    expect(paths).toEqual(parseNpmPackPaths(npm11Output))
+  })
+
+  test("#given output of neither shape #when packed paths are read #then it fails naming npm pack instead of throwing on undefined", () => {
+    // given
+    const malformed = ["[]", "{}", "null", '{"pkg":{"id":"x"}}']
+
+    // when / then
+    for (const raw of malformed) {
+      expect(() => parseNpmPackPaths(raw)).toThrow("npm pack --json returned no packed file list")
+    }
+  })
+})

--- a/script/npm-pack-paths.test.ts
+++ b/script/npm-pack-paths.test.ts
@@ -34,4 +34,22 @@ describe("npm pack path reader", () => {
       expect(() => parseNpmPackPaths(raw)).toThrow("npm pack --json returned no packed file list")
     }
   })
+
+  test("#given output that is not JSON at all #when packed paths are read #then it fails naming npm pack rather than raising a bare SyntaxError", () => {
+    // given
+    const notJson = ["", "npm warn config production Use --omit=dev instead."]
+
+    // when / then
+    for (const raw of notJson) {
+      expect(() => parseNpmPackPaths(raw)).toThrow("npm pack --json did not return JSON")
+    }
+  })
+
+  test("#given a packed entry without a string path #when packed paths are read #then it fails naming the entry", () => {
+    // given
+    const rawEntry = JSON.stringify([{ id: "x", files: [{ path: "package.json" }, { size: 12 }] }])
+
+    // when / then
+    expect(() => parseNpmPackPaths(rawEntry)).toThrow("packed entry without a string path")
+  })
 })

--- a/script/verify-npm-payload.mjs
+++ b/script/verify-npm-payload.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 
 import { findMissingPayloadPaths, requiredCodexInstallPaths } from "./npm-payload-required-paths.mjs"
+import { parseNpmPackPaths } from "./npm-pack-paths.mjs"
 
 const FORBIDDEN_RULES = [
   { name: "nested node_modules", matches: (path) => path.includes("node_modules/") },
@@ -32,8 +33,7 @@ function packedPaths() {
     maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "inherit"],
   })
-  const [result] = JSON.parse(raw)
-  return result.files.map((file) => file.path)
+  return parseNpmPackPaths(raw)
 }
 
 const paths = packedPaths()


### PR DESCRIPTION
## What breaks

`script/verify-npm-payload.mjs` is the last gate before `npm publish`. On npm 12 it dies before it
checks a single path:

```
TypeError: parsed is not iterable
    at packedPaths (script/verify-npm-payload.mjs:33)
```

npm 11 prints `npm pack --json` as an array of package results; **npm 12 prints an object keyed by
package name**, and npm 12 is the npm bundled with Node 26. `publish.yml` and `ci.yml` pin Node 24
today, so this is not breaking CI right now - it breaks the day that pin moves, and it already breaks
every local run of the script on a current Node.

## Failing input

Real output from this repository, `npm pack --dry-run --json --ignore-scripts` on npm 12.0.2:

```
old reader THROWS: TypeError: parsed is not iterable
new reader -> 1222 paths
new reader first path: .agents/command/get-unpublished-changes.md
```

## Root cause

`packedPaths()` destructures the array form directly:

```js
const [result] = JSON.parse(raw)
return result.files.map((file) => file.path)
```

Any non-array shape throws on the destructure, and a result without `files` throws a
read-of-undefined - neither names npm pack, so the failure reads as a broken script.

## RED / GREEN

| Input | Before | After |
| --- | --- | --- |
| real npm 12 `pack --json` output | `TypeError: parsed is not iterable` | 1222 paths |
| npm 11 array output | 2 paths | 2 paths (control, unchanged) |
| `[]`, `{}`, `null`, a result without `files` | read of undefined | `Error: npm pack --json returned no packed file list` |
| whole verifier run against the npm 12 payload | never reached the checks | `npm payload containment OK (1222 packed paths, 0 offenders)`, exit 0 |

Evidence: `.omo/evidence/20260906-npm-pack-json-shape/`.

## The fix

One reader, `script/npm-pack-paths.mjs`, that accepts both shapes and fails with a named error for
anything else, plus its unit test. The verifier's forbidden-rule and required-path logic is untouched.

## Scope deliberately not touched

- No Node or npm version pin is changed; this only removes the assumption.
- `execFileSync("npm", ...)` still cannot resolve `npm.cmd` on Windows without a shell
  (`spawnSync npm ENOENT`), so the script remains Linux/macOS-only to run locally. That is a separate
  defect and I left it out of this diff; happy to send it separately if you want it.
- No change to the forbidden rules, the shared-skills requirement, or `publish.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the publish payload verifier so it reads both npm 11 and npm 12 `npm pack --json` output shapes. npm 12 (bundled with Node 26) prints an object keyed by package name; the old array-only reader threw `TypeError: parsed is not iterable` before checking a single path.

- Extracts the path reader into `script/npm-pack-paths.mjs` with unit tests; npm 11 array output behavior is unchanged.
- Malformed output, non-JSON output, and entries without a string path now fail with errors that name `npm pack` instead of a bare `SyntaxError` or read-of-undefined.
- Adds captured RED/GREEN evidence under `.omo/evidence/20260906-npm-pack-json-shape/` and `.omo/evidence/20260907-rebase-7840/`.
- No Node or npm version pins change; CI still runs Node 24 and is unaffected.

<sup>Written for commit 601880588564695b4a84c7b0cbf37d8fbf189764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

