### PR TITLE
fix(publish): read both npm pack --json shapes in the omo-ai verifier

### DIFF
--- a/script/npm-pack-paths.mjs
+++ b/script/npm-pack-paths.mjs
@@ -2,7 +2,7 @@
 // Node 26) prints an object keyed by package name. Reading only the array shape throws
 // "TypeError: parsed is not iterable" on npm 12, which reads as a broken script rather than a
 // version difference.
-export function parseNpmPackPaths(raw) {
+export function parseNpmPackResult(raw) {
   let parsed
   try {
     parsed = JSON.parse(raw)
@@ -14,7 +14,11 @@ export function parseNpmPackPaths(raw) {
   if (result === null || typeof result !== "object" || !Array.isArray(result.files)) {
     throw new Error("npm pack --json returned no packed file list; expected an array of results or an object keyed by package name")
   }
-  return result.files.map((file) => {
+  return result
+}
+
+export function parseNpmPackPaths(raw) {
+  return parseNpmPackResult(raw).files.map((file) => {
     if (file === null || typeof file !== "object" || typeof file.path !== "string") {
       throw new Error("npm pack --json returned a packed entry without a string path")
     }

--- a/script/verify-omo-ai-payload.mjs
+++ b/script/verify-omo-ai-payload.mjs
@@ -6,6 +6,7 @@ import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { npmSpawnOptions } from "./npm-invocation.mjs"
+import { parseNpmPackResult } from "./npm-pack-paths.mjs"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, "..")
@@ -50,8 +51,7 @@ function packedPaths() {
     stdio: ["ignore", "pipe", "inherit"],
     ...npmSpawnOptions(),
   })
-  const [result] = JSON.parse(raw)
-  if (!result) return { paths: [], unpackedSize: 0 }
+  const result = parseNpmPackResult(raw)
   return {
     paths: result.files.map((file) => file.path),
     unpackedSize: result.unpackedSize ?? 0,

--- a/script/verify-omo-ai-payload.test.ts
+++ b/script/verify-omo-ai-payload.test.ts
@@ -18,6 +18,7 @@ import { fileURLToPath } from "node:url"
  */
 const verifierSource = fileURLToPath(new URL("./verify-omo-ai-payload.mjs", import.meta.url))
 const npmInvocationSource = fileURLToPath(new URL("./npm-invocation.mjs", import.meta.url))
+const npmPackPathsSource = fileURLToPath(new URL("./npm-pack-paths.mjs", import.meta.url))
 const guardTimeoutMs = 120_000
 
 setDefaultTimeout(guardTimeoutMs)
@@ -56,6 +57,7 @@ function runVerifierOnPayload(payloadPaths: readonly string[]): VerifierRun {
     mkdirSync(join(fakeRepoRoot, "script"), { recursive: true })
     copyFileSync(verifierSource, join(fakeRepoRoot, "script", "verify-omo-ai-payload.mjs"))
     copyFileSync(npmInvocationSource, join(fakeRepoRoot, "script", "npm-invocation.mjs"))
+    copyFileSync(npmPackPathsSource, join(fakeRepoRoot, "script", "npm-pack-paths.mjs"))
 
     const packageDir = join(fakeRepoRoot, "packages", "omo-native")
     mkdirSync(packageDir, { recursive: true })


### PR DESCRIPTION
`script/verify-omo-ai-payload.mjs` cannot read `npm pack --json` under npm 12, so a healthy payload fails verification and the report never names the real cause:

```
omo-ai payload verification FAILED (14 issue(s)):
  npm pack failed: {} is not iterable
  missing artifact: bin/omo.js
  missing artifact: bin/omo-agent-toolkit.js
  ... all twelve pinned artifacts
```

npm 11 prints an array of package results; npm 12, the npm bundled with Node 26, prints an object keyed by package name:

```
$ npm --version
12.0.2
$ cd packages/omo-native && npm pack --dry-run --json --ignore-scripts
{  "omo-ai": {    "id": "omo-ai@5.0.0-0.beta.45", ...
```

#7835's sibling #7840 already taught `script/verify-npm-payload.mjs` about both shapes and left `script/npm-pack-paths.mjs` behind for it. This verifier was not switched over and still does `const [result] = JSON.parse(raw)`, which throws on an object and then lets every artifact check run against an empty path set.

### RED and GREEN

`script/verify-omo-ai-payload.test.ts` is the repo's own gate for this and is red on `dev` at `ad62603f0`:

| | dev at ad62603f0 | this branch |
|---|---|---|
| `bun test script/verify-omo-ai-payload.test.ts` | 1 pass, 1 fail | 2 pass, 0 fail |
| `... plus script/npm-pack-paths.test.ts` | 5 pass, 2 fail | 7 pass, 0 fail |

Mutating the fix back to `const [result] = JSON.parse(raw)` returns the suite to 1 pass / 1 fail, so the assertion is bound to this line.

### The change

The shared helper gains `parseNpmPackResult`, which is the normalization `parseNpmPackPaths` already did, returned before the paths are projected out. This verifier needs `unpackedSize` as well as the paths, which is why it could not call the existing export. `parseNpmPackPaths` becomes a wrapper and `script/npm-pack-paths.test.ts` is unchanged and green.

The test fixture copies the verifier into a temp tree, so it now copies the helper next to it as well. That is the only test change; no assertion was touched.

Two commits: the helper split first, then the verifier, so the refactor can be read on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the omo-ai payload verifier to read both npm pack --json output shapes, so a healthy payload no longer fails with "npm pack failed: {} is not iterable" and then reports all pinned artifacts as missing.

<sup>Written for commit 30f67ccfe0ecb250a616c91745156f4a67ded7b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

