### PR TITLE
fix(postinstall): bound the opencode version probe

### DIFF
--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -15,6 +15,7 @@ import { detectPlatformBinaryMismatch } from "./bin/version-mismatch.js";
 const require = createRequire(import.meta.url);
 
 const MIN_OPENCODE_VERSION = "1.4.0";
+const OPENCODE_VERSION_PROBE_TIMEOUT_MS = 3_000;
 const OPENCODE_PLUGIN_PACKAGES = ["oh-my-opencode", "oh-my-openagent"];
 const RENAME_NOTICE =
   "oh-my-openagent: the 'omo' command is now 'omo-agent-toolkit' (the old name was removed in this major release).";
@@ -62,6 +63,7 @@ function checkOpenCodeVersion() {
     const result = require("child_process").execSync("opencode --version", {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "ignore"],
+      timeout: OPENCODE_VERSION_PROBE_TIMEOUT_MS,
     });
     const version = result.trim();
     const ok = compareVersions(version, MIN_OPENCODE_VERSION);

--- a/postinstall.test.ts
+++ b/postinstall.test.ts
@@ -2,7 +2,8 @@
 
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { mkdtempSync, rmSync } from "node:fs"
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { delimiter } from "node:path"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -10,6 +11,8 @@ import { fileURLToPath } from "node:url"
 const postinstallPath = fileURLToPath(new URL("./postinstall.mjs", import.meta.url))
 const RENAME_NOTICE =
   "oh-my-openagent: the 'omo' command is now 'omo-agent-toolkit' (the old name was removed in this major release)."
+const SUBPROCESS_TEST_TIMEOUT_MS = 30_000
+const HANGING_OPENCODE_MS = 60_000
 
 type PostinstallRun = {
   status: number | null
@@ -17,14 +20,16 @@ type PostinstallRun = {
   stderr: string
 }
 
-function runPostinstallInFixtureEnv(): PostinstallRun {
+function runPostinstallInFixtureEnv(options: { readonly pathPrefix?: string; readonly timeoutMs?: number } = {}): PostinstallRun {
   const fixtureHome = mkdtempSync(join(tmpdir(), "omo-postinstall-fixture-"))
+  const inheritedPath = process.env.PATH ?? ""
   try {
     const result = spawnSync(process.execPath, [postinstallPath], {
       encoding: "utf8",
+      timeout: options.timeoutMs,
       env: {
         ...inheritedPlatformEnv(),
-        PATH: process.env.PATH ?? "",
+        PATH: options.pathPrefix === undefined ? inheritedPath : `${options.pathPrefix}${delimiter}${inheritedPath}`,
         HOME: fixtureHome,
         USERPROFILE: fixtureHome,
         XDG_CACHE_HOME: join(fixtureHome, "cache"),
@@ -34,6 +39,15 @@ function runPostinstallInFixtureEnv(): PostinstallRun {
   } finally {
     rmSync(fixtureHome, { recursive: true, force: true })
   }
+}
+
+function writeHangingOpencodeShim(): string {
+  const binDir = mkdtempSync(join(tmpdir(), "omo-postinstall-hanging-opencode-"))
+  const hang = `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, ${HANGING_OPENCODE_MS})"`
+  writeFileSync(join(binDir, "opencode"), `#!/bin/sh\nexec ${hang}\n`)
+  chmodSync(join(binDir, "opencode"), 0o755)
+  writeFileSync(join(binDir, "opencode.cmd"), `@${hang}\r\n`)
+  return binDir
 }
 
 function inheritedPlatformEnv(): Record<string, string> {
@@ -59,7 +73,7 @@ describe("postinstall rename notice", () => {
 
     // #then
     expect(countNoticeLines(run.stdout)).toBe(1)
-  })
+  }, SUBPROCESS_TEST_TIMEOUT_MS)
 
   test("never fails the install regardless of platform binary resolution", () => {
     // #given
@@ -70,7 +84,24 @@ describe("postinstall rename notice", () => {
 
     // #then
     expect(run.status).toBe(0)
-  })
+  }, SUBPROCESS_TEST_TIMEOUT_MS)
+
+  test("finishes when the opencode version probe never returns", () => {
+    // #given
+    const hangingBinDir = writeHangingOpencodeShim()
+
+    try {
+      // #when
+      const startedAt = Date.now()
+      const run = runPostinstallInFixtureEnv({ pathPrefix: hangingBinDir, timeoutMs: HANGING_OPENCODE_MS * 2 })
+
+      // #then
+      expect(run.status).toBe(0)
+      expect(Date.now() - startedAt).toBeLessThan(HANGING_OPENCODE_MS)
+    } finally {
+      rmSync(hangingBinDir, { recursive: true, force: true })
+    }
+  }, SUBPROCESS_TEST_TIMEOUT_MS)
 
   test("stays idempotent across repeated runs", () => {
     // #given
@@ -82,5 +113,5 @@ describe("postinstall rename notice", () => {
     // #then
     expect(countNoticeLines(firstRun.stdout)).toBe(1)
     expect(countNoticeLines(secondRun.stdout)).toBe(1)
-  })
+  }, SUBPROCESS_TEST_TIMEOUT_MS)
 })


### PR DESCRIPTION
## Why

`postinstall.mjs` probes `opencode --version` through `execSync` with no timeout. On a machine whose `opencode` never exits (the ascii box harness shim, a wedged wrapper, a stalled login shell) `bun install` / `npm install` hang forever in postinstall. Hit while running this repo's test suite on an ascii box today (`node postinstall.mjs` sat in `opencode --version` until killed).

## What

- `postinstall.mjs`: the probe gets a 3 s budget (`OPENCODE_VERSION_PROBE_TIMEOUT_MS`). A timed-out probe already falls into the existing "no opencode" branch, so the only observable change is that the install finishes.
- `postinstall.test.ts`: new test puts a hanging `opencode` (`opencode` + `opencode.cmd`) first on PATH and asserts postinstall exits 0 well inside the shim's lifetime; the subprocess tests carry an explicit 30 s timeout instead of bun's 5 s default.

## Verification (ascii box, x86_64, bun 1.4.0)

- With the fix: `bun test postinstall.test.ts` → 4 pass (each ~3.2 s; the box's own `opencode` shim hangs, so the probe timeout is exercised by every test).
- With the `timeout` line removed: all 4 tests hang until the 30 s test timeout (0 pass / 4 fail, 120 s) — the exact hang this fixes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the postinstall `opencode` version probe with a 3-second timeout so installs no longer hang forever when `opencode --version` never returns. A timed-out probe already falls into the existing "no opencode" branch, so install behavior is otherwise unchanged.

- Adds a test that places a hanging `opencode` shim first on `PATH` and asserts postinstall still exits 0.
- Gives postinstall subprocess tests an explicit 30-second timeout instead of bun's 5-second default.

<sup>Written for commit b7639ca31350640390f3f5a46a45d1f88e557f26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

