### PR TITLE
fix(test): stop the unreachable-server stale sweep from expiring on the wall clock

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/task-poller-unreachable-server.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-poller-unreachable-server.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import { checkAndInterruptStaleTasks } from "./task-poller"
 import type { BackgroundTask } from "./types"
@@ -6,7 +6,7 @@ import type { BackgroundTask } from "./types"
 type StaleSweepArgs = Parameters<typeof checkAndInterruptStaleTasks>[0]
 
 const UNREACHABLE_MESSAGE = "Unable to connect. Is the computer able to access the url?"
-const FIXED_NOW = new Date("2026-09-07T03:00:00.000Z").getTime()
+const MINUTE_MS = 60 * 1000
 
 function unreachableClient(): StaleSweepArgs["client"] {
   const reject = () => Promise.reject(new Error(UNREACHABLE_MESSAGE))
@@ -48,15 +48,8 @@ async function sweep(task: BackgroundTask): Promise<ReturnType<typeof mock>> {
 }
 
 describe("checkAndInterruptStaleTasks while the OpenCode server is unreachable", () => {
-  const nowSpy = spyOn(Date, "now")
-
-  afterEach(() => {
-    nowSpy.mockReset()
-  })
-
   test("#given a task stale past the default timeout #when every session call rejects as unreachable #then the task is finalized and the parent is told once", async () => {
-    nowSpy.mockReturnValue(FIXED_NOW)
-    const task = runningTask(new Date(FIXED_NOW - 46 * 60 * 1000))
+    const task = runningTask(new Date(Date.now() - 46 * MINUTE_MS))
 
     const notify = await sweep(task)
 
@@ -66,8 +59,7 @@ describe("checkAndInterruptStaleTasks while the OpenCode server is unreachable",
   })
 
   test("#given a task with recent activity #when every session call rejects as unreachable #then the task keeps running and the parent is not told", async () => {
-    nowSpy.mockReturnValue(FIXED_NOW)
-    const task = runningTask(new Date(FIXED_NOW - 5 * 60 * 1000))
+    const task = runningTask(new Date(Date.now() - 5 * MINUTE_MS))
 
     const notify = await sweep(task)
 


### PR DESCRIPTION
`task-poller-unreachable-server.test.ts` is red on `dev` right now and will stay red on every run from here.

```
$ bun test packages/omo-opencode/src/features/background-agent/task-poller-unreachable-server.test.ts
expect(received).toBe(expected)
Expected: "running"
Received: "cancelled"
 1 pass, 1 fail
```

### Why it started failing an hour after it landed

The second test never actually had a mocked clock. The spy is created once for the describe and `afterEach` calls `mockReset()`. In bun that detaches it, so re-arming the same handle with `mockReturnValue` does nothing. Minimal reproduction of just that:

```
test1  Date.now() = 1788750000000  matches FIXED: true
test2  Date.now() = 1788752706386  matches FIXED: false     <- the real clock
```

So the second test compares a task pinned to `2026-09-07T02:55:00.000Z` against the real time. It passes only while the wall clock stays within the 45 minute default stale timeout of the hardcoded `FIXED_NOW`, which expired at about **2026-09-07T03:40Z**. That is also why it looks intermittent in CI today rather than uniformly red: `test (ubuntu-latest, 1/2)` passed on a run at 03:2xZ and failed on one at 03:37Z.

### The change

Drop the spy and derive both fixtures from the real clock, 46 minutes stale and 5 minutes fresh. That is exactly what each test means, it needs no mock, and it cannot expire.

| | dev at `b2f688f1c` | this branch |
|---|---|---|
| that file | 1 pass, 1 fail | 2 pass, 0 fail, three consecutive runs |
| `features/background-agent` | | 757 pass, 0 fail |

`bun run typecheck` in `packages/omo-opencode` exits 0. The assertions are untouched; only the clock the fixtures are built from changed.

I hit this because it turned my own #7888 red, and it is not mine, so I went and found it. Worth landing ahead of anything else I have open, since it fails the required `test` job for every PR against `dev`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `task-poller-unreachable-server.test.ts` stale sweep test so it no longer expires against the wall clock. The previous test relied on a `Date.now` spy that detached after the first test, so the second test compared against real time and started failing once the fixed timestamp passed the 45-minute stale timeout. The fixtures now derive from the real clock (46 minutes stale, 5 minutes fresh), making the tests deterministic and immune to expiry.

<sup>Written for commit 63c5307cf495c02fb0569a084a98c88cb5794531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

