### PR TITLE
fix(publish): spawn npm through a shell on Windows in the payload verifier

### DIFF
--- a/.omo/evidence/20260906-npm-pack-json-shape/README.md
+++ b/.omo/evidence/20260906-npm-pack-json-shape/README.md
@@ -1,0 +1,40 @@
+# The payload verifier reads only npm 11's pack --json shape
+
+## What was tested
+
+`script/verify-npm-payload.mjs`, the gate `publish.yml` runs before every `npm publish`, against
+real `npm pack --dry-run --json` output produced by npm 12.0.2 on this machine (1222 packed paths).
+
+## What was observed
+
+`red-npm12.log`, both readers on the same real npm 12 payload:
+
+```
+old reader THROWS: TypeError: parsed is not iterable
+new reader -> 1222 paths
+new reader first path: .agents/command/get-unpublished-changes.md
+```
+
+| Input | Before | After |
+| --- | --- | --- |
+| real npm 12 `pack --json` output | `TypeError: parsed is not iterable` | 1222 paths, identical to the npm 11 shape |
+| npm 11 array output | 2 paths | 2 paths (unchanged) |
+| output of neither shape (`[]`, `{}`, `null`, a result without `files`) | read of undefined | `Error: npm pack --json returned no packed file list` |
+| whole verifier end to end on the npm 12 payload | could not reach the checks | `npm payload containment OK (1222 packed paths, 0 offenders)`, exit 0 |
+
+Unit run: `green-unit.log`, 3 pass / 0 fail. Verifier run: `green-verifier.log`.
+
+## Why it is enough
+
+The RED is real registry-tool output from this repository, not a synthetic fixture, and the GREEN
+run drives the actual script rather than the extracted helper. Severity is forward-looking: CI and
+`publish.yml` pin Node 24 (npm 11) today, so this is the gate breaking the day that pin moves, plus
+a named error instead of a read-of-undefined for any other shape.
+
+## What was omitted
+
+The end-to-end verifier run substitutes the `npm pack` spawn with the saved npm 12 payload for the
+duration of that one run, because `execFileSync("npm", ...)` cannot resolve `npm.cmd` on Windows
+without a shell (`spawnSync npm ENOENT`). That Windows spawn gap is a separate defect and is not
+fixed here. The substitution was reverted with `git checkout --` immediately after the capture; the
+committed script still spawns npm. No secrets appear in the logs.

--- a/.omo/evidence/20260906-npm-pack-json-shape/green-unit.log
+++ b/.omo/evidence/20260906-npm-pack-json-shape/green-unit.log
@@ -1,0 +1,11 @@
+bun test v1.3.14 (0d9b296a)
+
+script\npm-pack-paths.test.ts:
+(pass) npm pack path reader > #given npm 11 array output #when packed paths are read #then every packed path is returned [2.74ms]
+(pass) npm pack path reader > #given npm 12 object output keyed by package name #when packed paths are read #then the same paths are returned [1.02ms]
+(pass) npm pack path reader > #given output of neither shape #when packed paths are read #then it fails naming npm pack instead of throwing on undefined [9.17ms]
+
+ 3 pass
+ 0 fail
+ 6 expect() calls
+Ran 3 tests across 1 file. [1.66s]

--- a/.omo/evidence/20260906-npm-pack-json-shape/green-verifier.log
+++ b/.omo/evidence/20260906-npm-pack-json-shape/green-verifier.log
@@ -1,0 +1,1 @@
+npm payload containment OK (1222 packed paths, 0 offenders)

--- a/.omo/evidence/20260906-npm-pack-json-shape/red-npm12.log
+++ b/.omo/evidence/20260906-npm-pack-json-shape/red-npm12.log
@@ -1,0 +1,3 @@
+old reader THROWS: TypeError: parsed is not iterable
+new reader -> 1222 paths
+new reader first path: .agents/command/get-unpublished-changes.md

