### PR TITLE
test(background-agent): build stale-sweep fixtures relative to the wall clock

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/task-poller-unreachable-server.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-poller-unreachable-server.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 import { checkAndInterruptStaleTasks } from "./task-poller"
 import type { BackgroundTask } from "./types"
@@ -6,7 +6,13 @@ import type { BackgroundTask } from "./types"
 type StaleSweepArgs = Parameters<typeof checkAndInterruptStaleTasks>[0]
 
 const UNREACHABLE_MESSAGE = "Unable to connect. Is the computer able to access the url?"
-const FIXED_NOW = new Date("2026-09-07T03:00:00.000Z").getTime()
+const MINUTE_MS = 60 * 1000
+
+// The sweep reads the wall clock through Date.now(); fixtures are built relative to
+// the same clock so the assertions never depend on when the suite happens to run.
+function minutesAgo(minutes: number): Date {
+  return new Date(Date.now() - minutes * MINUTE_MS)
+}
 
 function unreachableClient(): StaleSweepArgs["client"] {
   const reject = () => Promise.reject(new Error(UNREACHABLE_MESSAGE))
@@ -48,15 +54,8 @@ async function sweep(task: BackgroundTask): Promise<ReturnType<typeof mock>> {
 }
 
 describe("checkAndInterruptStaleTasks while the OpenCode server is unreachable", () => {
-  const nowSpy = spyOn(Date, "now")
-
-  afterEach(() => {
-    nowSpy.mockReset()
-  })
-
   test("#given a task stale past the default timeout #when every session call rejects as unreachable #then the task is finalized and the parent is told once", async () => {
-    nowSpy.mockReturnValue(FIXED_NOW)
-    const task = runningTask(new Date(FIXED_NOW - 46 * 60 * 1000))
+    const task = runningTask(minutesAgo(46))
 
     const notify = await sweep(task)
 
@@ -66,8 +65,7 @@ describe("checkAndInterruptStaleTasks while the OpenCode server is unreachable",
   })
 
   test("#given a task with recent activity #when every session call rejects as unreachable #then the task keeps running and the parent is not told", async () => {
-    nowSpy.mockReturnValue(FIXED_NOW)
-    const task = runningTask(new Date(FIXED_NOW - 5 * 60 * 1000))
+    const task = runningTask(minutesAgo(5))
 
     const notify = await sweep(task)
 


### PR DESCRIPTION
## Why
`task-poller-unreachable-server.test.ts` (#7854) pinned `FIXED_NOW = 2026-09-07T03:00Z` and spied `Date.now`, but after `afterEach`'s `mockReset()` the second test's `mockReturnValue` no longer governed the clock the poller read (reproduced on the box: the second test observes the real `Date.now()`). That made the "recent activity" assertion depend on wall time: the fixture (`02:55Z`) stays "recent" only while `Date.now() - 02:55Z < 45 min`. At **03:40Z today** it crossed the default stale timeout and the sweep correctly cancelled it — every shard on every OS is red from then on (dev CI 34080004387 `test (windows-latest, 1/2)`, release-state PR #7887 `test (macos-latest, 1/2)`), which is what killed the beta.46 prepare (run 34080011948).

The poller is correct: a 5-minute-old task under a 45-minute timeout must keep running. This is a test defect only.

## What
- Fixtures are built with `minutesAgo(n)` against the same `Date.now()` the poller reads; the spy and the absolute date are gone, so no fixture can rot again.
- Comment names the failure mode for the next reader.

## Evidence (ascii box, bun 1.4.0, omo dev 50aa9a8bf)
- RED (original file at 03:5xZ): `1 fail` — `Expected: "running" / Received: "cancelled"`.
- GREEN (this change): `2 pass, 0 fail`; whole `background-agent/` dir: `757 pass, 0 fail` across 63 files.