### PR TITLE
ci: fail the build job when committed schema artifacts are stale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,6 +638,18 @@ jobs:
           test -f dist/index.js || (echo "ERROR: dist/index.js not found!" && exit 1)
           test -f dist/index.d.ts || (echo "ERROR: dist/index.d.ts not found!" && exit 1)
 
+      # `bun run build` regenerates both JSON Schema artifacts, and every job
+      # builds before it tests, so tests/omo-schema-freshness.test.ts compares
+      # the regenerated file with itself in CI. Diffing against the commit is
+      # what actually catches a stale committed schema.
+      - name: Verify generated schema artifacts are committed
+        if: needs.ci-mode.outputs.run_heavy == 'true'
+        run: |
+          if ! git diff --exit-code -- assets/oh-my-opencode.schema.json assets/omo.schema.json; then
+            echo "::error::Committed JSON Schema artifacts are stale. Run 'bun run build:schema && bun run build:omo-schema' and commit assets/*.schema.json."
+            exit 1
+          fi
+
       - name: Verify dist bundle tests
         if: needs.ci-mode.outputs.run_heavy == 'true'
         run: bun test --timeout 20000 packages/omo-opencode/src/shared/dist-bundle-bun-globals.test.ts packages/omo-opencode/src/shared/dist-bundle-prompt-content.test.ts
@@ -651,8 +663,9 @@ jobs:
           JOB_SUMMARY_DETAILS: |
             - Builds the distributable OpenCode/Codex packages.
             - Confirms `dist/index.js` and `dist/index.d.ts` exist.
+            - Fails when the build regenerates `assets/oh-my-opencode.schema.json` or `assets/omo.schema.json` differently from the committed copy.
             - Runs dist bundle regression tests.
-          JOB_SUMMARY_NEXT: Fix the first failing build prerequisite before debugging downstream dist checks.
+          JOB_SUMMARY_NEXT: Fix the first failing build prerequisite before debugging downstream dist checks; a stale schema artifact is fixed by `bun run build:schema && bun run build:omo-schema` plus committing the result.
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
   omo-ai-payload-check:

--- a/script/ci-schema-freshness-gate.test.ts
+++ b/script/ci-schema-freshness-gate.test.ts
@@ -1,0 +1,68 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { load } from "js-yaml"
+
+const ciWorkflowPath = new URL("../.github/workflows/ci.yml", import.meta.url)
+const SCHEMA_GATE_STEP_NAME = "Verify generated schema artifacts are committed"
+const SCHEMA_ARTIFACTS = ["assets/oh-my-opencode.schema.json", "assets/omo.schema.json"]
+
+interface WorkflowStep {
+  readonly name: string | undefined
+  readonly run: string | undefined
+  readonly if: string | undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === "string" ? value : undefined
+}
+
+function toWorkflowStep(value: unknown): WorkflowStep {
+  if (!isRecord(value)) return { name: undefined, run: undefined, if: undefined }
+  return { name: stringField(value, "name"), run: stringField(value, "run"), if: stringField(value, "if") }
+}
+
+function buildJobSteps(): readonly WorkflowStep[] {
+  const parsed: unknown = load(readFileSync(ciWorkflowPath, "utf8"))
+  if (!isRecord(parsed) || !isRecord(parsed["jobs"]) || !isRecord(parsed["jobs"]["build"])) {
+    throw new Error("ci.yml must define a build job")
+  }
+  const steps = parsed["jobs"]["build"]["steps"]
+  if (!Array.isArray(steps)) throw new Error("ci.yml build job must define steps")
+  return steps.map(toWorkflowStep)
+}
+
+describe("ci build job schema freshness gate", () => {
+  test("#given the build job #when its steps are read #then a schema drift gate runs after the build that regenerates the artifacts", () => {
+    // given
+    const steps = buildJobSteps()
+
+    // when
+    const buildIndex = steps.findIndex((step) => step.name === "Build")
+    const gateIndex = steps.findIndex((step) => step.name === SCHEMA_GATE_STEP_NAME)
+    const gate = steps[gateIndex]
+
+    // then
+    expect(buildIndex).toBeGreaterThanOrEqual(0)
+    expect(gateIndex).toBeGreaterThan(buildIndex)
+    expect(gate?.if).toBe("needs.ci-mode.outputs.run_heavy == 'true'")
+    expect(gate?.run).toContain(`git diff --exit-code -- ${SCHEMA_ARTIFACTS.join(" ")}`)
+  })
+
+  test("#given the schema drift gate #when it fails #then it tells the author which command regenerates the artifacts", () => {
+    // given
+    const gate = buildJobSteps().find((step) => step.name === SCHEMA_GATE_STEP_NAME)
+
+    // when
+    const run = gate?.run ?? ""
+
+    // then
+    expect(run).toContain("bun run build:schema && bun run build:omo-schema")
+  })
+})


### PR DESCRIPTION
## Summary

