### PR TITLE
fix(install): tell the user how to retry a failed Codex half

### DIFF
--- a/.omo/evidence/20260906-codex-partial-install-retry-hint/README.md
+++ b/.omo/evidence/20260906-codex-partial-install-retry-hint/README.md
@@ -1,0 +1,31 @@
+# A failed Codex half of `--platform=both` left the user with no next step
+
+## What was tested
+
+Both installer surfaces, with `runCodexInstaller` stubbed to reject: the non-interactive CLI
+(`runCliInstaller`) and the TUI (`runTuiInstaller`).
+
+## What was observed
+
+| Input | Before | After |
+| --- | --- | --- |
+| `--platform=both`, Codex half fails, CLI path | warning only, then the run ends with exit 0 | warning plus `bunx oh-my-openagent install --platform=codex` as the retry |
+| `--platform=both`, Codex half fails, TUI path | `p.log.warn` only | `p.log.warn` plus the same retry line via `p.log.info` |
+| `bun test cli-installer.platform.test.ts tui-installer-codex-installation.test.ts` | new assertions fail (1 fail per file) | 15 pass / 0 fail |
+
+RED was captured before the production change: the added assertions failed with the existing code
+(`red.log`), which is what a real user hit when `5.0.0-beta.43` failed at `sync:skills` and the run
+still ended on a green "Configuration updated!" banner.
+
+## Why it is enough
+
+The assertions run the real installer entrypoints with the Codex installer stubbed to fail, which is
+the exact branch the user hit, and they fail without the change.
+
+## What was omitted
+
+The exit code is deliberately unchanged: `--platform=both` still exits 0 when only the Codex half
+fails, which is pinned by an existing test and is the maintainer's stated intent
+("OpenCode install is still complete"). Noted for the maintainer rather than changed: the adjacent
+Senpi branch returns 1 in the same situation, so the two optional harnesses disagree on partial
+failure. No secrets appear in the logs.

--- a/.omo/evidence/20260906-codex-partial-install-retry-hint/green.log
+++ b/.omo/evidence/20260906-codex-partial-install-retry-hint/green.log
@@ -1,0 +1,25 @@
+bun test v1.3.14 (0d9b296a)
+
+packages\omo-opencode\src\cli\cli-installer.platform.test.ts:
+(pass) runCliInstaller platform branching > runs only OpenCode installation for platform=opencode [4.44ms]
+(pass) runCliInstaller platform branching > runs only Codex installation and skips OpenCode version checks for platform=codex [2.16ms]
+(pass) runCliInstaller platform branching > runs only Senpi installation and skips OpenCode provider checks for platform=senpi [1.81ms]
+(pass) runCliInstaller platform branching > passes Codex autonomous selection into Codex installer [2.18ms]
+(pass) runCliInstaller platform branching > passes explicit Codex autonomous opt-out into Codex installer [1.72ms]
+(pass) runCliInstaller platform branching > runs OpenCode and Codex installation for platform=both [1.51ms]
+(pass) runCliInstaller platform branching > fails when Senpi-only installation cannot install Senpi [1.21ms]
+(pass) runCliInstaller platform branching > fails when Codex-only installation cannot install Codex [1.34ms]
+(pass) runCliInstaller platform branching > keeps OpenCode success when Codex fails for platform=both [2.81ms]
+(pass) runCliInstaller platform branching > does not print star commands in noninteractive installs [1.52ms]
+(pass) runCliInstaller platform branching > does not prompt for GitHub stars in noninteractive installs even when stdout is a TTY [9.34ms]
+
+packages\omo-opencode\src\cli\tui-installer-codex-installation.test.ts:
+(pass) runTuiInstaller Codex installation detection > #given Codex is missing #when installing Codex interactively #then warns and still installs [2.29ms]
+(pass) runTuiInstaller Codex installation detection > #given Codex is installed #when installing Codex interactively #then suppresses the missing-install warning [1.23ms]
+(pass) runTuiInstaller Codex install failure exit status > #given a Codex-only install whose Codex step fails #when the installer runs #then it reports failure and the exit status is non-zero [1.40ms]
+(pass) runTuiInstaller Codex install failure exit status > #given platform=both where OpenCode succeeds and Codex fails #when the installer runs #then the partial-success warning path is preserved [1.29ms]
+
+ 15 pass
+ 0 fail
+ 47 expect() calls
+Ran 15 tests across 2 files. [2.15s]

