### PR TITLE
fix(openclaw): identify the reply-listener daemon on Windows

### DIFF
--- a/packages/openclaw-core/src/__tests__/reply-listener-process.real-process.test.ts
+++ b/packages/openclaw-core/src/__tests__/reply-listener-process.real-process.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { isReplyListenerDaemonProcess, REPLY_LISTENER_DAEMON_IDENTITY_MARKER } from "../reply-listener-process"
+
+// The fake-spawn tests prove which branch runs; only a real child proves the platform
+// command line lookup works (#7885: the win32 branch shipped with zero Windows execution).
+// The child reports its own pid after exec: probing the spawn-returned pid immediately
+// can race the exec and read the pre-exec command line (observed on ubuntu CI).
+const scriptDir = mkdtempSync(join(tmpdir(), "openclaw-reply-listener-identity-"))
+const idleScript = join(scriptDir, "idle-daemon.ts")
+writeFileSync(
+  idleScript,
+  `const fs = require("node:fs")\nfs.writeFileSync(process.argv[2] + ".ready", String(process.pid))\nsetTimeout(() => {}, 60_000)\n`,
+)
+
+function spawnIdleChild(name: string, extraArgs: readonly string[]) {
+  return {
+    readyPath: join(scriptDir, `${name}.ready`),
+    child: Bun.spawn([process.execPath, "run", idleScript, join(scriptDir, name), ...extraArgs], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    }),
+  }
+}
+
+async function awaitReady(readyPath: string): Promise<number> {
+  const deadline = Date.now() + 20_000
+  while (Date.now() < deadline) {
+    if (existsSync(readyPath)) {
+      const pid = Number(readFileSync(readyPath, "utf-8").trim())
+      if (Number.isSafeInteger(pid) && pid > 0) return pid
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  throw new Error(`waited 20s for the spawned child's ready marker, never appeared: ${readyPath}`)
+}
+
+afterAll(() => {
+  rmSync(scriptDir, { recursive: true, force: true })
+})
+
+describe("isReplyListenerDaemonProcess against real processes", () => {
+  test(
+    "#given live children with and without the daemon marker #when probing their self-reported pids #then only the marked child is the daemon and a dead pid is not",
+    async () => {
+      const marked = spawnIdleChild("marked", [REPLY_LISTENER_DAEMON_IDENTITY_MARKER])
+      const unmarked = spawnIdleChild("unmarked", [])
+      const markedPid = await awaitReady(marked.readyPath)
+      const unmarkedPid = await awaitReady(unmarked.readyPath)
+      try {
+        expect(await isReplyListenerDaemonProcess(markedPid)).toBe(true)
+        expect(await isReplyListenerDaemonProcess(unmarkedPid)).toBe(false)
+      } finally {
+        marked.child.kill()
+        unmarked.child.kill()
+        await Promise.all([marked.child.exited, unmarked.child.exited])
+      }
+      expect(await isReplyListenerDaemonProcess(markedPid)).toBe(false)
+    },
+    30_000,
+  )
+})

--- a/packages/openclaw-core/src/__tests__/reply-listener-process.test.ts
+++ b/packages/openclaw-core/src/__tests__/reply-listener-process.test.ts
@@ -69,4 +69,28 @@ describe("isReplyListenerDaemonProcess", () => {
     expect(await probe).toBe(true)
     expect(procReadCalls).toBe(0)
   })
+
+  test("#given windows where ps does not exist #when probing a daemon pid #then the command line still identifies it", async () => {
+    const spawnedCommands: string[][] = []
+
+    const result = await isReplyListenerDaemonProcessWithDeps(1234, {
+      platform: "win32",
+      spawn: (command) => {
+        spawnedCommands.push(command)
+        if (command[0] === "ps") {
+          throw Object.assign(new Error("spawn ps ENOENT"), { code: "ENOENT" })
+        }
+        return {
+          exitCode: 0,
+          exited: Promise.resolve(0),
+          stdout: createOutputStream(
+            '"C:\\\\Program Files\\\\nodejs\\\\node.exe" daemon.js --openclaw-reply-listener-daemon',
+          ),
+        }
+      },
+    })
+
+    expect(result).toBe(true)
+    expect(spawnedCommands.some((command) => command[0] === "ps")).toBe(false)
+  })
 })

--- a/packages/openclaw-core/src/reply-listener-process.ts
+++ b/packages/openclaw-core/src/reply-listener-process.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { spawn } from "@oh-my-opencode/utils/runtime"
 
 export const REPLY_LISTENER_DAEMON_IDENTITY_MARKER = "--openclaw-reply-listener-daemon"
@@ -35,6 +36,28 @@ const REPLY_LISTENER_DAEMON_ENV_ALLOWLIST = [
   "windir",
   "COMSPEC",
 ] as const
