### PR TITLE
test(background-agent): pin the stale sweep against an unreachable server end to end

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/task-poller-unreachable-server.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-poller-unreachable-server.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { checkAndInterruptStaleTasks } from "./task-poller"
+import type { BackgroundTask } from "./types"
+
+type StaleSweepArgs = Parameters<typeof checkAndInterruptStaleTasks>[0]
+
+const UNREACHABLE_MESSAGE = "Unable to connect. Is the computer able to access the url?"
+const FIXED_NOW = new Date("2026-09-07T03:00:00.000Z").getTime()
+
+function unreachableClient(): StaleSweepArgs["client"] {
+  const reject = () => Promise.reject(new Error(UNREACHABLE_MESSAGE))
+  return unsafeTestValue<StaleSweepArgs["client"]>({
+    session: {
+      abort: mock(reject),
+      get: mock(reject),
+      status: mock(reject),
+    },
+  })
+}
+
+function runningTask(lastUpdate: Date): BackgroundTask {
+  return {
+    id: "task-1",
+    sessionId: "ses-1",
+    parentSessionId: "parent-ses-1",
+    parentMessageId: "msg-1",
+    description: "test",
+    prompt: "test",
+    agent: "explore",
+    status: "running",
+    startedAt: lastUpdate,
+    progress: { toolCalls: 2, lastUpdate },
+  }
+}
+
+async function sweep(task: BackgroundTask): Promise<ReturnType<typeof mock>> {
+  const notify = mock(() => Promise.resolve())
+  await checkAndInterruptStaleTasks({
+    tasks: [task],
+    client: unreachableClient(),
+    config: undefined,
+    concurrencyManager: unsafeTestValue<StaleSweepArgs["concurrencyManager"]>({ release: mock(() => {}) }),
+    notifyParentSession: notify,
+    sessionStatuses: undefined,
+  })
+  return notify
+}
+
+describe("checkAndInterruptStaleTasks while the OpenCode server is unreachable", () => {
+  const nowSpy = spyOn(Date, "now")
+
+  afterEach(() => {
+    nowSpy.mockReset()
+  })
+
+  test("#given a task stale past the default timeout #when every session call rejects as unreachable #then the task is finalized and the parent is told once", async () => {
+    nowSpy.mockReturnValue(FIXED_NOW)
+    const task = runningTask(new Date(FIXED_NOW - 46 * 60 * 1000))
+
+    const notify = await sweep(task)
+
+    expect(task.status).toBe("cancelled")
+    expect(task.error).toContain("Stale timeout")
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  test("#given a task with recent activity #when every session call rejects as unreachable #then the task keeps running and the parent is not told", async () => {
+    nowSpy.mockReturnValue(FIXED_NOW)
+    const task = runningTask(new Date(FIXED_NOW - 5 * 60 * 1000))
+
+    const notify = await sweep(task)
+
+    expect(task.status).toBe("running")
+    expect(notify).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- #7850 and #7851 each pin their own half of the unreachable-endpoint fix: the session readers (#7850) and the post-abort re-check in `interruptStaleTask` (#7851). Neither test exercises the path users actually hit, where `session.status()`, `session.get` and `session.abort` all reject because the OpenCode endpoint is gone.
- On that path the sweep runs with `sessionStatuses === undefined`, so `sessionGone` and the activity refresh are both off; the only route to finalization is `interruptStaleTask` -> failed abort -> existence re-check -> `"missing"`. Reverting either PR silently reopens the hang, and nothing in the suite would notice.
- This adds the end-to-end regression test for the combined behavior, with the blip-safety control alongside it. Test-only; no production change.

## Changes

- `packages/omo-opencode/src/features/background-agent/task-poller-unreachable-server.test.ts`: drives `checkAndInterruptStaleTasks` with a client whose `session.get` / `session.abort` / `session.status` all reject with the real Bun fetch message `Unable to connect. Is the computer able to access the url?` and no status registry.
  - a task 46 min stale (past `DEFAULT_STALE_TIMEOUT_MS`) must end `cancelled` with a `Stale timeout` error and exactly one `notifyParentSession` call;
  - a task 5 min stale must stay `running` with no notification, so a transient outage cannot finalize live work.

## QA & Evidence

- **What was tested:** the new file against four trees on an isolated Linux box (bun 1.4.0): `dev` before either PR, `dev` + #7850 only, `dev` + #7851 only, and `dev` + both.
  **Observed result:** stale case FAILS on `dev` (`Expected: "cancelled" / Received: "running"`), FAILS with only #7850 applied, FAILS with only #7851 applied, PASSES on the combined tree; the fresh-task control PASSES on all four. Re-run on this branch's tree: see the follow-up comment below.
  **Why sufficient:** the stale case fails on every tree that lacks either half and passes only on the combined tree, so the assertion is bound to the interaction the two PRs create, not to either PR alone. The control passes on every tree, which is the intended invariant (a fresh task is never finalized by an outage).
- **What was tested:** `bun test packages/omo-opencode/src/features/background-agent/` on the combined tree.
  **Observed result:** 757 pass, 0 fail across 63 files (bun 1.4.0, Linux box)
- **What was tested:** `bun run typecheck` on the combined tree.
  **Observed result:** exit 0.

## Risks & Residuals

- Test-only change. The test pins the default timeouts through `config: undefined`; a deliberate change to `DEFAULT_STALE_TIMEOUT_MS` above 46 minutes would need the fixture's staleness bumped with it — that is the intended coupling.

## Automated Checks

```bash
bun run typecheck
bun test packages/omo-opencode/src/features/background-agent/
```

## Related Issues

Follow-up to #7850 and #7851 (LilMGenius), as promised in my review there. Precedent for the shape: #5971.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end regression test for the stale-sweep path where every session call rejects because the OpenCode server is unreachable, covering the interaction of the session-reader fix (#7850) and the post-abort re-check fix (#7851) that neither prior test exercised.

- The test drives `checkAndInterruptStaleTasks` with a client whose `session.get`, `session.abort`, and `session.status` all reject with the real Bun unreachable message and no status registry.
- A task 46 minutes stale must end `cancelled` with a `Stale timeout` error and exactly one `notifyParentSession` call.
- A task 5 minutes stale must stay `running` with no notification, so a transient outage never finalizes live work.
- The stale case fails on `dev` without either fix and passes only when both fixes are present; the fresh-task control passes on all trees.
- Test-only change; the fixture pins `DEFAULT_STALE_TIMEOUT_MS` via `config: undefined`, so bumping that timeout above 46 minutes requires bumping the fixture's staleness too.

<sup>Written for commit cc7d8fc9ab5a09b896d619d5a4f1303be4baa989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

