### PR TITLE
fix(ulw-loop): owner-verified lock release and locked legacy-plan migration

### DIFF
--- a/packages/omo-codex/plugin/components/ulw-loop/src/plan-io.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/plan-io.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createReadStream, readdirSync } from "node:fs";
 import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline";
@@ -20,6 +21,10 @@ import { iso, ULW_LOOP_DIR, ULW_LOOP_GOALS, ULW_LOOP_LEDGER, UlwLoopError } from
 const LEGACY_OBJECTIVE_PREFIX = `Complete all ulw-loop stories in ${ULW_LOOP_DIR}/${ULW_LOOP_GOALS}: `;
 const LEGACY_OBJECTIVE = `Complete all ulw-loop stories listed in ${ULW_LOOP_DIR}/${ULW_LOOP_GOALS}. Use ${ULW_LOOP_DIR}/${ULW_LOOP_LEDGER} as the durable audit trail.`;
 const locks = new Map<string, Promise<undefined>>();
+// Tracks which state dirs the CURRENT async continuation holds, so a read nested
+// inside a locked mutation can tell itself apart from an unlocked read elsewhere
+// in the same process.
+const heldLocks = new AsyncLocalStorage<ReadonlySet<string>>();
 
 function hasCode(error: unknown, code: string): boolean {
 	return error instanceof Error && "code" in error && error.code === code;
@@ -56,7 +61,8 @@ export async function withUlwLoopMutationLock<T>(
 	const lockPath = ulwLoopStateLockPath(repoRoot, scope);
 	// The promise chain orders callers inside this process; the file lock is what
 	// excludes every other process (each CLI invocation) touching the same state dir.
-	const locked = (): Promise<T> => withStateLock(lockPath, fn);
+	const locked = (): Promise<T> =>
+		withStateLock(lockPath, () => heldLocks.run(new Set([...(heldLocks.getStore() ?? []), lockKey]), fn));
 	const prior = locks.get(lockKey) ?? Promise.resolve(undefined);
 	const run = prior.then(locked, locked);
 	// The stored gate resolves to undefined so the map never retains fn's result
@@ -96,7 +102,7 @@ export async function readUlwLoopPlan(repoRoot: string, scope?: UlwLoopScope): P
 		(parsed.codexGoalMode ?? "per_story") === "aggregate" &&
 		isLegacyEnumeratedAggregateObjective(previousObjective)
 	) {
-		if (!locks.has(`${repoRoot}\0${ulwLoopRelativeDir(scope)}`)) {
+		if (!(heldLocks.getStore()?.has(`${repoRoot}\0${ulwLoopRelativeDir(scope)}`) ?? false)) {
 			// A read path (status/criteria) must not mutate state: mutating here runs
 			// unlocked and a second reader could write a partially-migrated plan.
 			throw new UlwLoopError(

--- a/packages/omo-codex/plugin/components/ulw-loop/src/plan-io.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/plan-io.ts
@@ -96,6 +96,14 @@ export async function readUlwLoopPlan(repoRoot: string, scope?: UlwLoopScope): P
 		(parsed.codexGoalMode ?? "per_story") === "aggregate" &&
 		isLegacyEnumeratedAggregateObjective(previousObjective)
 	) {
+		if (!locks.has(`${repoRoot}\0${ulwLoopRelativeDir(scope)}`)) {
+			// A read path (status/criteria) must not mutate state: mutating here runs
+			// unlocked and a second reader could write a partially-migrated plan.
+			throw new UlwLoopError(
+				`The ulw-loop plan at ${repoRelative(path, repoRoot)} carries a legacy enumerated aggregate objective that must be migrated before reads continue. Run any state-mutating ulw-loop command once (e.g. \`record-evidence\`, \`steer\`, \`checkpoint\`) to migrate it under the state lock, then retry.`,
+				"ULW_LOOP_MIGRATION_REQUIRED",
+			);
+		}
 		const now = iso();
 		parsed.codexObjective = aggregateCodexObjectiveForScope(scope);
 		parsed.codexObjectiveAliases = [...new Set([...(parsed.codexObjectiveAliases ?? []), previousObjective])];

--- a/packages/omo-codex/plugin/components/ulw-loop/src/state-lock.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/src/state-lock.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { closeSync, mkdirSync, openSync, readFileSync, statSync, unlinkSync, writeSync } from "node:fs";
 import { dirname } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -10,9 +11,12 @@ import { UlwLoopError } from "./types.js";
 // read-modify-write of goals.json (and the counters next to it) atomic.
 //
 // Protocol: the lock is a file created with O_EXCL whose body records the
-// owner. A waiter reclaims it only when the owner is provably gone (pid dead)
-// or the record is older than `staleMs` (pid reuse guard); otherwise it backs
-// off and fails closed at `timeoutMs` rather than proceeding unlocked.
+// owner (pid + a per-acquisition token). A waiter reclaims it only when the
+// owner is provably gone (pid dead) or the body never became a record within
+// `staleMs` (a creator that died mid-write); a live owner is never reclaimed by
+// age alone, because overlapping two bodies is exactly the lost update this lock
+// exists to prevent. Waiters back off and fail closed at `timeoutMs`. Release
+// unlinks only a lock that still carries the releaser's own token.
 
 export const ULW_LOOP_LOCK_TIMEOUT_CODE = "ULW_LOOP_LOCK_TIMEOUT";
 
@@ -24,6 +28,7 @@ export interface StateLockOptions {
 interface LockRecord {
 	readonly pid: number;
 	readonly createdAt: string;
+	readonly token: string;
 }
 
 interface LockSnapshot {
@@ -32,7 +37,7 @@ interface LockSnapshot {
 	readonly ageMs: number;
 }
 
-type AttemptOutcome = "acquired" | "retry" | "wait";
+type AttemptOutcome = { readonly kind: "acquired"; readonly token: string } | { readonly kind: "retry" | "wait" };
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_STALE_MS = 60_000;
@@ -45,20 +50,20 @@ export async function withStateLock<T>(
 	fn: () => Promise<T>,
 	options: StateLockOptions = {},
 ): Promise<T> {
-	await acquireAsync(lockPath, options);
+	const token = await acquireAsync(lockPath, options);
 	try {
 		return await fn();
 	} finally {
-		release(lockPath);
+		release(lockPath, token);
 	}
 }
 
 export function withStateLockSync<T>(lockPath: string, fn: () => T, options: StateLockOptions = {}): T {
-	acquireSync(lockPath, options);
+	const token = acquireSync(lockPath, options);
 	try {
 		return fn();
 	} finally {
-		release(lockPath);
+		release(lockPath, token);
 	}
 }
 
@@ -66,28 +71,28 @@ export function isStateLockTimeout(error: unknown): error is UlwLoopError {
 	return error instanceof UlwLoopError && error.code === ULW_LOOP_LOCK_TIMEOUT_CODE;
 }
 
-async function acquireAsync(lockPath: string, options: StateLockOptions): Promise<void> {
+async function acquireAsync(lockPath: string, options: StateLockOptions): Promise<string> {
 	const deadline = Date.now() + (options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 	const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
 	mkdirSync(dirname(lockPath), { recursive: true });
 	for (let attempt = 0; ; ) {
 		const outcome = attemptOnce(lockPath, staleMs);
-		if (outcome === "acquired") return;
-		if (outcome === "retry") continue;
+		if (outcome.kind === "acquired") return outcome.token;
+		if (outcome.kind === "retry") continue;
 		if (Date.now() >= deadline) throw lockTimeout(lockPath, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 		await sleep(backoffMs(attempt));
 		attempt += 1;
 	}
 }
 
-function acquireSync(lockPath: string, options: StateLockOptions): void {
+function acquireSync(lockPath: string, options: StateLockOptions): string {
 	const deadline = Date.now() + (options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 	const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
 	mkdirSync(dirname(lockPath), { recursive: true });
 	for (let attempt = 0; ; ) {
 		const outcome = attemptOnce(lockPath, staleMs);
-		if (outcome === "acquired") return;
-		if (outcome === "retry") continue;
+		if (outcome.kind === "acquired") return outcome.token;
+		if (outcome.kind === "retry") continue;
 		if (Date.now() >= deadline) throw lockTimeout(lockPath, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 		Atomics.wait(SLEEP_CELL, 0, 0, backoffMs(attempt));
 		attempt += 1;
@@ -97,32 +102,42 @@ function acquireSync(lockPath: string, options: StateLockOptions): void {
 // EINTR surfaces raw from macOS fs syscalls under some runtimes; it is a retry, never a verdict.
 function attemptOnce(lockPath: string, staleMs: number): AttemptOutcome {
 	try {
-		if (tryCreate(lockPath)) return "acquired";
+		const token = tryCreate(lockPath);
+		if (token !== null) return { kind: "acquired", token };
 		const snapshot = readSnapshot(lockPath);
-		if (snapshot === null) return "retry";
-		if (isStale(snapshot, staleMs) && reclaim(lockPath, snapshot.raw)) return "retry";
-		return "wait";
+		if (snapshot === null) return { kind: "retry" };
+		if (isStale(snapshot, staleMs) && reclaim(lockPath, snapshot.raw)) return { kind: "retry" };
+		return { kind: "wait" };
 	} catch (error) {
-		if (hasCode(error, "EINTR")) return "wait";
+		if (hasCode(error, "EINTR")) return { kind: "wait" };
 		throw error;
 	}
 }
 
-function tryCreate(lockPath: string): boolean {
+function tryCreate(lockPath: string): string | null {
 	let fd: number;
 	try {
 		fd = openSync(lockPath, "wx");
 	} catch (error) {
-		if (hasCode(error, "EEXIST")) return false;
+		if (hasCode(error, "EEXIST")) return null;
 		throw error;
 	}
+	const record: LockRecord = { pid: process.pid, createdAt: new Date().toISOString(), token: randomUUID() };
 	try {
-		const record: LockRecord = { pid: process.pid, createdAt: new Date().toISOString() };
 		writeSync(fd, JSON.stringify(record));
-	} finally {
+	} catch (error) {
 		closeSync(fd);
+		// A failed write (e.g. EINTR) must not leave a partial lock the owner never recorded;
+		// otherwise later readers see a young ownerless lock and only age can retire it.
+		try {
+			unlinkSync(lockPath);
+		} catch {
+			// another process already reclaimed the partial file; leave it alone
+		}
+		throw error;
 	}
-	return true;
+	closeSync(fd);
+	return record.token;
 }
 
 function readSnapshot(lockPath: string): LockSnapshot | null {
@@ -143,18 +158,21 @@ function parseRecord(raw: string): LockRecord | null {
 		const record = parsed as Record<string, unknown>;
 		const pid = record["pid"];
 		const createdAt = record["createdAt"];
+		const token = record["token"];
 		if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0 || typeof createdAt !== "string") return null;
-		return { pid, createdAt };
+		if (typeof token !== "string" || token.length === 0) return null;
+		return { pid, createdAt, token };
 	} catch (error) {
 		if (error instanceof SyntaxError) return null;
 		throw error;
 	}
 }
 
-// A young record without an owner pid is a lock mid-write; only age retires it.
+// A body that is not a record is a lock mid-write (or a foreign/legacy file); only
+// age retires it. A parsable record is stale only when its owner is dead: a live
+// owner running past staleMs is slow, not gone, and the waiter fails closed instead.
 function isStale(snapshot: LockSnapshot, staleMs: number): boolean {
-	if (snapshot.ageMs > staleMs) return true;
-	if (snapshot.record === null) return false;
+	if (snapshot.record === null) return snapshot.ageMs > staleMs;
 	return !isProcessAlive(snapshot.record.pid);
 }
 
@@ -183,7 +201,11 @@ function reclaim(lockPath: string, expectedRaw: string): boolean {
 	return true;
 }
 
-function release(lockPath: string): void {
+// Only the acquisition that wrote this token may unlink: if the file now carries
+// another token, a waiter has legitimately taken over and its lock must stand.
+function release(lockPath: string, token: string): void {
+	const current = readSnapshot(lockPath);
+	if (current === null || current.record?.token !== token) return;
 	try {
 		unlinkSync(lockPath);
 	} catch (error) {

--- a/packages/omo-codex/plugin/components/ulw-loop/test/plan-io.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/plan-io.test.ts
@@ -155,6 +155,39 @@ describe("readUlwLoopPlan", () => {
 			before: { codexObjective: legacyObjective },
 		});
 	});
+
+	it("readUlwLoopPlan refuses to migrate a legacy aggregate plan outside the mutation lock (no unlocked write on a read path)", async () => {
+		// given: the same legacy plan, but the read is not wrapped in withUlwLoopMutationLock
+		const legacyObjective = "Complete all ulw-loop stories in .omo/ulw-loop/goals.json: G001 Build auth service";
+		await writeRawPlan(repoRoot, makePlan({ codexObjective: legacyObjective }));
+
+		// when
+		let caught: unknown;
+		try {
+			await readUlwLoopPlan(repoRoot);
+		} catch (error) {
+			caught = error;
+		}
+
+		// then: it refuses with a recovery hint and writes nothing
+		expect(caught).toBeInstanceOf(UlwLoopError);
+		expect((caught as UlwLoopError).code).toBe("ULW_LOOP_MIGRATION_REQUIRED");
+		const persisted = JSON.parse(await readFile(ulwLoopGoalsPath(repoRoot), "utf8"));
+		expect(persisted.codexObjective).toBe(legacyObjective);
+		expect(await readLedgerLines(repoRoot)).toHaveLength(0);
+	});
+
+	it("a read of an already-migrated plan outside the lock still succeeds", async () => {
+		// given
+		await writeRawPlan(repoRoot, makePlan({ codexObjective: STABLE_OBJECTIVE }));
+
+		// when
+		const plan = await readUlwLoopPlan(repoRoot);
+
+		// then
+		expect(plan.codexObjective).toBe(STABLE_OBJECTIVE);
+		expect(await readLedgerLines(repoRoot)).toHaveLength(0);
+	});
 });
 
 describe("writePlan", () => {

--- a/packages/omo-codex/plugin/components/ulw-loop/test/plan-io.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/plan-io.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { appendFile, copyFile, mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -140,8 +141,8 @@ describe("readUlwLoopPlan", () => {
 		const legacyObjective = "Complete all ulw-loop stories in .omo/ulw-loop/goals.json: G001 Build auth service";
 		await writeRawPlan(repoRoot, makePlan({ codexObjective: legacyObjective }));
 
-		// when
-		const plan = await readUlwLoopPlan(repoRoot);
+		// when: read inside the mutation lock, the way every mutating command does
+		const plan = await withUlwLoopMutationLock(repoRoot, () => readUlwLoopPlan(repoRoot));
 
 		// then
 		expect(plan.codexObjective).toBe(STABLE_OBJECTIVE);
@@ -174,7 +175,7 @@ describe("readUlwLoopPlan", () => {
 		expect((caught as UlwLoopError).code).toBe("ULW_LOOP_MIGRATION_REQUIRED");
 		const persisted = JSON.parse(await readFile(ulwLoopGoalsPath(repoRoot), "utf8"));
 		expect(persisted.codexObjective).toBe(legacyObjective);
-		expect(await readLedgerLines(repoRoot)).toHaveLength(0);
+		expect(existsSync(ulwLoopLedgerPath(repoRoot))).toBe(false);
 	});
 
 	it("a read of an already-migrated plan outside the lock still succeeds", async () => {
@@ -186,7 +187,7 @@ describe("readUlwLoopPlan", () => {
 
 		// then
 		expect(plan.codexObjective).toBe(STABLE_OBJECTIVE);
-		expect(await readLedgerLines(repoRoot)).toHaveLength(0);
+		expect(existsSync(ulwLoopLedgerPath(repoRoot))).toBe(false);
 	});
 });
 

--- a/packages/omo-codex/plugin/components/ulw-loop/test/spawn-guard.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/spawn-guard.test.ts
@@ -552,7 +552,10 @@ describe("applySpawnGuards session state lock", () => {
 	it("#given the state lock held by a live process past the timeout #when guarded #then denies without counting", () => {
 		writeGoals();
 		mkdirSync(sessionDir(), { recursive: true });
-		writeFileSync(lockPath(), JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString(), token: "live" }),
+		);
 
 		const output = applySpawnGuards(payload("spawn_agent", { message: "scan" }), { lockTimeoutMs: 100 });
 
@@ -565,7 +568,10 @@ describe("applySpawnGuards session state lock", () => {
 	it("#given a stale lock from a dead process #when guarded #then reclaims it and counts normally", () => {
 		writeGoals();
 		mkdirSync(sessionDir(), { recursive: true });
-		writeFileSync(lockPath(), JSON.stringify({ pid: 2147483646, createdAt: "2026-01-01T00:00:00.000Z" }));
+		writeFileSync(
+			lockPath(),
+			JSON.stringify({ pid: 2147483646, createdAt: "2026-01-01T00:00:00.000Z", token: "gone" }),
+		);
 
 		expect(applySpawnGuards(payload("spawn_agent", { message: "scan" }), { lockTimeoutMs: 1000 })).toBe("");
 

--- a/packages/omo-codex/plugin/components/ulw-loop/test/state-lock.test.ts
+++ b/packages/omo-codex/plugin/components/ulw-loop/test/state-lock.test.ts
@@ -29,7 +29,7 @@ const fs = require("node:fs");
 const [lockPath, holdMs] = process.argv.slice(1);
 fs.mkdirSync(require("node:path").dirname(lockPath), { recursive: true });
 const fd = fs.openSync(lockPath, "wx");
-fs.writeSync(fd, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+fs.writeSync(fd, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString(), token: "holder-" + process.pid }));
 fs.closeSync(fd);
 process.stdout.write("HELD\\n");
 setTimeout(() => {
@@ -116,11 +116,59 @@ describe("withStateLock", () => {
 		it("#when acquiring #then the stale lock is reclaimed immediately", async () => {
 			const deadPid = await spawnExitedProcess();
 			mkdirSync(join(workDir, ".omo", "ulw-loop", "s1"), { recursive: true });
-			await writeFile(lockPath, JSON.stringify({ pid: deadPid, createdAt: new Date().toISOString() }));
+			await writeFile(
+				lockPath,
+				JSON.stringify({ pid: deadPid, createdAt: new Date().toISOString(), token: "gone" }),
+			);
 
 			const seenOwner = await withStateLock(lockPath, async () => ownerPid(), { timeoutMs: 1_000 });
 
 			expect(seenOwner).toBe(process.pid);
+		});
+
+		it("#when a legacy record without a token is young #then it is treated as mid-write and waited on, not stolen", async () => {
+			mkdirSync(join(workDir, ".omo", "ulw-loop", "s1"), { recursive: true });
+			await writeFile(lockPath, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+
+			const attempt = withStateLock(lockPath, async () => "unreachable", { timeoutMs: 150, staleMs: 60_000 });
+
+			await expect(attempt).rejects.toMatchObject({ code: ULW_LOOP_LOCK_TIMEOUT_CODE });
+			expect(existsSync(lockPath)).toBe(true);
+		});
+	});
+
+	describe("#given a live holder whose lock is older than staleMs", () => {
+		it("#when acquiring #then age alone never reclaims it and the waiter fails closed", async () => {
+			await spawnForeignHolder(5_000);
+			const holderPid = ownerPid();
+			const twoMinutesAgo = new Date(Date.now() - 120_000);
+			await utimes(lockPath, twoMinutesAgo, twoMinutesAgo);
+			let bodyRan = false;
+
+			const attempt = withStateLock(
+				lockPath,
+				async () => {
+					bodyRan = true;
+				},
+				{ timeoutMs: 200, staleMs: 60_000 },
+			);
+
+			await expect(attempt).rejects.toMatchObject({ code: ULW_LOOP_LOCK_TIMEOUT_CODE });
+			expect(bodyRan).toBe(false);
+			expect(ownerPid()).toBe(holderPid);
+		});
+	});
+
+	describe("#given the lock changed hands while the body ran", () => {
+		it("#when the original owner releases #then it leaves the successor's lock in place", async () => {
+			const foreign = JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString(), token: "successor" });
+
+			await withStateLock(lockPath, async () => {
+				await writeFile(lockPath, foreign);
+			});
+
+			expect(existsSync(lockPath)).toBe(true);
+			expect(readFileSync(lockPath, "utf8")).toBe(foreign);
 		});
 
 		it("#when the record is unreadable but older than staleMs #then it is reclaimed", async () => {


### PR DESCRIPTION
## Why

Gate review of #7908 found two correctness gaps in the new cross-process state lock:

1. `state-lock.ts` treated any lock older than `staleMs` as reclaimable even while its owner was alive, and `release` unlinked by pathname. A checkpoint that ran past 60 s could therefore be overlapped by a second CLI process (the exact lost update the lock exists to prevent), and the slow owner's `finally` then deleted the successor's lock.
2. `readUlwLoopPlan` persisted the legacy aggregate-objective migration (plan write + ledger append) from inside a read, so `status` and `criteria` mutated `goals.json` without the lock.

## What

- Each acquisition records a per-acquisition `token` next to `pid`/`createdAt`. A parsable record is stale only when its pid is dead; a tokenless/unparsable body (a creator that died mid-write, or a legacy file) is still retired by age. A live owner is never reclaimed by age — the waiter fails closed with `ULW_LOOP_LOCK_TIMEOUT` as before.
- `release` re-reads the lock and unlinks only when it still carries its own token, so a lock that legitimately changed hands stands.
- A failed record write (e.g. EINTR after `openSync("wx")`) removes the partial file instead of leaving a young ownerless lock.
- The migration now runs only inside `withUlwLoopMutationLock` (every mutating command reads the plan there first). Which locks the current async continuation holds rides an `AsyncLocalStorage`, so a nested read inside its own locked mutation migrates, while an unlocked read of a legacy plan fails closed with `ULW_LOOP_MIGRATION_REQUIRED` and names the recovery (run any mutating command once).

## Proof

New tests (RED on `origin/dev`): live holder older than `staleMs` is not reclaimed and the waiter times out with the holder's pid intact; a young tokenless record is waited on, not stolen; release leaves a successor's lock in place; unlocked read of a legacy plan refuses and writes nothing; locked read migrates exactly once; already-migrated reads succeed. Fixtures that hand-write lock records now carry the token a real acquisition writes. Full component suite + `npm run check` on an ascii box before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `ulw-loop` state lock so a live owner running past `staleMs` is never reclaimed by age alone and release can no longer delete a successor's lock, and moves the legacy aggregate-objective migration off read paths so `status` and `criteria` never mutate `goals.json` without the lock.

**Bug Fixes**
- Each acquisition records a per-acquisition token; a parsable lock is stale only when its owner pid is dead, while a tokenless or unparsable body is still retired by age.
- Release re-reads the lock and unlinks only when it still carries its own token; a failed lock-file write removes the partial file instead of leaving a young ownerless lock.
- The legacy migration now runs only inside `withUlwLoopMutationLock`; an unlocked read of a legacy plan fails with `ULW_LOOP_MIGRATION_REQUIRED` and names the recovery, while reads of already-migrated plans still succeed.

<sup>Written for commit af000e46556b3394aa3586f4c9c7e726e6d3016f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

