### PR TITLE
fix(monitor): kill the monitored process tree on Windows

### DIFF
--- a/packages/omo-opencode/src/features/monitor/process.test.ts
+++ b/packages/omo-opencode/src/features/monitor/process.test.ts
@@ -135,7 +135,7 @@ describe("spawnMonitoredProcess", () => {
 
       const monitored = spawnMonitoredProcess(
         { command: "bun test", maxRuntimeMs: 60_000 },
-        { spawn: createFakeSpawn([subprocess], spawnCalls), ...clock.deps },
+        { spawn: createFakeSpawn([subprocess], spawnCalls), platform: "linux", ...clock.deps },
       )
 
       // when
@@ -150,6 +150,40 @@ describe("spawnMonitoredProcess", () => {
     })
   })
 
+  describe("#given windows, where a negative pid is rejected", () => {
+    test("#when kill runs #then it takes the process tree down instead of doing nothing", () => {
+      // given
+      const pendingExit = new Promise<number>(() => {})
+      const subprocess = createFakeSubprocess({ pid: 4321, exited: pendingExit })
+      const spawnCalls: SpawnCall[] = []
+      const clock = createFakeClock()
+      const killCalls: Array<{ pid: number; signal: string | number | undefined }> = []
+      const treeKills: number[] = []
+      process.kill = ((pid: number, signal?: string | number) => {
+        killCalls.push({ pid, signal })
+        return true
+      }) satisfies typeof process.kill
+
+      const monitored = spawnMonitoredProcess(
+        { command: "bun test", maxRuntimeMs: 60_000 },
+        {
+          spawn: createFakeSpawn([subprocess], spawnCalls),
+          platform: "win32",
+          killProcessTree: (pid) => treeKills.push(pid),
+          ...clock.deps,
+        },
+      )
+
+      // when
+      monitored.kill("SIGTERM")
+      clock.fireByMs(5_000)
+
+      // then
+      expect(treeKills).toEqual([4321, 4321])
+      expect(killCalls).toEqual([])
+    })
+  })
+
   describe("#given a subprocess exits immediately", () => {
     test("#when awaiting exited #then it resolves with the exit code and signal data", async () => {
       // given
@@ -160,7 +194,7 @@ describe("spawnMonitoredProcess", () => {
       // when
       const monitored = spawnMonitoredProcess(
         { command: "missing-command", maxRuntimeMs: 60_000 },
-        { spawn: createFakeSpawn([subprocess], spawnCalls), ...clock.deps },
+        { spawn: createFakeSpawn([subprocess], spawnCalls), platform: "linux", ...clock.deps },
       )
       const result = await monitored.exited
 
@@ -185,7 +219,7 @@ describe("spawnMonitoredProcess", () => {
 
       const monitored = spawnMonitoredProcess(
         { command: "bun test", maxRuntimeMs: 1234 },
-        { spawn: createFakeSpawn([subprocess], spawnCalls), ...clock.deps },
+        { spawn: createFakeSpawn([subprocess], spawnCalls), platform: "linux", ...clock.deps },
       )
 
       // when
@@ -213,7 +247,7 @@ describe("spawnMonitoredProcess", () => {
       // when
       spawnMonitoredProcess(
         { command: "printf 'ok'", cwd: "/tmp", env: { OMO_TEST: "1" }, maxRuntimeMs: 60_000 },
-        { spawn: createFakeSpawn([subprocess], spawnCalls), ...clock.deps },
+        { spawn: createFakeSpawn([subprocess], spawnCalls), platform: "linux", ...clock.deps },
       )
 
       // then

--- a/packages/omo-opencode/src/features/monitor/process.ts
+++ b/packages/omo-opencode/src/features/monitor/process.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path"
+
 import { tokenizeCommand } from "../../tools/interactive-bash/tools"
 import { spawn as runtimeSpawn } from "../../shared/bun-spawn-shim"
 
@@ -5,6 +7,8 @@ export type TimerHandle = ReturnType<typeof setTimeout> | number
 
 export interface SpawnDeps {
   spawn?: SpawnFunction
+  killProcessTree?: (pid: number) => void
+  platform?: NodeJS.Platform
   setTimer: (fn: () => void, ms: number) => TimerHandle
   clearTimer: (handle: TimerHandle) => void
 }
@@ -36,8 +40,31 @@ type SpawnFunction = (argv: readonly string[], options: {
 
 const KILL_GRACE_MS = 5_000
 
-function killProcessGroup(pid: number, signal: NodeJS.Signals | 0): void {
+// Windows has no process groups, so process.kill(-pid) is rejected and the empty catch turns every
+// kill into a no-op. The child is spawned detached, so nothing else reaps it: a watchdog timeout
+// reports SIGALRM while the process keeps running. taskkill /T is what takes the tree down, the way
+// execute-hook-command already does it, addressed through SystemRoot because PATH can lack
+// System32 (#6738).
+function killWindowsProcessTree(pid: number): void {
+  const systemRoot = process.env.SystemRoot ?? process.env.SYSTEMROOT ?? "C:\\Windows"
+  const taskkill = join(systemRoot, "System32", "taskkill.exe")
+  runtimeSpawn([taskkill, "/PID", String(pid), "/T", "/F"], {
+    stdin: "ignore",
+    stdout: "ignore",
+    stderr: "ignore",
+  })
+}
+
+function killProcessGroup(pid: number, signal: NodeJS.Signals | 0, platform: NodeJS.Platform, killTree: (pid: number) => void): void {
   try {
+    if (platform === "win32") {
+      if (signal === 0) {
+        process.kill(pid, 0)
+        return
+      }
+      killTree(pid)
+      return
+    }
     process.kill(-pid, signal)
   } catch (error) {
     void error
@@ -103,13 +130,13 @@ export function spawnMonitoredProcess(
     if (actualExited) return
 
     if (subprocess.pid !== undefined) {
-      killProcessGroup(subprocess.pid, signal)
+      killProcessGroup(subprocess.pid, signal, deps.platform ?? process.platform, deps.killProcessTree ?? killWindowsProcessTree)
     }
     if (graceTimer === undefined) {
       graceTimer = deps.setTimer(() => {
         if (!actualExited) {
           if (subprocess.pid !== undefined) {
-            killProcessGroup(subprocess.pid, "SIGKILL")
+            killProcessGroup(subprocess.pid, "SIGKILL", deps.platform ?? process.platform, deps.killProcessTree ?? killWindowsProcessTree)
           }
         }
       }, KILL_GRACE_MS)


### PR DESCRIPTION
On Windows the monitor never kills anything. `killProcessGroup` calls `process.kill(-pid, signal)`, Windows has no process groups, and the empty catch swallows the rejection. The child is spawned `detached: true`, so nothing else reaps it.

Measured on Windows against a real detached child:

```
child pid: 46476  alive before: true
process.kill(-pid, "SIGTERM")  -> THREW ESRCH
alive after negative-pid kill: true
taskkill /PID 46476 /T /F      -> exit 0
alive after taskkill: false
```

So a monitor whose `maxRuntimeMs` expires runs its watchdog, calls `kill("SIGTERM")`, waits the 5s grace, calls `kill("SIGKILL")`, and then resolves `{ code: null, signal: "SIGALRM" }` to the caller while the process it was watching is still running. Every timeout leaks one detached tree, and the caller is told it was terminated.

### The change

Use `taskkill /PID <pid> /T /F` on win32, which is what `execute-hook-command.ts` in this repo already does for the same reason. It is addressed through `SystemRoot` rather than PATH, because PATH can be missing System32, which is the failure in #6738. A bare liveness probe (`signal === 0`) still goes through `process.kill` with a positive pid, since that works on Windows.

`platform` and `killProcessTree` join `spawn` as optional deps, matching how this file already injects its seams, so the test spawns nothing real.

### About the two edited tests

They assert `killCalls` equals `[{pid: -4321, ...}]`, which is POSIX process-group semantics. They passed on Windows only because they stub `process.kill`, so the negative pid never reached the OS. They now say `platform: "linux"` outright. No assertion changed, and without that they would exercise the new branch on `windows-latest` and go red in your CI.

| | before | after |
|---|---|---|
| `process.test.ts` | 3 pass, 2 fail (on Windows, with the fix and unpinned platform) | 5 pass, 0 fail |
| `bun test .../features/monitor` | | 96 tests, 0 fail |

Removing the win32 branch fails the new test. `bun run typecheck` in `packages/omo-opencode` exits 0.

Found by grepping the published `oh-my-opencode@5.0.0-beta.45` bundle for POSIX-only constructs and checking each for a Windows guard. The other `process.kill(-pid)` sites are guarded; this one was not. No ordering against anything else I have open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows monitor kills so a watchdog timeout actually terminates the process tree, where before `process.kill(-pid)` silently failed and left the detached child running.

**Bug Fixes**
- On Windows, `killProcessGroup` now uses `taskkill /PID <pid> /T /F` via `SystemRoot` instead of a negative-pid kill.
- The liveness probe (`signal === 0`) still uses `process.kill` with a positive pid.
- Tests pin POSIX process-group semantics to Linux and add a Windows case asserting `taskkill` is called.

<sup>Written for commit d67eec270bd6b7973520fd97db1927c6ed9b338d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