- `tests/omo-schema-freshness.test.ts` is red on a clean `dev` checkout whenever a Zod change lands without regenerating `assets/omo.schema.json` (#7873 fixed the latest instance: 44 stale `memory.tool_exposure` lines that had been shipping since 6fd53f2cf). Yet dev CI was green the whole time.
- Root cause: `script/build.ts` runs `build:schema` and `build:omo-schema`, and every CI job runs `bun install` (root `prepare` = `bun run build`) or `bun run build` before its tests. By the time the freshness test runs in CI the committed artifact has already been overwritten with the regenerated one, so the comparison is a tautology. `auto-commit-schema` cannot backstop it either: it is gated on `refs/heads/master` (last commit 2026-07-13) while the default branch is `dev`, so it has been skipped on every run.
- Fix: make the required `build` job diff the two artifacts against the commit right after `bun run build` regenerates them. Drift now fails the PR with the exact command that repairs it.

## Changes

- `.github/workflows/ci.yml`: new step `Verify generated schema artifacts are committed` in the `build` job after `Verify build output`: `git diff --exit-code -- assets/oh-my-opencode.schema.json assets/omo.schema.json`, emitting a `::error::` with the regeneration command on failure. Job summary updated to name the check and the fix.
- `script/ci-schema-freshness-gate.test.ts`: workflow contract test (same shape as `script/ci-fast-path.test.ts`) that parses `ci.yml` and asserts the gate step exists in the `build` job after the `Build` step, carries the `run_heavy` condition, diffs exactly those two artifacts, and names the regeneration command.

`auto-commit-schema` is left as is: `script/ci-fast-path.test.ts` deliberately pins it to `master`, and retiring it is a separate decision. With this gate in place it is no longer load-bearing for `dev`.

## QA & Evidence

- **What was tested:** the step's exact shell, locally, after `bun run build:omo-schema && bun run build:schema` (the regeneration `bun run build` performs).
  **Observed result:** on `ad62603f0` (pre-#7873) exit 1 with the `::error::` line and the 44-line `tool_exposure` diff; on `32744fb16` (post-#7873 dev) exit 0 with empty output.
  **Why sufficient:** it is the same command CI runs, against the same two trees CI would see before and after the regeneration fix.
- **What was tested:** `bun test script/ci-schema-freshness-gate.test.ts` on an isolated Linux box (bun 1.4.0) against the old `ci.yml` and the new one.
  **Observed result:** old `ci.yml`: 0 pass / 2 fail (`Expected: > 4 / Received: -1` — no gate step; and the regeneration hint absent); new `ci.yml`: 2 pass / 0 fail.
- **What was tested:** the adjacent workflow contract suites on the new `ci.yml`: `script/ci-fast-path.test.ts`, `script/ci-job-summary-workflow.test.ts`, `script/publish-workflow.test.ts`, `script/omo-ai-ci-job.test.ts`, `script/ci-root-test-partition.test.ts`.
  **Observed result:** 50 pass / 1 fail — the one failure is `publish-workflow.test.ts` calling `git ls-files` inside a tree shipped without `.git` (box artifact, not a change effect); it passes in CI where the checkout has `.git`.
- **What was tested:** `actionlint .github/workflows/ci.yml` and `bun run typecheck:script`.
  **Observed result:** both exit 0.
- **Real surface:** this PR's own `build` check runs the new step against a fresh `dev` and must be green.

## Risks & Residuals

- A PR that changes a Zod schema without regenerating now fails `build` instead of merging silently; the error message names the two commands. That is the intended behavior change.
- The step only guards the two committed artifacts; other generated files are out of scope.

## Automated Checks

```bash
actionlint .github/workflows/ci.yml
bun run typecheck:script
bun test script/ci-schema-freshness-gate.test.ts script/ci-fast-path.test.ts script/ci-job-summary-workflow.test.ts script/publish-workflow.test.ts script/omo-ai-ci-job.test.ts script/ci-root-test-partition.test.ts
```

## Related Issues

Follow-up to #7873 (LilMGenius), which surfaced the red-but-toothless gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails the build job when committed schema artifacts are stale, so schema drift can no longer merge silently. Previously, `bun run build` regenerated the schema files in CI before the freshness test ran, so the test compared regenerated output with itself and always passed.

- Adds a `Verify generated schema artifacts are committed` step to the `build` job that diffs `assets/oh-my-opencode.schema.json` and `assets/omo.schema.json` against the working tree after the build.
- On drift, the step fails the job with a message naming the exact repair command: `bun run build:schema && bun run build:omo-schema`.
- Adds `script/ci-schema-freshness-gate.test.ts`, which asserts the gate step exists after the `Build` step, runs under the `run_heavy` condition, and names the regeneration command.
- `auto-commit-schema` stays unchanged; it's no longer relied on to backstop `dev` since the gate now catches drift.

<sup>Written for commit 8bea4caaacf888f46c64895bb16dacf36c8b337f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

