### PR TITLE
chore(omo-senpi): un-ignore the tracked generated extension bundles

### DIFF
--- a/packages/omo-senpi/.gitignore
+++ b/packages/omo-senpi/.gitignore
@@ -1,4 +1,13 @@
-/plugin/extensions/
+/plugin/extensions/*
+!/plugin/extensions/dream-persona.md
+!/plugin/extensions/facts-persona.md
+!/plugin/extensions/memorian-persona.md
+!/plugin/extensions/memory-run-supervisor.mjs
+!/plugin/extensions/omo-init-deep-advisor.js
+!/plugin/extensions/omo-member.js
+!/plugin/extensions/omo-task.js
+!/plugin/extensions/omo.js
+!/plugin/extensions/reflection-persona.md
 /plugin/skills/
 /plugin/skills-conditional/
 /plugin/runtime/ast-grep-mcp/


### PR DESCRIPTION
## Summary
- Keep untracked byproducts under `plugin/extensions` ignored.
- Allow the nine tracked generated extension bundles to be added with plain `git add`.

## Verification
RED (before change):
```text
packages/omo-senpi/.gitignore:1:/plugin/extensions/  packages/omo-senpi/plugin/extensions/omo.js
exit=0
```

GREEN (after change):
```text
dream-persona.md exit=1
facts-persona.md exit=1
memorian-persona.md exit=1
memory-run-supervisor.mjs exit=1
omo-init-deep-advisor.js exit=1
omo-member.js exit=1
omo-task.js exit=1
omo.js exit=1
reflection-persona.md exit=1
zz-untracked.tmp exit=0
 M packages/omo-senpi/.gitignore
```

No senpi-qa run is required: this is repo hygiene with no runtime change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxes the `packages/omo-senpi` gitignore so the nine tracked generated extension bundles can be added with plain `git add`, while untracked byproducts under `plugin/extensions/` stay ignored. Previously those bundles required `git add -f`.

No runtime change, so no QA run is required.

<sup>Written for commit 5b4649a0e82cc0f8dcb1d9327515c6c44841feb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

