### PR TITLE
fix(codex-plugin): resolve shared skills through the linked package in the installer cache

### DIFF
--- a/packages/omo-codex/plugin/scripts/sync-skills.mjs
+++ b/packages/omo-codex/plugin/scripts/sync-skills.mjs
@@ -5,8 +5,8 @@ import { fileURLToPath } from "node:url";
 
 import { resolveCanonicalUltraworkDirectivePath } from "./canonical-ultrawork-directive.mjs";
 import { isCliEntry } from "./entry-guard.mjs";
-import { sharedSkillsRootPath } from "../../../shared-skills/index.mjs";
-import { createSkillSourceCopyFilter } from "../../../shared-skills/skill-source-filter.mjs";
+import { sharedSkillsRootPath } from "@oh-my-opencode/shared-skills";
+import { createSkillSourceCopyFilter } from "@oh-my-opencode/shared-skills/skill-source-filter";
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const repoRoot = join(root, "..", "..", "..");

--- a/packages/omo-codex/plugin/test/sync-skills-codex-compatibility.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills-codex-compatibility.test.mjs
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
-import { readdir, readFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, sep } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+
+import { canonicalUltraworkDirectiveRelativePath } from "../scripts/canonical-ultrawork-directive.mjs";
 
 import {
 	codexHarnessToolCompatibility,
@@ -100,10 +104,43 @@ test("#given the aggregate sync implementation #when its skill adaptation pipeli
 	assert.match(script, /await adaptSkillForCodex\(skillName\)/);
 });
 
