### PR TITLE
fix(lsp-daemon): clean up dead owner when the endpoint socket vanished (fixes #7827)

### DIFF
--- a/.omo/evidence/20260908-7855-lsp-restart/README.md
+++ b/.omo/evidence/20260908-7855-lsp-restart/README.md
@@ -1,0 +1,92 @@
+# PR 7855: real vanished-endpoint restart proof
+
+## Scope and result
+
+Addresses review [discussion_r3944865688](https://github.com/code-yeongyu/oh-my-openagent/pull/7855#discussion_r3944865688)
+on source head `da130a5550e78c2181f412fb7373e4c1ba2e8d4b`, for issue #7827.
+This remediation adds evidence only; it does not change ownership behavior.
+
+**PASS:** real OpenCode 1.18.4 invoked `lsp_status` through the PR-built daemon's
+stdio MCP proxy after a dead owner's persisted Unix endpoint had disappeared.
+The daemon replaced PID **692** / nonce `bcce7221-e59b-4fea-826f-91be257eab19`
+with live PID **743** / nonce `f605a639-eb96-40a3-9897-39ff96bee275`, recreated
+the socket, rotated authentication, answered an authenticated owner ping and
+tool call, and rejected the old token. No token is included in this evidence.
+
+## What was tested
+
+The matching OpenCode QA guidance selected an isolated server/tool surface,
+not a TUI smoke or an in-process daemon substitute. `replay.mjs` drives:
+
+1. A task-owned child that exits naturally; its PID is confirmed dead by ESRCH.
+2. A real temporary Unix socket whose device/inode identity is captured before
+   closing it. The socket is confirmed absent before stale owner, PID, endpoint
+   and auth metadata are written. An authenticated ping fails with ENOENT.
+3. Real `opencode serve`, configured with a local MCP command pointing directly
+   at this worktree's built `packages/lsp-daemon/dist/cli.js`, not an installed
+   or main-checkout runtime. Its bundle SHA-256 is in `result.json`.
+4. A synchronous HTTP prompt whose deterministic local provider selects the
+   actual LSP tool advertised by OpenCode. The completed tool part is read back
+   from OpenCode's session messages; the model and daemon are not mocked.
+5. Replacement-owner and authentication checks, followed by owned-process and
+   sandbox teardown. Event waits are registered before triggers and bounded;
+   the driver has no fixed sleeps or polling delays.
+
+Only the model responses are scripted. The test used Node 24.18.0 and Bun 1.4.0
+inside an ARM64 disposable `omo-qa` container. Docker inspection confirmed its
+only host mount was the task repository; no real-home configuration, credential,
+database, or daemon state was mounted. One isolated session was created and
+removed with the sandbox. The container was removed after capture.
+
+## Replay
+
+Use a disposable ARM64 container with OpenCode, Node, Bun 1.4.0, and sqlite3.
+Mount a checkout of the tested PR at `/repo`, with no host configuration mounts.
+Install workspace dependencies and build this checkout's daemon, then run:
+
+```sh
+npm --prefix packages/lsp-daemon ci
+npm --prefix packages/lsp-daemon run typecheck
+npm --prefix packages/lsp-daemon run build
+node .omo/evidence/20260908-7855-lsp-restart/replay.mjs /repo
+```
+
+Run the driver **inside the disposable container**, not against a real home.
+The command emits sanitized JSON and fails if the required assertions fail.
+The provider is bound to loopback; no live model account is needed.
+
+## Captures and validation
+
+- `result.json`: exact successful harness tool output, before/after ownership,
+  auth booleans, runtime digest, isolation and cleanup receipts.
+- `checks.txt`: successful typecheck/build, lead-provided 13/13 focused test
+  result, independent 162/162 package-suite result, and all observed setup,
+  driver and lint failures with their disposition.
+- `replay.mjs`: reviewer-repeatable driver used for the successful capture.
+
+The package lint command still reports **11 existing format/import-order
+errors** on unchanged PR source/test files. They are not hidden or fixed by this
+evidence-only patch. The root automatic prepare build hit a container Git-pointer
+limitation; only the relevant daemon build is claimed green.
+
+## Why this is enough, and limits
+
+The reported failure happens before daemon startup can reclaim metadata. The
+fixture preserves the exact persisted `kind: "unix"` versus absent endpoint
+mismatch, and a real harness tool request triggers recovery without a manual
+metadata sweep. The new PID/nonce, rebuilt socket, authenticated responses and
+old-token rejection prove ownership and authentication were re-established.
+The existing ownership tests cover live-owner deferral and ownership guards.
+
+This scoped proof exercises the actual daemon MCP package with a direct local
+OpenCode MCP registration. It does not claim full OMO adapter bootstrap, a
+language-server diagnostics session, concurrent restart coverage, or Windows
+coverage; the status response honestly reports zero installed language servers.
+
+## What was omitted
+
+Auth tokens, auth headers, provider request bodies, unrelated environment or
+configuration, host-specific checkout paths, and unrelated logs are omitted.
+Sandbox paths are normalized. Public ownership nonces are retained to identify
+the state transition; they are not authentication tokens. No private prompt or
+personal-skill content was loaded or copied into the capture.

--- a/.omo/evidence/20260908-7855-lsp-restart/checks.txt
+++ b/.omo/evidence/20260908-7855-lsp-restart/checks.txt
@@ -1,0 +1,85 @@
+SOURCE
+PR head: da130a5550e78c2181f412fb7373e4c1ba2e8d4b
+No runtime or test source changes in this remediation.
+
+CONTAINER TYPECHECK AND BUILD (Node 24.18.0; Bun 1.4.0)
+npm --prefix packages/lsp-daemon ci
+exit=0; found 0 vulnerabilities
+npm --prefix packages/lsp-daemon run typecheck
+exit=0; tsc --noEmit; no diagnostics
+npm --prefix packages/lsp-daemon run build
+exit=0
+Bundled 83 modules in 41ms
+cli.js     250.43 KB (entry point)
+index.js   231.13 KB (entry point)
+client.js  228.86 KB (entry point)
+
+LEAD-RUN HOST CROSS-CHECK (reported by the lead during this task)
+Working directory: packages/lsp-daemon
+PATH: verified Bun 1.4.0 plus package/root node_modules/.bin
+tsc --noEmit && node scripts/build.mjs
+exit=0; compiler silent
+Bundled 83 modules in 82ms
+cli.js 250.43 KB; index.js 231.13 KB; client.js 228.86 KB
+vitest run test/auth-ownership.test.ts
+exit=0; Test Files 1 passed (1); Tests 13 passed (13)
+Initial host Vitest startup lacked the Darwin ARM64 native binding; no test
+assertions ran. The lead installed that binding without changing manifests
+before the successful focused run. These host results are lead-provided;
+the independent container results above/below were captured by this driver task.
+
+FULL RELATED PACKAGE SUITE
+Initial npm test: 161 passed, 1 failed, 22 files.
+Failure: qa-driver-portability.test.ts could not execute git ls-files because
+this sibling worktree's host .git pointer was not accessible in the container:
+fatal: not a git repository: (null)
+Repair: initialize a private bare Git directory in the container and copy only
+this task worktree's index into it. No host Git metadata mount is required.
+A subsequent launcher attempt failed before assertions: .bin/vitest returned
+Invalid argument after host dependency preparation changed the bind-mounted
+executable link. The existing JavaScript entry point avoids that broken link.
+Final command (working directory packages/lsp-daemon):
+GIT_DIR=<container-private-git> GIT_WORK_TREE=/repo node node_modules/vitest/vitest.mjs run
+exit=0
+Test Files 22 passed (22)
+Tests 162 passed (162)
+Duration 1.96s
+No assertions changed, no tests skipped, no ordering/retry flags.
+
+PRE-EXISTING PR LINT FAILURE (not repaired by evidence-only remediation)
+npm --prefix packages/lsp-daemon run lint
+exit=1; Checked 43 files; Found 11 errors.
+Format: src/ipc-protocol.ts, src/paths.ts, src/proxy.ts,
+src/request-routing.ts, src/version-reap.ts, test/auth-ownership.test.ts,
+test/build-script.test.ts, test/path-contract.test.ts, test/proxy.test.ts.
+Import order: src/ownership.ts, test/daemon-client.test.ts.
+git diff --exit-code HEAD -- packages/lsp-daemon/src packages/lsp-daemon/test
+exit=0; these files are unchanged from the reviewed PR head.
+
+REAL HARNESS
+node .omo/evidence/20260908-7855-lsp-restart/replay.mjs /repo
+exit=0; result.json records replacement PID/nonce and authenticated responses.
+The first two driver attempts reached the real harness but the supplementary
+raw IPC tool call omitted typed request context, then used an obsolete env
+field. The final driver uses the actual typed context contract. Those attempts
+were not counted as passes; no production code or test assertion was weakened.
+
+DIAGNOSTICS AND SETUP LIMITATIONS
+LSP diagnostics tool rejected sibling-worktree paths as outside request cwd.
+The package compiler above checked the actual task worktree instead.
+node --check .omo/evidence/20260908-7855-lsp-restart/replay.mjs
+exit=0
+Root bun install --frozen-lockfile populated dependencies, but its automatic
+prepare/root build failed when frontend submodule materialization could not
+resolve the host worktree Git pointer. The relevant daemon build passed;
+no full root-build pass is claimed.
+The cached Bun image initially supplied an amd64 executable to the arm64 QA
+container. Pulling oven/bun:1.4.0 explicitly for linux/arm64 repaired setup
+before package validators and real QA ran.
+
+ISOLATION AND TEARDOWN
+Docker inspection: exactly one bind mount, this task repository at /repo.
+No host HOME, OpenCode configuration, database, credentials or daemon mounts.
+The model provider was local; no external model calls or credential copies.
+No OpenCode/daemon/probe processes remained in the task container after QA.
+The named task container was removed; subsequent docker inspect failed as expected.

--- a/.omo/evidence/20260908-7855-lsp-restart/replay.mjs
+++ b/.omo/evidence/20260908-7855-lsp-restart/replay.mjs
@@ -1,0 +1,220 @@
+// Run inside a disposable Linux container with this PR mounted at /repo.
+// Only the provider is scripted; OpenCode, MCP proxy and daemon are real.
+import assert from "node:assert/strict";
+import { spawn, execFileSync } from "node:child_process";
+import { randomBytes, randomUUID, createHash } from "node:crypto";
+import { once } from "node:events";
+import { createServer as httpServer } from "node:http";
+import { createConnection, createServer as socketServer } from "node:net";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, watch, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const repo = resolve(process.argv[2] ?? "/repo");
+const cli = join(repo, "packages/lsp-daemon/dist/cli.js");
+assert(existsSync(cli), "Build the PR daemon first");
+const root = mkdtempSync(join(tmpdir(), "pr7855-"));
+const project = join(root, "project");
+const home = join(root, "home");
+const version = JSON.parse(readFileSync(join(repo, "packages/lsp-daemon/package.json"))).version;
+const daemonRoot = join(root, "daemon");
+const dir = join(daemonRoot, `v${version}`);
+const endpoint = join(dir, "daemon.sock");
+const ownerPath = join(dir, "daemon.owner");
+const authPath = join(dir, "daemon.auth");
+for (const path of [project, home, dir, ...["data", "config", "cache", "state"].map(x => join(root, x))]) {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+}
+const env = {
+  PATH: process.env.PATH, HOME: home, TMPDIR: root,
+  XDG_DATA_HOME: join(root, "data"), XDG_CONFIG_HOME: join(root, "config"),
+  XDG_CACHE_HOME: join(root, "cache"), XDG_STATE_HOME: join(root, "state"),
+  OPENCODE_TEST_HOME: home, OPENCODE_DISABLE_AUTOUPDATE: "1", OPENCODE_DISABLE_MODELS_FETCH: "1",
+  OMO_DISABLE_POSTHOG: "1", OPENCODE_DISABLE_PROJECT_CONFIG: "true",
+  OMO_LSP_DAEMON_DIR: daemonRoot, OMO_LSP_DAEMON_CLI: cli, OMO_LSP_DAEMON_VERSION: version,
+  LSP_TOOLS_MCP_PROJECT_CONFIG: join(project, "lsp.json"),
+  LSP_TOOLS_MCP_USER_CONFIG: join(home, "lsp.json"),
+  LSP_TOOLS_MCP_INSTALL_DECISIONS: join(home, "install-decisions.json"),
+};
+const deadline = (label, ms = 60000) => AbortSignal.timeout(ms);
+function waitEvent(emitter, event, label, ms = 60000) {
+  return once(emitter, event, { signal: deadline(label, ms) });
+}
+function rpc(params, method = "omo/ping") {
+  return new Promise((resolveResult, reject) => {
+    const socket = createConnection(endpoint);
+    const timer = setTimeout(() => { socket.destroy(); reject(new Error("IPC response timeout")); }, 10000);
+    let data = "";
+    socket.once("error", error => { clearTimeout(timer); reject(error); });
+    socket.once("connect", () => socket.write(JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n"));
+    socket.on("data", chunk => {
+      data += chunk;
+      if (!data.includes("\n")) return;
+      clearTimeout(timer);
+      socket.destroy();
+      try { resolveResult(JSON.parse(data.split("\n")[0])); } catch (error) { reject(error); }
+    });
+  });
+}
+let server;
+let model;
+let replacement;
+let selectedTool;
+let modelCalls = 0;
+const result = {
+  sourceHead: "da130a5550e78c2181f412fb7373e4c1ba2e8d4b",
+  capturedAt: new Date().toISOString(),
+  node: process.version,
+  bun: execFileSync("bun", ["--version"], { env }).toString().trim(),
+  opencode: execFileSync("opencode", ["--version"], { env }).toString().trim(),
+  runtime: "packages/lsp-daemon/dist/cli.js",
+  runtimeSha256: createHash("sha256").update(readFileSync(cli)).digest("hex"),
+  isolation: { home: "<sandbox>/home", xdg: "<sandbox>/{data,config,cache,state}", daemon: "<sandbox>/daemon", hostMounts: "repository-only" },
+};
+try {
+  // This child exits naturally: the fixture PID is verified dead, never guessed.
+  const dead = spawn(process.execPath, ["-e", ""], { env, stdio: "ignore" });
+  const deadExit = waitEvent(dead, "exit", "fixture process exit");
+  assert.equal((await deadExit)[0], 0);
+  assert.throws(() => process.kill(dead.pid, 0), { code: "ESRCH" });
+  const fixtureSocket = socketServer();
+  const listening = waitEvent(fixtureSocket, "listening", "fixture socket");
+  fixtureSocket.listen(endpoint);
+  await listening;
+  const { dev, ino } = statSync(endpoint);
+  const closed = waitEvent(fixtureSocket, "close", "fixture socket close");
+  fixtureSocket.close();
+  await closed;
+  assert.equal(existsSync(endpoint), false);
+  const staleToken = randomBytes(32).toString("hex");
+  const stale = { pid: dead.pid, nonce: randomUUID(), startedAt: new Date(0).toISOString(), endpoint: { kind: "unix", path: endpoint, dev, ino } };
+  for (const [name, text] of [["daemon.owner", JSON.stringify(stale)], ["daemon.pid", String(dead.pid)], ["daemon.endpoint", endpoint], ["daemon.auth", staleToken]]) {
+    writeFileSync(join(dir, name), text, { mode: 0o600 });
+  }
+  await assert.rejects(rpc({ _omo: { protocolVersion: 1, token: staleToken } }), { code: "ENOENT" });
+  result.before = { pid: dead.pid, nonce: stale.nonce, pidDead: true, persistedEndpointKind: "unix", endpointAbsent: true, authenticatedPingError: "ENOENT" };
+
+  // The provider selects the actual tool name advertised by OpenCode, not a stub.
+  model = httpServer(async (request, response) => {
+    try {
+      let raw = "";
+      for await (const chunk of request) raw += chunk;
+      const body = JSON.parse(raw);
+      const tools = (body.tools ?? []).map(tool => tool.name ?? tool.function?.name);
+      const name = tools.find(name => name?.endsWith("lsp_status"));
+      const input = JSON.stringify(body.input ?? []);
+      const toolResult = input.includes('"type":"function_call_output"');
+      const call = ++modelCalls;
+      const id = `resp_${call}`;
+      const item = `item_${call}`;
+      const tool = name && !toolResult && input.includes("PR7855_RESTART");
+      if (tool) selectedTool = name;
+      const output = tool
+        ? { type: "function_call", id: item, call_id: `call_${call}`, name, arguments: "{}" }
+        : { type: "message", id: item, role: "assistant", content: [{ type: "output_text", text: "Restart probe complete." }] };
+      const events = [
+        { type: "response.created", response: { id, created_at: Math.floor(Date.now() / 1000), model: "gpt-fake" } },
+        { type: "response.output_item.added", output_index: 0, item: tool ? { ...output, arguments: "" } : { type: "message", id: item } },
+        tool ? { type: "response.function_call_arguments.delta", item_id: item, output_index: 0, delta: "{}" }
+          : { type: "response.output_text.delta", item_id: item, output_index: 0, delta: "Restart probe complete." },
+        { type: "response.output_item.done", output_index: 0, item: { ...output, status: "completed" } },
+        { type: "response.completed", response: { usage: { input_tokens: 10, output_tokens: 5, input_tokens_details: { cached_tokens: 0 }, output_tokens_details: { reasoning_tokens: 0 } } } },
+      ];
+      response.writeHead(200, { "content-type": "text/event-stream" });
+      for (const event of events) response.write(`data: ${JSON.stringify(event)}\n\n`);
+      response.end("data: [DONE]\n\n");
+    } catch (error) { response.writeHead(500).end(String(error)); }
+  });
+  const modelReady = waitEvent(model, "listening", "local provider");
+  model.listen(0, "127.0.0.1");
+  await modelReady;
+  const config = {
+    model: "openai/gpt-fake", permission: "allow", plugin: [],
+    provider: { openai: { options: { apiKey: "local-fixture", baseURL: `http://127.0.0.1:${model.address().port}/v1` }, models: { "gpt-fake": { tool_call: true, limit: { context: 200000, output: 8192 } } } } },
+    mcp: { lsp: { type: "local", command: [process.execPath, cli, "mcp"], environment: env } },
+  };
+  const configPath = join(root, "opencode.json");
+  writeFileSync(configPath, JSON.stringify(config));
+  const password = randomBytes(24).toString("hex");
+  const auth = "Basic " + Buffer.from(`opencode:${password}`).toString("base64");
+  server = spawn("opencode", ["serve", "--hostname", "127.0.0.1", "--port", "0"], {
+    cwd: project, env: { ...env, OPENCODE_CONFIG: configPath, OPENCODE_SERVER_PASSWORD: password }, stdio: ["ignore", "pipe", "pipe"],
+  });
+  const url = await new Promise((resolveUrl, reject) => {
+    let output = "";
+    const timer = setTimeout(() => reject(new Error("OpenCode did not report listening")), 60000);
+    server.once("error", error => { clearTimeout(timer); reject(error); });
+    server.once("exit", code => { clearTimeout(timer); reject(new Error(`OpenCode exited ${code}`)); });
+    for (const stream of [server.stdout, server.stderr]) stream.on("data", chunk => {
+      output += chunk;
+      const match = output.match(/opencode server listening on (http:\/\/[^\s]+)/);
+      if (match) { clearTimeout(timer); resolveUrl(match[1]); }
+    });
+  });
+  async function api(path, body) {
+    const response = await fetch(url + path, { method: body === undefined ? "GET" : "POST", headers: { authorization: auth, "content-type": "application/json" }, body: body === undefined ? undefined : JSON.stringify(body), signal: deadline(path, 90000) });
+    assert(response.ok, `${path}: HTTP ${response.status}`);
+    return response.json();
+  }
+  result.health = await api("/global/health");
+  const session = await api("/session", { title: "PR 7855 isolated restart" });
+  // The synchronous prompt response is the exact turn-completion signal.
+  await api(`/session/${session.id}/message`, { model: { providerID: "openai", modelID: "gpt-fake" }, parts: [{ type: "text", text: "PR7855_RESTART: invoke the LSP status tool once." }] });
+  const messages = await api(`/session/${session.id}/message`);
+  const tool = messages.flatMap(message => message.parts ?? []).find(part => part.type === "tool" && part.tool === selectedTool);
+  assert(tool, "OpenCode did not invoke the advertised LSP tool");
+  assert.equal(tool.state.status, "completed");
+  assert(tool.state.output.length > 0);
+  replacement = JSON.parse(readFileSync(ownerPath));
+  assert.notEqual(replacement.pid, stale.pid);
+  assert.notEqual(replacement.nonce, stale.nonce);
+  process.kill(replacement.pid, 0);
+  assert(statSync(endpoint).isSocket());
+  const token = readFileSync(authPath, "utf8").trim();
+  assert.notEqual(token, staleToken);
+  const ping = await rpc({ _omo: { protocolVersion: 1, token } });
+  assert.equal(ping.result.pid, replacement.pid);
+  assert.equal(ping.result.nonce, replacement.nonce);
+  const rejected = await rpc({ _omo: { protocolVersion: 1, token: staleToken } });
+  assert.equal(rejected.error.data.code, "daemon_authentication_failed");
+  const context = {
+    cwd: project, projectConfigPaths: [env.LSP_TOOLS_MCP_PROJECT_CONFIG],
+    userConfigPath: env.LSP_TOOLS_MCP_USER_CONFIG,
+    installDecisionsPath: env.LSP_TOOLS_MCP_INSTALL_DECISIONS,
+    capabilities: { installDecisionTool: true },
+  };
+  const call = await rpc({ name: "lsp_status", arguments: { _context: context }, _omo: { protocolVersion: 1, token } }, "tools/call");
+  assert.equal(call.error, undefined);
+  assert.equal(Boolean(call.result.isError), false);
+  assert(call.result.content.length > 0);
+  result.after = { pid: replacement.pid, nonce: replacement.nonce, pidAlive: true, endpointSocket: true, authRotated: true, authenticatedPingMatchesOwner: true, staleAuthRejected: true, authenticatedToolCallSucceeded: true };
+  result.harness = { surface: "OpenCode serve HTTP prompt -> lsp MCP stdio proxy -> authenticated daemon", tool: selectedTool, status: tool.state.status, output: tool.state.output, modelCalls, externalModelCalls: 0 };
+  result.isolation.sandboxSessions = Number(execFileSync("sqlite3", [join(root, "data/opencode/opencode.db"), "select count(*) from session"]).toString().trim());
+  const serialized = JSON.stringify(result);
+  for (const secret of [token, staleToken, password, auth]) assert(!serialized.includes(secret), "Secret in public capture");
+} finally {
+  if (server && server.exitCode === null) {
+    const stopped = waitEvent(server, "exit", "OpenCode exit", 15000);
+    server.kill("SIGTERM");
+    await stopped;
+  }
+  if (existsSync(ownerPath)) {
+    const current = JSON.parse(readFileSync(ownerPath));
+    // Only terminate the daemon spawned under this task's private root.
+    assert(current.pid !== result.before?.pid);
+    if (replacement) assert.equal(current.nonce, replacement.nonce);
+    const watcher = watch(dir);
+    const removed = new Promise((resolveRemoved, reject) => {
+      const timer = setTimeout(() => reject(new Error("Owned daemon metadata remained")), 15000);
+      watcher.on("change", () => { if (!existsSync(ownerPath)) { clearTimeout(timer); resolveRemoved(); } });
+    });
+    process.kill(current.pid, "SIGTERM");
+    try { await removed; } finally { watcher.close(); }
+  }
+  if (model) { const stopped = waitEvent(model, "close", "provider exit"); model.closeAllConnections(); model.close(); await stopped; }
+  result.cleanup = { opencodeExited: !server || server.exitCode !== null || server.signalCode !== null, daemonMetadataRemoved: !existsSync(ownerPath), providerClosed: true };
+  rmSync(root, { recursive: true, force: true });
+  result.cleanup.sandboxRemoved = !existsSync(root);
+}
+result.result = "PASS";
+console.log(JSON.stringify(result, null, 2).replaceAll(root, "<sandbox>").replaceAll(repo, "<repo>"));

--- a/.omo/evidence/20260908-7855-lsp-restart/result.json
+++ b/.omo/evidence/20260908-7855-lsp-restart/result.json
@@ -1,0 +1,65 @@
+{
+  "sourceHead": "da130a5550e78c2181f412fb7373e4c1ba2e8d4b",
+  "capturedAt": "2026-09-08T15:03:55.310Z",
+  "node": "v24.18.0",
+  "bun": "1.4.0",
+  "opencode": "1.18.4",
+  "runtime": "packages/lsp-daemon/dist/cli.js",
+  "runtimeSha256": "53b5c08e3e1db0cf2ea0ebd94a1a92070f42f4abbba1572fb0976de4fd7c209f",
+  "isolation": {
+    "home": "<sandbox>/home",
+    "xdg": "<sandbox>/{data,config,cache,state}",
+    "daemon": "<sandbox>/daemon",
+    "hostMounts": "repository-only",
+    "sandboxSessions": 1
+  },
+  "before": {
+    "pid": 692,
+    "nonce": "bcce7221-e59b-4fea-826f-91be257eab19",
+    "pidDead": true,
+    "persistedEndpointKind": "unix",
+    "endpointAbsent": true,
+    "authenticatedPingError": "ENOENT"
+  },
+  "health": {
+    "healthy": true,
+    "version": "1.18.4"
+  },
+  "after": {
+    "pid": 743,
+    "nonce": "f605a639-eb96-40a3-9897-39ff96bee275",
+    "pidAlive": true,
+    "endpointSocket": true,
+    "authRotated": true,
+    "authenticatedPingMatchesOwner": true,
+    "staleAuthRejected": true,
+    "authenticatedToolCallSucceeded": true
+  },
+  "harness": {
+    "surface": "OpenCode serve HTTP prompt -> lsp MCP stdio proxy -> authenticated daemon",
+    "tool": "lsp_status",
+    "status": "completed",
+    "output": "Configured LSP servers: 42\nInstalled LSP servers: 0\n\n- typescript: missing; source=builtin; extensions=.ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts\n- deno: missing; source=builtin; extensions=.ts, .tsx, .js, .jsx, .mjs\n- vue: missing; source=builtin; extensions=.vue\n- eslint: missing; source=builtin; extensions=.ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue\n- oxlint: missing; source=builtin; extensions=.ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte\n- biome: missing; source=builtin; extensions=.ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .json, .jsonc, .vue, .astro, .svelte, .css, .graphql, .gql, .html\n- gopls: missing; source=builtin; extensions=.go\n- ruby-lsp: missing; source=builtin; extensions=.rb, .rake, .gemspec, .ru\n- basedpyright: missing; source=builtin; extensions=.py, .pyi\n- pyright: missing; source=builtin; extensions=.py, .pyi\n- ty: missing; source=builtin; extensions=.py, .pyi\n- ruff: missing; source=builtin; extensions=.py, .pyi\n- elixir-ls: missing; source=builtin; extensions=.ex, .exs\n- zls: missing; source=builtin; extensions=.zig, .zon\n- csharp: missing; source=builtin; extensions=.cs\n- fsharp: missing; source=builtin; extensions=.fs, .fsi, .fsx, .fsscript\n- sourcekit-lsp: missing; source=builtin; extensions=.swift, .m, .mm\n- rust: missing; source=builtin; extensions=.rs\n- clangd: missing; source=builtin; extensions=.c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++\n- svelte: missing; source=builtin; extensions=.svelte\n- astro: missing; source=builtin; extensions=.astro\n- bash: missing; source=builtin; extensions=.sh, .bash, .zsh, .ksh\n- bash-ls: missing; source=builtin; extensions=.sh, .bash, .zsh, .ksh\n- jdtls: missing; source=builtin; extensions=.java\n- yaml-ls: missing; source=builtin; extensions=.yaml, .yml\n- lua-ls: missing; source=builtin; extensions=.lua\n- php: missing; source=builtin; extensions=.php\n- dart: missing; source=builtin; extensions=.dart\n- terraform: missing; source=builtin; extensions=.tf, .tfvars\n- terraform-ls: missing; source=builtin; extensions=.tf, .tfvars\n- prisma: missing; source=builtin; extensions=.prisma\n- ocaml-lsp: missing; source=builtin; extensions=.ml, .mli\n- texlab: missing; source=builtin; extensions=.tex, .bib\n- dockerfile: missing; source=builtin; extensions=.dockerfile\n- gleam: missing; source=builtin; extensions=.gleam\n- clojure-lsp: missing; source=builtin; extensions=.clj, .cljs, .cljc, .edn\n- nixd: missing; source=builtin; extensions=.nix\n- tinymist: missing; source=builtin; extensions=.typ, .typc\n- haskell-language-server: missing; source=builtin; extensions=.hs, .lhs\n- kotlin-ls: missing; source=builtin; extensions=.kt, .kts\n- julials: missing; source=builtin; extensions=.jl\n- razor: missing; source=builtin; extensions=.razor, .cshtml\n\nActive LSP clients: 0",
+    "modelCalls": 2,
+    "externalModelCalls": 0
+  },
+  "cleanup": {
+    "opencodeExited": true,
+    "daemonMetadataRemoved": true,
+    "providerClosed": true,
+    "sandboxRemoved": true
+  },
+  "result": "PASS",
+  "captureId": "pr7855-vanished-endpoint-20260908T150355Z",
+  "container": {
+    "image": "omo-qa:latest",
+    "imageId": "sha256:e40c321a338bacdc02dd643f1b968570b2f5522509c46523b862d05e0bed5ab2",
+    "platform": "linux/arm64",
+    "mountDestinations": [
+      "/repo"
+    ],
+    "hostConfigurationMounted": false,
+    "hostDatabaseMounted": false,
+    "removedAfterCapture": true
+  }
+}

--- a/packages/lsp-daemon/src/ownership.ts
+++ b/packages/lsp-daemon/src/ownership.ts
@@ -143,7 +143,8 @@ async function validateExistingOwner(
 		if (isProcessAlive(owner.pid)) throw new DaemonStartupDeferredError("owner_pid_live_unreachable");
 		const reread = readDaemonOwner(paths);
 		const endpoint = endpointIdentity(owner.endpoint.path);
-		if (!reread || reread.nonce !== owner.nonce || !sameEndpoint(endpoint, owner.endpoint)) {
+		const endpointRebound = endpoint.kind !== "missing" && !sameEndpoint(endpoint, owner.endpoint);
+		if (!reread || reread.nonce !== owner.nonce || endpointRebound) {
 			throw new DaemonStartupDeferredError("owner_changed_during_cleanup");
 		}
 		cleanupDeadOwner(paths, owner);

--- a/packages/lsp-daemon/test/auth-ownership.test.ts
+++ b/packages/lsp-daemon/test/auth-ownership.test.ts
@@ -269,6 +269,31 @@ describe("daemon IPC authentication and ownership", () => {
 		expect(readDaemonOwner(paths)?.nonce).not.toBe("dead");
 	});
 
+	it("given a dead owner with a missing Unix socket when candidate starts then it rotates auth and takes ownership", async () => {
+		if (process.platform === "win32") return;
+		const paths = tempPaths();
+		mkdirSync(paths.dir, { recursive: true });
+		writeFileSync(paths.auth, "old-token", { mode: 0o600 });
+		writeFileSync(
+			paths.owner,
+			JSON.stringify({
+				pid: 9_999_999,
+				nonce: "dead",
+				startedAt: "old",
+				endpoint: { kind: "unix", path: paths.socket, dev: 1, ino: 1 },
+			}),
+			{
+				mode: 0o600,
+			},
+		);
+		writeFileSync(paths.endpoint, paths.socket, { mode: 0o600 });
+		const server = await startDaemonServer(paths, { onIdleShutdown: () => {} });
+		openServers.push(server);
+
+		expect(readFileSync(paths.auth, "utf8").trim()).not.toBe("old-token");
+		expect(readDaemonOwner(paths)?.nonce).not.toBe("dead");
+	});
+
 	it("given a stale close from an old owner when a new owner exists then winner metadata survives", async () => {
 		const paths = tempPaths();
 		const first = await startDaemonServer(paths, { onIdleShutdown: () => {} });


### PR DESCRIPTION
## Summary

After a reboot the LSP daemon could never start again: it failed on `DaemonStartupDeferredError: owner_changed_during_cleanup` in a loop, and the dead daemon's metadata was never cleaned. This makes the dead-owner cleanup actually run in the case it was written for.

## Root Cause

`writeDaemonOwner` persists the owner as `JSON.stringify(owner)`, where `endpoint` is a concrete `{ kind: "unix", path, dev, ino }`. `parseEndpoint` only re-derives the identity from disk when `kind` is **absent** (`ownership.ts:190`); when `kind === "unix"` it returns the persisted value verbatim (`ownership.ts:195`).

So after a reboot, inside `validateExistingOwner`:

```ts
if (isProcessAlive(owner.pid)) throw new DaemonStartupDeferredError("owner_pid_live_unreachable"); // owner is dead, falls through
const reread = readDaemonOwner(paths);
const endpoint = endpointIdentity(owner.endpoint.path);   // socket file is gone -> { kind: "missing" }
if (!reread || reread.nonce !== owner.nonce || !sameEndpoint(endpoint, owner.endpoint)) {
  throw new DaemonStartupDeferredError("owner_changed_during_cleanup");   // <- thrown here
}
cleanupDeadOwner(paths, owner);   // <- never reached
```

`sameEndpoint` returns `false` immediately on the `kind` mismatch (`missing` vs the persisted `unix`), so it throws before `cleanupDeadOwner` can remove `daemon.owner` / `daemon.pid` / `daemon.endpoint`. Every later startup repeats this, until an unrelated sweep happens to wipe the directory.

Note this branch is only reached once `isProcessAlive(owner.pid)` is already `false`, so the owner is definitively dead.

## Changes

| File | Change |
|------|--------|
| `packages/lsp-daemon/src/ownership.ts` | Defer only on a genuine rebind: treat a vanished (`missing`) endpoint as cleanup-eligible instead of as an owner-change race. The nonce re-read guard is unchanged. |
| `packages/lsp-daemon/test/auth-ownership.test.ts` | Regression test: dead pid + persisted `{ kind: "unix", ... }` endpoint + no socket file on disk. |

The endpoint comparison exists to catch the endpoint being rebound to a **different still-existing** endpoint. A vanished endpoint means nothing is bound, so the dead owner's metadata is safe to clean.

Windows is unaffected: `endpointIdentity` returns `{ kind: "windows" }` there and never `"missing"`, so the new guard is a no-op. The test is skipped on win32 for the same reason.

## Reproduction (before fix)

Reverting only the 2-line source change, keeping the new test:

```
FAIL  test/auth-ownership.test.ts > daemon IPC authentication and ownership >
      given a dead owner with a missing Unix socket when candidate starts then it rotates auth and takes ownership
DaemonStartupDeferredError: LSP daemon startup deferred: owner_changed_during_cleanup
    147|    throw new DaemonStartupDeferredError("owner_changed_during_cleanup"...

Tests  1 failed | 12 passed (13)
```

## Verification (after fix)

```
Test Files  1 passed (1)
     Tests  13 passed (13)
```

The pre-existing neighbours still pass, including `given live unreachable owner metadata when candidate starts then it defers without unlinking endpoint` (proves live owners still defer) and `given a dead unchanged owner when candidate starts then it rotates auth and takes ownership`.

## Test

- Regression test: `packages/lsp-daemon/test/auth-ownership.test.ts` (newly added, Unix-guarded)
- Package suite: `npm run test` in `packages/lsp-daemon` - 162 pass across 22 files
- Typecheck: `tsc --noEmit` clean
- Note: `npm run check` also runs `biome check .`, which reports 2 pre-existing errors on these files. I verified this is unrelated to this change: stashing the change and running biome on the pristine `dev` files reports the same 2 errors. I left them alone rather than reformatting unrelated code.

Fixes #7827

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LSP daemon startup deadlock after a reboot where a dead owner's stale metadata was never cleaned, so the daemon now starts again instead of throwing `owner_changed_during_cleanup` in a loop.

- Defer only when the endpoint was rebound to a different still-existing socket; a vanished socket means the stale metadata is safe to remove.
- The nonce re-read race guard is unchanged.
- Adds a regression test for a dead pid plus a persisted Unix endpoint with no socket file on disk; Windows is unaffected.
- Adds sanitized replay evidence under `.omo/evidence/`.

<sup>Written for commit 5d397e798a095e35496a01d689ae9d110ba7a61f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

