### PR TITLE
test(memory): close the control channel only after the holder has connected

### DIFF
--- a/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
+++ b/packages/omo-senpi/src/components/memory/worker/hold-lock-lifecycle.test.ts
@@ -73,6 +73,7 @@ describe("hold-lock fixture lifecycle", () => {
     const marker = join(root, "holder-exited.marker")
     const control = createServer()
     const connections = new Set<Socket>()
+    const firstConnection = new Promise<void>((resolve) => control.once("connection", () => resolve()))
     control.on("connection", (socket) => connections.add(socket))
     const port = await listenOnLoopback(control)
     const child = spawn(process.execPath, [holdLockFixture, join(root, "control.lock")], {
@@ -81,6 +82,11 @@ describe("hold-lock fixture lifecycle", () => {
     })
     try {
       await waitForReady(child)
+      // The holder connects to CONTROL_PORT after it prints readiness, so tearing the channel down
+      // on the readiness signal alone races the connect. Losing that race leaves the holder owning a
+      // socket accepted from the listen backlog that nobody ever closes, and the control branch is
+      // its only exit path, so it parks forever. Wait for the connection this test intends to close.
+      await firstConnection
       const exit = exitWithin(child, EXIT_TIMEOUT_MS)
 
       // when


### PR DESCRIPTION
`hold-lock fixture lifecycle > exits when ONLY the parent-owned control channel closes while stdin stays open` fails on Windows:

```
error: child 64980 did not exit within 5000ms
```

The holder fixture connects to `CONTROL_PORT` **after** it prints `held`, so tearing the channel down on the readiness signal alone races that connect. When the teardown wins, `connections` is still empty, the loop destroys nothing, and `control.close()` only stops the listener. The holder's connect is then satisfied from the listen backlog, leaving it owning a socket nobody ever closes. Its `control.once("close")` / `once("error")` branch is the only exit path this test leaves open, so it parks forever.

### Measured

A standalone driver against the real fixture, three runs of each arm on Windows:

| | connections seen | holder exit |
|---|---|---|
| tear down on readiness (current test) | 0 | never, still alive at 8000ms |
| await the connection first | 1 | 18ms, 18ms, 24ms |

Deterministic in both directions, 3/3.

### The change

Wait for the connection the test intends to close, then close it. Six lines, one file, no assertion touched: it still destroys an established channel and still requires the holder's own exit plus the marker on disk.

| | before | after |
|---|---|---|
| that file | 2 pass, 1 fail | 3 pass, 0 fail |

Removing the new `await` returns it to 2 pass / 1 fail, and three consecutive runs with it are 3 pass / 0 fail. `bun run typecheck` in `packages/omo-senpi` exits 0.

Linux presumably wins the race, since the connect completes before the teardown lands, which is why CI is green. Nothing about the fix is platform-specific: it removes the race rather than special-casing an OS.

Found by running `bun test packages/omo-senpi packages/omo-native packages/omo-codex packages/shared-skills` on a Windows machine. No ordering against anything else I have open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the hold-lock lifecycle test hanging on Windows by waiting for the holder to connect before closing the control channel. The previous teardown-on-readiness raced the holder's connect; when teardown won, the holder was left owning a socket nobody closes and never exited, so the test hit its 5s bound.

<sup>Written for commit 41c5c67c4de578a56caf48f1291e051a43019cb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

