### PR TITLE
fix(background-agent): stop reading an unreachable server as a live session

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/error-classifier.ts
+++ b/packages/omo-opencode/src/features/background-agent/error-classifier.ts
@@ -6,6 +6,24 @@ export function isAbortedSessionError(error: unknown): boolean {
   return message.toLowerCase().includes("aborted")
 }
 
+const TRANSPORT_UNREACHABLE_PATTERNS: readonly RegExp[] = [
+  /unable to connect/i,
+  /econnrefused/i,
+  /econnreset/i,
+  /enotfound/i,
+  /socket hang up/i,
+  /fetch failed/i,
+  /network(?:\s|_)?error/i,
+  /not connected/i,
+  /connection (?:closed|refused|reset)/i,
+]
+
+export function isTransportUnreachableError(error: unknown): boolean {
+  const text = extractErrorMessage(error) ?? getErrorText(error)
+  if (!text) return false
+  return TRANSPORT_UNREACHABLE_PATTERNS.some((pattern) => pattern.test(text))
+}
+
 export function getErrorText(error: unknown): string {
   if (!error) return ""
   if (typeof error === "string") return error

--- a/packages/omo-opencode/src/features/background-agent/session-activity.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-activity.ts
@@ -1,4 +1,5 @@
 import { isRecord, log } from "../../shared"
+import { isTransportUnreachableError } from "./error-classifier"
 import type { OpencodeClient } from "./opencode-client"
 
 export type SessionActivityLookup =
@@ -39,6 +40,10 @@ export async function getSessionActivityFromClient(
       ...(directory ? { query: { directory } } : {}),
     })
     if (isRecord(response) && response.error !== undefined && response.error !== null) {
+      if (isTransportUnreachableError(response.error)) {
+        log("[background-agent] Session server is unreachable while reading activity:", { sessionID, error: response.error })
+        return { type: "missing" }
+      }
       log("[background-agent] Failed to read session activity:", { sessionID, error: response.error })
       return { type: "unavailable" }
     }
@@ -46,6 +51,13 @@ export async function getSessionActivityFromClient(
     const sessionInfo = isRecord(response) && "data" in response ? response.data : response
     return sessionActivityLookupFromInfo(sessionInfo)
   } catch (error) {
+    if (isTransportUnreachableError(error)) {
+      log("[background-agent] Session server is unreachable while reading activity:", {
+        sessionID,
+        error: error instanceof Error ? error.message : error,
+      })
+      return { type: "missing" }
+    }
     if (error instanceof Error) {
       log("[background-agent] Failed to read session activity:", { sessionID, error: error.message })
       return { type: "unavailable" }

--- a/packages/omo-opencode/src/features/background-agent/session-existence.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-existence.ts
@@ -1,3 +1,4 @@
+import { isTransportUnreachableError } from "./error-classifier"
 import type { OpencodeClient } from "./opencode-client"
 
 export const MIN_SESSION_GONE_POLLS = 3
@@ -48,11 +49,13 @@ export async function checkSessionExistence(
     })
 
     if (response.error !== undefined && response.error !== null) {
+      if (isTransportUnreachableError(response.error)) return "missing"
       return isSessionNotFoundError(response.error) ? "missing" : "unknown"
     }
 
     return response.data != null ? "exists" : "missing"
   } catch (error) {
+    if (isTransportUnreachableError(error)) return "missing"
     return isSessionNotFoundError(error) ? "missing" : "unknown"
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/session-reads-unreachable.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/session-reads-unreachable.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, mock, test } from "bun:test"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { getSessionActivityFromClient } from "./session-activity"
+import { checkSessionExistence } from "./session-existence"
+import type { OpencodeClient } from "./opencode-client"
+
+function clientThatRejects(error: unknown): OpencodeClient {
+  return unsafeTestValue<OpencodeClient>({
+    session: {
+      abort: mock(() => Promise.resolve()),
+      get: mock(() => Promise.reject(error)),
+    },
+  })
+}
+
+function clientThatReturnsError(error: unknown): OpencodeClient {
+  return unsafeTestValue<OpencodeClient>({
+    session: {
+      abort: mock(() => Promise.resolve()),
+      get: mock(() => Promise.resolve({ error })),
+    },
+  })
+}
+
+const UNREACHABLE = new Error("Unable to connect. Is the computer able to access the url?")
+
+describe("session reads against an unreachable server", () => {
+  test("#given the server cannot be reached #when checking existence #then the session is not reported as live", async () => {
+    expect(await checkSessionExistence(clientThatRejects(UNREACHABLE), "ses-1")).toBe("missing")
+  })
+
+  test("#given the server cannot be reached #when reading activity #then no activity is reported", async () => {
+    const lookup = await getSessionActivityFromClient(clientThatRejects(UNREACHABLE), "ses-1")
+    expect(lookup.type).toBe("missing")
+  })
+
+  test("#given a rejected connection reported in the response #when checking existence #then it is treated the same as a thrown one", async () => {
+    const connectionRefused = { message: "connect ECONNREFUSED 127.0.0.1:4096" }
+    expect(await checkSessionExistence(clientThatReturnsError(connectionRefused), "ses-1")).toBe("missing")
+  })
+
+  test("#given a real server error #when checking existence #then the answer stays unknown", async () => {
+    const serverError = { status: 500, message: "internal server error" }
+    expect(await checkSessionExistence(clientThatReturnsError(serverError), "ses-1")).toBe("unknown")
+  })
+
+  test("#given a real server error #when reading activity #then the answer stays unavailable", async () => {
+    const serverError = { status: 500, message: "internal server error" }
+    const lookup = await getSessionActivityFromClient(clientThatReturnsError(serverError), "ses-1")
+    expect(lookup.type).toBe("unavailable")
+  })
+})
+