--- a/.omo/evidence/20260906-codex-partial-install-retry-hint/red.log
+++ b/.omo/evidence/20260906-codex-partial-install-retry-hint/red.log
@@ -14,7 +14,7 @@ npm notice run node scripts/build.mjs
 (pass) runCliInstaller platform branching > runs OpenCode and Codex installation for platform=both [2.34ms]
 (pass) runCliInstaller platform branching > fails when Senpi-only installation cannot install Senpi [2.38ms]
 (pass) runCliInstaller platform branching > fails when Codex-only installation cannot install Codex [2.74ms]
-217 | 
+217 |
 218 |     // then
 219 |     const output = consoleLogMock.mock.calls.map((call) => call.join(" ")).join("\n")
 220 |     expect(result).toBe(0)

--- a/.omo/evidence/20260906-codex-partial-install-retry-hint/red.log
+++ b/.omo/evidence/20260906-codex-partial-install-retry-hint/red.log
@@ -1,0 +1,37 @@
+bun test v1.3.14 (0d9b296a)
+
+packages\omo-opencode\src\cli\cli-installer.platform.test.ts:
+[test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...
+npm notice run @code-yeongyu/lsp-daemon@0.1.0 build
+npm notice run node scripts/build.mjs
+(node:42640) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+(pass) runCliInstaller platform branching > runs only OpenCode installation for platform=opencode [7.58ms]
+(pass) runCliInstaller platform branching > runs only Codex installation and skips OpenCode version checks for platform=codex [3.34ms]
+(pass) runCliInstaller platform branching > runs only Senpi installation and skips OpenCode provider checks for platform=senpi [2.86ms]
+(pass) runCliInstaller platform branching > passes Codex autonomous selection into Codex installer [2.30ms]
+(pass) runCliInstaller platform branching > passes explicit Codex autonomous opt-out into Codex installer [1.95ms]
+(pass) runCliInstaller platform branching > runs OpenCode and Codex installation for platform=both [2.34ms]
+(pass) runCliInstaller platform branching > fails when Senpi-only installation cannot install Senpi [2.38ms]
+(pass) runCliInstaller platform branching > fails when Codex-only installation cannot install Codex [2.74ms]
+217 | 
+218 |     // then
+219 |     const output = consoleLogMock.mock.calls.map((call) => call.join(" ")).join("\n")
+220 |     expect(result).toBe(0)
+221 |     expect(output).toContain("Codex install failed (OpenCode install is still complete): codex failed")
+222 |     expect(output).toContain("install --platform=codex")
+                         ^
+error: expect(received).toContain(expected)
+
+Expected to contain: "install --platform=codex"
+Received: "\n oMoMoMoMo... Install \n\n[1/4] Checking OpenCode installation...\n[OK] OpenCode 1.4.0 detected\n[2/4] Adding oh-my-openagent plugin...\n[OK] Plugin added -> /tmp/opencode.jsonc\n[3/4] Writing oh-my-openagent configuration...\n[OK] Config written -> /tmp/omo.jsonc\n\n┌─ Installation Complete ───────────────────────────────────────────────────────────────────┐\n│ Configuration Summary                                                                      │\n│                                                                                            │\n│   [i] Platform: both                                                                       │\n│   [i] Codex autonomous mode: enabled                                                       │\n│                                                                                            │\n│   ○ Claude                                                                                 │\n│   ○ OpenAI/ChatGPT (GPT-5.6 Sol for Oracle)                                                │\n│   ○ Gemini                                                                                 │\n│   ○ GitHub Copilot (fallback)                                                              │\n│   ○ OpenCode Zen (opencode/ models)                                                        │\n│   ○ Z.ai Coding Plan (GLM fallbacks)                                                       │\n│   ○ Kimi For Coding (Sisyphus/Prometheus fallback)                                         │\n│   ○ Bailian Coding Plan (Qwen/GLM/Kimi fallback)                                           │\n│   ○ MiniMax Coding Plan (minimaxi.com) (MiniMax-M3 fallback)                               │\n│   ○ MiniMax Coding Plan (minimax.io) (MiniMax-M3 fallback)                                 │\n│   ○ Vercel AI Gateway (universal proxy)                                                    │\n│                                                                                            │\n│ ────────────────────────────────────────                                                   │\n│                                                                                            │\n│ Model Assignment                                                                           │\n│                                                                                            │\n│   [i] Models auto-configured based on provider priority                                    │\n│   * Priority: Native > Copilot > OpenCode Zen > Z.ai > Kimi > Bailian > MiniMax > Vercel   │\n└────────────────────────────────────────────────────────────────────────────────────────────┘\n\n[i] Note: Sisyphus agent performs best with Claude Opus 5. Other models work but may have reduced orchestration quality.\n[!] No model providers configured. Using opencode/gpt-5-nano as fallback.\n* Installation complete!\n  Run opencode to start!\n\n[i] Installing Codex harness adapter...\n[!] Codex install failed (OpenCode install is still complete): codex failed\n\n[i] Anonymous telemetry is enabled by default. Disable it with OMO_SEND_ANONYMOUS_TELEMETRY=0 or OMO_DISABLE_POSTHOG=1.\n[i] Docs: docs/legal/privacy-policy.md and docs/legal/terms-of-service.md\n\n\n┌─ The Magic Word ─────────────────────────────────────────────────┐\n│ Pro Tip: Include ultrawork (or ulw) in your prompt.               │\n│ All features work like magic-parallel agents, background tasks,   │\n│ deep exploration, and relentless execution until completion.      │\n└───────────────────────────────────────────────────────────────────┘\n\noMoMoMoMo... Enjoy!\n"
+
+      at <anonymous> (C:\Users\LilMG\Desktop\oh-my-openagent\.local-ignore\pr-worktrees\retry-hint\packages\omo-opencode\src\cli\cli-installer.platform.test.ts:222:20)
+(fail) runCliInstaller platform branching > keeps OpenCode success when Codex fails for platform=both [3.39ms]
+(pass) runCliInstaller platform branching > does not print star commands in noninteractive installs [2.65ms]
+(pass) runCliInstaller platform branching > does not prompt for GitHub stars in noninteractive installs even when stdout is a TTY [10.76ms]
+
+ 10 pass
+ 1 fail
+ 32 expect() calls
+Ran 11 tests across 1 file. [9.48s]

--- a/packages/omo-opencode/src/cli/cli-installer.platform.test.ts
+++ b/packages/omo-opencode/src/cli/cli-installer.platform.test.ts
@@ -219,6 +219,7 @@ describe("runCliInstaller platform branching", () => {
     const output = consoleLogMock.mock.calls.map((call) => call.join(" ")).join("\n")
     expect(result).toBe(0)
     expect(output).toContain("Codex install failed (OpenCode install is still complete): codex failed")
+    expect(output).toContain("install --platform=codex")
   })
 
   test("does not print star commands in noninteractive installs", async () => {

--- a/packages/omo-opencode/src/cli/cli-installer.ts
+++ b/packages/omo-opencode/src/cli/cli-installer.ts
@@ -159,6 +159,9 @@ export async function runCliInstaller(args: InstallArgs, version: string): Promi
         return 1
       }
       printWarning(`Codex install failed (OpenCode install is still complete): ${message}`)
+      printInfo(
+        `The Codex harness is NOT installed. Fix the error above, then re-run: ${color.cyan("bunx oh-my-openagent install --platform=codex")}`,
+      )
     }
     console.log()
   }