--- a/.omo/evidence/20260906-verify-payload-windows-spawn/README.md
+++ b/.omo/evidence/20260906-verify-payload-windows-spawn/README.md
@@ -1,0 +1,29 @@
+# The publish payload gate cannot run on Windows
+
+## What was tested
+
+`node script/verify-npm-payload.mjs` on Windows 11, Node 26.1.0, npm 12.0.2, plus the extracted
+platform branch.
+
+## What was observed
+
+| Input | Before | After |
+| --- | --- | --- |
+| `node script/verify-npm-payload.mjs` on Windows | `Error: spawnSync npm ENOENT`, exit 1 (`red-windows.log`) | reaches npm; the run now stops at the npm 12 pack shape, which is PR #7840's defect (`green-windows.log`) |
+| the same run with #7840's reader also applied | dies before npm | `npm payload containment OK (1259 packed paths, 0 offenders)`, exit 0 (`combined-windows.log`) |
+| `bun test script/npm-invocation.test.ts` | file did not exist | 2 pass / 0 fail |
+| mutation: `npmSpawnOptions` always returns `{}` | - | 1 of 2 tests fails, green again on revert |
+| `bun test script/npm-invocation.test.ts script/npm-payload-containment.test.ts` | - | 7 pass / 0 fail |
+
+## Why it is enough
+
+The RED and GREEN are the real script on the platform that breaks it, and the failure mode moves from
+"npm was never spawned" to "npm ran and returned a shape this branch does not read yet", which is the
+exact boundary of this change. The combined run shows the end state once #7840 lands.
+
+## What was omitted
+
+`shell: true` makes Node print DEP0190 about argument escaping. The arguments here are four fixed
+literals with no interpolation, and `.cmd` cannot be spawned without a shell since the Node
+argument-injection fix, so the warning is accepted rather than worked around. No secrets appear in the
+logs.

--- a/.omo/evidence/20260906-verify-payload-windows-spawn/combined-windows.log
+++ b/.omo/evidence/20260906-verify-payload-windows-spawn/combined-windows.log
@@ -1,0 +1,3 @@
+npm payload containment OK (1259 packed paths, 0 offenders)
+(node:24224) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(Use `node --trace-deprecation ...` to show where the warning was created)

--- a/.omo/evidence/20260906-verify-payload-windows-spawn/green-regression.log
+++ b/.omo/evidence/20260906-verify-payload-windows-spawn/green-regression.log
@@ -1,0 +1,17 @@
+bun test v1.3.14 (0d9b296a)
+
+script\npm-invocation.test.ts:
+(pass) npm spawn options > #given win32 #when npm spawn options are resolved #then a shell is requested [6.45ms]
+(pass) npm spawn options > #given linux and darwin #when npm spawn options are resolved #then no shell is requested [1.08ms]
+
+script\npm-payload-containment.test.ts:
+(pass) root npm payload containment > #given root files allowlist #when senpi containment is checked #then senpi plugin payload is not shipped [10.59ms]
+(pass) root npm payload containment > #given root files allowlist #when hygiene negations are checked #then nested node_modules and retired component residue are excluded [1.32ms]
+(pass) root npm payload containment > #given root files allowlist #when vendored MCP shipping is checked #then each ships its package.json alongside dist [1.10ms]
+(pass) lazycodex-ai publish payload containment > #given publish workflow files override #when hygiene negations are checked #then the rewritten files list carries the same exclusions [13.07ms]
+(pass) lazycodex-ai publish payload containment > #given publish workflow #when payload guards are checked #then verify-npm-payload runs before both npm publish paths [1.11ms]
+
+ 7 pass
+ 0 fail
+ 20 expect() calls
+Ran 7 tests across 2 files. [1.69s]

--- a/.omo/evidence/20260906-verify-payload-windows-spawn/green-unit.log
+++ b/.omo/evidence/20260906-verify-payload-windows-spawn/green-unit.log
@@ -1,0 +1,10 @@
+bun test v1.3.14 (0d9b296a)
+
+script\npm-invocation.test.ts:
+(pass) npm spawn options > #given win32 #when npm spawn options are resolved #then a shell is requested [4.46ms]
+(pass) npm spawn options > #given linux and darwin #when npm spawn options are resolved #then no shell is requested [7.87ms]
+
+ 2 pass
+ 0 fail
+ 3 expect() calls
+Ran 2 tests across 1 file. [1.65s]