### PR DESCRIPTION
## Summary

- When the OpenCode server is unreachable, running background tasks are never finalized. `session.get` rejects with `Unable to connect. Is the computer able to access the url?`, and both readers report that as "cannot tell", which the stale-task sweep reads as "keep waiting". A task with no activity for its entire timeout window stays `running` and the parent session is never told.
- Root cause: `checkSessionExistence` returns `"unknown"` for any error that is not a 404, and `getSessionActivityFromClient` returns `"unavailable"` for any thrown error. Both answers are indistinguishable from a healthy server that had a transient hiccup, so the sweep skips its own timeout.
- Fix: classify connection-level failures separately. An unreachable server is no longer evidence that the session is alive. A real API error still answers `"unknown"` / `"unavailable"` exactly as before.

## Changes

- `error-classifier.ts`: adds `isTransportUnreachableError`, matching connection-level failure text only (`unable to connect`, `ECONNREFUSED`, `ECONNRESET`, `ENOTFOUND`, `socket hang up`, `fetch failed`, `network error`, `not connected`, `connection closed/refused/reset`).
- `session-existence.ts`: a connection-level failure answers `"missing"` instead of `"unknown"`, for both a rejected promise and an error carried in the response.
- `session-activity.ts`: the same failure answers `{ type: "missing" }` instead of `{ type: "unavailable" }`, with its own log line so the reason is visible.
- `session-reads-unreachable.test.ts`: new tests, including two controls.

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/features/background-agent/session-reads-unreachable.test.ts`.
  **Observed result:** RED before the change, 3 fail / 2 pass. GREEN after, 5 pass.
  **Why sufficient:** the three failing cases are exactly the reads this PR changes, and the two that passed both before and after are the controls: a 500 API error must still answer `"unknown"` and `"unavailable"`, so the change is not a blanket loosening.
- **What was tested:** the error text was taken from a real client, not invented. A `createOpencodeClient({ baseUrl: "http://127.0.0.1:59117" })` pointed at a closed port rejects with `Error: Unable to connect. Is the computer able to access the url?`, which `dev` classified as `existence=unknown`, `activity=unavailable`.
  **Observed result:** recorded locally at `.omo/evidence/20260907-archive-branch-triage/live-transport-probe.test.ts.txt`.
  **Why sufficient:** it pins the patterns to what the SDK actually emits today rather than to a guess.
- **What was tested:** `bun test packages/omo-opencode/src/features/background-agent/` as the regression control.
  **Observed result:** 754 pass, 0 fail across 61 files.
- **What was tested:** `bun run typecheck`.
  **Observed result:** exit 0.

## Risks & Residuals

- Reading an unreachable server as "not visible" makes a task eligible for the stale path it was already eligible for by time: the default windows are 45 minutes of no activity and 60 minutes of message staleness, so a brief network blip cannot finalize live work on its own. Accepted, and stated here rather than left for review to find.
- The classifier matches text, so a provider that words a connection failure differently is not covered. Narrow by design: adding a pattern is cheap, and a broad match would swallow real API errors, which the two control tests forbid.
- Open PR #7265 also edits `session-existence.ts` (session-id prefix stripping, issue #6263). Different root cause, adjacent lines; if it lands first I will rebase onto it.

## Automated Checks

```bash
bun run typecheck
bun test packages/omo-opencode/src/features/background-agent/
```

## Related Issues

None open for this root cause. Searched `checkSessionExistence`, `getSessionActivityFromClient session activity unavailable`, `Unable to connect background task` and `stale task never finalized running forever` across open issues and PRs. The precedent is #5971, which landed terminate-and-notify for terminal session errors; this is the same shape for an endpoint that cannot be reached at all.



The companion case is #7851: when the abort of a confirmed-gone session fails, the sweep backs off forever. They are independent and can merge in either order; together they close the unreachable-endpoint path end to end.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stale-task sweep so background tasks no longer stay `running` forever when the OpenCode server is unreachable. Connection-level failures now read as "session missing" instead of "unknown"/"unavailable", letting the sweep finalize stale tasks, while real API errors still answer as before.

**Bug Fixes**
- Added `isTransportUnreachableError` matching connection failure patterns like `ECONNREFUSED`, `ENOTFOUND`, and "unable to connect".
- Connection failures in the activity read log a dedicated line so the reason stays visible.
- Added tests covering thrown and response-carried connection errors, with 500-response controls that must stay `unknown`/`unavailable`.

<sup>Written for commit 412c240a2a41f44306e23c4158f332734c2606f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

