### PR TITLE
docs(memory): document the Memorian recall gate behind the Aha moment notice

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -597,8 +597,9 @@ Disable built-in skills: `{ "disabled_skills": ["playwright"] }`
 ### Memory
 
 Persistent, per-agent memory stored as a git repository. Memory is on by default and learns
-actively: it reflects on its own, nudges when durable facts go unsaved, extracts facts in the
-background, consolidates during a dream pass, and keeps records about people.
+actively: it reflects on its own, nudges when durable facts go unsaved, recalls a stored memory
+mid-session when it would change the next step, extracts facts in the background, consolidates
+during a dream pass, and keeps records about people.
 
 Configured under `memory` in `omo.json`, with per-agent overrides under `memory.agents.<name>`.
 
@@ -646,6 +647,25 @@ Reminds the agent to save when durable facts have gone unwritten.
 | ------------------------- | ------- | ---------------------------------------------------- |
 | `nudge.enabled`           | `true`  | Emit the nudge line in the memory metadata block      |
 | `nudge.every_user_turns`  | `10`    | Nudge after this many user turns without a save       |
+
+#### Recall (Aha moments)
+
+The nudge above asks the agent to write. Recall is the other direction: a read-only judge called
+Memorian watches each turn, checks stored memory against what the agent is doing, and hands back
+a hint only when that memory would change the next step (a constraint being ignored, a past
+failure of the same approach, an answer about to be re-derived). Silence is the default. Most
+turns produce nothing, and a judge that finds nothing leaves no trace.
+
+When it does fire, you see an `Aha moment!` line in the transcript written in the agent's own
+voice (`just remembered: <hint>`) with the memory path beneath it. It's a transcript entry, not a
+toast. The hint is one sentence of at most 200 characters, and the same memory surfaces at most
+once per session. Treat it as a hint, not current state: the agent is told to verify before
+relying on it, and expanding the entry shows that caveat.
+
+| Option              | Default | Description                                                     |
+| ------------------- | ------- | --------------------------------------------------------------- |
+| `recall.enabled`    | `true`  | Run the Memorian judge and surface Aha moments                  |
+| `recall.max_items`  | `2`     | Most memories one judge run may surface (1-5)                   |
 
 #### Facts
 

--- a/docs/reference/omo-json.md
+++ b/docs/reference/omo-json.md
@@ -138,7 +138,7 @@ The block may also appear at the shared top level or in profile layers and follo
 
 ### `memory` (Senpi harness)
 
-The optional `memory` block configures the Senpi memory subsystem (`schema/memory.ts` `OmoMemorySettingsSchema`). Keys: `enabled` (default `true`), `agent` (default `"auto"`), the sub-blocks `reflection`, `nudge`, `facts`, `dream`, `people`, `soul`, `write_notice`, `sync`, `search`, plus `compile_warn_tokens` and per-agent overrides under `agents`.
+The optional `memory` block configures the Senpi memory subsystem (`schema/memory.ts` `OmoMemorySettingsSchema`). Keys: `enabled` (default `true`), `agent` (default `"auto"`), the sub-blocks `reflection`, `nudge`, `recall` (the Memorian judge behind `Aha moment!` notices: `enabled`, `max_items`), `facts`, `dream`, `people`, `soul`, `write_notice`, `sync`, `search`, plus `compile_warn_tokens` and per-agent overrides under `agents`.
 
 ### `git_master` (Senpi harness)
 

--- a/packages/omo-senpi/skills/AGENTS.md
+++ b/packages/omo-senpi/skills/AGENTS.md
@@ -15,7 +15,7 @@ Native Senpi skills authored directly against the Senpi tool surface (not ported
 | `init-deep/` | Hierarchical AGENTS.md generation via a size-formula dag map-reduce (quick scanners -> high writers, ALWAYS-REDUCE); senpi-local override shadowing the shared-pool copy. |
 | `dag-library/` | Store a dag definition once and re-run it by name; loads through `plugin/runtime/dag/library.js`. |
 | `onboarding/` | First-run onboarding; `qa-validator.sh` pins the skill contract (front matter `name: onboarding`), `qa-savings-fixture.sh` expects `qa-savings-fixture: OK`. |
-| `give-me-tips/` | Explains any senpi tip in depth (`Tip:` lines incl. the Fable-5-refusal fallback tip); queries `senpi --list-tips` first, checks what THIS user can see, verifies feature code before explaining. |
+| `give-me-tips/` | Explains any senpi tip in depth (`Tip:` lines incl. the Fable-5-refusal fallback tip and the memorian `Aha moment!` recall notice); queries `senpi --list-tips` first, checks what THIS user can see, verifies feature code before explaining. |
 
 ## CONVENTIONS
 

--- a/packages/omo-senpi/skills/give-me-tips/SKILL.md
+++ b/packages/omo-senpi/skills/give-me-tips/SKILL.md
@@ -100,3 +100,58 @@ it), reminders ride inside queued prompts instead of burning extra assistant tur
 nudge self-cancels the moment Fable 5 becomes the active model again or senpi reverts the
 fallback. One refusal triggers a coordinated downgrade in visibility with zero downgrade in
 reachable reasoning depth.
