### PR TITLE
fix(web): enlarge OmO social image typography and star count

### DIFF
--- a/packages/web/lib/og/social-image.tsx
+++ b/packages/web/lib/og/social-image.tsx
@@ -16,7 +16,7 @@ const rule = {
 
 export function SocialImage({ stats }: { readonly stats: FormattedStatsData }) {
   return (
-            <div
+    <div
       style={{
         display: "flex",
         position: "relative",

--- a/packages/web/lib/og/social-image.tsx
+++ b/packages/web/lib/og/social-image.tsx
@@ -122,17 +122,28 @@ export function SocialImage({ stats }: { readonly stats: FormattedStatsData }) {
           alignItems: "center",
           justifyContent: "space-between",
           fontFamily: "Geist Mono",
-          fontSize: 30,
+          fontSize: 24,
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 28 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 12, color: accent }}>
-            <svg width="26" height="26" viewBox="0 0 24 24" fill={accent} aria-hidden="true">
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              color: accent,
+              fontSize: 48,
+              fontWeight: 500,
+            }}
+          >
+            <svg width="38" height="38" viewBox="0 0 24 24" fill={accent} aria-hidden="true">
               <path d="m12 1 3.4 6.9 7.6 1.1-5.5 5.4 1.3 7.6-6.8-3.6L5.2 22l1.3-7.6L1 9l7.6-1.1Z" />
             </svg>
             {stats.stars} stars
           </div>
-          <div style={{ display: "flex", color: textLo }}>{stats.totalDownloads} downloads</div>
+          <div style={{ display: "flex", color: textLo, fontSize: 24 }}>
+            {stats.totalDownloads} downloads
+          </div>
         </div>
         <div style={{ display: "flex", color: textMid }}>omo.dev</div>
       </div>
@@ -157,7 +168,7 @@ export function MinimalSocialImage({ stats }: { readonly stats: FormattedStatsDa
     >
       <div style={{ display: "flex", fontSize: 64, fontWeight: 700 }}>OmO</div>
       <div style={{ display: "flex", fontSize: 48, lineHeight: 1.2 }}>{stats.description}</div>
-      <div style={{ display: "flex", fontSize: 36, color: accent }}>
+      <div style={{ display: "flex", fontSize: 54, color: accent, fontWeight: 600 }}>
         {stats.stars} stars · omo.dev
       </div>
     </div>

--- a/packages/web/lib/og/social-image.tsx
+++ b/packages/web/lib/og/social-image.tsx
@@ -16,7 +16,7 @@ const rule = {
 
 export function SocialImage({ stats }: { readonly stats: FormattedStatsData }) {
   return (
-    <div
+            <div
       style={{
         display: "flex",
         position: "relative",
@@ -65,18 +65,18 @@ export function SocialImage({ stats }: { readonly stats: FormattedStatsData }) {
             style={{
               display: "flex",
               fontWeight: 500,
-              fontSize: 30,
+              fontSize: 46,
               letterSpacing: -0.6,
               color: textHi,
             }}
           >
-            Oh My OpenAgent
+            OmO
           </div>
           <div
             style={{
               display: "flex",
               fontFamily: "Geist Mono",
-              fontSize: 15,
+              fontSize: 18,
               letterSpacing: 3.2,
               color: textLo,
             }}
@@ -122,7 +122,7 @@ export function SocialImage({ stats }: { readonly stats: FormattedStatsData }) {
           alignItems: "center",
           justifyContent: "space-between",
           fontFamily: "Geist Mono",
-          fontSize: 26,
+          fontSize: 30,
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 28 }}>
@@ -155,9 +155,9 @@ export function MinimalSocialImage({ stats }: { readonly stats: FormattedStatsDa
         fontFamily: "sans-serif",
       }}
     >
-      <div style={{ display: "flex", fontSize: 44, fontWeight: 700 }}>Oh My OpenAgent</div>
-      <div style={{ display: "flex", fontSize: 40, lineHeight: 1.2 }}>{stats.description}</div>
-      <div style={{ display: "flex", fontSize: 30, color: accent }}>
+      <div style={{ display: "flex", fontSize: 64, fontWeight: 700 }}>OmO</div>
+      <div style={{ display: "flex", fontSize: 48, lineHeight: 1.2 }}>{stats.description}</div>
+      <div style={{ display: "flex", fontSize: 36, color: accent }}>
         {stats.stars} stars · omo.dev
       </div>
     </div>

--- a/packages/web/lib/og/tagline.tsx
+++ b/packages/web/lib/og/tagline.tsx
@@ -29,8 +29,8 @@ export function OgTagline({ text }: { readonly text: string }) {
         overflow: "hidden",
         fontFamily: "Geist",
         fontWeight: 500,
-        fontSize: 48,
-        lineHeight: 1.12,
+        fontSize: 54,
+        lineHeight: 1.08,
         letterSpacing: -1.6,
         color: ogPalette.textHi,
       }}


### PR DESCRIPTION
## Summary

<!-- Explain what changed, why it changed, and how observable behavior is different. Use plain reviewer-facing language, not a file list. -->

- <!-- summary item -->

## Changes

<!-- Group by reviewer-relevant area. Each bullet should say what changed and how to map it to the diff. -->

- <!-- change item -->

## QA & Evidence

<!-- For each command or manual QA action: what was tested, what you observed, where the saved artifact/log lives, and why that evidence is sufficient. Link sanitized artifacts under .omo/evidence/ when applicable. Do not paste raw secret-bearing logs, env dumps, tokens, auth headers, or private credentials. -->

- **What was tested:** <!-- command or surface driven -->
  **Observed result:** <!-- actual result -->
  **Artifact:** <!-- saved sanitized artifact/log path -->
  **Why sufficient:** <!-- covered behavior or risk -->

## Risks & Residuals

<!-- Map each meaningful risk to the evidence above and state the conclusion: mitigated, accepted, blocked, or not applicable. -->

- <!-- risk item -->

## Screenshots

<!-- If applicable, add screenshots or GIFs showing before/after. Delete this section if not needed. -->

| Before | After |
|:---:|:---:|
|  |  |

## Automated Checks

<!-- Keep only commands actually run. Explain unavailable gates in Risks & Residuals. -->

```bash
bun run typecheck
bun test
```

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close on merge. -->

<!-- Closes # -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Open Graph social image to use the new "OmO" branding and enlarges the typography and star count so the image reads clearly at small sizes.

<sup>Written for commit e22e8d63a5779845a8c3732acb019baa2eb9f762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