--- a/.omo/evidence/20260906-verify-payload-windows-spawn/green-windows.log
+++ b/.omo/evidence/20260906-verify-payload-windows-spawn/green-windows.log
@@ -1,0 +1,12 @@
+file:///C:/Users/LilMG/Desktop/oh-my-openagent/.local-ignore/pr-worktrees/win-spawn/script/verify-npm-payload.mjs:36
+  const [result] = JSON.parse(raw)
+                   ^
+
+TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
+    at packedPaths (file:///C:/Users/LilMG/Desktop/oh-my-openagent/.local-ignore/pr-worktrees/win-spawn/script/verify-npm-payload.mjs:36:20)
+    at file:///C:/Users/LilMG/Desktop/oh-my-openagent/.local-ignore/pr-worktrees/win-spawn/script/verify-npm-payload.mjs:40:15
+    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
+    at async node:internal/modules/esm/loader:636:26
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
+
+Node.js v26.1.0

--- a/.omo/evidence/20260906-verify-payload-windows-spawn/red-windows.log
+++ b/.omo/evidence/20260906-verify-payload-windows-spawn/red-windows.log
@@ -1,0 +1,28 @@
+node:internal/child_process:1127
+    result.error = new ErrnoException(result.error, 'spawnSync ' + options.file);
+                   ^
+
+<ref *1> Error: spawnSync npm ENOENT
+    at Object.spawnSync (node:internal/child_process:1127:20)
+    at spawnSync (node:child_process:911:24)
+    at execFileSync (node:child_process:954:15)
+    at packedPaths (file:///C:/Users/LilMG/Desktop/oh-my-openagent/.local-ignore/pr-worktrees/win-spawn/script/verify-npm-payload.mjs:28:15)
+    at file:///C:/Users/LilMG/Desktop/oh-my-openagent/.local-ignore/pr-worktrees/win-spawn/script/verify-npm-payload.mjs:37:15
+    at ModuleJob.run (node:internal/modules/esm/module_job:439:25)
+    at async node:internal/modules/esm/loader:636:26
+    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) {
+  errno: -4058,
+  code: 'ENOENT',
+  syscall: 'spawnSync npm',
+  path: 'npm',
+  spawnargs: [ 'pack', '--dry-run', '--json', '--ignore-scripts' ],
+  error: [Circular *1],
+  status: null,
+  signal: null,
+  output: null,
+  pid: 0,
+  stdout: undefined,
+  stderr: undefined
+}
+
+Node.js v26.1.0

--- a/.omo/evidence/20260907-rebase-7840/combined-verifier.log
+++ b/.omo/evidence/20260907-rebase-7840/combined-verifier.log
@@ -1,0 +1,4 @@
+imports present: 2 of 2 (npm-pack-paths.mjs + npm-payload-required-paths.mjs)
+npm payload containment OK (1260 packed paths, 0 offenders)
+exit=0
+note: the npm spawn was temporarily substituted with saved npm 12.0.2 pack output for this capture because the Windows spawn fix lives in PR #7844; the substitution was reverted with git checkout -- and git status is clean.

--- a/.omo/evidence/20260907-rebase-7840/green-rebased.log
+++ b/.omo/evidence/20260907-rebase-7840/green-rebased.log
@@ -1,0 +1,21 @@
+bun test v1.3.14 (0d9b296a)
+
+script\npm-pack-paths.test.ts:
+(pass) npm pack path reader > #given npm 11 array output #when packed paths are read #then every packed path is returned [7.58ms]
+(pass) npm pack path reader > #given npm 12 object output keyed by package name #when packed paths are read #then the same paths are returned [2.88ms]
+(pass) npm pack path reader > #given output of neither shape #when packed paths are read #then it fails naming npm pack instead of throwing on undefined [4.99ms]
+(pass) npm pack path reader > #given output that is not JSON at all #when packed paths are read #then it fails naming npm pack rather than raising a bare SyntaxError [4.78ms]
+(pass) npm pack path reader > #given a packed entry without a string path #when packed paths are read #then it fails naming the entry [3.83ms]
+
+script\npm-payload-containment.test.ts:
+(pass) root npm payload containment > #given root files allowlist #when senpi containment is checked #then senpi plugin payload is not shipped [5.92ms]
+(pass) root npm payload containment > #given root files allowlist #when hygiene negations are checked #then nested node_modules and retired component residue are excluded [17.25ms]
+(pass) root npm payload containment > #given root files allowlist #when vendored MCP shipping is checked #then each ships its package.json alongside dist [2.36ms]
+(pass) root npm payload containment > #given root files allowlist #when the Codex plugin payload is checked #then the canonical prompts-core directive sync:skills reads is shipped [2.63ms]
+(pass) lazycodex-ai publish payload containment > #given publish workflow files override #when hygiene negations are checked #then the rewritten files list carries the same exclusions [12.87ms]
+(pass) lazycodex-ai publish payload containment > #given publish workflow #when payload guards are checked #then verify-npm-payload runs before both npm publish paths [3.10ms]
+
+ 11 pass
+ 0 fail
+ 27 expect() calls
+Ran 11 tests across 2 files. [12.99s]

--- a/script/npm-invocation.d.mts
+++ b/script/npm-invocation.d.mts
@@ -1,0 +1,1 @@
+export declare function npmSpawnOptions(platform?: NodeJS.Platform): { shell?: true }

--- a/script/npm-invocation.mjs
+++ b/script/npm-invocation.mjs
@@ -1,0 +1,6 @@
+// npm is npm.cmd on Windows, and Node's spawn does not apply PATHEXT without a shell, so
+// execFileSync("npm", ...) dies with "spawnSync npm ENOENT" there. Every npm spawn in script/ takes
+// its options from here so the platform branch lives in one place.
+export function npmSpawnOptions(platform = process.platform) {
+  return platform === "win32" ? { shell: true } : {}
+}

--- a/script/npm-invocation.test.ts
+++ b/script/npm-invocation.test.ts
@@ -1,8 +1,17 @@
 /// <reference types="bun-types" />
 
-import { describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, test } from "bun:test"
 import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { npmSpawnOptions } from "./npm-invocation.mjs"
+
+const packFixtures: string[] = []
+
+afterAll(() => {
+  for (const fixture of packFixtures) rmSync(fixture, { recursive: true, force: true })
+})
 
 describe("npm spawn options", () => {
   test("#given win32 #when npm spawn options are resolved #then a shell is requested", () => {
@@ -33,5 +42,25 @@ describe("npm spawn options", () => {
 
     // then
     expect(version).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  test("#given a minimal package #when npm pack --dry-run --json is spawned with these options #then its stdout is parseable JSON naming that package", () => {
+    // given
+    const fixture = mkdtempSync(join(tmpdir(), "omo-npm-pack-"))
+    packFixtures.push(fixture)
+    writeFileSync(join(fixture, "package.json"), JSON.stringify({ name: "omo-pack-probe", version: "1.0.0", private: true }))
+
+    // when
+    const raw = execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+      cwd: fixture,
+      encoding: "utf8",
+      maxBuffer: 8 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+      ...npmSpawnOptions(),
+    })
+
+    // then
+    expect(() => JSON.parse(raw)).not.toThrow()
+    expect(raw).toContain("omo-pack-probe")
   })
 })

--- a/script/npm-invocation.test.ts
+++ b/script/npm-invocation.test.ts
@@ -1,0 +1,24 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { npmSpawnOptions } from "./npm-invocation.mjs"
+
+describe("npm spawn options", () => {
+  test("#given win32 #when npm spawn options are resolved #then a shell is requested", () => {
+    // given / when
+    const options = npmSpawnOptions("win32")
+
+    // then
+    expect(options).toEqual({ shell: true })
+  })
+
+  test("#given linux and darwin #when npm spawn options are resolved #then no shell is requested", () => {
+    // given / when
+    const linux = npmSpawnOptions("linux")
+    const darwin = npmSpawnOptions("darwin")
+
+    // then
+    expect(linux).toEqual({})
+    expect(darwin).toEqual({})
+  })
+})

--- a/script/npm-invocation.test.ts
+++ b/script/npm-invocation.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
+import { execFileSync } from "node:child_process"
 import { npmSpawnOptions } from "./npm-invocation.mjs"
 
 describe("npm spawn options", () => {
@@ -20,5 +21,17 @@ describe("npm spawn options", () => {
     // then
     expect(linux).toEqual({})
     expect(darwin).toEqual({})
+  })
+
+  test("#given the current platform #when npm is spawned with these options #then npm actually runs", () => {
+    // given
+    const spawnNpm = () =>
+      execFileSync("npm", ["--version"], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], ...npmSpawnOptions() })
+
+    // when
+    const version = spawnNpm().trim()
+
+    // then
+    expect(version).toMatch(/^\d+\.\d+\.\d+/)
   })
 })

--- a/script/npm-pack-paths.d.mts
+++ b/script/npm-pack-paths.d.mts
@@ -1,0 +1,1 @@
+export declare function parseNpmPackPaths(raw: string): string[]

--- a/script/npm-pack-paths.mjs
+++ b/script/npm-pack-paths.mjs
@@ -1,0 +1,13 @@
+// npm 11 prints `npm pack --json` as an array of package results; npm 12 (the npm bundled with
+// Node 26) prints an object keyed by package name. Reading only the array shape throws
+// "TypeError: parsed is not iterable" on npm 12, which reads as a broken script rather than a
+// version difference.
+export function parseNpmPackPaths(raw) {
+  const parsed = JSON.parse(raw)
+  const results = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {})
+  const [result] = results
+  if (result === null || typeof result !== "object" || !Array.isArray(result.files)) {
+    throw new Error("npm pack --json returned no packed file list; expected an array of results or an object keyed by package name")
+  }
+  return result.files.map((file) => file.path)
+}