-test("#given the published package layout #when sync-skills resolves shared skill helpers #then it uses files shipped beside the package instead of a workspace-only dependency", async () => {
-	const script = await readFile(join(pluginRoot, "scripts", "sync-skills.mjs"), "utf8");
+test("#given the flattened plugin cache the Codex installer produces #when sync-skills runs inside it #then it resolves shared skills through the linked package and writes the skill tree", async () => {
+	// given: installMarketplaceLocally copies plugin/ (minus node_modules) to
+	// <CODEX_HOME>/plugins/cache/<marketplace>/omo/<version>, materializes the canonical directive
+	// under that root, links @oh-my-opencode/shared-skills through the rewritten file: dependency,
+	// and only then runs `npm run sync:skills` there. packages/shared-skills is NOT a sibling of
+	// that directory, so a checkout-relative import cannot resolve in this layout.
+	const codexHome = await mkdtemp(join(tmpdir(), "omo-codex-cache-layout-"));
+	const cachedPluginRoot = join(codexHome, "plugins", "cache", "sisyphuslabs", "omo", "0.0.0-cache-layout");
+	await cp(pluginRoot, cachedPluginRoot, {
+		recursive: true,
+		filter: (source) => {
+			const parts = relative(pluginRoot, source).split(sep);
+			return parts[0] !== "skills" && !parts.includes("node_modules") && !parts.includes(".git");
+		},
+	});
+	const directiveTarget = join(cachedPluginRoot, canonicalUltraworkDirectiveRelativePath);
+	await mkdir(dirname(directiveTarget), { recursive: true });
+	await cp(join(repositoryRoot, "..", canonicalUltraworkDirectiveRelativePath), directiveTarget);
+	const linkedSharedSkills = join(cachedPluginRoot, "node_modules", "@oh-my-opencode", "shared-skills");
+	await mkdir(dirname(linkedSharedSkills), { recursive: true });
+	await symlink(join(repositoryRoot, "shared-skills"), linkedSharedSkills, "dir");
 
-	assert.match(script, /from "\.\.\/\.\.\/\.\.\/shared-skills\/index\.mjs"/);
-	assert.match(script, /from "\.\.\/\.\.\/\.\.\/shared-skills\/skill-source-filter\.mjs"/);
-	assert.doesNotMatch(script, /from "@oh-my-opencode\/shared-skills/);
+	try {
+		// when: the installer runs `npm run sync:skills` here, whose script is `node scripts/sync-skills.mjs`
+		const result = spawnSync(process.execPath, [join(cachedPluginRoot, "scripts", "sync-skills.mjs")], {
+			cwd: cachedPluginRoot,
+			encoding: "utf8",
+		});
+
+		// then
+		assert.equal(result.status, 0, `sync-skills failed in the cache layout:\n${result.stderr}`);
+		const syncedSkills = (await readdir(join(cachedPluginRoot, "skills"), { withFileTypes: true }))
+			.filter((entry) => entry.isDirectory())
+			.map((entry) => entry.name);
+		assert.ok(syncedSkills.includes("ultrawork"), "component skill ultrawork must be synced");
+		assert.ok(syncedSkills.includes("git-master"), "shared skill git-master must be synced from the linked package");
+	} finally {
+		await rm(codexHome, { recursive: true, force: true });
+	}
 });

--- a/packages/omo-codex/plugin/test/sync-skills.test.mjs
+++ b/packages/omo-codex/plugin/test/sync-skills.test.mjs
@@ -93,9 +93,11 @@ test("#given aggregate Codex skills #when source wiring is inspected #then share
 	assert.equal(rootPackageFiles.includes("packages/shared-skills/index.mjs"), true);
 	assert.equal(rootPackageFiles.includes("packages/shared-skills/skills"), true);
 	assert.equal(sharedSkillDependency, "file:../../shared-skills");
-	assert.match(syncScript, /from "\.\.\/\.\.\/\.\.\/shared-skills\/index\.mjs"/);
-	assert.match(syncScript, /from "\.\.\/\.\.\/\.\.\/shared-skills\/skill-source-filter\.mjs"/);
-	assert.doesNotMatch(syncScript, /from "@oh-my-opencode\/shared-skills/);
+	assert.match(syncScript, /from "@oh-my-opencode\/shared-skills"/);
+	assert.match(syncScript, /from "@oh-my-opencode\/shared-skills\/skill-source-filter"/);
+	// A checkout-relative path dangles once the installer flattens plugin/ into
+	// <CODEX_HOME>/plugins/cache/<marketplace>/omo/<version> (see canonical-ultrawork-directive.mjs).
+	assert.doesNotMatch(syncScript, /from "\.\.\/\.\.\/\.\.\/shared-skills\//);
 	assert.doesNotMatch(syncScript, /shared-skills",\s*"skills"/);
 });
 


### PR DESCRIPTION
## What breaks

`dev` (f4fdb53da) cannot install its Codex plugin from a published payload, for **both** `oh-my-openagent` and `lazycodex-ai`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<CODEX_HOME>/plugins/cache/sisyphuslabs/shared-skills/index.mjs'
  imported from <CODEX_HOME>/plugins/cache/sisyphuslabs/omo/.tmp-5.0.0-beta.43-…/scripts/sync-skills.mjs
```

Reproduced on an isolated Linux box by overlaying dev's `packages/omo-codex/plugin/scripts/sync-skills.mjs` onto the published 5.0.0-beta.43 tarballs and driving `installMarketplaceLocally` against a fresh `CODEX_HOME`: oh-my-openagent exit 1, lazycodex-ai exit 1. The same tarballs with the pre-#7814 imports install (oh-my-openagent exit 0 once the payload carries `codex.md`, #7835).

## Root cause

#7814 changed the two shared-skills imports in `sync-skills.mjs` from the package specifier `@oh-my-opencode/shared-skills` to the checkout-relative `../../../shared-skills/*.mjs`. `installMarketplaceLocally` copies **only** `plugin/` into `<CODEX_HOME>/plugins/cache/<marketplace>/omo/<version>` (see `canonical-ultrawork-directive.mjs`, which already documents this flattening), rewrites the `file:../../shared-skills` dependency to the extracted package, runs `npm install`, and only then `npm run sync:skills`. In that directory `../../../shared-skills` is `plugins/cache/<marketplace>/shared-skills`, which does not exist; the package specifier resolves through the `node_modules` link the installer just created.

The actual beta.43 lazycodex-ai failure was the **missing file** (`skill-source-filter.mjs` absent from the curated `files` list), not the specifier — #7813's payload guard is the fix for that and is untouched here.

## Fix

- `sync-skills.mjs`: package-specifier imports restored.
- `sync-skills-codex-compatibility.test.mjs`: the static import pin from #7814 is replaced by a test that builds the installer's cache layout (copy `plugin/` minus `node_modules`, materialize `packages/prompts-core/prompts/ultrawork/codex.md` under the cached root, symlink `node_modules/@oh-my-opencode/shared-skills`) and runs `sync-skills.mjs` inside it — RED on dev (ERR_MODULE_NOT_FOUND), GREEN here.
- `sync-skills.test.mjs`: pins the specifier imports and forbids the checkout-relative form.

## Verification

Run on a disposable Linux box (bun 1.4.0 / node 24 / npm 11), logs attached in the follow-up comment: plugin `node --test` on the two touched files, RED with dev's `sync-skills.mjs` swapped in, and the reconstruction installs of both packages exiting 0 with the fixed script.

Part of the 5.0.0-beta.44 hotfix (#7835 / #7836 / #7837).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex plugin installation failing in the installer cache layout by restoring package-specifier imports for shared-skills. The relative `../../../shared-skills/*.mjs` imports from #7814 resolved in a checkout but dangle after `installMarketplaceLocally` flattens `plugin/` into the cache, causing `ERR_MODULE_NOT_FOUND` when `sync-skills.mjs` runs.

**Bug Fixes**
- Restores `@oh-my-opencode/shared-skills` imports in `sync-skills.mjs` so shared skills resolve through the linked package in the installer cache.
- Replaces the static import pin with a test that builds the cache layout, symlinks `shared-skills`, and runs `sync-skills.mjs` to verify the fix.
- Adds a regression test forbidding checkout-relative shared-skills imports.

<sup>Written for commit 631e3f3f100228845b88d71edced9427fcadf81c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

