### PR TITLE
fix(codex-install): retry a cached-plugin promote whose directory is still busy

### DIFF
--- a/packages/omo-codex/scripts/install-dist/install-local.mjs
+++ b/packages/omo-codex/scripts/install-dist/install-local.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// omo-codex-install:81cf03496fa0db52b428d9e5f1d2a022f753fe60530d84f72d767af03333373f:cc1555990cc7467cc545d7f3fcb60ad36f9dc529737a841ed819c2d8ac9303be
+// omo-codex-install:e3b01c9c644553d3d24772808854b691edfe72f6e4a5520c62fb39a167063866:9a6a7b7fce7ae3051ac44306753da57f686bcebab247b8268978191e3beea728
 var __defProp = Object.defineProperty;
 var __returnValue = (v) => v;
 function __exportSetter(name, newValue) {
@@ -3075,32 +3075,32 @@ var init_release = () => {};
 // node_modules/.bun/@posthog+core@1.48.9/node_modules/@posthog/core/dist/error-tracking/index.mjs
 var exports_error_tracking = {};
 __export(exports_error_tracking, {
-  DEFAULT_EXCEPTION_STEPS_CONFIG: () => DEFAULT_EXCEPTION_STEPS_CONFIG,
-  DOMExceptionCoercer: () => DOMExceptionCoercer,
-  EXCEPTION_STEP_INTERNAL_FIELDS: () => EXCEPTION_STEP_INTERNAL_FIELDS,
-  ErrorCoercer: () => ErrorCoercer,
-  ErrorEventCoercer: () => ErrorEventCoercer,
-  ErrorPropertiesBuilder: () => ErrorPropertiesBuilder,
-  EventCoercer: () => EventCoercer,
-  ExceptionStepsBuffer: () => ExceptionStepsBuffer,
-  ObjectCoercer: () => ObjectCoercer,
-  PrimitiveCoercer: () => PrimitiveCoercer,
-  PromiseRejectionEventCoercer: () => PromiseRejectionEventCoercer,
-  ReduceableCache: () => ReduceableCache,
-  StringCoercer: () => StringCoercer,
-  chromeStackLineParser: () => chromeStackLineParser,
-  createDefaultStackParser: () => createDefaultStackParser,
-  createStackParser: () => createStackParser,
-  geckoStackLineParser: () => geckoStackLineParser,
-  getInjectedReleaseId: () => getInjectedReleaseId,
-  getUtf8ByteLength: () => getUtf8ByteLength,
-  nodeStackLineParser: () => nodeStackLineParser,
-  opera10StackLineParser: () => opera10StackLineParser,
-  opera11StackLineParser: () => opera11StackLineParser,
-  resolveExceptionStepsConfig: () => resolveExceptionStepsConfig,
-  reverseAndStripFrames: () => reverseAndStripFrames,
+  winjsStackLineParser: () => winjsStackLineParser,
   stripReservedExceptionStepFields: () => stripReservedExceptionStepFields,
-  winjsStackLineParser: () => winjsStackLineParser
+  reverseAndStripFrames: () => reverseAndStripFrames,
+  resolveExceptionStepsConfig: () => resolveExceptionStepsConfig,
+  opera11StackLineParser: () => opera11StackLineParser,
+  opera10StackLineParser: () => opera10StackLineParser,
+  nodeStackLineParser: () => nodeStackLineParser,
+  getUtf8ByteLength: () => getUtf8ByteLength,
+  getInjectedReleaseId: () => getInjectedReleaseId,
+  geckoStackLineParser: () => geckoStackLineParser,
+  createStackParser: () => createStackParser,
+  createDefaultStackParser: () => createDefaultStackParser,
+  chromeStackLineParser: () => chromeStackLineParser,
+  StringCoercer: () => StringCoercer,
+  ReduceableCache: () => ReduceableCache,
+  PromiseRejectionEventCoercer: () => PromiseRejectionEventCoercer,
+  PrimitiveCoercer: () => PrimitiveCoercer,
+  ObjectCoercer: () => ObjectCoercer,
+  ExceptionStepsBuffer: () => ExceptionStepsBuffer,
+  EventCoercer: () => EventCoercer,
+  ErrorPropertiesBuilder: () => ErrorPropertiesBuilder,
+  ErrorEventCoercer: () => ErrorEventCoercer,
+  ErrorCoercer: () => ErrorCoercer,
+  EXCEPTION_STEP_INTERNAL_FIELDS: () => EXCEPTION_STEP_INTERNAL_FIELDS,
+  DOMExceptionCoercer: () => DOMExceptionCoercer,
+  DEFAULT_EXCEPTION_STEPS_CONFIG: () => DEFAULT_EXCEPTION_STEPS_CONFIG
 });
 var init_error_tracking = __esm(() => {
   init_error_properties_builder();
@@ -8183,14 +8183,14 @@ var init_posthog = __esm(() => {
 // packages/omo-codex/src/telemetry/index.ts
 var exports_telemetry = {};
 __export(exports_telemetry, {
-  __resetActivityStateProviderForTesting: () => __resetActivityStateProviderForTesting,
-  __resetOsProviderForTesting: () => __resetOsProviderForTesting,
-  __setActivityStateProviderForTesting: () => __setActivityStateProviderForTesting,
-  __setOsProviderForTesting: () => __setOsProviderForTesting,
-  createCliPostHog: () => createCliPostHog,
-  createInstallPostHog: () => createInstallPostHog,
+  getPostHogDistinctId: () => getPostHogDistinctId,
   createPluginPostHog: () => createPluginPostHog,
-  getPostHogDistinctId: () => getPostHogDistinctId
+  createInstallPostHog: () => createInstallPostHog,
+  createCliPostHog: () => createCliPostHog,
+  __setOsProviderForTesting: () => __setOsProviderForTesting,
+  __setActivityStateProviderForTesting: () => __setActivityStateProviderForTesting,
+  __resetOsProviderForTesting: () => __resetOsProviderForTesting,
+  __resetActivityStateProviderForTesting: () => __resetActivityStateProviderForTesting
 });
 var init_telemetry = __esm(() => {
   init_posthog();
@@ -9445,6 +9445,25 @@ function collectCommands(value, commands) {
 }
 
 // packages/omo-codex/src/install/codex-cache-install.ts
+var DIRECTORY_RENAME_RETRY_DELAYS_MS = [50, 100, 200, 400, 800];
+var RETRIABLE_DIRECTORY_RENAME_CODES = new Set(["EPERM", "EBUSY"]);
+async function renameDirectoryWithRetry(fromPath, toPath) {
+  for (let attempt = 0;; attempt += 1) {
+    try {
+      await rename(fromPath, toPath);
+      return;
+    } catch (error) {
+      if (!isRetriableDirectoryRenameError(error) || attempt >= DIRECTORY_RENAME_RETRY_DELAYS_MS.length)
+        throw error;
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, DIRECTORY_RENAME_RETRY_DELAYS_MS[attempt] ?? 0));
+    }
+  }
+}
+function isRetriableDirectoryRenameError(error) {
+  if (!(error instanceof Error) || !("code" in error))
+    return false;
+  return typeof error.code === "string" && RETRIABLE_DIRECTORY_RENAME_CODES.has(error.code);
+}
 async function installCachedPlugin(input) {
   const env = input.env ?? process.env;
   const npmInstallEnv = sanitizeNpmInstallEnv(env);
@@ -9470,7 +9489,7 @@ async function installCachedPlugin(input) {
     await rewriteCachedMcpManifest(tempPath, input.sourcePath);
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath);
     await assertHookCommandTargets(tempPath);
-    await promoteDirectory(tempPath, targetPath, input.renameDirectory ?? rename);
+    await promoteDirectory(tempPath, targetPath, input.renameDirectory ?? renameDirectoryWithRetry);
   } catch (error) {
     await rm4(tempPath, { recursive: true, force: true });
     throw error;
@@ -13696,23 +13715,23 @@ async function runLazyCodexInstallLocalCli(input) {
   return 0;
 }
 export {
-  PASSTHROUGH_COMMANDS,
-  assertHookCommandTargets,
-  buildDelegatedOmoInvocation,
-  findMissingHookCommandTargets,
-  formatLazyCodexInstallHelp,
-  installCachedPlugin,
-  installMarketplaceLocally,
-  linkCachedPluginBins,
-  linkRootRuntimeBin,
-  parseLazyCodexInstallCliArgs,
-  readCodexModelCatalog,
-  repairNearestProjectLocalCodexArtifacts,
-  resolveCodexInstallerBinDir,
-  resolveDefaultRepoRoot,
-  resolveDefaultRepoRootForEntrypoint,
-  runDelegatedOmoCommand,
-  runLazyCodexInstallLocalCli,
+  updateCodexConfig,
   stampGitBashMcpEnv,
-  updateCodexConfig
+  runLazyCodexInstallLocalCli,
+  runDelegatedOmoCommand,
+  resolveDefaultRepoRootForEntrypoint,
+  resolveDefaultRepoRoot,
+  resolveCodexInstallerBinDir,
+  repairNearestProjectLocalCodexArtifacts,
+  readCodexModelCatalog,
+  parseLazyCodexInstallCliArgs,
+  linkRootRuntimeBin,
+  linkCachedPluginBins,
+  installMarketplaceLocally,
+  installCachedPlugin,
+  formatLazyCodexInstallHelp,
+  findMissingHookCommandTargets,
+  buildDelegatedOmoInvocation,
+  assertHookCommandTargets,
+  PASSTHROUGH_COMMANDS
 };

--- a/packages/omo-codex/src/install/codex-cache-install.ts
+++ b/packages/omo-codex/src/install/codex-cache-install.ts
@@ -9,6 +9,29 @@ import { assertHookCommandTargets } from "./codex-hook-targets"
 import type { InstalledPlugin, RunCommand } from "./types"
 
 type RenameDirectory = (fromPath: string, toPath: string) => Promise<void>
+// Windows refuses to rename a directory while a process holds a file inside it open or has it as a
+// cwd, and an npm helper that is still exiting keeps its cwd in the freshly built temp directory.
+// The promote then fails in a few milliseconds over a lock that clears in a few hundred, so it
+// waits the way renameWithRetry in codex-config-atomic-write.ts waits for a busy rename.
+const DIRECTORY_RENAME_RETRY_DELAYS_MS = [50, 100, 200, 400, 800] as const
+const RETRIABLE_DIRECTORY_RENAME_CODES = new Set(["EPERM", "EBUSY"])
+
+async function renameDirectoryWithRetry(fromPath: string, toPath: string): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await rename(fromPath, toPath)
+      return
+    } catch (error) {
+      if (!isRetriableDirectoryRenameError(error) || attempt >= DIRECTORY_RENAME_RETRY_DELAYS_MS.length) throw error
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, DIRECTORY_RENAME_RETRY_DELAYS_MS[attempt] ?? 0))
+    }
+  }
+}
+
+function isRetriableDirectoryRenameError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false
+  return typeof error.code === "string" && RETRIABLE_DIRECTORY_RENAME_CODES.has(error.code)
+}
 
 export async function installCachedPlugin(input: {
   readonly buildSource?: boolean
@@ -51,7 +74,7 @@ export async function installCachedPlugin(input: {
     await rewriteCachedMcpManifest(tempPath, input.sourcePath)
     await rewriteCachedManifestRoot(tempPath, tempPath, targetPath)
     await assertHookCommandTargets(tempPath)
-    await promoteDirectory(tempPath, targetPath, input.renameDirectory ?? rename)
+    await promoteDirectory(tempPath, targetPath, input.renameDirectory ?? renameDirectoryWithRetry)
   } catch (error) {
     await rm(tempPath, { recursive: true, force: true })
     throw error

--- a/packages/omo-codex/src/install/codex-cache-promote.test.ts
+++ b/packages/omo-codex/src/install/codex-cache-promote.test.ts
@@ -1,0 +1,51 @@
+/// <reference path="../../../../bun-test.d.ts" />
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { spawn } from "node:child_process"
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { installCachedPlugin } from "./codex-cache"
+
+describe("codex-cache promotion", () => {
+  test("#given a helper still holding the active cache #when it exits during promotion #then the new version lands", async () => {
+    // given
+    const root = await mkdtemp(join(tmpdir(), "omo-codex-cache-promote-busy-"))
+    const codexHome = join(root, "codex-home")
+    const sourceRoot = join(root, "plugin")
+    const cacheRoot = join(codexHome, "plugins", "cache", "debug", "omo", "0.1.0")
+    await mkdir(sourceRoot, { recursive: true })
+    await mkdir(join(cacheRoot, "node_modules"), { recursive: true })
+    await writeFile(join(sourceRoot, "package.json"), JSON.stringify({ name: "@scope/omo", version: "0.1.0" }))
+    await writeFile(join(cacheRoot, "package.json"), JSON.stringify({ name: "@scope/omo-old", version: "0.0.9" }))
+
+    const holder = spawn(process.execPath, ["-e", "setTimeout(() => {}, 30000)"], {
+      cwd: join(cacheRoot, "node_modules"),
+      stdio: "ignore",
+    })
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    setTimeout(() => { try { holder.kill() } catch { /* already gone */ } }, 300)
+
+    try {
+      // when
+      const installed = await installCachedPlugin({
+        codexHome,
+        marketplaceName: "debug",
+        name: "omo",
+        sourcePath: sourceRoot,
+        version: "0.1.0",
+        runCommand: async () => undefined,
+      })
+
+      // then
+      expect(installed.path).toBe(cacheRoot)
+      expect(await readFile(join(cacheRoot, "package.json"), "utf8")).toBe(
+        JSON.stringify({ name: "@scope/omo", version: "0.1.0" })
+      )
+    } finally {
+      try { holder.kill() } catch { /* already gone */ }
+    }
+  }, { timeout: 20_000 })
+})


### PR DESCRIPTION
Installing or updating the Codex plugin fails on Windows whenever anything from the previous install is still exiting.

```
EPERM: operation not permitted, rename
  '<CODEX_HOME>/plugins/cache/<marketplace>/omo/<version>'
  -> '<CODEX_HOME>/plugins/cache/<marketplace>/omo/.backup-<version>-...'
```

`promoteDirectory` in `packages/omo-codex/src/install/codex-cache-install.ts` renames with a bare `rename`. Windows refuses a directory rename while any process holds a file inside it open or has it as its cwd, and an npm helper that has not finished exiting keeps its cwd in the directory the installer just built. The promote gives up in single-digit milliseconds over a lock that clears a few hundred milliseconds later, and the user is left on the old plugin version.

This retries the rename over 50/100/200/400/800ms on EPERM and EBUSY, the same shape `renameWithRetry` in `codex-config-atomic-write.ts` already uses for a busy file rename. The delays are longer here because the holder is an exiting child process rather than a file handle being closed on the same thread.

### Measured

A driver that starts a helper with its cwd inside the live cache directory, under **both runtimes the installer runs on**:

| | node v26.1.0 | bun 1.3.14 |
|---|---|---|
| helper exits at 300ms, as shipped | threw EPERM (4ms), plugin dir old | threw EPERM (11ms), plugin dir old |
| helper exits at 300ms, with retry | ok (377ms), plugin dir **new** | ok (377ms), plugin dir **new** |
| helper never exits, with retry | throws EPERM (1594ms) | throws EPERM (1616ms) |

The last row is the intended ceiling: a genuinely stuck holder still fails, it just fails after the window instead of inside it. The backup restore path holds in every case, so a failed promote always leaves the previous plugin dir intact.

### Test

`packages/omo-codex/src/install/codex-cache-promote.test.ts` drives `installCachedPlugin` against that holder. Reverting the default back to a bare `rename` fails it with the EPERM above; with the retry it passes in 848ms.

`bun test src/install` in `packages/omo-codex`: 267 pass / 12 fail on my Windows machine, against 266 pass / 12 fail on `dev` at `ad62603f0` with the same `node_modules`. Same twelve pre-existing local failures, one new pass. `bun run typecheck` exits 0.

### One line that is not mine

The bundle commit also moves the embedded version from `5.0.0-beta.43` to `5.0.0-beta.45`. The checked-in `install-local.mjs` was stale against the current `package.json`, and `bun run build:codex-install` picks that up on any regeneration. Happy to split it out if you would rather it landed on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex plugin installs on Windows failing with EPERM when a process from the previous install is still exiting. The cache directory promote now retries the rename on EPERM and EBUSY, so a busy hold clears and the new plugin version lands instead of the old staying in place.

- Retries with 50/100/200/400/800ms delays; a holder that never exits still fails after about 1.6s.
- The backup restore path still holds, so a failed promote leaves the previous plugin dir intact.
- Adds a test that drives `installCachedPlugin` against a busy directory and exits the holder during promotion.
- The checked-in `install-local.mjs` bundle is regenerated, which also moves the embedded package version from `5.0.0-beta.43` to `5.0.0-beta.45`.

<sup>Written for commit 0da7baaa4dc3bd0470a97a2d745d87e6cfba8669. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