--- a/script/npm-pack-paths.mjs
+++ b/script/npm-pack-paths.mjs
@@ -3,11 +3,21 @@
 // "TypeError: parsed is not iterable" on npm 12, which reads as a broken script rather than a
 // version difference.
 export function parseNpmPackPaths(raw) {
-  const parsed = JSON.parse(raw)
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    throw new Error(`npm pack --json did not return JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
   const results = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {})
   const [result] = results
   if (result === null || typeof result !== "object" || !Array.isArray(result.files)) {
     throw new Error("npm pack --json returned no packed file list; expected an array of results or an object keyed by package name")
   }
-  return result.files.map((file) => file.path)
+  return result.files.map((file) => {
+    if (file === null || typeof file !== "object" || typeof file.path !== "string") {
+      throw new Error("npm pack --json returned a packed entry without a string path")
+    }
+    return file.path
+  })
 }

--- a/script/npm-pack-paths.test.ts
+++ b/script/npm-pack-paths.test.ts
@@ -1,0 +1,37 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { parseNpmPackPaths } from "./npm-pack-paths.mjs"
+
+const npm11Output = JSON.stringify([{ id: "oh-my-opencode@5.0.0", files: [{ path: "package.json" }, { path: "bin/omo.js" }] }])
+const npm12Output = JSON.stringify({
+  "oh-my-opencode": { id: "oh-my-opencode@5.0.0", files: [{ path: "package.json" }, { path: "bin/omo.js" }] },
+})
+
+describe("npm pack path reader", () => {
+  test("#given npm 11 array output #when packed paths are read #then every packed path is returned", () => {
+    // given / when
+    const paths = parseNpmPackPaths(npm11Output)
+
+    // then
+    expect(paths).toEqual(["package.json", "bin/omo.js"])
+  })
+
+  test("#given npm 12 object output keyed by package name #when packed paths are read #then the same paths are returned", () => {
+    // given / when
+    const paths = parseNpmPackPaths(npm12Output)
+
+    // then
+    expect(paths).toEqual(parseNpmPackPaths(npm11Output))
+  })
+
+  test("#given output of neither shape #when packed paths are read #then it fails naming npm pack instead of throwing on undefined", () => {
+    // given
+    const malformed = ["[]", "{}", "null", '{"pkg":{"id":"x"}}']
+
+    // when / then
+    for (const raw of malformed) {
+      expect(() => parseNpmPackPaths(raw)).toThrow("npm pack --json returned no packed file list")
+    }
+  })
+})

--- a/script/npm-pack-paths.test.ts
+++ b/script/npm-pack-paths.test.ts
@@ -34,4 +34,22 @@ describe("npm pack path reader", () => {
       expect(() => parseNpmPackPaths(raw)).toThrow("npm pack --json returned no packed file list")
     }
   })
+
+  test("#given output that is not JSON at all #when packed paths are read #then it fails naming npm pack rather than raising a bare SyntaxError", () => {
+    // given
+    const notJson = ["", "npm warn config production Use --omit=dev instead."]
+
+    // when / then
+    for (const raw of notJson) {
+      expect(() => parseNpmPackPaths(raw)).toThrow("npm pack --json did not return JSON")
+    }
+  })
+
+  test("#given a packed entry without a string path #when packed paths are read #then it fails naming the entry", () => {
+    // given
+    const rawEntry = JSON.stringify([{ id: "x", files: [{ path: "package.json" }, { size: 12 }] }])
+
+    // when / then
+    expect(() => parseNpmPackPaths(rawEntry)).toThrow("packed entry without a string path")
+  })
 })

--- a/script/verify-npm-payload.mjs
+++ b/script/verify-npm-payload.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 
 import { findMissingPayloadPaths, requiredCodexInstallPaths } from "./npm-payload-required-paths.mjs"
+import { npmSpawnOptions } from "./npm-invocation.mjs"
 import { parseNpmPackPaths } from "./npm-pack-paths.mjs"
 
 const FORBIDDEN_RULES = [
@@ -32,6 +33,7 @@ function packedPaths() {
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "inherit"],
+    ...npmSpawnOptions(),
   })
   return parseNpmPackPaths(raw)
 }

--- a/script/verify-npm-payload.mjs
+++ b/script/verify-npm-payload.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process"
 import { readFileSync } from "node:fs"
 
 import { findMissingPayloadPaths, requiredCodexInstallPaths } from "./npm-payload-required-paths.mjs"
+import { parseNpmPackPaths } from "./npm-pack-paths.mjs"
 
 const FORBIDDEN_RULES = [
   { name: "nested node_modules", matches: (path) => path.includes("node_modules/") },
@@ -32,8 +33,7 @@ function packedPaths() {
     maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "inherit"],
   })
-  const [result] = JSON.parse(raw)
-  return result.files.map((file) => file.path)
+  return parseNpmPackPaths(raw)
 }
 
 const paths = packedPaths()

--- a/script/verify-omo-ai-payload.mjs
+++ b/script/verify-omo-ai-payload.mjs
@@ -5,6 +5,8 @@ import { existsSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
+import { npmSpawnOptions } from "./npm-invocation.mjs"
+
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, "..")
 const pkgDir = resolve(repoRoot, "packages", "omo-native")
@@ -46,6 +48,7 @@ function packedPaths() {
     encoding: "utf8",
     maxBuffer: 64 * 1024 * 1024,
     stdio: ["ignore", "pipe", "inherit"],
+    ...npmSpawnOptions(),
   })
   const [result] = JSON.parse(raw)
   if (!result) return { paths: [], unpackedSize: 0 }

--- a/script/verify-omo-ai-payload.test.ts
+++ b/script/verify-omo-ai-payload.test.ts
@@ -54,8 +54,8 @@ function runVerifierOnPayload(payloadPaths: readonly string[]): VerifierRun {
   const fakeRepoRoot = mkdtempSync(join(tmpdir(), "omo-ai-payload-guard-"))
   try {
     mkdirSync(join(fakeRepoRoot, "script"), { recursive: true })
-  copyFileSync(verifierSource, join(fakeRepoRoot, "script", "verify-omo-ai-payload.mjs"))
-  copyFileSync(npmInvocationSource, join(fakeRepoRoot, "script", "npm-invocation.mjs"))
+    copyFileSync(verifierSource, join(fakeRepoRoot, "script", "verify-omo-ai-payload.mjs"))
+    copyFileSync(npmInvocationSource, join(fakeRepoRoot, "script", "npm-invocation.mjs"))
 
     const packageDir = join(fakeRepoRoot, "packages", "omo-native")
     mkdirSync(packageDir, { recursive: true })

--- a/script/verify-omo-ai-payload.test.ts
+++ b/script/verify-omo-ai-payload.test.ts
@@ -17,6 +17,7 @@ import { fileURLToPath } from "node:url"
  * payload under test.
  */
 const verifierSource = fileURLToPath(new URL("./verify-omo-ai-payload.mjs", import.meta.url))
+const npmInvocationSource = fileURLToPath(new URL("./npm-invocation.mjs", import.meta.url))
 const guardTimeoutMs = 120_000
 
 setDefaultTimeout(guardTimeoutMs)
@@ -53,7 +54,8 @@ function runVerifierOnPayload(payloadPaths: readonly string[]): VerifierRun {
   const fakeRepoRoot = mkdtempSync(join(tmpdir(), "omo-ai-payload-guard-"))
   try {
     mkdirSync(join(fakeRepoRoot, "script"), { recursive: true })
-    copyFileSync(verifierSource, join(fakeRepoRoot, "script", "verify-omo-ai-payload.mjs"))
+  copyFileSync(verifierSource, join(fakeRepoRoot, "script", "verify-omo-ai-payload.mjs"))
+  copyFileSync(npmInvocationSource, join(fakeRepoRoot, "script", "npm-invocation.mjs"))
 
     const packageDir = join(fakeRepoRoot, "packages", "omo-native")
     mkdirSync(packageDir, { recursive: true })


### PR DESCRIPTION
## What breaks

A contributor on Windows cannot run the publish payload gate at all:

```
$ node script/verify-npm-payload.mjs
Error: spawnSync npm ENOENT
    at packedPaths (script/verify-npm-payload.mjs:28)
  syscall: 'spawnSync npm', path: 'npm',
  spawnargs: [ 'pack', '--dry-run', '--json', '--ignore-scripts' ]
```

It never reaches npm, so the whole containment check is unavailable locally on that platform. CI runs
it on Linux, so the gate itself is fine in the pipeline; this is purely the local surface.

## Root cause

npm is `npm.cmd` on Windows, and Node's `spawnSync` does not apply `PATHEXT` unless a shell is
requested, so `execFileSync("npm", ...)` cannot resolve it. Spawning `.cmd` directly is rejected by
Node since the argument-injection fix, so a shell is the remaining route.

## RED / GREEN

| Input | Before | After |
| --- | --- | --- |
| `node script/verify-npm-payload.mjs` on Windows | `spawnSync npm ENOENT`, exit 1 | reaches npm; stops at the npm 12 pack shape, which is #7840 |
| the same run with #7840's reader also applied | dies before npm | `npm payload containment OK (1259 packed paths, 0 offenders)`, exit 0 |
| `bun test script/npm-invocation.test.ts` | file did not exist | 2 pass / 0 fail; 1 fails under a mutation that drops the win32 branch |
| `bun test script/npm-invocation.test.ts script/npm-payload-containment.test.ts` | - | 7 pass / 0 fail |

Evidence: `.omo/evidence/20260906-verify-payload-windows-spawn/`.

## The fix

One exported helper, `npmSpawnOptions(platform)`, returning `{ shell: true }` on win32 and `{}`
elsewhere, spread into the existing `execFileSync` options. Non-Windows behavior is byte-identical.

Worth checking in review: the four npm arguments are fixed literals with no interpolation, so the
shell carries no caller-controlled input. Node still prints DEP0190 about argument escaping under
`shell: true`; the alternative would be resolving npm's JS entry by hand, which is more fragile than
the warning is costly.

## Scope deliberately not touched

- The npm 12 `pack --json` object shape is #7840; this PR only removes the spawn failure. They are
  independent and can merge in either order.
- No other npm spawn in the repo is changed; the helper exists so the next one can adopt it
  deliberately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes both publish payload verifiers so they can run on Windows, and makes the npm payload verifier accept npm 12's pack output. They previously died before inspecting any packed paths: `spawnSync npm ENOENT` on Windows (npm is `npm.cmd` there, and Node's spawn doesn't apply `PATHEXT` without a shell) and `TypeError: parsed is not iterable` on npm 12, which prints `pack --json` as an object keyed by package name rather than an array.

**Details**
- Both verifiers spread `npmSpawnOptions()` into their `execFileSync` calls; the helper returns `{ shell: true }` on win32 and `{}` elsewhere, so non-Windows behavior is byte-identical.
- The npm verifier's pack reader `parseNpmPackPaths()` accepts both the npm 11 array shape and the npm 12 object shape, failing with a named error on non-JSON output, entries without a string path, or unrecognized shapes.
- Tests spawn real npm through those options, pack a temp package, and assert `stdout` parses as JSON; the omo-ai verifier fixture copies the helper so its import resolves there.
- Node prints a DEP0190 deprecation warning about arg escaping under `shell: true`; the npm arguments are fixed literals with no interpolation, so the warning is accepted rather than worked around.

<sup>Written for commit 8b6bd37391af4a0c197ce69d48420647e769b47a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

