### PR TITLE
fix(omo-senpi): make DAG owner-scope snapshot keys posix on Windows

### DIFF
--- a/packages/omo-senpi/scripts/qa/dag-owner-scope-fixture.mjs
+++ b/packages/omo-senpi/scripts/qa/dag-owner-scope-fixture.mjs
@@ -29,6 +29,13 @@ export function seedRun(stateDir, runId, owner, holder) {
   return record
 }
 
+// Snapshot keys are the contract evaluate() matches against (`dag/runs/<id>.json`, ...), so they
+// must be posix-separated on every platform; node:path.relative yields backslashes on Windows.
+// The state tree is synthetic and never contains a backslash in a file name, so both separators fold.
+export function toPosixKey(relativePath) {
+  return relativePath.split(/[\\/]+/).join("/")
+}
+
 export function snapshot(stateDir) {
   const files = {}
   function visit(dir) {
@@ -36,7 +43,7 @@ export function snapshot(stateDir) {
     for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
       const path = join(dir, entry.name)
       if (entry.isDirectory()) visit(path)
-      else if (entry.isFile()) files[relative(stateDir, path)] = createHash("sha256").update(readFileSync(path)).digest("hex")
+      else if (entry.isFile()) files[toPosixKey(relative(stateDir, path))] = createHash("sha256").update(readFileSync(path)).digest("hex")
     }
   }
   visit(stateDir)

--- a/packages/omo-senpi/scripts/qa/dag-owner-scope.test.mjs
+++ b/packages/omo-senpi/scripts/qa/dag-owner-scope.test.mjs
@@ -5,6 +5,7 @@ import { createDagFileStore } from "../../../senpi-task/src/dag/store.ts"
 import { readDagNodeResult } from "../../../senpi-task/src/dag/results.ts"
 import { createSandbox } from "./drive.mjs"
 import { evaluate, selfTest } from "./dag-owner-scope.mjs"
+import * as fixture from "./dag-owner-scope-fixture.mjs"
 import { SESSION_A, SESSION_B, seedRun, snapshot } from "./dag-owner-scope-fixture.mjs"
 
 describe("synthetic DAG selection evidence", () => {
@@ -22,6 +23,20 @@ describe("synthetic DAG selection evidence", () => {
       expect(checkpoint.status).toBe("paused")
       expect(checkpoint.nodes.every((node) => node.state === "completed")).toBe(true)
       expect(result).toEqual({ output: "SYNTHETIC_COMPLETED_OUTPUT\n" })
+    } finally { rmSync(sandbox.root, { recursive: true, force: true }) }
+  })
+
+  test("snapshot keys use posix separators so evaluate() prefixes match on every platform", () => {
+    // given
+    const sandbox = createSandbox()
+    try {
+      seedRun(sandbox.root, "a", SESSION_A, 999999)
+      // when
+      const keys = Object.keys(snapshot(sandbox.root).files)
+      // then
+      expect(keys).toEqual(["dag/events/a.jsonl", "dag/results/a/done.txt", "dag/runs/a.json"])
+      expect(fixture.toPosixKey("dag\\events\\a.jsonl")).toBe("dag/events/a.jsonl")
+      expect(fixture.toPosixKey("dag/results/a/done.txt")).toBe("dag/results/a/done.txt")
     } finally { rmSync(sandbox.root, { recursive: true, force: true }) }
   })
 


### PR DESCRIPTION
## What
`dag-owner-scope-fixture.mjs` keyed its state snapshot by `node:path.relative()`, which is backslash-separated on Windows. `evaluate()` in `dag-owner-scope.mjs` matches those keys against posix prefixes (`dag/runs/<id>.json`, `dag/events/<id>.jsonl`, `dag/results/<id>/`), so on Windows no changed path ever matched a run id and `forbiddenMutations` was always `[]`.

## Why
`senpi-compatibility (windows-latest)` is red on `dev` (run 34080004387, 2777 pass / 2 fail):
- `synthetic DAG selection evidence > detects an unrelated event mutation even without checkpoint reparenting`
- `synthetic DAG selection evidence > driver self-test detects ownership changes and rejects invalid options`

Introduced with #7869 (`b2f688f1c`). This blocks the beta.46 release gate (`publish.yml` gate-reuse counts every failing check).

The repeated `error: subscriber exploded` lines in the same job are unrelated: they come from `dag-runtime.test.ts:688`, a test that deliberately throws inside a subscriber to prove isolation; the test passes and the line is its expected stderr.

## Corroboration
Independently derived from source by a second session (w37:p2) without seeing this diff: `evaluate()` (`dag-owner-scope.mjs` ~142-143) matches posix prefixes with `path === prefix || path.startsWith(prefix)`; `snapshot()` keys via `relative()` without separator normalization, so on Windows the key is `dag\events\a.jsonl`, never matches, and yields exactly `Expected ['a'], Received []` at `dag-owner-scope.test.mjs:39` and the self-test at driver:252. Prescribed fix: normalize snapshot keys to posix. Two independent derivations, one cause.

## Fix
Add `toPosixKey()` to the fixture and route every snapshot key through it. New test pins the key shape (`dag/events/a.jsonl`, `dag/results/a/done.txt`, `dag/runs/a.json`) and the helper's backslash folding.

## Evidence
- RED (mengmotaMac, bun 1.4.0, dev `50aa9a8bf` + test only): `1 fail` - `fixture.toPosixKey is not a function`.
- GREEN (same box, with the fix): `5 pass / 0 fail` on `dag-owner-scope.test.mjs`.
- Full `bun test --timeout 20000 packages/omo-senpi` on mengmotaMac: result appended below when it finishes.
- Windows proof: this PR's own `senpi-compatibility (windows-latest)` job.

Test-only change under `scripts/qa`; no runtime code touched.