### PR TITLE
ci(windows): raise test timeouts for git/fs-heavy tests

### DIFF
--- a/packages/git-bash-mcp/src/runner.test.ts
+++ b/packages/git-bash-mcp/src/runner.test.ts
@@ -21,6 +21,8 @@ afterEach(() => {
 });
 
 describe("Git Bash runner", () => {
+  // Windows CI compiles a fake bash.exe via Bun.build and then spawns it; both
+  // steps are much slower than the 5 s Bun default on the shared runners.
   it("#given fake bash executable #when command runs #then invokes bash with -lc and command payload", async () => {
     const directory = createTemporaryDirectory("omo-git-bash-runner-");
     const argvPath = join(directory, "argv.txt");
@@ -71,5 +73,5 @@ describe("Git Bash runner", () => {
       stderr: `fake stderr${expectedLineEnding}`,
       timedOut: false,
     });
-  });
+  }, { timeout: 30_000 });
 });

--- a/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
+++ b/packages/omo-opencode/src/cli/worktree-sweep/worktree-sweep.test.ts
@@ -15,6 +15,9 @@ import type { WorktreeSweepRepoReport } from "./types"
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const GIT_COMMAND_TIMEOUT_MS = 10_000
+// Windows CI runners have much slower git/fs I/O than the 5 s Bun default;
+// give every git-heavy test enough room to avoid flakes.
+const GIT_HEAVY_TEST_TIMEOUT_MS = 30_000
 const temporaryDirectories: string[] = []
 
 afterAll(async () => {
@@ -401,7 +404,7 @@ describe("sweepWorktrees --older-than", () => {
     })
     expect(result.sweepCount).toBe(1)
     expect(result.keepCount).toBe(2)
-  })
+  }, { timeout: GIT_HEAVY_TEST_TIMEOUT_MS })
 
   test("olderThanDays 0 never sweeps unmerged worktrees regardless of age", async () => {
     const { base, repo } = await createFixture("wt-sweep-age0-")
@@ -440,7 +443,7 @@ describe("sweepWorktrees --apply", () => {
     expect(porcelain).not.toContain(toPosix(missing))
     expect(porcelain).not.toContain(toPosix(merged))
     expect(porcelain).toContain(toPosix(kept))
-  })
+  }, { timeout: GIT_HEAVY_TEST_TIMEOUT_MS })
 
   test("leaves locked and dirty worktrees in place even under --apply", async () => {
     const { base, repo } = await createFixture("wt-sweep-apply2-")
@@ -459,7 +462,7 @@ describe("sweepWorktrees --apply", () => {
     expect(await fs.stat(locked)).toBeTruthy()
     expect(await fs.stat(dirty)).toBeTruthy()
     expect(result.sweepCount).toBe(0)
-  })
+  }, { timeout: GIT_HEAVY_TEST_TIMEOUT_MS })
 })
 
 describe("worktreeSweep output", () => {
@@ -492,7 +495,7 @@ describe("worktreeSweep output", () => {
     expect(summary).toBe(
       "SUMMARY mode=dry-run repos=1 sweep=1 keep=1 prune=0 removed=0 failed=0",
     )
-  })
+  }, { timeout: GIT_HEAVY_TEST_TIMEOUT_MS })
 
   test("returns exit code 1 and a stderr message for a non-repository path", async () => {
     const base = await newTmpDir("wt-sweep-bad-")

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-delivering-loss.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-delivering-loss.test.ts
@@ -1,8 +1,11 @@
 /// <reference types="bun-types" />
 
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { randomUUID } from "node:crypto"
 import { mkdir, mkdtemp, rm, stat } from "node:fs/promises"
+
+// Windows CI runners can exceed the 5 s Bun default on fs-heavy team-mode tests.
+setDefaultTimeout(process.platform === "win32" ? 30_000 : 10_000)
 import { tmpdir } from "node:os"
 import path from "node:path"
 

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-leader.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-leader.test.ts
@@ -1,8 +1,11 @@
 /// <reference types="bun-types" />
 
-import { afterEach, describe, expect, mock, test } from "bun:test"
+import { afterEach, describe, expect, mock, setDefaultTimeout, test } from "bun:test"
 import { randomUUID } from "node:crypto"
 import { mkdtemp, mkdir, rm } from "node:fs/promises"
+
+// Windows CI runners can exceed the 5 s Bun default on fs-heavy team-mode tests.
+setDefaultTimeout(process.platform === "win32" ? 30_000 : 10_000)
 import { tmpdir } from "node:os"
 import path from "node:path"
 

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-pending-delivery-verify.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint-pending-delivery-verify.test.ts
@@ -7,9 +7,12 @@
 // to processed/ and lost. The fix verifies session.messages history and requeues
 // unconfirmed messages back to the inbox instead.
 
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { randomUUID } from "node:crypto"
 import { mkdtemp, mkdir, readdir, rm } from "node:fs/promises"
+
+// Windows CI runners can exceed the 5 s Bun default on fs-heavy team-mode tests.
+setDefaultTimeout(process.platform === "win32" ? 30_000 : 10_000)
 import { tmpdir } from "node:os"
 import path from "node:path"
 

--- a/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.test.ts
+++ b/packages/omo-opencode/src/hooks/team-session-events/team-idle-wake-hint.test.ts
@@ -1,6 +1,10 @@
 /// <reference types="bun-types" />
 
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { afterEach, describe, expect, mock, setDefaultTimeout, spyOn, test } from "bun:test"
+
+// Windows CI runners can exceed the 5 s Bun default on fs-heavy team-mode tests
+// (tmpdir creation, file moves, readdir). Give every test in this file enough room.
+setDefaultTimeout(process.platform === "win32" ? 30_000 : 10_000)
 import { randomUUID } from "node:crypto"
 import { mkdtemp, mkdir, readdir, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"


### PR DESCRIPTION
## Summary

Windows CI runners have much slower git/fs I/O than the 5 s Bun default timeout, causing intermittent flakes that block merges and cost full 8-minute reruns.

Three test families were affected:
- `sweepWorktrees --apply` — fixture setup (`git commit --allow-empty`) exceeded 5 s
- `createTeamIdleWakeHint` — tmpdir creation + file moves exceeded 5 s
- `git-bash-runner` — `Bun.build({ compile: true })` for fake bash.exe + EBUSY on teardown

## Changes

**`worktree-sweep.test.ts`**
- Add `GIT_HEAVY_TEST_TIMEOUT_MS` (30 s) constant
- Apply to `--apply`, `--older-than`, and output tests that were still on default budget

**`runner.test.ts` (git-bash-mcp)**
- Add `{ timeout: 30_000 }` to the single test (Windows compiles a fake bash.exe)

**team-idle-wake-hint tests (4 files)**
- `setDefaultTimeout(process.platform === 'win32' ? 30_000 : 10_000)`
- Applied to: `team-idle-wake-hint.test.ts`, `*-delivering-loss.test.ts`, `*-leader.test.ts`, `*-pending-delivery-verify.test.ts`

Note: `runner.test.ts` already has `rmSync` with `maxRetries: 10, retryDelay: 100` for the EBUSY teardown issue.

Closes #7709

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises test timeouts for git/fs-heavy tests on Windows CI to prevent intermittent flakes that caused failed merges and slow 8-minute reruns.

- Adds a 30 s timeout for `worktree-sweep` tests that rely on git fixtures (`--apply`, `--older-than`, output tests).
- Sets a 30 s timeout for the git-bash-runner test that compiles a fake `bash.exe` via `Bun.build` on Windows.
- Applies a default timeout of 30 s on Windows (10 s elsewhere) to all four `team-idle-wake-hint` test files.

Closes #7709.

<sup>Written for commit e5c39d30d0884320c5cebda6ac98b6b8bc147285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

