### PR TITLE
fix(lsp-daemon): force BUN_BE_BUN when spawning the packaged daemon

### DIFF
--- a/packages/lsp-daemon/src/ensure-daemon.ts
+++ b/packages/lsp-daemon/src/ensure-daemon.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, type SpawnOptions, spawn } from "node:child_process";
 import { closeSync, existsSync, mkdirSync, openSync, writeSync } from "node:fs";
 import { Socket } from "node:net";
 import { dirname, isAbsolute } from "node:path";
@@ -120,11 +120,18 @@ export function pingDaemon(
 	});
 }
 
-export function spawnDaemonProcess(paths: DaemonPaths): void {
+export interface SpawnDaemonProcessDeps {
+	spawn: (executable: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
+	resolveExecutable: () => string;
+}
+
+export function spawnDaemonProcess(paths: DaemonPaths, deps: Partial<SpawnDaemonProcessDeps> = {}): void {
 	mkdirSync(dirname(paths.log), { recursive: true });
 	const logFd = openSync(paths.log, "a");
 	try {
-		const child = spawn(resolveDaemonNodeExecutable(), [paths.cliPath, "daemon"], {
+		const spawnDaemonChild = deps.spawn ?? spawn;
+		const executable = deps.resolveExecutable?.() ?? resolveDaemonNodeExecutable();
+		const child = spawnDaemonChild(executable, [paths.cliPath, "daemon"], {
 			detached: true,
 			stdio: ["ignore", logFd, logFd],
 			windowsHide: true,

--- a/packages/lsp-daemon/src/ensure-daemon.ts
+++ b/packages/lsp-daemon/src/ensure-daemon.ts
@@ -135,6 +135,11 @@ export function spawnDaemonProcess(paths: DaemonPaths, deps: Partial<SpawnDaemon
 			detached: true,
 			stdio: ["ignore", logFd, logFd],
 			windowsHide: true,
+			// Under the packaged runtime execPath is the compiled omo binary, not a
+			// node interpreter; without BUN_BE_BUN it runs its embedded entrypoint, so
+			// the CLI argv boots a billable agent session instead of the daemon
+			// (issue #7914). Inert for node and for the bun interpreter itself.
+			env: { ...process.env, BUN_BE_BUN: "1" },
 		});
 		child.once("spawn", () => closeSync(logFd));
 		child.once("error", (error) => {

--- a/packages/lsp-daemon/test/ensure-daemon.test.ts
+++ b/packages/lsp-daemon/test/ensure-daemon.test.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawnSync, type SpawnOptions } from "node:child_process";
+import { type ChildProcess, type SpawnOptions, spawnSync } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/lsp-daemon/test/ensure-daemon.test.ts
+++ b/packages/lsp-daemon/test/ensure-daemon.test.ts
@@ -63,11 +63,11 @@ describe("spawnDaemonProcess", () => {
 			// Compiled-binary style path: under the packaged runtime execPath IS the
 			// omo binary, not a node interpreter, so without BUN_BE_BUN the CLI argv
 			// boots a billable agent session instead of the daemon.
-			resolveExecutable: () => "/opt/omo/payload/bin/omo",
+			resolveExecutable: () => "/opt/omo/payload/omo",
 		});
 
 		expect(observed).toHaveLength(1);
-		expect(observed[0]?.executable).toBe("/opt/omo/payload/bin/omo");
+		expect(observed[0]?.executable).toBe("/opt/omo/payload/omo");
 		expect(observed[0]?.args).toEqual([paths.cliPath, "daemon"]);
 		expect(observed[0]?.options.env).toEqual({ ...process.env, BUN_BE_BUN: "1" });
 	});

--- a/packages/lsp-daemon/test/ensure-daemon.test.ts
+++ b/packages/lsp-daemon/test/ensure-daemon.test.ts
@@ -1,4 +1,7 @@
-import { spawnSync } from "node:child_process";
+import { type ChildProcess, spawnSync, type SpawnOptions } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -6,6 +9,7 @@ import {
 	type EnsureDaemonDeps,
 	ensureDaemonRunning,
 	resolveDaemonNodeExecutable,
+	spawnDaemonProcess,
 } from "../src/ensure-daemon.js";
 import { daemonTestPaths } from "./daemon-path-fixture.js";
 
@@ -36,6 +40,38 @@ function makeHarness(config: { probeQueue: boolean[]; onSpawnPush?: boolean[] })
 
 	return { deps, counts };
 }
+
+describe("spawnDaemonProcess", () => {
+	it("#given the packaged omo binary #when spawning the daemon #then the env forces Bun runtime mode", () => {
+		const paths = daemonTestPaths(mkdtempSync(join(tmpdir(), "lsp-daemon-spawn-env-")), "9.9.9");
+		const observed: Array<{ executable: string; args: string[]; options: SpawnOptions }> = [];
+		const stubChild: ChildProcess = {
+			once(event: string, listener: () => void) {
+				if (event === "spawn") listener();
+				return stubChild;
+			},
+			unref() {
+				return undefined;
+			},
+		} as unknown as ChildProcess;
+
+		spawnDaemonProcess(paths, {
+			spawn: (executable, args, options) => {
+				observed.push({ executable, args: [...args], options });
+				return stubChild;
+			},
+			// Compiled-binary style path: under the packaged runtime execPath IS the
+			// omo binary, not a node interpreter, so without BUN_BE_BUN the CLI argv
+			// boots a billable agent session instead of the daemon.
+			resolveExecutable: () => "/opt/omo/payload/bin/omo",
+		});
+
+		expect(observed).toHaveLength(1);
+		expect(observed[0]?.executable).toBe("/opt/omo/payload/bin/omo");
+		expect(observed[0]?.args).toEqual([paths.cliPath, "daemon"]);
+		expect(observed[0]?.options.env).toEqual({ ...process.env, BUN_BE_BUN: "1" });
+	});
+});
 
 describe("ensureDaemonRunning", () => {
 	it("#given the cached Node executable was removed #when resolving the daemon launcher #then uses argv0", () => {


### PR DESCRIPTION
## Summary

- `spawnDaemonProcess` spawned the daemon without an explicit `env`, so the child inherited the parent environment verbatim. Under the packaged runtime `resolveDaemonNodeExecutable()` returns `execPath`, which IS the compiled omo binary — invoking a compiled Bun binary without `BUN_BE_BUN=1` runs its embedded entrypoint, so `[cliPath, "daemon"]` arrives as user prompt argv and boots a billable omo agent session instead of the LSP daemon (issue #7914).
- The fix pins `env: { ...process.env, BUN_BE_BUN: "1" }` on the spawn. The override is inert for node (real node never sees `BUN_BE_BUN`) and for the bun interpreter itself; it only changes behavior for a compiled binary acting as the runtime — exactly the incident shape. This mirrors the existing staged ast-grep runtime spawn in `packages/omo-senpi/src/components/ast-grep/index.ts`.

**The defect is intermittent, not absent.** Real-surface baseline measured on the affected host with the UNFIXED runtime (`0.0.0-omob.b210521.093ecee`): `daemon.sock` present (`srw-------`) and connectable, `daemon.pid` 85815 matching a live daemon (ppid 1, ~30MB RSS), `daemon.owner` recorded, zero extra daemon-argv processes. Contrast with the incident capture: NO `daemon.sock`/`pid`/`owner` at all, three concurrent phantom sessions at 264/381/382 MB (one reached 475 MB, one ignored SIGTERM), and ~448 KB of pure phantom LLM output in `daemon.log`. So a daemon can eventually win the spawn race and appear healthy while earlier retries have already burned sessions — this PR removes the phantom mode rather than racing it.

Measurement note for anyone re-verifying on a live host: count processes by the daemon SPAWN ARGV (the staged `cli.js`), not by grepping the runtime path — the runtime path matches every omo process including ~12 legitimate interactive sessions and would misreport real user sessions as phantoms.

## Changes

- `packages/lsp-daemon/src/ensure-daemon.ts` — `spawnDaemonProcess` now passes `env: { ...process.env, BUN_BE_BUN: "1" }` in the spawn options (spread keeps PATH/HOME alive for the child). Comment on the option names the mechanism and #7914.
- Same file — added an optional `deps` parameter (`SpawnDaemonProcessDeps`: `spawn`, `resolveExecutable`) defaulting to the production implementations, so tests can observe the exact spawn arguments. The production call path is unchanged (`deps.spawn ?? spawn`); `resolveDaemonNodeExecutable` is untouched.
- `packages/lsp-daemon/test/ensure-daemon.test.ts` — regression test injecting a fake `spawn` and a compiled-binary-style executable path, asserting the third spawn argument carries `BUN_BE_BUN: "1"` over the inherited environment.

## QA & Evidence

- **What was tested:** RED-first regression run of the new assertion BEFORE the production change, on a Linux runner with bun 1.4.0 (matching CI's pin) and node 24.
  **Observed result:** `expect(observed[0]?.options.env).toEqual({ ...process.env, BUN_BE_BUN: "1" })` failed with `+ Received: undefined` at `test/ensure-daemon.test.ts:72:36` (1 failed | 9 passed) — read from the assertion text, not the exit code.
  **Artifact:** vitest output quoted in the PR discussion.
  **Why sufficient:** the failing assertion proves the test observes the spawned options and fails on the unfixed code.
- **What was tested:** mutation proof after GREEN — deleted ONLY the `env` key from the spawn options and re-ran.
  **Observed result:** exactly ONE assertion failed (the same env `toEqual`, `Received: undefined`, marker `[1/1]`); the three earlier assertions in the test and all 9 other tests still passed. Restored → green again.
  **Why sufficient:** the assertion count shows no assertion was shadowed and no other test accidentally covers this.
- **What was tested:** full `packages/lsp-daemon` suite (`npm test`, vitest), package `tsc --noEmit`, root `bun run typecheck`, scoped `biome check` on both changed files, `test/daemon-roundtrip.test.ts`, and CI's bundle-freshness gate (`build-extension.mjs --check`) on a pristine branch checkout with `bun install --frozen-lockfile --ignore-scripts`.
  **Observed result:** 22 files / 162 tests passed; typecheck rc 0; biome rc 0 on the changed files; roundtrip 5/5; `omo-senpi extension build is current` (rc 0) — the committed extension bundles do not embed lsp-daemon sources, so no bundle regeneration is needed for this change.
  **Why sufficient:** covers the package suite CI runs, the repo typecheck entry, lint on changed files, and the committed-bundle freshness check CI performs.
- **Fixture discrimination:** the injected `resolveExecutable` returns `/opt/omo/payload/bin/omo` (compiled-binary style), NOT a real node path — a real-node fixture would pass either way and prove nothing. The assertion is value-exact (`toEqual({...process.env, BUN_BE_BUN: "1" })`), so it fails on a deleted env key AND on a wrong value; a weaker `toBeDefined()` would be satisfied by inherited env.

## Risks & Residuals

- **Live-host "zero phantom sessions after install"** — NOT yet verified: that criterion needs the fixed build released and installed. The host measurement above is a PRE-FIX baseline (it shows the intermittent shape, not the fix). Mitigation lands with the next release; unit-level proof carries the coverage claim. Accepted for this PR.
- **`BUN_BE_BUN` semantics on non-Bun hosts** — inert: node ignores the variable and a plain `bun` interpreter is already Bun. Mirrors the shipped ast-grep spawn. Mitigated by precedent.
- **`deps` seam surface** — additive optional parameter, production defaults unchanged, no callers modified. Not applicable as a risk.

## Automated Checks

```bash
npm test                    # packages/lsp-daemon (vitest, 162 tests)
npm run typecheck           # packages/lsp-daemon (tsc)
npx biome check src/ensure-daemon.ts test/ensure-daemon.test.ts
bun run typecheck           # repository root (tsgo + script + packages)
node packages/omo-senpi/plugin/scripts/build-extension.mjs --check
```

All run on Linux with bun 1.4.0 / node 24.20.0; all rc 0 (the full matrix runs in CI for this PR).

## Related Issues

Fixes #7914

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LSP daemon spawn under the packaged runtime so it no longer launches billable agent sessions instead of the daemon.

- `spawnDaemonProcess` now sets `BUN_BE_BUN=1` on the child environment, which is inert for node and the bun interpreter.
- Adds an optional `deps` parameter to `spawnDaemonProcess` so tests can observe the exact spawn arguments.
- Adds a regression test that pins the env value for a compiled-binary executable path.

<sup>Written for commit 51385f235745114abadab4d6bc2688ad072c17e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

