### PR TITLE
fix(repo): normalize shell scripts to LF like every other text type

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@
 *.toml text eol=lf
 *.yml text eol=lf
 *.yaml text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
`.gitattributes` pins thirteen text extensions to `eol=lf` and omits `*.sh`. On a Git for Windows install, whose setup default is `core.autocrlf=true`, that means all 66 shell scripts in the tree check out with CRLF, and a Linux bash refuses them on line 2:

```
./write-job-summary.sh: line 2: set: pipefail: invalid option name
exit 2
```

### Isolated

Same file, one copy converted to CRLF and one to LF, run through GNU bash 5.3.9 (x86_64-pc-linux-gnu) and through Git Bash, with no test harness in the way:

| shell | CRLF copy | LF copy |
|---|---|---|
| GNU bash 5.3.9 (Linux) | exit 2, `set: pipefail: invalid option name` | exit 0 |
| Git Bash (MSYS2) | exit 0 | exit 0 |

Git Bash strips the CR, which is why `windows-latest` in CI never sees this: `actions/checkout` leaves `core.autocrlf` unset and the runner's bash tolerates CR either way. It surfaces on a developer machine, where the checkout is CRLF and the shell may be a real Linux bash.

`git ls-files --eol .github/scripts/write-job-summary.sh` on such a checkout:

```
i/lf    w/crlf  attr/
```

The index is already LF for all 66 files. After the attribute it is `i/lf w/crlf attr/text eol=lf` and the next checkout writes LF, so this changes what checkout produces and no committed content moves. `git add --renormalize` stages nothing under `*.sh`.

### What this does not do

It does not by itself make `script/ci-job-summary-workflow.test.ts` pass on a Windows machine. That test spawns bare `bash`, which on a host with WSL installed resolves to `C:\Windows\System32\bash.exe`; WSL does not forward the spawned environment, so the script then exits on `GITHUB_STEP_SUMMARY is not set`. That is a separate problem in the harness and I am not touching it here. Removing the CRLF is the first of the two, and it is the one that is about the repository rather than about my machine.

One line, matching the thirteen already in the file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `*.sh` to `.gitattributes` so shell scripts check out with LF. On a Git for Windows install with the default `core.autocrlf=true`, scripts previously checked out with CRLF and a Linux bash refused them on line 2 (`set: pipefail: invalid option name`). The index already stores these files as LF, so this only changes what checkout writes; no committed content moves.

This doesn't fix the separate Windows test harness issue where bare `bash` resolves to WSL and the spawned environment is lost.

<sup>Written for commit f07080b6b53871029486176acc680e71dea1756e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