+
+// Windows has no ps and no /proc, so the daemon marker has to come from the process command line,
+// which Win32_Process is the only supported way to read. PATH can be missing System32 (#6747), so
+// PowerShell is addressed absolutely. pid is a number, so it cannot escape the filter string.
+async function windowsProcessCommandLineHasMarker(pid: number, deps: ReplyListenerProcessDeps): Promise<boolean> {
+  const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT ?? "C:\\Windows"
+  const powershell = join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+  const processInfo = deps.spawn(
+    [
+      powershell,
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" | Select-Object -ExpandProperty CommandLine`,
+    ],
+    { stdout: "pipe", stderr: "ignore" },
+  )
+  const stdout = await new Response(processInfo.stdout).text()
+  await processInfo.exited
+  if (processInfo.exitCode !== 0) return false
+  return stdout.includes(REPLY_LISTENER_DAEMON_IDENTITY_MARKER)
+}
 
 function ignoreReplyListenerProcessProbeError(error: unknown): void {
   if (error instanceof Error) return
@@ -95,6 +118,10 @@ export async function isReplyListenerDaemonProcessWithDeps(
         ((targetPid) => readFileSync(`/proc/${targetPid}/cmdline`, "utf-8"))
       const cmdline = readProcCmdline(pid)
       return cmdline.includes(REPLY_LISTENER_DAEMON_IDENTITY_MARKER)
+    }
+
+    if (platform === "win32") {
+      return await windowsProcessCommandLineHasMarker(pid, deps)
     }
 
     const processInfo = deps.spawn(["ps", "-p", String(pid), "-o", "args="], {

--- a/script/ci-fast-path.full-matrix.test.ts
+++ b/script/ci-fast-path.full-matrix.test.ts
@@ -157,6 +157,7 @@ describe("full-matrix classification", () => {
       ["classifier itself", "script/ci-fast-path.mjs"],
       ["windows shard bunfig", "bunfig.win2.parallel.toml"],
       ["shared serial quarantine", "script/root-test-serial-quarantine.ts"],
+      ["reply-listener process identity (win32 branch)", "packages/openclaw-core/src/reply-listener-process.ts"],
     ])("#then %s forces the full matrix", (_name, changedPath) => {
       // given / when
       const mode = classify({

--- a/script/ci-fast-path.mjs
+++ b/script/ci-fast-path.mjs
@@ -14,6 +14,7 @@ const platformSensitiveExactPaths = new Set([
   "script/ci-fast-path.mjs",
   "bunfig.win2.parallel.toml",
   "script/root-test-serial-quarantine.ts",
+  "packages/openclaw-core/src/reply-listener-process.ts",
 ])
 
 function parseArguments(argv) {


### PR DESCRIPTION
On Windows the reply-listener daemon can never be detected or stopped, and every attempt orphans it.

`isReplyListenerDaemonProcessWithDeps` reads `/proc/<pid>/cmdline` on linux and falls back to `ps -p <pid> -o args=` everywhere else. Windows has neither, so the spawn fails, `ignoreReplyListenerProcessProbeError` swallows it, and the function returns `false` for every pid including a genuine daemon.

That `false` decides three things:

- `isDaemonRunning` reports a live daemon as not running **and** calls `removeReplyListenerPid()`, deleting the only record of its pid.
- `stopReplyListener` returns `success: false` with *"Refusing to kill PID N: process identity does not match the reply listener daemon (stale or reused PID - removed PID file)"* and removes the PID file.
- `terminateReplyListenerProcess` returns without sending SIGTERM.

So a Windows user who starts the daemon cannot stop it through the product, and the first status check strands it.

### Measured against real processes

Driving the exported `isReplyListenerDaemonProcess` against processes spawned with and without the marker in argv:

| | dev at `b2f688f1c` | this branch |
|---|---|---|
| marker in argv, process alive | `false` | `true` (1021ms) |
| no marker, process alive | `false` | `false` |
| same pid after it exited | `false` | `false` |

The middle and bottom rows are the controls: the fix must not make it say yes to everything.

### The change

Read the command line from `Win32_Process`, which is the supported way to get it on Windows:

```
Get-CimInstance Win32_Process -Filter "ProcessId=<pid>" | Select-Object -ExpandProperty CommandLine
```

PowerShell is addressed through `SystemRoot` rather than PATH, because PATH can be missing System32, which is the failure in #6747. `pid` is typed `number`, so it cannot escape the filter string. A dead pid returns exit 0 with empty output, so the marker check is already the right answer there.

The branch goes through the existing `deps.spawn` seam, so the new test needs no real process. It models Windows by throwing `ENOENT` for `ps`, and asserts the outcome rather than the command shape.

`bun test packages/openclaw-core` is 69 pass / 0 fail; removing the win32 branch returns the file to 2 pass / 1 fail. `bun run typecheck` in `packages/openclaw-core` exits 0.

Found by scanning the published `oh-my-opencode@5.0.0-beta.45` bundle for calls that cannot work on Windows, then checking each for reachability. No ordering against anything else I have open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reply-listener daemon detection on Windows so the daemon can be stopped and status checks no longer orphan it.

- Reads the command line from `Win32_Process` via PowerShell instead of relying on `ps` or `/proc`.
- Locates PowerShell through `SystemRoot` to avoid missing PATH entries.
- Adds fake-spawn and real-process tests, and forces the full OS matrix when the probe file changes.

<sup>Written for commit 6ef4963db5b80d0b74644612260aa8070d2ef95e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