--- a/packages/omo-opencode/src/cli/tui-installer-codex-installation.test.ts
+++ b/packages/omo-opencode/src/cli/tui-installer-codex-installation.test.ts
@@ -245,6 +245,7 @@ describe("runTuiInstaller Codex install failure exit status", () => {
     // given
     const warnSpy = spyOn(p.log, "warn").mockImplementation(() => undefined)
     const errorSpy = spyOn(p.log, "error").mockImplementation(() => undefined)
+    const infoSpy = spyOn(p.log, "info").mockImplementation(() => undefined)
     const restoreSpies = [
       spyOn(p, "spinner").mockReturnValue(createMockSpinner()),
       spyOn(p, "intro").mockImplementation(() => undefined),
@@ -317,8 +318,10 @@ describe("runTuiInstaller Codex install failure exit status", () => {
 
     // then
     const warningText = warnSpy.mock.calls.map((call) => String(call[0])).join("\n")
+    const infoText = infoSpy.mock.calls.map((call) => String(call[0])).join("\n")
     expect(result).toBe(0)
     expect(warningText).toContain("Codex install failed (OpenCode install remains successful): codex failed")
+    expect(infoText).toContain("install --platform=codex")
     expect(errorSpy).not.toHaveBeenCalled()
 
     for (const spy of restoreSpies) {
@@ -326,6 +329,7 @@ describe("runTuiInstaller Codex install failure exit status", () => {
     }
     warnSpy.mockRestore()
     errorSpy.mockRestore()
+    infoSpy.mockRestore()
     installSpy.mockRestore()
   })
 })

--- a/packages/omo-opencode/src/cli/tui-installer.ts
+++ b/packages/omo-opencode/src/cli/tui-installer.ts
@@ -142,6 +142,9 @@ export async function runTuiInstaller(args: InstallArgs, version: string): Promi
         return 1
       }
       p.log.warn(`Codex install failed (OpenCode install remains successful): ${message}`)
+      p.log.info(
+        "The Codex harness is NOT installed. Fix the error above, then re-run: bunx oh-my-openagent install --platform=codex",
+      )
     }
   }
 


