### PR TITLE
test(script): resolve Git Bash instead of spawning a bare bash on Windows

### DIFF
--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
+import { testBashCommand } from "./test-bash-command"
 import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -177,7 +178,7 @@ describe("GitHub workflow job summaries", () => {
     const summaryPath = join(tempDir, "summary.md")
     writeFileSync(summaryPath, "")
 
-    const result = spawnSync("bash", [".github/scripts/write-job-summary.sh"], {
+    const result = spawnSync(testBashCommand(), [".github/scripts/write-job-summary.sh"], {
       cwd: new URL("..", import.meta.url),
       encoding: "utf8",
       env: {

--- a/script/publish-readiness-budget.test.ts
+++ b/script/publish-readiness-budget.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
+import { testBashCommand } from "./test-bash-command"
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -62,7 +63,7 @@ function runReadiness(readyAfterViews: number): Outcome {
     ].join("\n")
     const script = join(root, "readiness.sh")
     writeFileSync(script, preamble + readinessRunBlock())
-    const result = spawnSync("bash", [script], {
+    const result = spawnSync(testBashCommand(), [script], {
       encoding: "utf8",
       env: { ...process.env, COUNTER: counter, SLEEPS: sleeps, READY_AFTER: String(readyAfterViews), OMO_AI_VERSION: "5.0.0-0.beta.42", ALREADY_PUBLISHED: "false" },
     })

--- a/script/publish-stale-stamp-reuse.test.ts
+++ b/script/publish-stale-stamp-reuse.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
+import { testBashCommand } from "./test-bash-command"
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -68,7 +69,7 @@ function runPrepare(fixture: Fixture, version: string): { status: number; stdout
   writeFileSync(outputFile, "")
   const script = join(fixture.root, "prepare.sh")
   writeFileSync(script, prepareRunBlock())
-  const result = spawnSync("bash", [script], {
+  const result = spawnSync(testBashCommand(), [script], {
     cwd: fixture.work,
     encoding: "utf8",
     env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null", VERSION: version, OMO_AI_VERSION: version, RELEASE_REF: "dev", PREPARED_RELEASE_SHA: "", GITHUB_SHA: "", GITHUB_OUTPUT: outputFile },

--- a/script/test-bash-command.ts
+++ b/script/test-bash-command.ts
@@ -1,0 +1,11 @@
+import { resolveGitBashForCurrentProcess } from "../packages/utils/src/runtime/git-bash"
+
+// A bare `bash` is resolved through PATH, and on a Windows host with WSL installed that is
+// C:\\Windows\\System32\\bash.exe, which runs inside the Linux VM: a Windows script path arrives with its
+// backslashes eaten and the spawn exits 127. bundled-rules/windows-git-bash.md already forbids a bare
+// `bash` for exactly this reason, so these harnesses resolve Git Bash the way the product does and fall
+// back to PATH only where the product does not need a resolution.
+export function testBashCommand(): string {
+  const resolution = resolveGitBashForCurrentProcess()
+  return resolution.found && resolution.path !== null ? resolution.path : "bash"
+}


### PR DESCRIPTION
Four tests are red on `dev` at `ad62603f0` on any Windows machine that has WSL installed, and they fail for one reason: they spawn a generated shell script through a bare `bash`.

```
/bin/bash: C:UsersLilMGAppDataLocalTemppublish-readiness-vEHLy4readiness.sh: No such file or directory
exit 127
```

The backslashes are gone because `bash` resolved through PATH to `C:\Windows\System32\bash.exe`, which runs inside the Linux VM and never sees a Windows path.

This repository already says not to do that. `packages/omo-codex/plugin/components/rules/bundled-rules/windows-git-bash.md`:

> NEVER set the shell to a bare `bash` [...] a bare `bash` on PATH frequently resolves to WSL's `C:\Windows\System32\bash.exe`

It also already ships the resolver: `packages/utils/src/runtime/git-bash.ts` prefers `OMO_CODEX_GIT_BASH_PATH`, then the two Program Files locations, then a PATH entry that is not a known non-Git-Bash launcher. This wires that resolver into the three harnesses; no new resolution logic.

### Affected

| Test file | Failing tests on dev |
|---|---|
| `script/publish-readiness-budget.test.ts` | 2 |
| `script/ci-job-summary-workflow.test.ts` | 1 |
| `script/publish-stale-stamp-reuse.test.ts` | 1 |

### RED and GREEN

```
bun test script/ci-job-summary-workflow.test.ts script/publish-readiness-budget.test.ts script/publish-stale-stamp-reuse.test.ts
  bare bash   -> 4 pass, 4 fail
  resolved    -> 8 pass, 0 fail
```

Mutating `testBashCommand` back to a literal `"bash"` fails exactly those four and no others, so the assertion is bound to the resolution rather than to anything else in the diff.

### Nothing changes off Windows

`resolveGitBashForCurrentProcess` returns `{ source: "not-required", path: null }` on every non-win32 platform, and the helper falls back to `"bash"` both there and on a Windows box where Git Bash cannot be found. Linux and macOS CI spawn the same command they spawn today.

No workflow file is touched. These tests read `.github/workflows/*.yml` and assert its behavior; the change is entirely in how the harness starts a shell.

Independent of #7875, which removes the CRLF from the same `.sh` files. I checked: with Git Bash resolved, the job-summary test passes against a CRLF copy as well, because Git Bash strips the CR. Either can land first.

Two commits so the helper reads on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four script tests that failed on Windows machines with WSL by resolving Git Bash instead of spawning a bare `bash`, which WSL intercepts and cannot run Windows script paths with. The three test harnesses now use the existing `resolveGitBashForCurrentProcess` helper and fall back to `"bash"` when no Git Bash is found.

- On Linux, macOS, or a Windows box without Git Bash, the spawned command is unchanged, so non-Windows CI is unaffected.
- The four failing tests pass with the resolver; reverting to a bare `bash` fails exactly those four and no others.
- No workflow files or generated script content changed; only the shell command used to run them.

<sup>Written for commit 792ba338144f4ecc61b9899131df1dd149069a62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

