### PR TITLE
fix(background-agent): finalize a stale task whose session is gone and cannot be aborted

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/task-poller-abort-failure.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-poller-abort-failure.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { checkAndInterruptStaleTasks } from "./task-poller"
+import type { BackgroundTask } from "./types"
+
+describe("checkAndInterruptStaleTasks abort failure on a confirmed-gone session", () => {
+  const originalDateNow = Date.now
+  const fixedTime = new Date("2026-09-07T03:00:00.000Z").getTime()
+
+  afterEach(() => {
+    Date.now = originalDateNow
+  })
+
+  test("finalizes a stale task whose session is gone even when abort fails", async () => {
+    //#given - the session is gone from the status registry and from storage, and abort can no longer reach it
+    spyOn(globalThis.Date, "now").mockReturnValue(fixedTime)
+    const staleActivity = new Date(fixedTime - 45 * 60 * 1000)
+    const task: BackgroundTask = {
+      id: "task-1",
+      sessionId: "ses-1",
+      parentSessionId: "parent-ses-1",
+      parentMessageId: "msg-1",
+      description: "test",
+      prompt: "test",
+      agent: "explore",
+      status: "running",
+      startedAt: staleActivity,
+      progress: { toolCalls: 2, lastUpdate: staleActivity },
+      consecutiveMissedPolls: 3,
+    }
+    const client = unsafeTestValue<Parameters<typeof checkAndInterruptStaleTasks>[0]["client"]>({
+      session: {
+        abort: mock(() => Promise.reject(new Error("session abort failed"))),
+        get: mock(() => Promise.resolve({ error: { status: 404, message: "session not found" } })),
+      },
+    })
+    const notify = mock(() => Promise.resolve())
+
+    //#when - the stale sweep runs well past the session-gone timeout
+    await checkAndInterruptStaleTasks({
+      tasks: [task],
+      client,
+      config: { staleTimeoutMs: 60_000, sessionGoneTimeoutMs: 60_000 },
+      concurrencyManager: unsafeTestValue<Parameters<typeof checkAndInterruptStaleTasks>[0]["concurrencyManager"]>({
+        release: mock(() => {}),
+      }),
+      notifyParentSession: notify,
+      sessionStatuses: {},
+    })
+
+    //#then - the task is cancelled and the parent is told, instead of waiting on a session that no longer exists
+    expect(task.status).toBe("cancelled")
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/packages/omo-opencode/src/features/background-agent/task-poller.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-poller.ts
@@ -114,6 +114,7 @@ export type SessionStatusMap = Record<string, { type: string }>
 async function interruptStaleTask(args: {
   task: BackgroundTask
   client: OpencodeClient
+  directory?: string
   concurrencyManager: ConcurrencyManager
   notifyParentSession: (task: BackgroundTask) => Promise<void>
   onTaskInterrupted: (task: BackgroundTask) => void
@@ -127,6 +128,7 @@ async function interruptStaleTask(args: {
   const {
     task,
     client,
+    directory,
     concurrencyManager,
     notifyParentSession,
     onTaskInterrupted,
@@ -140,12 +142,20 @@ async function interruptStaleTask(args: {
 
   const aborted = await abortWithTimeout(client, sessionID)
   if (!aborted) {
-    log("[background-agent] Task stale interruption skipped because session abort failed:", {
+    const existence = await checkSessionExistence(client, sessionID, directory)
+    if (existence !== "missing") {
+      log("[background-agent] Task stale interruption skipped because session abort failed:", {
+        taskId: task.id,
+        sessionID,
+        reason,
+      })
+      return
+    }
+    log("[background-agent] Session is gone and cannot be aborted; finalizing the stale task:", {
       taskId: task.id,
       sessionID,
       reason,
     })
-    return
   }
 
   if (task.status !== "running" || task.sessionId !== sessionID) return
@@ -249,6 +259,7 @@ export async function checkAndInterruptStaleTasks(args: {
         interruptStaleTask({
           task,
           client,
+          directory,
           concurrencyManager,
           notifyParentSession,
           onTaskInterrupted,
@@ -299,6 +310,7 @@ export async function checkAndInterruptStaleTasks(args: {
       interruptStaleTask({
         task,
         client,
+        directory,
         concurrencyManager,
         notifyParentSession,
         onTaskInterrupted,


### PR DESCRIPTION
## Summary

- A background task whose child session is already gone is never finalized when the abort call cannot succeed, so the task stays `running` forever and the parent session is never notified.
- `interruptStaleTask` treats a failed abort as a reason to retry on the next sweep. When the session is gone, that retry can never succeed, so the sweep backs off forever.
- Fix: before backing off, confirm whether the session still exists. A session that exists keeps the retry path unchanged; a session confirmed missing is finalized without a clean abort.

## Changes

- `packages/omo-opencode/src/features/background-agent/task-poller.ts`: `interruptStaleTask` now takes the caller's `directory` and, when `abortWithTimeout` returns false, calls `checkSessionExistence` before returning. Only `"missing"` proceeds to finalization; `"exists"` and `"unknown"` keep the existing skip-and-retry behavior and the existing log line.
- `packages/omo-opencode/src/features/background-agent/task-poller-abort-failure.test.ts`: new regression test for that path.

## QA & Evidence

- **What was tested:** `bun test packages/omo-opencode/src/features/background-agent/task-poller-abort-failure.test.ts` on a running task whose session is absent from the status registry, whose `session.get` answers 404, and whose `session.abort` rejects.
  **Observed result:** RED before the change, `Expected: "cancelled" / Received: "running"`. GREEN after: 1 pass, and `notifyParentSession` called once.
  **Why sufficient:** the assertion fails on exactly the behavior this PR changes, and it observes the user-visible outcome (task finalized, parent told) rather than the internal call.
- **What was tested:** `bun test packages/omo-opencode/src/features/background-agent/` as the regression control.
  **Observed result:** 750 pass, 0 fail across 61 files.
  **Why sufficient:** the surrounding stale-task, parent-wake and session-status suites are unchanged, so the new path did not loosen the existing ones.
- **What was tested:** `bun run typecheck`.
  **Observed result:** exit 0.

## Risks & Residuals

- A session that still exists, or whose existence cannot be determined, is unaffected: the early return, its log line and the retry path are byte-identical for those two cases. Mitigated by the control run above.
- `checkSessionExistence` adds one `session.get` call, and only on the path where an abort has already failed. Accepted.
- Open PR #5656 also touches `interruptStaleTask`, but refactors terminalization through a `completeTask` callback and leaves this `if (!aborted) return` early return untouched, so the two changes are independent. If #5656 lands first I will rebase onto it.

## Automated Checks

```bash
bun run typecheck
bun test packages/omo-opencode/src/features/background-agent/
```

## Related Issues

None open for this root cause. Searched `interruptStaleTask`, `interruptStaleTask abortWithTimeout`, `abortWithTimeout` and `stale task never finalized running forever` across open issues and PRs; the nearest open items (#6263, #7265, #5656) are different root causes in the same files.

The companion case is #7850: an unreachable server currently answers `unknown` to the same existence check, so that PR is what makes this one fire when the endpoint is down rather than 404-ing. They are independent and can merge in either order; merging this one alone already fixes the confirmed-gone case.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale background tasks staying `running` forever when their child session is already gone and abort can never succeed. `interruptStaleTask` now confirms the session still exists before backing off; a confirmed-missing session is finalized and the parent is notified, while `exists` and `unknown` keep the existing retry behavior.

**Changes**
- Threads `directory` into `interruptStaleTask` and calls `checkSessionExistence` only when the abort fails.
- Adds a regression test asserting the task is cancelled and the parent notified when the session returns 404 and abort rejects.

<sup>Written for commit 98385e2509bfec0e98ba73a128e6a195a360f4ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

