### PR TITLE
feat: add explicit freeinference.org provider from docs

### DIFF
--- a/packages/omo-senpi/src/components/freeinference/index.ts
+++ b/packages/omo-senpi/src/components/freeinference/index.ts
@@ -1,0 +1,15 @@
+export { registerFreeInferenceProvider } from "./provider";
+import type { ComponentContext, OmoSenpiComponent, SenpiExtensionAPI } from "../../extension/types"
+import { registerFreeInferenceProvider } from "./provider"
+
+export const FREEINFERENCE_COMPONENT_NAME = "freeinference"
+
+export function createFreeInferenceComponent(): OmoSenpiComponent {
+  return {
+    name: FREEINFERENCE_COMPONENT_NAME,
+    register(pi: SenpiExtensionAPI, ctx: ComponentContext): void {
+      registerFreeInferenceProvider(pi)
+      ctx.logger.debug?.("freeinference.org provider registered", { component: FREEINFERENCE_COMPONENT_NAME })
+    },
+  }
+}

--- a/packages/omo-senpi/src/components/freeinference/provider.ts
+++ b/packages/omo-senpi/src/components/freeinference/provider.ts
@@ -1,0 +1,162 @@
+import type { ExtensionAPI } from "@code-yeongyu/senpi";
+
+/**
+ * FreeInference.org provider — explicit from https://doc.freeinference.org/models
+ * Harvard SEAS MadSys Lab, free for research, OpenAI-compatible.
+ * Base URLs: https://freeinference.org/v1 (OpenAI) and https://freeinference.org/anthropic
+ * Auth: Authorization: Bearer $FREEINFERENCE_API_KEY, filtered by access level via GET /v1/models
+ */
+const BASE_URL = "https://freeinference.org/v1";
+const API_KEY_ENV = "FREEINFERENCE_API_KEY";
+
+const MODELS = [
+  {
+    id: "deepseek-v4-flash",
+    name: "DeepSeek V4 Flash (1M ctx, 393K out) - Agentic coding [Free]",
+    reasoning: true,
+    input: ["text"] as const,
+    cost: { input: 0.44, output: 1.32, cacheRead: 0.014, cacheWrite: 0 },
+    contextWindow: 1000000,
+    maxTokens: 393216,
+  },
+  {
+    id: "glm-5.1",
+    name: "GLM-5.1 (200K ctx, 128K out) - General coding, bilingual [Free]",
+    reasoning: true,
+    input: ["text"] as const,
+    cost: { input: 0.1, output: 0.4, cacheRead: 0.01, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 131072,
+  },
+  {
+    id: "minimax-m2.5",
+    name: "MiniMax M2.5 (205K ctx, 131K out) - General reasoning [Free]",
+    reasoning: true,
+    input: ["text"] as const,
+    cost: { input: 0.15, output: 0.6, cacheRead: 0.01, cacheWrite: 0 },
+    contextWindow: 205000,
+    maxTokens: 131072,
+  },
+  {
+    id: "minimax-m3",
+    name: "MiniMax M3 (1M ctx, 131K out, multimodal) - Long context [Free]",
+    reasoning: true,
+    input: ["text", "image", "video"] as const,
+    cost: { input: 0.2, output: 0.8, cacheRead: 0.02, cacheWrite: 0 },
+    contextWindow: 1000000,
+    maxTokens: 131072,
+  },
+  {
+    id: "glm-5.3-flash",
+    name: "GLM-5.3 Flash (1M ctx, 131K out) - Coding, always-on thinking [Free]",
+    reasoning: true,
+    input: ["text"] as const,
+    cost: { input: 0.08, output: 0.32, cacheRead: 0.01, cacheWrite: 0 },
+    contextWindow: 1000000,
+    maxTokens: 131072,
+  },
+  {
+    id: "qwen3.6-35b",
+    name: "Qwen3.6 35B (262K ctx, 8K out, multimodal) - Fast non-thinking [Free]",
+    reasoning: false,
+    input: ["text", "image", "video"] as const,
+    cost: { input: 0.08, output: 0.28, cacheRead: 0.01, cacheWrite: 0 },
+    contextWindow: 262144,
+    maxTokens: 8192,
+  },
+  {
+    id: "diffusiongemma",
+    name: "DiffusionGemma 26B (262K ctx, 8K out) - Fast local [Free]",
+    reasoning: true,
+    input: ["text"] as const,
+    cost: { input: 0.02, output: 0.08, cacheRead: 0.01, cacheWrite: 0 },
+    contextWindow: 262144,
+    maxTokens: 8192,
+  },
+  {
+    id: "glm-5.2",
+    name: "GLM-5.2 (1M ctx, 131K out) - Switchable thinking [Pro]",
+    reasoning: true,
+    input: ["text"] as const,
+    cost: { input: 0.15, output: 0.6, cacheRead: 0.015, cacheWrite: 0 },
+    contextWindow: 1000000,
+    maxTokens: 131072,
+  },
+  {
+    id: "glm-5.3",
+    name: "GLM-5.3 (1M ctx, 131K out) - Strongest coding, always-on [Pro]",
+    reasoning: true,
+    input: ["text"] as const,
+    cost: { input: 0.25, output: 1.0, cacheRead: 0.02, cacheWrite: 0 },
+    contextWindow: 1000000,
+    maxTokens: 131072,
+  },
+  {
+    id: "kimi-k2.7-code",
+    name: "Kimi K2.7 Code (262K ctx, 131K out, multimodal) - Coding agents [Pro]",
+    reasoning: true,
+    input: ["text", "image", "video"] as const,
+    cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0 },
+    contextWindow: 262144,
+    maxTokens: 131072,
+  },
+  {
+    id: "bge-m3",
+    name: "BGE-M3 (8K ctx, Embedding) - Codebase indexing via /v1/embeddings [Free]",
+    reasoning: false,
+    input: ["text"] as const,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8192,
+    maxTokens: 8192,
+  },
+] as const;
+
+export function registerFreeInferenceProvider(pi: ExtensionAPI) {
+  const apiKey = `$${API_KEY_ENV}`;
+  pi.registerProvider("freeinference.org", {
+    baseUrl: BASE_URL,
+    apiKey,
+    api: "openai-completions",
+    models: MODELS as any,
+    async refreshModels(ctx: any) {
+      try {
+        const key = process.env[API_KEY_ENV]?.trim() ?? "";
+        if (!key) return MODELS as any;
+        const res = await fetch(`${BASE_URL}/models`, {
+          headers: { Authorization: `Bearer ${key}` },
+          signal: ctx.signal,
+        });
+        if (!res.ok) return MODELS as any;
+        const data = (await res.json()) as any;
+        return (data.data as any[]).map((m: any) => {
+          const isEmbedding = m.output_modalities?.includes("embedding");
+          const reasoning = !isEmbedding && (m.supported_sampling_parameters || []).some((p: string) => ["thinking", "reasoning_effort"].includes(p));
+          const input = (m.input_modalities || ["text"]) as ("text" | "image" | "video")[];
+          const pricing = m.pricing || {};
+          return {
+            id: m.id,
+            name: m.name || m.id,
+            reasoning,
+            input,
+            cost: {
+              input: parseFloat(pricing.prompt || "0"),
+              output: parseFloat(pricing.completion || "0"),
+              cacheRead: parseFloat(pricing.input_cache_reads || "0"),
+              cacheWrite: parseFloat(pricing.input_cache_writes || "0"),
+            },
+            contextWindow: m.context_length || 8192,
+            maxTokens: isEmbedding ? 8192 : m.max_output_length || 8192,
+          };
+        });
+      } catch {
+        return MODELS as any;
+      }
+    },
+  });
+  pi.registerProvider("freeinference", {
+    baseUrl: BASE_URL,
+    apiKey: `$${API_KEY_ENV}`,
+    api: "openai-completions",
+    models: MODELS as any,
+  });
+}