### PR DESCRIPTION
## What breaks

A real `bunx oh-my-openagent@5.0.0-beta.43 install` with platform `both`: the Codex half died at
`npm run sync:skills`, and the session still ended on

```
â—†  Configuration updated!
â”‚  Run opencode to start!
â””  oMoMoMoMo... Enjoy!
```

The failure was one warning several screens up, with no statement of what is missing and no way to
retry just that half. The user reasonably read the install as complete.

## Root cause

Both installer surfaces warn and continue:

- `packages/omo-opencode/src/cli/cli-installer.ts`: `printWarning("Codex install failed (OpenCode install is still complete): ...")`
- `packages/omo-opencode/src/cli/tui-installer.ts`: `p.log.warn("Codex install failed (OpenCode install remains successful): ...")`

Neither says the Codex harness is absent, and neither names the command that installs only that half.

## RED / GREEN

| Input | Before | After |
| --- | --- | --- |
| `--platform=both`, Codex half rejects, CLI | warning only | warning plus `bunx oh-my-openagent install --platform=codex` |
| `--platform=both`, Codex half rejects, TUI | `p.log.warn` only | same retry line via `p.log.info` |
| `bun test cli-installer.platform.test.ts tui-installer-codex-installation.test.ts` | new assertions fail | 15 pass / 0 fail |

Evidence: `.omo/evidence/20260906-codex-partial-install-retry-hint/`.

## The fix

One line per surface, plus the assertions that pin it. **The exit code is unchanged**: partial
success still exits 0, which is what `keeps OpenCode success when Codex fails for platform=both`
already pins and what the warning text states as intent. This PR only makes the missing half legible
and actionable.

## Observation, not a change

In the same function, the Senpi branch returns 1 when its install fails even though OpenCode
succeeded, while the Codex branch returns 0. The two optional harnesses disagree about partial
failure. I left that alone because it is a policy call, not a defect I can prove; say the word and I
will send it separately.

## Scope deliberately not touched

- No exit-code change, no banner reordering, no wording change to the existing warnings.
- The `sync:skills` failure that triggered this for real is #7835.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the install flow so that when the Codex half fails during a `--platform=both` install, both the CLI and TUI now print a retry command (`bunx oh-my-openagent install --platform=codex`) after the warning. Previously both surfaces warned, then ended on the success banner, making the run look complete. Exit code is unchanged; partial success still exits 0.

**Tests**

- Added assertions on both installer surfaces that the retry command appears; they fail without the production change.
- Captured RED/GREEN evidence in `.omo/evidence/20260906-codex-partial-install-retry-hint/`.

<sup>Written for commit 1cf5e97d65132b9f8f3a0cfbdc3bbc44b0aaf1fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