+
+## The Memorian "Aha moment!" notice specifically
+
+When the user asks about the `✦ Aha moment!` line that shows up mid-session ("just remembered:
+..."), or about the memory tip that promises stored memory can resurface on its own, explain the
+whole memorian recall gate, citing `packages/omo-senpi/src/components/memory/` and
+`packages/memory-core/src/recall/`. This is NOT the periodic save reminder: `memory.nudge` in
+`nudge-wiring.ts` asks the agent to WRITE memory every N user turns, while memorian only READS
+memory and hands one hint back. Keep the two apart in the explanation.
+
+1. **Candidate collection** (`recall-wiring.ts`, `recall-session-read.ts`,
+   `recall-query-planner-tools.ts`): on every `tool_call` and on settle the component snapshots the
+   live session synchronously (the host disposes the ctx once the handler returns), runs a lexical
+   planner over the user-only text window plus the last 8 tool-argument payloads, and scores memory
+   files against it. Memory-owned hidden channels are excluded from the window, so a previous hint
+   can never seed the next query.
+2. **Delta gate and launch** (`memorian-trigger.ts`, `memorian-concurrency.ts`): the judge only
+   launches when the sorted candidate-path fingerprint differs from the session's last launch. A
+   launch that lands while a judge is already running is parked as the single trailing request. Per
+   session the count stops at 200, `tool_call` launches carry a 90 s deadline, and at most 2 judges
+   run process-wide; a capped launch is skipped, never queued.
+3. **The judge** (`memorian-runner.ts`, `memorian-judge-spec.ts`, persona at
+   `packages/memory-core/src/recall/assets/memorian-persona.md`): a quick-category in-process child
+   with exactly ONE tool, `nudge(path, hint)`, and no file access. Its instruction is that silence is
+   the default: it nudges only when a stored memory would change the agent's next action (it
+   contradicts the current approach, records a past failure of it, answers a question the agent is
+   about to re-derive, or names a constraint being ignored). Topical similarity alone is rejected.
+4. **Hint contract** (`memorian-nudge-tool.ts`, `packages/memory-core/src/recall/gate.ts`): the
+   path must be copied from the offered candidates, must not already be surfaced this session, and
+   must not be a `system/` path; the hint is one factual present-tense sentence, at most 200
+   characters (`NUDGE_HINT_MAX_CHARS`), single line, and secret-like text is rejected. The parent
+   re-validates every accepted nudge against the same rules plus `memory.recall.max_items`
+   (default 2, range 1 to 5) before anything is persisted.
+5. **Delivery** (`memorian-delivery.ts`, `recall-drain.ts`): accepted nudges are marked surfaced in
+   the session ledger at ACCEPT time, so a parallel judge can't repeat them. The model-facing half
+   is a hidden `omo-memorian:recall` message (`display: false`) carrying a `<recalled-memory
+   source="[[path]]">` block that says the memory is a hint, not current state, and must be
+   verified. It is steered in at the next `tool_result` when nothing else is pending, ridden in on
+   another source's idle flush, or drained into the next prompt; the pending file is stamped with
+   the compaction epoch and a compaction drops everything held.
+6. **The visible half** (`memorian-notice.ts`): because senpi draws nothing for the hidden message,
+   the component appends an `omo-memorian:nudged` entry and renders it in the agent's own voice:
+   `✦ Aha moment!` with `just remembered: <hint>`, `also remembered: ...` for a second nudge, and the
+   source paths in dim text. Expanding the entry reveals the caveat that it's a hint, not current
+   state. The record keeps `via` (`steer`, `wake`, or `prompt`) for forensics, but no provenance is
+   ever drawn. It's a transcript entry, not a toast: nothing pops over the input, and the renderer
+   is fail-closed, so a malformed record draws nothing rather than a half-formed notice.
+
+What's worth bragging about: the user sees one calm line, and behind it a read-only judge with a
+single tool, a fingerprint-gated launch, a hard deadline, a 200-character hint budget, a ledger
+that guarantees a memory surfaces at most once per session, and a compaction-epoch check that
+refuses a verdict about a transcript that no longer exists. A judge that finds nothing says nothing,
+and that silence is the designed outcome, not a failure. Gate skips and failures render separately
+as `Memorian gate skipped` / `Memorian gate failed`; a deadline drop renders no notice at all and
+only leaves an `outcome.json` behind. Turn the whole thing off with `memory.recall.enabled: false`.


### PR DESCRIPTION
## Problem

The Aha moment notice shipped in #7906 with no user-facing documentation: configuration.md never mentioned , omo-json.md omitted the recall sub-block, and the give-me-tips skill could not explain the notice when a user asked about it.

## Fix

- : new **Recall (Aha moments)** subsection under Memory, with the  /  table (defaults and range read from ) and one clause in the Memory intro
- : list  among the memory sub-blocks
- : a Memorian section walking the recall gate stage by stage with file references, kept apart from the every-N-turns  write reminder
- : name the notice in the give-me-tips row

Companion tip in senpi:  (separate PR). Docs only; no renderer, delivery, or hidden-payload code changes.

## Verification

- synced omo-senpi skills to /Users/yeongyu/tmp/omo-wt/feat/memorian-in-process/packages/omo-senpi/plugin/skills clean
- bun test v1.4.0 (34cbb9a40): 40 pass, 0 fail

Written by Claude (OmO ultrawork session).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Memorian recall gate behind the "Aha moment!" notice, which previously shipped without user-facing documentation.

- Adds a `Recall (Aha moments)` subsection under Memory in `configuration.md` with the `recall.enabled` and `recall.max_items` settings and their defaults.
- Lists `recall` among the memory sub-blocks in `omo-json.md`.
- Expands the `give-me-tips` skill with a stage-by-stage walkthrough of the recall gate and names the notice in `AGENTS.md`.

<sup>Written for commit 21643b54933096c9ca2d8a6735eb11db5fdeba0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