--- a/packages/omo-senpi/src/extension/component-list.ts
+++ b/packages/omo-senpi/src/extension/component-list.ts
@@ -15,6 +15,7 @@ import { createTodoFanoutReminderComponent } from "../components/todo-fanout-rem
 import { createUltraworkComponent } from "../components/ultrawork"
 import { createUlwExecuteContinuationComponent } from "../components/ulw-execute-continuation"
 import { createUlwLoopComponent } from "../components/ulw-loop"
+import { createFreeInferenceComponent } from "../components/freeinference"
 import { createXSearchComponent } from "../components/x-search"
 import type { OmoSenpiComponent } from "./types"
 
@@ -35,6 +36,7 @@ export function createOmoSenpiComponents(taskComponent: OmoSenpiComponent): OmoS
     createAstGrepComponent(),
     createLspComponent(),
     createXSearchComponent(),
+    createFreeInferenceComponent(),
     createCommentCheckerComponent(),
     taskComponent,
     createMemoryComponent(),


### PR DESCRIPTION
Add built-in provider for https://freeinference.org per https://doc.freeinference.org/models — Harvard SEAS MadSys Lab, free for research, OpenAI-compatible.

**Provider:** `freeinference.org` (alias `freeinference`) — `baseUrl: https://freeinference.org/v1`, `apiKey: $FREEINFERENCE_API_KEY`, `api: openai-completions`, `refreshModels()` live from `GET /v1/models` (filtered by access level).

**Explicit Model Overview (11 models) from docs:**
- Free: `deepseek-v4-flash` 1M/393K agentic coding, `glm-5.1` 200K/128K bilingual, `minimax-m2.5` 205K/131K, `minimax-m3` 1M/131K multimodal, `glm-5.3-flash` 1M/131K always-on thinking, `qwen3.6-35b` 262K/8K multimodal fast, `diffusiongemma` 262K/8K fast local, `bge-m3` 8K embedding (`/v1/embeddings`)
- Pro: `glm-5.2`/`glm-5.3` 1M/131K, `kimi-k2.7-code` 262K/131K multimodal

All models produce text except `bge-m3` (embedding vector). Correct `contextWindow`/`maxTokens`/`reasoning`/`input`/`cost` per docs, visible to reflection/task children via prior fix. Follows `packages/omo-opencode/src/features/opengateway-provider` pattern: credential-gated, `FALLBACK_MODELS` static + live `refreshModels()`.

**Usage:** `FREEINFERENCE_API_KEY=hyi-... omo --provider freeinference.org --model deepseek-v4-flash` or set as default in `~/.omo/omo.jsonc`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in `freeinference.org` provider so the free Harvard SEAS MadSys Lab models are available without manual OpenAI-compatible configuration. The provider registers under both `freeinference.org` and the alias `freeinference`, ships 11 documented models, and refreshes the model list live from `GET /v1/models` when `FREEINFERENCE_API_KEY` is set.

**Key details**
- Static model list covers context window, max tokens, reasoning, and cost per the docs; it's the fallback when the API is unreachable or no key is set.
- Includes the `bge-m3` embedding model, which only works with `/v1/embeddings`.

<sup>Written for commit 887ba3458016fdbe57d46686a43e457dc5af3b4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

