### PR TITLE
test(codex-install): keep the project-local cleanup fixtures inside their sandbox

### DIFF
--- a/packages/omo-codex/src/install/codex-project-local-cleanup.test.ts
+++ b/packages/omo-codex/src/install/codex-project-local-cleanup.test.ts
@@ -183,6 +183,10 @@ describe("codex project-local cleanup", () => {
     const globalConfigPath = join(codexHome, "config.toml")
     await mkdir(projectDirectory, { recursive: true })
     await mkdir(codexHome, { recursive: true })
+    // tmpdir() is inside the user profile on Windows, so without a project boundary the upward walk
+    // leaves the fixture and reaches the developer real ~/.codex. The marker keeps the walk inside
+    // the sandbox; the configured codexHome still sits in the parent chain being exercised.
+    await mkdir(join(homeRoot, ".git"), { recursive: true })
     await writeFile(
       globalConfigPath,
       [

--- a/packages/omo-codex/src/install/install-codex-project-local-cleanup.test.ts
+++ b/packages/omo-codex/src/install/install-codex-project-local-cleanup.test.ts
@@ -98,6 +98,10 @@ describe("install-codex project-local cleanup", () => {
     const repoRoot = await createPackagedCodexRepoRoot()
     await mkdir(projectDirectory, { recursive: true })
     await mkdir(codexHome, { recursive: true })
+    // tmpdir() is inside the user profile on Windows, so without a project boundary the upward walk
+    // leaves the fixture and reaches the developer real ~/.codex. The marker keeps the walk inside
+    // the sandbox; the configured codexHome still sits in the parent chain being exercised.
+    await mkdir(join(homeRoot, ".git"), { recursive: true })
     // A pinned v1 model keeps the legacy cap raise observable; the stamped
     // v2-preferred default would remove agents.max_threads instead.
     await writeFile(


### PR DESCRIPTION
Running the installer suite on Windows reads the developer's real `~/.codex/config.toml`:

```
$ bun test packages/omo-codex/src/install
expect(received).toBeNull()
Received: "C:\Users\LilMG\.codex\config.toml"
```

Both fixtures build a project under `tmpdir()` and let `repairNearestProjectLocalCodexArtifacts` walk upward looking for a project boundary. On Windows `tmpdir()` is `C:\Users\<user>\AppData\Local\Temp`, which is inside the user profile, so the walk climbs out of the fixture, through `AppData`, into the real home, and finds the real config there. On Linux `/tmp` is not under `$HOME`, the walk reaches the filesystem root with nothing, and CI stays green.

Redirecting `HOME` does not help, and the suite already does: `homedir()` inside the run returns a fake home under `tmpdir()`, but `tmpdir()` itself still resolves under the real profile, so the parent chain is real regardless.

### It is not only a read

`repairProjectLocalCodexConfigText` rewrites the config it finds, after copying it to `<config>.backup-<timestamp>`, whenever `features.multi_agent_v2.enabled` is true and `[agents]` carries `max_threads`. On my machine `enabled = false`, so nothing was written and no backup exists; I checked rather than assumed. A Windows contributor whose config has both would have `agents.max_threads` stripped out of their real Codex config by running the test suite.

### The fix

Each fixture root gets a `.git` directory. That is the walk's own boundary marker, so it terminates inside the sandbox instead of escaping. Test-only; no production file is touched.

The configured `codexHome` still sits in the parent chain between the project and that boundary, so the exclusion these tests exist to check is still load-bearing:

| | before | after |
|---|---|---|
| the two files, as they are | 8 pass, 2 fail | 10 pass, 0 fail |
| with the `codexHome` exclusion forced off | - | 8 pass, 2 fail |

`bun test packages/omo-codex/src/install` goes from 276 pass / 2 fail to **278 pass / 0 fail** on Windows. `bun run typecheck` in `packages/omo-codex` exits 0.

### One thing I did not change

The walk excludes only the `codexHome` it is given. A user who points `CODEX_HOME` elsewhere still has a default `~/.codex/config.toml` sitting in the parent chain of any project under their home, and it is not excluded. I had a patch for that and dropped it: it is a behavior change in your file with no failing input behind it, and it does not fix the leak above. Happy to open it separately if you want it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows codex-install test suite so a cleanup fixture's upward walk can no longer escape the sandbox and touch the developer's real `~/.codex/config.toml`.

**Bug Fixes**
- On Windows `tmpdir()` sits inside the user profile, so the walk climbed out to the real config; Linux `/tmp` never exposed the bug in CI.
- Each fixture root now gets a `.git` marker, the walk's own project boundary, keeping the cleanup's rewrite-with-backup strictly inside the sandbox.
- The configured `codexHome` stays in the parent chain; forcing the exclusion off brings back 2 failures, so the tests still cover it.
- `bun test packages/omo-codex/src/install` goes from 276 pass / 2 fail to 278 pass / 0 fail on Windows.

<sup>Written for commit 764588830454bcdb1f28b44e611a95ab9236c8ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

