### PR TITLE
fix(omo-senpi): keep one omo-senpi package entry and isolate the local launcher

### DIFF
--- a/packages/omo-senpi/plugin/scripts/install.mjs
+++ b/packages/omo-senpi/plugin/scripts/install.mjs
@@ -146,8 +146,9 @@ import { dirname as dirname3, join as join4 } from "node:path";
 // packages/omo-senpi/src/install/senpi-settings.ts
 import { constants } from "node:fs";
 import { access, copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname as dirname2, join as join3, resolve as resolve3 } from "node:path";
+import { basename, dirname as dirname2, join as join3, resolve as resolve3 } from "node:path";
 var OMO_SENPI_PACKAGE_NAME = "@code-yeongyu/omo-senpi";
+var GENERATED_PLUGIN_BASENAME = /^omo-senpi-cli-plugin-[A-Za-z0-9]{6}$/;
 var LEGACY_BUILTIN_SHADOW_PACKAGES = [
   join3("packages", "pi-goal"),
   join3("packages", "pi-webfetch")
@@ -188,7 +189,11 @@ async function removeSupersededOmoPackages(packages, currentPluginPath, agentDir
     const packagePath = resolve3(agentDir, entry);
     if (packagePath === currentPath)
       return currentPath;
-    return await readPackageName(packagePath) === OMO_SENPI_PACKAGE_NAME ? undefined : entry;
+    if (await readPackageName(packagePath) === OMO_SENPI_PACKAGE_NAME)
+      return;
+    if (GENERATED_PLUGIN_BASENAME.test(basename(entry)) && !await fileExists(packagePath))
+      return;
+    return entry;
   }));
   return entries.filter((entry) => entry !== undefined);
 }
@@ -231,7 +236,14 @@ async function readPackageName(packagePath) {
       return;
     throw error;
   }
