### PR TITLE
test(omo-opencode): declare the module type of the built runtime fixture

### DIFF
--- a/packages/omo-opencode/src/create-runtime-tmux-config.test.ts
+++ b/packages/omo-opencode/src/create-runtime-tmux-config.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { mkdtempSync, rmSync } from "node:fs"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -31,6 +31,10 @@ describe("createRuntimeTmuxConfig", () => {
           format: "esm",
         })
         expect(build.success).toBe(true)
+        // Bun.build writes .js with no package.json beside it, so node resolves the module type from
+        // the nearest ancestor. tmpdir() is inside the user profile on Windows, so that ancestor is the
+        // developer own package.json and node warns on stderr about it, which this test reads as output.
+        writeFileSync(join(outdir, "package.json"), JSON.stringify({ type: "module" }))
 
         const result = spawnSync(Bun.which("node") ?? "node", [
           "--input-type=module",


### PR DESCRIPTION
`packages/omo-opencode/src/create-runtime-tmux-config.test.ts` fails on Windows because node writes a warning to stderr and the test asserts stderr is empty:

```
(node:59036) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of
file:///C:/Users/<user>/AppData/Local/Temp/omo-desktop-runtime-1haXo8/interactive-bash-availability.js
is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to \\?\C:\Users\<user>\package.json.
```

`Bun.build` writes a bare `.js` into the temp outdir with no `package.json` beside it, so node resolves the module type from the nearest ancestor. On Windows `tmpdir()` is `C:\Users\<user>\AppData\Local\Temp`, inside the user profile, so the nearest ancestor is the developer's own `package.json` and node names it in the warning. Whether the suite passes therefore depends on what sits in the contributor's home directory, which is why `windows-latest` in CI is green: `C:\Users\runneradmin` has no `package.json`.

The assertion is right; the fixture is under-specified. An ESM build should declare itself, so this writes `{"type":"module"}` next to the output, which is exactly what the warning asks for and makes the run independent of anything above `tmpdir()`.

| | before | after |
|---|---|---|
| `bun test packages/omo-opencode/src/create-runtime-tmux-config.test.ts` | 1 pass, 1 fail | 2 pass, 0 fail |

Removing the new line returns it to 1 pass / 1 fail, so the stderr assertion still bites. `bun run typecheck` in `packages/omo-opencode` exits 0.

Test-only, one file. Found by running `bun test packages/omo-opencode packages/memory-core` on a Windows machine, which is 9044 pass / 5 fail on `dev`; this is one of the five and has its own cause. No ordering against anything else I have open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows-only failure in `create-runtime-tmux-config.test.ts` by writing a `{"type":"module"}` `package.json` next to the built fixture, so node no longer warns about the untyped module and the stderr assertion passes.

<sup>Written for commit de366ae3fd365a5edb4fc37a9ccb6477de22fdf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

