### PR TITLE
test(omo-senpi): drop the reverted filler-hint render expectation

### DIFF
--- a/packages/omo-senpi/src/components/memory/memorian-notice.test.ts
+++ b/packages/omo-senpi/src/components/memory/memorian-notice.test.ts
@@ -73,13 +73,6 @@ describe("memorian nudged recollection", () => {
     }
   })
 
-  test("#given an already-persisted filler hint #when rendered #then nothing is drawn", () => {
-    for (const hint of ["placeholder", "<hint>", "TODO"]) {
-      const record = { version: 1, nudges: [{ path: "a.md", hint }], via: "steer" }
-      expect(renderMemorianNudgedEntry(entry(record), { expanded: false }, theme)).toBeUndefined()
-    }
-  })
-
   test("#given a second nudge #when rendered #then the extra hint continues the recollection", () => {
     const component = renderMemorianNudgedEntry(
       entry({ version: 1, nudges: [{ path: "a.md", hint: "Use it." }, { path: "b.md", hint: "Also this." }], via: "wake" }),


### PR DESCRIPTION
## What

The #7959 merge carried a stale test forward: our branch was cut before the revert of #7956 (2f07008f6), so the rebase conflict resolution in `memorian-notice.test.ts` re-introduced the "already-persisted filler hint" render expectation. Dev's `isValidHint` no longer rejects `placeholder` / `<hint>` / `TODO` (the filler filter was reverted), so the merged tree fails that one test.

This drops the reverted expectation — restoring dev green.

## Evidence

- Merged dev (f7b4b43bd) on gorky: memory scope 1263 pass / 1 fail, exactly this test.
- Dev head be0b3a90d never had the test (the revert removed it); the merge re-added it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the already-persisted filler-hint render expectation from `memorian-notice.test.ts` that was re-introduced during merge conflict resolution, restoring the test suite to green on dev.

<sup>Written for commit 8875d11689e6b3788a26ceda981a0c30a1e71100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