-  const parsed = JSON.parse(raw);
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    if (error instanceof SyntaxError)
+      return;
+    throw error;
+  }
   return isRecord(parsed) && typeof parsed.name === "string" ? parsed.name : undefined;
 }
 async function fileExists(path) {
@@ -389,9 +401,10 @@ async function runSenpiInstaller(options = {}) {
     packages.push(context.pluginPath);
   settings.packages = packages;
   const backupPath = await writeSettingsAtomically(context.settingsPath, settings);
-  installLocalLauncher({
+  const launcherPath = installLocalLauncher({
     pluginPath: context.pluginPath,
-    senpiCliPath: join5(context.repoRoot, "packages", "coding-agent", "dist", "cli.js")
+    senpiCliPath: join5(context.repoRoot, "packages", "coding-agent", "dist", "cli.js"),
+    homeDir: context.homeDir
   });
   return {
     ok: true,
@@ -399,6 +412,7 @@ async function runSenpiInstaller(options = {}) {
     agentDir: context.agentDir,
     settingsPath: context.settingsPath,
     pluginPath: context.pluginPath,
+    launcherPath,
     changed: JSON.stringify(settings) !== before,
     backupPath
   };
@@ -411,13 +425,14 @@ async function runSenpiUninstaller(options = {}) {
   const nextPackages = packages.filter((entry) => entry !== context.pluginPath);
   settings.packages = nextPackages;
   const backupPath = await writeSettingsAtomically(context.settingsPath, settings);
-  uninstallLocalLauncher();
+  uninstallLocalLauncher(context.homeDir);
   return {
     ok: true,
     action: "uninstall",
     agentDir: context.agentDir,
     settingsPath: context.settingsPath,
     pluginPath: context.pluginPath,
+    launcherPath: undefined,
     changed: JSON.stringify(settings) !== before,
     backupPath,
     removed: nextPackages.length !== packages.length
@@ -427,12 +442,14 @@ function resolveInstallContext(options) {
   const env = options.env ?? process.env;
   const allowBuild = options.pluginPath === undefined;
   const repoRoot = resolve4(options.repoRoot ?? (allowBuild ? findRepoRoot(dirname4(fileURLToPath(import.meta.url))) : dirname4(resolve4(options.pluginPath))));
-  const agentDir = resolve4(options.agentDir ?? resolveAgentHome({ env, homeDir: env.HOME ?? homedir3() }));
+  const homeDir = options.homeDir ?? env.HOME ?? homedir3();
+  const agentDir = resolve4(options.agentDir ?? resolveAgentHome({ env, homeDir }));
   const pluginPath = resolve4(options.pluginPath ?? join5(repoRoot, "packages", "omo-senpi", "plugin"));
   return {
     env,
     repoRoot,
     agentDir,
+    homeDir,
     settingsPath: join5(agentDir, "settings.json"),
     pluginPath,
     platform: options.platform ?? process.platform,

--- a/packages/omo-senpi/scripts/qa/lsp-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/lsp-e2e.mjs
@@ -1222,7 +1222,7 @@ async function runSelfTest(evidenceDir) {
       "bun",
       [
         "-e",
-        `import { runSenpiInstaller } from ${JSON.stringify(pathToFileURL(join(packageRoot, "src", "install", "install-senpi.ts")).href)}; await runSenpiInstaller({ agentDir: ${JSON.stringify(agentDir)}, pluginPath: ${JSON.stringify(plugin)} })`,
+        `import { runSenpiInstaller } from ${JSON.stringify(pathToFileURL(join(packageRoot, "src", "install", "install-senpi.ts")).href)}; await runSenpiInstaller({ agentDir: ${JSON.stringify(agentDir)}, homeDir: ${JSON.stringify(join(workRoot, "home"))}, pluginPath: ${JSON.stringify(plugin)} })`,
       ],
       { cwd: repoRoot, encoding: "utf8" },
     )

--- a/packages/omo-senpi/scripts/qa/task-parent-restart-e2e.mjs
+++ b/packages/omo-senpi/scripts/qa/task-parent-restart-e2e.mjs
@@ -88,7 +88,7 @@ async function runScenario(options) {
   try {
     seedResumeProject(sandbox, resumeOmoConfig())
     if (options.pluginPath === undefined) {
-      await runSenpiInstaller({ agentDir: sandbox.agentDir, repoRoot })
+      await runSenpiInstaller({ agentDir: sandbox.agentDir, homeDir: sandbox.homeDir, repoRoot })
     } else {
       const settingsPath = join(sandbox.agentDir, "settings.json")
       const settings = JSON.parse(readFileSync(settingsPath, "utf8"))

--- a/packages/omo-senpi/src/install/cli-local.test.ts
+++ b/packages/omo-senpi/src/install/cli-local.test.ts
@@ -121,6 +121,7 @@ async function runCliLocal(
     cwd: repoRoot,
     env: {
       ...process.env,
+      HOME: join(agentDir, "home"),
       OMO_CODING_AGENT_DIR: agentDir,
       SENPI_CODING_AGENT_DIR: agentDir,
       PI_CODING_AGENT_DIR: agentDir,
@@ -154,14 +155,16 @@ describe("cli-local", () => {
 
     // then
     expect(install.exitCode).toBe(0)
-    const installResult = JSON.parse(install.stdout) as { readonly pluginPath: string }
+    const installResult = JSON.parse(install.stdout) as { readonly pluginPath: string; readonly launcherPath?: string }
     expect(installResult).toMatchObject({ ok: true, action: "install" })
     expect(install.stdout.trim().split("\n")).toHaveLength(1)
     expect(installedSettings.packages).toEqual([installResult.pluginPath])
+    expect(installResult.launcherPath).toBe(join(agentDir, "home", ".local", "bin", "omo"))
     expect(uninstall.exitCode).toBe(0)
     expect(JSON.parse(uninstall.stdout)).toMatchObject({ ok: true, action: "uninstall" })
     expect(uninstall.stdout.trim().split("\n")).toHaveLength(1)
     expect(uninstalledSettings.packages).toEqual([])
+    await expect(readFile(join(agentDir, "home", ".local", "bin", "omo"), "utf8")).rejects.toThrow()
     expect(install.stderr).toBe("")
   })
 

--- a/packages/omo-senpi/src/install/install-senpi-launcher.test.ts
+++ b/packages/omo-senpi/src/install/install-senpi-launcher.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { runSenpiInstaller, runSenpiUninstaller } from "./install-senpi"
+import { createPluginFixture } from "./install-test-fixture"
+import { localLauncherPath } from "./local-launcher"
+
+const repoRoot = resolve(import.meta.dir, "../../../..")
+const tempDirs: string[] = []
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function makePluginFixture(): Promise<string> {
+  const pluginPath = await createPluginFixture()
+  tempDirs.push(pluginPath)
+  return pluginPath
+}
+
+async function readSettings(agentDir: string): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(join(agentDir, "settings.json"), "utf8")) as Record<string, unknown>
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("runSenpiInstaller local launcher", () => {
+  test("#given a sandbox home #when installing #then the launcher is written under that home and reported", async () => {
+    // given
+    const agentDir = await makeTempDir("omo-senpi-launcher-agent-")
+    const homeDir = await makeTempDir("omo-senpi-launcher-home-")
+    const pluginPath = await makePluginFixture()
+
+    // when
+    const result = await runSenpiInstaller({ env: { HOME: homeDir, SENPI_CODING_AGENT_DIR: agentDir }, repoRoot, pluginPath })
+
+    // then
+    expect(result.launcherPath).toBe(localLauncherPath(homeDir))
+    expect(await readFile(localLauncherPath(homeDir), "utf8")).toContain("omo-local-launcher")
+  })
+
+  test("#given a foreign omo launcher #when installing #then the plugin is registered and the launcher is left untouched", async () => {
+    // given
+    const agentDir = await makeTempDir("omo-senpi-launcher-agent-")
+    const homeDir = await makeTempDir("omo-senpi-launcher-home-")
+    const pluginPath = await makePluginFixture()
+    const foreignLauncher = "#!/bin/sh\necho foreign\n"
+    await mkdir(join(homeDir, ".local", "bin"), { recursive: true })
+    await writeFile(localLauncherPath(homeDir), foreignLauncher)
+    await writeFile(join(agentDir, "settings.json"), JSON.stringify({ packages: ["keep-me"] }))
+
+    // when
+    const result = await runSenpiInstaller({ env: { HOME: homeDir, SENPI_CODING_AGENT_DIR: agentDir }, repoRoot, pluginPath })
+
+    // then
+    expect(result.launcherPath).toBeUndefined()
+    expect(await readSettings(agentDir)).toEqual({ packages: ["keep-me", pluginPath] })
+    expect(await readFile(localLauncherPath(homeDir), "utf8")).toBe(foreignLauncher)
+  })
+
+  test("#given an installed launcher #when uninstalling #then the launcher under that home is removed", async () => {
+    // given
+    const agentDir = await makeTempDir("omo-senpi-launcher-agent-")
+    const homeDir = await makeTempDir("omo-senpi-launcher-home-")
+    const pluginPath = await makePluginFixture()
+    const env = { HOME: homeDir, SENPI_CODING_AGENT_DIR: agentDir }
+    await runSenpiInstaller({ env, repoRoot, pluginPath })
+
+    // when
+    await runSenpiUninstaller({ env, repoRoot, pluginPath })
+
+    // then
+    await expect(readFile(localLauncherPath(homeDir), "utf8")).rejects.toThrow()
+  })
+})

--- a/packages/omo-senpi/src/install/install-senpi-refresh.test.ts
+++ b/packages/omo-senpi/src/install/install-senpi-refresh.test.ts
@@ -40,6 +40,7 @@ describe("runSenpiInstaller source refresh", () => {
     // when
     await runSenpiInstaller({
       agentDir,
+      homeDir: await tempDir("omo-senpi-source-refresh-home-"),
       repoRoot,
       runCommand: async (command, args, options) => {
         calls.push({ command, args, cwd: options.cwd })
@@ -72,10 +73,27 @@ describe("runSenpiInstaller source refresh", () => {
     )
 
     // when
-    await runSenpiInstaller({ agentDir, repoRoot, pluginPath })
+    await runSenpiInstaller({ agentDir, homeDir: await tempDir("omo-senpi-package-replace-home-"), repoRoot, pluginPath })
 
     // then
     expect(await settingsPackages(agentDir)).toEqual(["keep-me", pluginPath])
+  })
+
+  test("#given dead generated and unrelated package entries #when installing #then only the generated omo entry is pruned", async () => {
+    // given
+    const agentDir = await tempDir("omo-senpi-package-cleanup-")
+    const readableUnrelated = await tempDir("omo-senpi-readable-unrelated-")
+    await writeFile(join(readableUnrelated, "package.json"), JSON.stringify({ name: "unrelated" }))
+    await writeFile(
+      join(agentDir, "settings.json"),
+      JSON.stringify({ packages: ["omo-senpi-cli-plugin-Ab12Cd", "omo-senpi-cli-plugin-bad", readableUnrelated, "dead-unrelated"] }),
+    )
+
+    // when
+    await runSenpiInstaller({ agentDir, homeDir: await tempDir("omo-senpi-package-cleanup-home-"), repoRoot, pluginPath })
+
+    // then
+    expect(await settingsPackages(agentDir)).toEqual(["omo-senpi-cli-plugin-bad", readableUnrelated, "dead-unrelated", pluginPath])
   })
 
   test("#given current and stale OMO entries #when refreshing #then the current package keeps its precedence", async () => {
@@ -89,7 +107,7 @@ describe("runSenpiInstaller source refresh", () => {
     )
 
     // when
-    await runSenpiInstaller({ agentDir, repoRoot, pluginPath })
+    await runSenpiInstaller({ agentDir, homeDir: await tempDir("omo-senpi-package-order-home-"), repoRoot, pluginPath })
 
     // then
     expect(await settingsPackages(agentDir)).toEqual(["before", pluginPath, "after"])

--- a/packages/omo-senpi/src/install/install-senpi.test.ts
+++ b/packages/omo-senpi/src/install/install-senpi.test.ts
@@ -4,8 +4,9 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { createHash } from "node:crypto"
 import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { dirname, join, relative, resolve } from "node:path"
+import { join, relative, resolve } from "node:path"
 import { runSenpiInstaller, runSenpiUninstaller } from "./install-senpi"
+import { createPluginFixture, writeFixtureFile } from "./install-test-fixture"
 
 const repoRoot = resolve(import.meta.dir, "../../../..")
 const tempDirs: string[] = []
@@ -24,75 +25,10 @@ async function backupFiles(agentDir: string): Promise<readonly string[]> {
   return (await readdir(agentDir)).filter((entry) => entry.startsWith("settings.json.") && entry.endsWith(".backup"))
 }
 
-async function makePluginFixture(options: { readonly runtime?: boolean } = { runtime: true }): Promise<string> {
-  const pluginPath = await mkdtemp(join(tmpdir(), "omo-senpi-plugin-fixture-"))
+async function makePluginFixture(options?: { readonly runtime?: boolean }): Promise<string> {
+  const pluginPath = await createPluginFixture(options)
   tempDirs.push(pluginPath)
-  await writeFixtureFile(join(pluginPath, "package.json"), JSON.stringify({ name: "@code-yeongyu/omo-senpi" }))
-  await writeFixtureFile(join(pluginPath, "extensions", "omo.js"), "export default {}\n")
-  await writeFixtureFile(join(pluginPath, "extensions", "omo-task.js"), "export const createTaskComponent = () => ({})\n")
-  await writeFixtureFile(join(pluginPath, "extensions", "omo-member.js"), "export default {}\n")
-  await writeFixtureFile(join(pluginPath, "extensions", "memory-run-supervisor.mjs"), "export {}\n")
-  await writeFixtureFile(join(pluginPath, "extensions", "reflection-persona.md"), "# reflection persona fixture\n")
-  await writeFixtureFile(join(pluginPath, "extensions", "dream-persona.md"), "# dream persona fixture\n")
-  await writeFixtureFile(join(pluginPath, "extensions", "facts-persona.md"), "# facts persona fixture\n")
-  await writeFixtureFile(join(pluginPath, "extensions", "memorian-persona.md"), "# memorian persona fixture\n")
-  const requiredSkillNames = [
-    "ast-grep",
-    "coding-agent-sessions",
-    "debugging",
-    "frontend",
-    "git-master",
-    "init-deep",
-    "lsp-setup",
-    "programming",
-    "refactor",
-    "remove-ai-slops",
-    "review-work",
-    "ultimate-browsing",
-    "ultrawork",
-    "ulw-execute",
-    "ulw-loop",
-    "ulw-plan",
-    "ulw-research",
-    "visual-qa",
-  ]
-  for (const skillName of requiredSkillNames) {
-    await writeFixtureFile(join(pluginPath, "skills", skillName, "SKILL.md"), `# ${skillName}\n`)
-  }
-  // Credential-gated skill: staged outside pi.skills but still a required payload artifact.
-  await writeFixtureFile(join(pluginPath, "skills-conditional", "x-search", "SKILL.md"), "# x-search\n")
-  await writeFixtureFile(join(pluginPath, "scripts", "install.mjs"), "#!/usr/bin/env node\n")
-  if (options.runtime !== false) {
-    const astGrepRuntime = join(pluginPath, "runtime", "ast-grep-mcp", "cli.js")
-    await writeFixtureFile(astGrepRuntime, "console.log('ast-grep')\n")
-    await chmod(astGrepRuntime, 0o755)
-    const astGrepRuntimeBytes = await readFile(astGrepRuntime)
-    await writeFixtureFile(
-      join(pluginPath, "runtime", "ast-grep-mcp", "manifest.json"),
-      `${JSON.stringify({
-        sha256: createHash("sha256").update(astGrepRuntimeBytes).digest("hex"),
-        mode: 0o755,
-        stagedAtUtc: "2026-08-03T00:00:00.000Z",
-      }, null, 2)}\n`,
-    )
-    await writeFixtureFile(join(pluginPath, "runtime", "agent-toolkit", "cli.js"), "export {}\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "agent-toolkit", "ulw-loop", "cli.js"), "console.log('ulw-loop')\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "agent-toolkit", "omo-agent-toolkit"), "#!/bin/sh\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "agent-toolkit", "omo-agent-toolkit.cmd"), "@echo off\r\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "cli.js"), "console.log('cli')\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "index.js"), "export {}\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "index.d.ts"), "export {}\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "daemon-client.js"), "export {}\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "daemon-client.d.ts"), "export {}\n")
-    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "package.json"), JSON.stringify({ version: "0.1.0" }))
-    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", ".omo-runtime-manifest.json"), "{}\n")
-  }
   return pluginPath
-}
-
-async function writeFixtureFile(path: string, content: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true })
-  await writeFile(path, content, "utf8")
 }
 
 afterEach(async () => {
@@ -104,7 +40,8 @@ describe("runSenpiInstaller", () => {
     // given
     const agentDir = await makeAgentDir()
     const pluginPath = await makePluginFixture()
-    const env = { SENPI_CODING_AGENT_DIR: agentDir }
+    const homeDir = await makeAgentDir()
+    const env = { HOME: homeDir, SENPI_CODING_AGENT_DIR: agentDir }
 
     // when
     const first = await runSenpiInstaller({ env, repoRoot, pluginPath })
@@ -122,6 +59,7 @@ describe("runSenpiInstaller", () => {
     // given
     const agentDir = await makeAgentDir()
     const pluginPath = await makePluginFixture()
+    const homeDir = await makeAgentDir()
     await writeFile(
       join(agentDir, "settings.json"),
       JSON.stringify({
@@ -132,7 +70,7 @@ describe("runSenpiInstaller", () => {
     )
 
     // when
-    await runSenpiInstaller({ env: { SENPI_CODING_AGENT_DIR: agentDir }, repoRoot, pluginPath })
+    await runSenpiInstaller({ env: { HOME: homeDir, SENPI_CODING_AGENT_DIR: agentDir }, repoRoot, pluginPath })
 
     // then
     const settings = await readSettings(agentDir)
@@ -161,7 +99,7 @@ describe("runSenpiInstaller", () => {
     )
 
     // when
-    await runSenpiInstaller({ env: { SENPI_CODING_AGENT_DIR: agentDir }, repoRoot, pluginPath })
+    await runSenpiInstaller({ env: { HOME: await makeAgentDir(), SENPI_CODING_AGENT_DIR: agentDir }, repoRoot, pluginPath })
 
     // then
     const settings = await readSettings(agentDir)
@@ -177,7 +115,7 @@ describe("runSenpiInstaller", () => {
 
     // when
     const result = await runSenpiInstaller({
-      env: { SENPI_CODING_AGENT_DIR: agentDir },
+      env: { HOME: await makeAgentDir(), SENPI_CODING_AGENT_DIR: agentDir },
       repoRoot,
       pluginPath,
       platform: "win32",
@@ -343,6 +281,7 @@ describe("runSenpiInstaller", () => {
     await expect(install).rejects.toThrow("missing required runtime artifacts")
     await expect(readFile(join(agentDir, "settings.json"), "utf8")).rejects.toThrow()
   })
+
 })
 
 describe("runSenpiUninstaller", () => {
@@ -359,7 +298,7 @@ describe("runSenpiUninstaller", () => {
     )
 
     // when
-    const result = await runSenpiUninstaller({ env: { SENPI_CODING_AGENT_DIR: agentDir }, repoRoot, pluginPath })
+    const result = await runSenpiUninstaller({ env: { HOME: await makeAgentDir(), SENPI_CODING_AGENT_DIR: agentDir }, repoRoot, pluginPath })
 
     // then
     const settings = await readSettings(agentDir)

--- a/packages/omo-senpi/src/install/install-senpi.ts
+++ b/packages/omo-senpi/src/install/install-senpi.ts
@@ -24,6 +24,7 @@ type Env = Readonly<Record<string, string | undefined>>
 
 export interface SenpiInstallOptions {
   readonly env?: Env
+  readonly homeDir?: string
   readonly repoRoot?: string
   readonly agentDir?: string
   readonly pluginPath?: string
@@ -37,6 +38,7 @@ export interface SenpiInstallResult {
   readonly agentDir: string
   readonly settingsPath: string
   readonly pluginPath: string
+  readonly launcherPath?: string | undefined
   readonly changed: boolean
   readonly backupPath: string
   readonly removed?: boolean
@@ -60,10 +62,12 @@ export async function runSenpiInstaller(options: SenpiInstallOptions = {}): Prom
   settings.packages = packages
   const backupPath = await writeSettingsAtomically(context.settingsPath, settings)
   // The local route runs the user's own engine checkout, so it needs the same launcher the
-  // published package ships; without it this install would boot unbranded.
-  installLocalLauncher({
+  // published package ships; without it this install would boot unbranded. A launcher this
+  // installer did not write (another product's `omo`) is left alone and reported as absent.
+  const launcherPath = installLocalLauncher({
     pluginPath: context.pluginPath,
     senpiCliPath: join(context.repoRoot, "packages", "coding-agent", "dist", "cli.js"),
+    homeDir: context.homeDir,
   })
 
   return {
@@ -72,6 +76,7 @@ export async function runSenpiInstaller(options: SenpiInstallOptions = {}): Prom
     agentDir: context.agentDir,
     settingsPath: context.settingsPath,
     pluginPath: context.pluginPath,
+    launcherPath,
     changed: JSON.stringify(settings) !== before,
     backupPath,
   }
@@ -85,7 +90,7 @@ export async function runSenpiUninstaller(options: SenpiInstallOptions = {}): Pr
   const nextPackages = packages.filter((entry) => entry !== context.pluginPath)
   settings.packages = nextPackages
   const backupPath = await writeSettingsAtomically(context.settingsPath, settings)
-  uninstallLocalLauncher()
+  uninstallLocalLauncher(context.homeDir)
 
   return {
     ok: true,
@@ -93,6 +98,7 @@ export async function runSenpiUninstaller(options: SenpiInstallOptions = {}): Pr
     agentDir: context.agentDir,
     settingsPath: context.settingsPath,
     pluginPath: context.pluginPath,
+    launcherPath: undefined,
     changed: JSON.stringify(settings) !== before,
     backupPath,
     removed: nextPackages.length !== packages.length,
@@ -103,6 +109,7 @@ function resolveInstallContext(options: SenpiInstallOptions): {
   readonly env: Env
   readonly repoRoot: string
   readonly agentDir: string
+  readonly homeDir: string
   readonly settingsPath: string
   readonly pluginPath: string
   readonly platform: NodeJS.Platform
@@ -112,12 +119,14 @@ function resolveInstallContext(options: SenpiInstallOptions): {
   const env = options.env ?? process.env
   const allowBuild = options.pluginPath === undefined
   const repoRoot = resolve(options.repoRoot ?? (allowBuild ? findRepoRoot(dirname(fileURLToPath(import.meta.url))) : dirname(resolve(options.pluginPath))))
-  const agentDir = resolve(options.agentDir ?? resolveAgentHome({ env, homeDir: env.HOME ?? homedir() }))
+  const homeDir = options.homeDir ?? env.HOME ?? homedir()
+  const agentDir = resolve(options.agentDir ?? resolveAgentHome({ env, homeDir }))
   const pluginPath = resolve(options.pluginPath ?? join(repoRoot, "packages", "omo-senpi", "plugin"))
   return {
     env,
     repoRoot,
     agentDir,
+    homeDir,
     settingsPath: join(agentDir, "settings.json"),
     pluginPath,
     platform: options.platform ?? process.platform,

--- a/packages/omo-senpi/src/install/install-test-fixture.ts
+++ b/packages/omo-senpi/src/install/install-test-fixture.ts
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto"
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+const REQUIRED_SKILL_NAMES = [
+  "ast-grep",
+  "coding-agent-sessions",
+  "debugging",
+  "frontend",
+  "git-master",
+  "init-deep",
+  "lsp-setup",
+  "programming",
+  "refactor",
+  "remove-ai-slops",
+  "review-work",
+  "ultimate-browsing",
+  "ultrawork",
+  "ulw-execute",
+  "ulw-loop",
+  "ulw-plan",
+  "ulw-research",
+  "visual-qa",
+] as const
+
+export async function createPluginFixture(options: { readonly runtime?: boolean } = { runtime: true }): Promise<string> {
+  const pluginPath = await mkdtemp(join(tmpdir(), "omo-senpi-plugin-fixture-"))
+  await writeFixtureFile(join(pluginPath, "package.json"), JSON.stringify({ name: "@code-yeongyu/omo-senpi" }))
+  await writeFixtureFile(join(pluginPath, "extensions", "omo.js"), "export default {}\n")
+  await writeFixtureFile(join(pluginPath, "extensions", "omo-task.js"), "export const createTaskComponent = () => ({})\n")
+  await writeFixtureFile(join(pluginPath, "extensions", "omo-member.js"), "export default {}\n")
+  await writeFixtureFile(join(pluginPath, "extensions", "memory-run-supervisor.mjs"), "export {}\n")
+  await writeFixtureFile(join(pluginPath, "extensions", "reflection-persona.md"), "# reflection persona fixture\n")
+  await writeFixtureFile(join(pluginPath, "extensions", "dream-persona.md"), "# dream persona fixture\n")
+  await writeFixtureFile(join(pluginPath, "extensions", "facts-persona.md"), "# facts persona fixture\n")
+  await writeFixtureFile(join(pluginPath, "extensions", "memorian-persona.md"), "# memorian persona fixture\n")
+  for (const skillName of REQUIRED_SKILL_NAMES) {
+    await writeFixtureFile(join(pluginPath, "skills", skillName, "SKILL.md"), `# ${skillName}\n`)
+  }
+  // Credential-gated skill: staged outside pi.skills but still a required payload artifact.
+  await writeFixtureFile(join(pluginPath, "skills-conditional", "x-search", "SKILL.md"), "# x-search\n")
+  await writeFixtureFile(join(pluginPath, "scripts", "install.mjs"), "#!/usr/bin/env node\n")
+  if (options.runtime !== false) {
+    const astGrepRuntime = join(pluginPath, "runtime", "ast-grep-mcp", "cli.js")
+    await writeFixtureFile(astGrepRuntime, "console.log('ast-grep')\n")
+    await chmod(astGrepRuntime, 0o755)
+    const astGrepRuntimeBytes = await readFile(astGrepRuntime)
+    await writeFixtureFile(
+      join(pluginPath, "runtime", "ast-grep-mcp", "manifest.json"),
+      `${JSON.stringify({
+        sha256: createHash("sha256").update(astGrepRuntimeBytes).digest("hex"),
+        mode: 0o755,
+        stagedAtUtc: "2026-08-03T00:00:00.000Z",
+      }, null, 2)}\n`,
+    )
+    await writeFixtureFile(join(pluginPath, "runtime", "agent-toolkit", "cli.js"), "export {}\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "agent-toolkit", "ulw-loop", "cli.js"), "console.log('ulw-loop')\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "agent-toolkit", "omo-agent-toolkit"), "#!/bin/sh\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "agent-toolkit", "omo-agent-toolkit.cmd"), "@echo off\r\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "cli.js"), "console.log('cli')\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "index.js"), "export {}\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "index.d.ts"), "export {}\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "daemon-client.js"), "export {}\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "daemon-client.d.ts"), "export {}\n")
+    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", "package.json"), JSON.stringify({ version: "0.1.0" }))
+    await writeFixtureFile(join(pluginPath, "runtime", "lsp-daemon", "dist", ".omo-runtime-manifest.json"), "{}\n")
+  }
+  return pluginPath
+}
+
+export async function writeFixtureFile(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, content, "utf8")
+}

--- a/packages/omo-senpi/src/install/senpi-settings.ts
+++ b/packages/omo-senpi/src/install/senpi-settings.ts
@@ -1,10 +1,11 @@
 import { constants } from "node:fs"
 import { access, copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises"
-import { dirname, join, resolve } from "node:path"
+import { basename, dirname, join, resolve } from "node:path"
 
 export type SettingsRecord = Record<string, unknown>
 
 const OMO_SENPI_PACKAGE_NAME = "@code-yeongyu/omo-senpi"
+const GENERATED_PLUGIN_BASENAME = /^omo-senpi-cli-plugin-[A-Za-z0-9]{6}$/
 
 const LEGACY_BUILTIN_SHADOW_PACKAGES = [
   join("packages", "pi-goal"),
@@ -57,7 +58,9 @@ export async function removeSupersededOmoPackages(
     packages.map(async (entry) => {
       const packagePath = resolve(agentDir, entry)
       if (packagePath === currentPath) return currentPath
-      return (await readPackageName(packagePath)) === OMO_SENPI_PACKAGE_NAME ? undefined : entry
+      if ((await readPackageName(packagePath)) === OMO_SENPI_PACKAGE_NAME) return undefined
+      if (GENERATED_PLUGIN_BASENAME.test(basename(entry)) && !(await fileExists(packagePath))) return undefined
+      return entry
     }),
   )
   return entries.filter((entry): entry is string => entry !== undefined)
@@ -106,7 +109,13 @@ async function readPackageName(packagePath: string): Promise<string | undefined>
     if (isErrno(error, "ENOENT") || isErrno(error, "ENOTDIR")) return undefined
     throw error
   }
-  const parsed: unknown = JSON.parse(raw)
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    if (error instanceof SyntaxError) return undefined
+    throw error
+  }
   return isRecord(parsed) && typeof parsed.name === "string" ? parsed.name : undefined
 }
 


### PR DESCRIPTION
## Why

Every `omo` start on a dev machine showed 24 skill-name collision warnings (`"refactor" collision: ✓ path (temp) …/omo-ai/plugin/skills/refactor/SKILL.md ✗ …/oh-my-openagent-wt/…/plugin/skills/refactor/SKILL.md (skipped)`). The published launcher loads its plugin via `--extension`, while `~/.omo/agent/settings.json` still held (a) a dev-worktree copy of `@code-yeongyu/omo-senpi` registered by the local installer and (b) 51 dead `omo-senpi-cli-plugin-XXXXXX` mkdtemp entries leaked by the pre-isolation `cli-local` test. The engine-side dedupe lands in code-yeongyu/senpi#1424; this PR stops the installer from leaving those entries behind and stops tests/QA from touching the real `~/.local/bin/omo`.

## What

- `senpi-settings.ts` `removeSupersededOmoPackages`: besides dropping other `@code-yeongyu/omo-senpi` copies, prunes nonexistent generated `omo-senpi-cli-plugin-[A-Za-z0-9]{6}` entries and treats an unreadable `package.json` as "not omo" instead of throwing. The current plugin path keeps its position.
- `install-senpi.ts`: `homeDir` (option → `env.HOME` → `os.homedir()`) is threaded into `installLocalLauncher` / `uninstallLocalLauncher`; a launcher this installer did not write is left untouched and reported as `launcherPath: undefined` rather than failing the install (`oh-my-openagent install` calls `runSenpiInstaller()` and treats a throw as a failed install).
- Tests: every successful install/uninstall passes a sandbox `HOME`; the `cli-local` subprocess gets a sandbox `HOME`; launcher behaviour moved to `install-senpi-launcher.test.ts`; the plugin fixture moved to `install-test-fixture.ts` (`install-senpi.test.ts` 297 → 219 pure LOC).
- QA drivers (`task-parent-restart-e2e.mjs`, `lsp-e2e.mjs`) pass their sandbox `homeDir`.
- `plugin/scripts/install.mjs` rebuilt on Linux from the new source.

## Verification (ascii box bx_4nkmtpre, x86_64, bun 1.4.0, fresh `bun install --frozen-lockfile`)

- `bun test packages/omo-senpi/src/install` → green (see PR comment for the run summary).
- `tsgo --noEmit -p packages/omo-senpi/tsconfig.json` → clean.
- Real surface: on the reporting machine, pruning the 52 stale entries took the loader's collision diagnostics from 24 to 0 and an interactive `omo` boot shows no "Skill conflicts" block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the local installer from leaving stale `omo-senpi` package entries and isolates launcher writes to an explicit home directory, so dev machines no longer see skill-name collision warnings on every `omo` start.

- Prunes nonexistent generated `omo-senpi-cli-plugin-XXXXXX` entries from `settings.packages` and tolerates unreadable `package.json` files as "not omo".
- Launcher writes now resolve from an explicit `homeDir`; a launcher this installer did not write is left untouched and reported as `launcherPath: undefined` instead of failing the install.
- Tests and QA drivers pass a sandbox `HOME` so they never touch the real `~/.local/bin/omo`.
- The packaged installer `plugin/scripts/install.mjs` is regenerated from the new source.

<sup>Written for commit d877b32e9fa95caaa8545c60d632c60b03ee2664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

