### PR TITLE
fix(schema): regenerate omo.schema.json after memory.tool_exposure was removed

### DIFF
--- a/assets/omo.schema.json
+++ b/assets/omo.schema.json
@@ -1314,14 +1314,6 @@
           "type": "string",
           "minLength": 1
         },
-        "tool_exposure": {
-          "default": "direct",
-          "type": "string",
-          "enum": [
-            "direct",
-            "search"
-          ]
-        },
         "reflection": {
           "default": {
             "enabled": true,
@@ -1844,7 +1836,6 @@
       "required": [
         "enabled",
         "agent",
-        "tool_exposure",
         "reflection",
         "nudge",
         "facts",
@@ -12998,13 +12989,6 @@
               "type": "string",
               "minLength": 1
             },
-            "tool_exposure": {
-              "type": "string",
-              "enum": [
-                "direct",
-                "search"
-              ]
-            },
             "reflection": {
               "type": "object",
               "properties": {
@@ -14624,13 +14608,6 @@
             "agent": {
               "type": "string",
               "minLength": 1
-            },
-            "tool_exposure": {
-              "type": "string",
-              "enum": [
-                "direct",
-                "search"
-              ]
             },
             "reflection": {
               "type": "object",
@@ -16257,13 +16234,6 @@
               "agent": {
                 "type": "string",
                 "minLength": 1
-              },
-              "tool_exposure": {
-                "type": "string",
-                "enum": [
-                  "direct",
-                  "search"
-                ]
               },
               "reflection": {
                 "type": "object",
@@ -27791,13 +27761,6 @@
                     "type": "string",
                     "minLength": 1
                   },
-                  "tool_exposure": {
-                    "type": "string",
-                    "enum": [
-                      "direct",
-                      "search"
-                    ]
-                  },
                   "reflection": {
                     "type": "object",
                     "properties": {
@@ -29417,13 +29380,6 @@
                   "agent": {
                     "type": "string",
                     "minLength": 1
-                  },
-                  "tool_exposure": {
-                    "type": "string",
-                    "enum": [
-                      "direct",
-                      "search"
-                    ]
                   },
                   "reflection": {
                     "type": "object",


### PR DESCRIPTION
`assets/omo.schema.json` still advertises `memory.tool_exposure`, and a config that uses it no longer parses:

```
OmoConfigSchema.safeParse({ memory: { enabled: true, agent: "auto", tool_exposure: "direct" } })
  -> success: false
  -> memory Unrecognized key: "tool_exposure"
```

That file is what `docs/reference/omo-json.md` tells users to point `$schema` at, so an editor completes the key with its `direct`/`search` enum and the completion is a config error.

`refactor: consolidate memory tool surface` (6fd53f2cf) removed the key from the Zod schema and the generated artifact was not regenerated with it. Nothing under `packages/`, `script/` or `docs/` mentions `tool_exposure` any more; only the published schema does.

### The gate for this already exists and is red

`tests/omo-schema-freshness.test.ts` compares the regenerated schema against the committed one. On `dev` at `ad62603f0`, with nothing applied:

```
$ bun test tests/omo-schema-freshness.test.ts
 2 pass
 1 fail
```

The reported diff is exactly the 44 `tool_exposure` lines. After `bun run build:omo-schema`, the same command is 3 pass / 0 fail.

### The change

Output of `bun run build:omo-schema`, deletions only, one file. Running the sibling generator `bun run build:schema` afterwards regenerates both artifacts and leaves the same single modified file, so the output is stable and `assets/oh-my-opencode.schema.json` was already fresh.

No source, test or workflow change. The existing gate goes from red to green on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates `assets/omo.schema.json` so it no longer advertises the removed `memory.tool_exposure` key. The stale schema made editor completions of that key produce configs that fail parsing; now the artifact matches the Zod schema.

- The change is deletions only, and the existing schema-freshness test goes from red to green.

<sup>Written for commit d33d45daff676a6d19429353735220d888d1ac4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

