### PR TITLE
refactor(web): describe agents by role instead of internal names on the public site

### DIFF
--- a/packages/web/DESIGN.md
+++ b/packages/web/DESIGN.md
@@ -21,7 +21,7 @@ An operations ledger read at night. The whole site is one framed sheet of ink ru
 
 **Signature material: ink + phosphor.** Flat ink surfaces step by luminance (`ink-0 → ink-3`), separated by 1px `line` hairlines with square corners. Cyan appears only where something is running, selectable, or verified. No gradients as decoration, no purple, no drop shadows.
 
-**The memorable moment:** the hero's agent graph lights up wave by wave — Sisyphus, then the planners, then the workers — and you can grab it and orbit it. Two sections later the same wave grammar plays inside a terminal as `mass ulw` runs. The product's idea (a DAG of specialised agents scheduled in waves and verified at the end) is understood before a paragraph is read.
+**The memorable moment:** the hero's agent graph lights up wave by wave — the orchestrator, then the planners, then the workers — and you can grab it and orbit it. Two sections later the same wave grammar plays inside a terminal as `mass ulw` runs. The product's idea (a DAG of specialised agents scheduled in waves and verified at the end) is understood before a paragraph is read.
 
 ## 2. Color
 
@@ -171,8 +171,8 @@ All primitives live in `components/ui/*` (existing shadcn shells re-tokened) or 
 
 ### BentoCell (`components/ledger/bento-cell.tsx`)
 
-- Cells of the agents grid (`grid-flow-dense`, 1px gaps revealing `--line`, so the grid itself draws the rules). Cell fill `--ink-1`, hover `--ink-2` + icon `--accent`, spans: Sisyphus 2×2, Hephaestus 2×1, others 1×1; mobile 1 column, tablet 2. Content: icon 20px (Lucide/Phosphor SVG), name (Subheading), role (Body/sm `--text-mid`), model chip (Meta mono on `--ink-2`, `--line` border, 2px radius).
-- Gapless verification: 4 columns × 3 rows desktop = 12 cells: Sisyphus 4 + Hephaestus 2 + 6 singles = 12. Tablet 2 columns: Sisyphus 2×2, Hephaestus 2×1, 6 singles → 4 + 2 + 6 = 12 = 2 × 6 rows. No holes.
+- Cells of the agents grid (`grid-flow-dense`, 1px gaps revealing `--line`, so the grid itself draws the rules). Cell fill `--ink-1`, hover `--ink-2` + icon `--accent`, spans: orchestrator 2×2, Hephaestus 2×1, others 1×1; mobile 1 column, tablet 2. Content: icon 20px (Lucide/Phosphor SVG), name (Subheading), role (Body/sm `--text-mid`), model chip (Meta mono on `--ink-2`, `--line` border, 2px radius).
+- Gapless verification: 4 columns × 3 rows desktop = 12 cells: orchestrator 4 + Hephaestus 2 + 6 singles = 12. Tablet 2 columns: orchestrator 2×2, Hephaestus 2×1, 6 singles → 4 + 2 + 6 = 12 = 2 × 6 rows. No holes.
 
 ### Terminal (`components/landing/terminal.tsx`)
 
@@ -253,11 +253,11 @@ Grain is not used (omp.sh's canvas grain and factory's texture PNG would fight t
 
 ### Meaning
 
-The GitHub one-liner calls the user "the master of graph engineering". The focal object is that graph: a directed acyclic graph of agent nodes scheduled in waves by `mass ulw`. Wave 1 = Sisyphus (lead) → wave 2 = Prometheus, Metis, Momus (plan + gates) → wave 3 = Atlas, Hephaestus, Oracle, Librarian, Explore, Sisyphus-Junior, Multimodal-Looker (execution). A 12s loop lights the waves in order, pulses travel down the edges, and a final "verified" flash settles the graph.
+The GitHub one-liner calls the user "the master of graph engineering". The focal object is that graph: a directed acyclic graph of agent nodes scheduled in waves by `mass ulw`. Wave 1 = orchestrator (lead) → wave 2 = planner, gap analysis, plan review (plan + gates) → wave 3 = Atlas, Hephaestus, Oracle, Librarian, Explore, worker, Multimodal-Looker (execution). A 12s loop lights the waves in order, pulses travel down the edges, and a final "verified" flash settles the graph.
 
 ### Content and geometry
 
-- Desktop 11 nodes / mobile 7 (drop Metis, Momus, Multimodal-Looker, Sisyphus-Junior). Positions precomputed in `components/landing/graph/graph-data.ts` (seeded, three planes along -Z).
+- Desktop 11 nodes / mobile 7 (drop gap analysis, plan review, Multimodal-Looker, worker). Positions precomputed in `components/landing/graph/graph-data.ts` (seeded, three planes along -Z).
 - Node = icosahedron (detail 1) `MeshStandardMaterial` (`--ink-3` base, emissive `--accent-dim`, emissiveIntensity 0.2 idle → 1.6 lit) + one additive-blended halo sprite (shared 64×64 radial CanvasTexture, `--accent-16` → transparent). No bloom / postprocessing.
 - Edges = one `LineSegments` geometry, `--accent-dim` at 0.35 opacity; lit edge 0.8.
 - Pulses = one `Points` object (≤ 48 desktop / 24 mobile) whose `t` along its edge advances per frame in a typed array; size 6px, `--accent-hot`.

--- a/packages/web/app/design/_showcase/ledger.tsx
+++ b/packages/web/app/design/_showcase/ledger.tsx
@@ -10,7 +10,7 @@ import { Showcase, Specimen } from "./showcase"
 
 const EVIDENCE = (
   <pre className="border-line bg-code-bg text-code-fg overflow-x-auto border p-4 font-mono text-sm leading-[1.55]">
-    {"$ mass ulw add auth\n> wave 1  sisyphus      planning\n> wave 2  prometheus   interview"}
+    {"$ mass ulw add auth\n> wave 1  orchestrator  planning\n> wave 2  planner       interview"}
   </pre>
 )
 
@@ -30,7 +30,8 @@ export function LedgerShowcase(): JSX.Element {
         <Specimen label="default / hover (forced) / active" stack>
           <div>
             <LedgerRow index="01" title="Interview before code" evidence={EVIDENCE}>
-              Prometheus researches the codebase and asks only the questions the code cannot answer.
+              The planner researches the codebase and asks only the questions the code cannot
+              answer.
             </LedgerRow>
             <LedgerRow
               index="02"
@@ -41,7 +42,8 @@ export function LedgerShowcase(): JSX.Element {
               Independent tracks run in parallel; dependent ones wait for the wave before them.
             </LedgerRow>
             <LedgerRow index="03" title="Verify at the end" active evidence={EVIDENCE}>
-              Momus gates the plan; the last wave proves the work against the acceptance criteria.
+              The plan reviewer gates the plan; the last wave proves the work against the acceptance
+              criteria.
             </LedgerRow>
           </div>
         </Specimen>
@@ -54,7 +56,7 @@ export function LedgerShowcase(): JSX.Element {
               colSpan={2}
               rowSpan={2}
               icon={<ListChecks />}
-              name="Sisyphus"
+              name="Orchestrator"
               role="Lead orchestrator. Plans, delegates, and refuses to stop before the work is verified."
               chip="claude-opus-4"
               active
@@ -66,14 +68,9 @@ export function LedgerShowcase(): JSX.Element {
               role="Deep worker for long, autonomous implementation runs."
               chip="gpt-5.6"
             />
-            <BentoCell
-              icon={<Compass />}
-              name="Prometheus"
-              role="Interview and plan."
-              chip="opus"
-            />
+            <BentoCell icon={<Compass />} name="Planner" role="Interview and plan." chip="opus" />
             <BentoCell icon={<Scale />} name="Metis" role="Pre-plan gap analysis." chip="opus" />
-            <BentoCell icon={<Eye />} name="Momus" role="Plan review gate." chip="opus" />
+            <BentoCell icon={<Eye />} name="Plan reviewer" role="Plan review gate." chip="opus" />
             <BentoCell icon={<Anvil />} name="Atlas" role="Executes the plan." chip="sonnet" />
             <BentoCell
               icon={<BookOpen />}

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -32,7 +32,6 @@ export async function generateMetadata(): Promise<Metadata> {
       "oh-my-openagent",
       "ai agent",
       "code agent",
-      "sisyphus",
       "multi-model",
       "team mode",
       "agent orchestration",

--- a/packages/web/app/manifest.ts
+++ b/packages/web/app/manifest.ts
@@ -5,7 +5,7 @@ export default function manifest(): MetadataRoute.Manifest {
     name: "Oh My OpenAgent",
     short_name: "OMO",
     description:
-      "The Best Agent Harness. Meet Sisyphus: The batteries-included agent that codes like you.",
+      "The Best Agent Harness. Meet OmO: the batteries-included agent harness that codes like you.",
     start_url: "/",
     display: "standalone",
     background_color: "#0a0a0a",

--- a/packages/web/components/landing/dag/dag-graph-view.tsx
+++ b/packages/web/components/landing/dag/dag-graph-view.tsx
@@ -139,7 +139,7 @@ export function DagGraphView({
   )
 
   const toolbarButton =
-    "text-text-mid hover:bg-ink-3 hover:text-text-hi focus-visible:outline-accent ease-standard flex size-7 cursor-pointer items-center justify-center transition-colors duration-[var(--dur-micro)] focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-40"
+    "text-text-mid hover:bg-ink-3 hover:text-text-hi focus-visible:outline-accent ease-standard flex size-11 cursor-pointer items-center justify-center transition-colors duration-[var(--dur-micro)] focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-40"
 
   return (
     <div

--- a/packages/web/components/landing/graph/graph-data.ts
+++ b/packages/web/components/landing/graph/graph-data.ts
@@ -7,10 +7,10 @@ export interface GraphNode {
 }
 
 export const graphNodes: readonly GraphNode[] = [
-  { id: "sisyphus", label: "Sisyphus", role: "lead", wave: 1, position: [-3, 0, 0] },
-  { id: "prometheus", label: "Prometheus", role: "planner", wave: 2, position: [0, 2, -2] },
+  { id: "sisyphus", label: "Orchestrator", role: "lead", wave: 1, position: [-3, 0, 0] },
+  { id: "prometheus", label: "Planner", role: "planner", wave: 2, position: [0, 2, -2] },
   { id: "metis", label: "Metis", role: "consultant", wave: 2, position: [0, 0, -2] },
-  { id: "momus", label: "Momus", role: "reviewer", wave: 2, position: [0, -2, -2] },
+  { id: "momus", label: "Plan reviewer", role: "reviewer", wave: 2, position: [0, -2, -2] },
   { id: "atlas", label: "Atlas", role: "executor", wave: 3, position: [3, 3, -4] },
   { id: "hephaestus", label: "Hephaestus", role: "builder", wave: 3, position: [4, 2, -4] },
   { id: "oracle", label: "Oracle", role: "advisor", wave: 3, position: [3, 1, -4] },
@@ -18,7 +18,7 @@ export const graphNodes: readonly GraphNode[] = [
   { id: "explore", label: "Explore", role: "search", wave: 3, position: [3, -1, -4] },
   {
     id: "sisyphus-junior",
-    label: "Sisyphus-Junior",
+    label: "Worker",
     role: "worker",
     wave: 3,
     position: [4, -2, -4],

--- a/packages/web/components/landing/sections/agents.tsx
+++ b/packages/web/components/landing/sections/agents.tsx
@@ -8,7 +8,7 @@ import { SectionHeader } from "@/components/landing/section-header"
 import { Frame } from "@/components/ledger/frame"
 
 /**
- * The 11 graph agents plus the dynamic agent as a gapless bento (DESIGN.md §5): Sisyphus
+ * The 11 graph agents plus the dynamic agent as a gapless bento (DESIGN.md §5): the orchestrator
  * 2×2, Hephaestus 2×1, the rest 1×1 — 16 units, no holes. Node ids are shared with the 3D
  * hero graph, so a focused node lights its cell (`data-active`).
  */

--- a/packages/web/components/landing/sections/orchestration.tsx
+++ b/packages/web/components/landing/sections/orchestration.tsx
@@ -20,7 +20,7 @@ function Features({ items }: { readonly items: readonly string[] }): ReactNode {
   )
 }
 
-/** The verified-plan pipeline as a ledger: Prometheus → Metis → Momus → Atlas. */
+/** The verified-plan pipeline as a ledger: planner → gap analysis → plan review → executor. */
 export async function OrchestrationSection(): Promise<JSX.Element> {
   const t = await getTranslations("landing.orchestration")
 

--- a/packages/web/e2e/landing.spec.ts
+++ b/packages/web/e2e/landing.spec.ts
@@ -52,16 +52,16 @@ test.describe("Landing Page", () => {
     // when / then
     await expect(grid.locator("li[id^='agent-']")).toHaveCount(12)
     const agentNames = [
-      "Sisyphus",
+      "Orchestrator",
       "Hephaestus",
       "Oracle",
       "Librarian",
       "Explore",
-      "Prometheus",
+      "Planner",
       "Metis",
-      "Momus",
+      "Plan reviewer",
       "Atlas",
-      "Sisyphus-Junior",
+      "Worker",
       "Multimodal-Looker",
     ]
     for (const name of agentNames) {

--- a/packages/web/messages/en.json
+++ b/packages/web/messages/en.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "Oh My OpenAgent",
-    "description": "The Best Agent Harness. Meet Sisyphus: The Batteries-Included Agent that codes like you."
+    "description": "The Best Agent Harness. Meet OmO: the batteries-included agent harness that codes like you."
   },
   "nav": {
     "brand": "Oh My OpenAgent",
@@ -39,7 +39,7 @@
       "rail": {
         "wave1": {
           "index": "01",
-          "label": "Sisyphus leads"
+          "label": "The orchestrator leads"
         },
         "wave2": {
           "index": "02",
@@ -110,10 +110,10 @@
     "agents": {
       "eyebrow": "The roster",
       "title": "Eleven agents, one graph.",
-      "subtitle": "A directed graph of 11 agents scheduled in waves: Sisyphus leads, Prometheus, Metis and Momus plan and gate, the workers execute. Click a node in the graph to find its cell here.",
+      "subtitle": "A directed graph of 11 agents scheduled in waves: the orchestrator leads, the planner, gap analysis and plan review gate the work, the workers execute. Click a node in the graph to find its cell here.",
       "sisyphus": {
-        "name": "Sisyphus",
-        "role": "Primary orchestrator",
+        "name": "Orchestrator",
+        "role": "Lead agent",
         "model": "Claude Opus 5 Max",
         "description": "Parses what you meant, maps the codebase before touching a line, delegates to specialists and verifies their work independently. Interrupted runs resume from boulder.json exactly where they stopped."
       },
@@ -123,7 +123,7 @@
         "model": "GPT 5.6 Sol Medium"
       },
       "prometheus": {
-        "name": "Prometheus",
+        "name": "Planner",
         "role": "Strategic planner",
         "model": "Claude Fable 5.1 XHigh"
       },
@@ -133,8 +133,8 @@
         "model": "Claude Opus 5 High"
       },
       "momus": {
-        "name": "Momus",
-        "role": "Plan reviewer",
+        "name": "Plan reviewer",
+        "role": "Review gate",
         "model": "GPT 6 Astra xHigh"
       },
       "atlas": {
@@ -158,7 +158,7 @@
         "model": "GPT 5.6 Luna Fast"
       },
       "sisyphusJunior": {
-        "name": "Sisyphus-Junior",
+        "name": "Worker",
         "role": "Focused task executor",
         "model": "Per-category"
       },
@@ -178,7 +178,7 @@
       "title": "Think, then act.",
       "subtitle": "Planning and execution are different jobs. The planner never writes code; the executor follows a plan two reviewers already passed.",
       "prometheus": {
-        "name": "Prometheus",
+        "name": "Planner",
         "role": "Strategic planner",
         "model": "Claude Fable 5.1 XHigh",
         "description": "Interviews you, explores the codebase, writes the plan. Never writes code.",
@@ -192,7 +192,7 @@
         "features": ["Missing requirements", "Unstated assumptions"]
       },
       "momus": {
-        "name": "Momus",
+        "name": "Plan reviewer",
         "role": "Plan review",
         "model": "GPT 6 Astra xHigh",
         "description": "Approves only when the plan holds up. Otherwise it goes back.",
@@ -285,7 +285,7 @@
         "author": "Arthur Guiot"
       },
       "review2": {
-        "text": "If Claude Code does in 7 days what a human does in 3 months, Sisyphus does it in 1 hour.",
+        "text": "If Claude Code does in 7 days what a human does in 3 months, OmO does it in 1 hour.",
         "author": "B, Quant Researcher"
       },
       "review3": {
@@ -402,9 +402,9 @@
       },
       "prometheus": {
         "badge": "Approach 2",
-        "title": "Prometheus + Atlas",
+        "title": "Planner + Executor",
         "subtitle": "When you want strategic control.",
-        "prometheusTitle": "Prometheus",
+        "prometheusTitle": "Planner",
         "prometheusDescription": "Conducts interview, researches context, and generates a detailed YAML plan.",
         "atlasTitle": "Atlas",
         "atlasDescription": "Executes the plan, delegates to sub-agents, manages waves, and tracks progress.",
@@ -429,7 +429,7 @@
       "title": "The Core Loop",
       "features": {
         "prometheus": {
-          "feature": "Prometheus",
+          "feature": "Planning interview",
           "purpose": "Extract intent through intelligent interview"
         },
         "metis": {
@@ -437,7 +437,7 @@
           "purpose": "Catch ambiguities before they become bugs"
         },
         "momus": {
-          "feature": "Momus",
+          "feature": "Plan review gate",
           "purpose": "Verify plans are complete before execution"
         },
         "orchestrator": {

--- a/packages/web/messages/ja.json
+++ b/packages/web/messages/ja.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "Oh My OpenAgent",
-    "description": "究極のエージェントハーネス。Sisyphusと出会おう：あなたのようなコーディングをする、バッテリー内蔵型エージェントです。"
+    "description": "究極のエージェントハーネス。OmO と出会おう：あなたのようにコーディングする、必要なものがすべて揃ったエージェントハーネス。"
   },
   "nav": {
     "brand": "Oh My OpenAgent",
@@ -39,7 +39,7 @@
       "rail": {
         "wave1": {
           "index": "01",
-          "label": "Sisyphus が率いる"
+          "label": "オーケストレーターが率いる"
         },
         "wave2": {
           "index": "02",
@@ -110,10 +110,10 @@
     "agents": {
       "eyebrow": "ロスター",
       "title": "11 のエージェント、一つのグラフ。",
-      "subtitle": "ウェーブでスケジュールされる 11 エージェントの有向グラフ。Sisyphus が率い、Prometheus・Metis・Momus が計画とゲートを担い、ワーカーが実行します。グラフのノードをクリックすると該当セルが点灯します。",
+      "subtitle": "ウェーブでスケジュールされる 11 エージェントの有向グラフ。オーケストレーターが率い、プランナー・ギャップ分析・プランレビューがゲートを担い、ワーカーが実行します。グラフのノードをクリックすると該当セルが点灯します。",
       "sisyphus": {
-        "name": "Sisyphus",
-        "role": "プライマリオーケストレーター",
+        "name": "オーケストレーター",
+        "role": "リードエージェント",
         "model": "Claude Opus 5 Max",
         "description": "言葉ではなく意図を読み、一行も触る前にコードベースを把握し、専門エージェントに委譲して結果を独立に検証します。中断した実行は boulder.json から止まった箇所で再開します。"
       },
@@ -123,7 +123,7 @@
         "model": "GPT 5.6 Sol Medium"
       },
       "prometheus": {
-        "name": "Prometheus",
+        "name": "プランナー",
         "role": "戦略プランナー",
         "model": "Claude Fable 5.1 XHigh"
       },
@@ -133,8 +133,8 @@
         "model": "Claude Opus 5 High"
       },
       "momus": {
-        "name": "Momus",
-        "role": "計画レビュアー",
+        "name": "プランレビュアー",
+        "role": "レビューゲート",
         "model": "GPT 6 Astra xHigh"
       },
       "atlas": {
@@ -158,7 +158,7 @@
         "model": "GPT 5.6 Luna Fast"
       },
       "sisyphusJunior": {
-        "name": "Sisyphus-Junior",
+        "name": "ワーカー",
         "role": "単一タスク実行者",
         "model": "Per-category"
       },
@@ -178,7 +178,7 @@
       "title": "考えてから、動く。",
       "subtitle": "計画と実行は別の仕事です。プランナーはコードを書かず、実行者は二人のレビュアーを通った計画に従います。",
       "prometheus": {
-        "name": "Prometheus",
+        "name": "プランナー",
         "role": "戦略プランナー",
         "model": "Claude Fable 5.1 XHigh",
         "description": "インタビューし、コードベースを探索し、計画を書く。コードは書かない。",
@@ -192,7 +192,7 @@
         "features": ["欠けた要件", "暗黙の前提"]
       },
       "momus": {
-        "name": "Momus",
+        "name": "プランレビュアー",
         "role": "計画レビュー",
         "model": "GPT 6 Astra xHigh",
         "description": "計画が持ちこたえる時だけ承認。そうでなければ差し戻す。",
@@ -285,7 +285,7 @@
         "author": "Arthur Guiot"
       },
       "review2": {
-        "text": "If Claude Code does in 7 days what a human does in 3 months, Sisyphus does it in 1 hour.",
+        "text": "If Claude Code does in 7 days what a human does in 3 months, OmO does it in 1 hour.",
         "author": "B, Quant Researcher"
       },
       "review3": {
@@ -402,9 +402,9 @@
       },
       "prometheus": {
         "badge": "アプローチ2",
-        "title": "Prometheus + Atlas",
+        "title": "プランナー + 実行者",
         "subtitle": "戦略的なコントロールが欲しい時。",
-        "prometheusTitle": "Prometheus",
+        "prometheusTitle": "プランナー",
         "prometheusDescription": "インタビューを実施し、コンテキストを調査し、詳細なYAMLプランを生成します。",
         "atlasTitle": "Atlas",
         "atlasDescription": "プランを実行し、サブエージェントに委譲し、ウェーブを管理し、進捗を追跡します。",
@@ -429,7 +429,7 @@
       "title": "コアループ",
       "features": {
         "prometheus": {
-          "feature": "Prometheus",
+          "feature": "プランニングインタビュー",
           "purpose": "知的なインタビューを通じて意図を抽出"
         },
         "metis": {
@@ -437,7 +437,7 @@
           "purpose": "バグになる前に曖昧さを捕捉"
         },
         "momus": {
-          "feature": "Momus",
+          "feature": "プランレビューゲート",
           "purpose": "実行前にプランが完全であることを検証"
         },
         "orchestrator": {

--- a/packages/web/messages/ko.json
+++ b/packages/web/messages/ko.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "Oh My OpenAgent",
-    "description": "최고의 Agent Harness. Sisyphus를 만나보세요: 당신처럼 코딩하는 완벽한 Agent."
+    "description": "최고의 Agent Harness. OmO를 만나보세요: 당신처럼 코딩하는, 필요한 것이 모두 들어 있는 에이전트 하네스."
   },
   "nav": {
     "brand": "Oh My OpenAgent",
@@ -39,7 +39,7 @@
       "rail": {
         "wave1": {
           "index": "01",
-          "label": "Sisyphus 가 이끕니다"
+          "label": "오케스트레이터가 이끕니다"
         },
         "wave2": {
           "index": "02",
@@ -110,10 +110,10 @@
     "agents": {
       "eyebrow": "로스터",
       "title": "열한 에이전트, 하나의 그래프.",
-      "subtitle": "웨이브로 스케줄되는 11개 에이전트의 방향 그래프: Sisyphus 가 이끌고, Prometheus, Metis, Momus 가 계획과 검문을, 워커가 실행을 맡습니다. 그래프의 노드를 클릭하면 해당 셀이 켜집니다.",
+      "subtitle": "웨이브로 스케줄되는 11개 에이전트의 방향 그래프: 오케스트레이터가 이끌고, 플래너·갭 분석·플랜 리뷰가 검문을, 워커가 실행을 맡습니다. 그래프의 노드를 클릭하면 해당 셀이 켜집니다.",
       "sisyphus": {
-        "name": "Sisyphus",
-        "role": "기본 오케스트레이터",
+        "name": "오케스트레이터",
+        "role": "리드 에이전트",
         "model": "Claude Opus 5 Max",
         "description": "말한 그대로가 아니라 의도를 읽고, 코드 한 줄을 건드리기 전에 코드베이스를 파악하고, 전문 에이전트에 위임한 뒤 결과를 독립적으로 검증합니다. 중단된 실행은 boulder.json 에서 멈춘 지점부터 재개됩니다."
       },
@@ -123,7 +123,7 @@
         "model": "GPT 5.6 Sol Medium"
       },
       "prometheus": {
-        "name": "Prometheus",
+        "name": "플래너",
         "role": "전략 플래너",
         "model": "Claude Fable 5.1 XHigh"
       },
@@ -133,8 +133,8 @@
         "model": "Claude Opus 5 High"
       },
       "momus": {
-        "name": "Momus",
-        "role": "계획 리뷰어",
+        "name": "플랜 리뷰어",
+        "role": "리뷰 게이트",
         "model": "GPT 6 Astra xHigh"
       },
       "atlas": {
@@ -158,7 +158,7 @@
         "model": "GPT 5.6 Luna Fast"
       },
       "sisyphusJunior": {
-        "name": "Sisyphus-Junior",
+        "name": "워커",
         "role": "단일 작업 실행자",
         "model": "Per-category"
       },
@@ -178,7 +178,7 @@
       "title": "먼저 생각하고, 그다음 실행.",
       "subtitle": "계획과 실행은 다른 일입니다. 플래너는 코드를 쓰지 않고, 실행자는 두 리뷰어를 통과한 계획을 따릅니다.",
       "prometheus": {
-        "name": "Prometheus",
+        "name": "플래너",
         "role": "전략 플래너",
         "model": "Claude Fable 5.1 XHigh",
         "description": "인터뷰하고, 코드베이스를 탐색하고, 계획을 씁니다. 코드는 쓰지 않습니다.",
@@ -192,7 +192,7 @@
         "features": ["누락된 요구사항", "암묵적 가정"]
       },
       "momus": {
-        "name": "Momus",
+        "name": "플랜 리뷰어",
         "role": "계획 리뷰",
         "model": "GPT 6 Astra xHigh",
         "description": "계획이 버틸 때만 승인합니다. 아니면 되돌려 보냅니다.",
@@ -285,7 +285,7 @@
         "author": "Arthur Guiot"
       },
       "review2": {
-        "text": "If Claude Code does in 7 days what a human does in 3 months, Sisyphus does it in 1 hour.",
+        "text": "If Claude Code does in 7 days what a human does in 3 months, OmO does it in 1 hour.",
         "author": "B, Quant Researcher"
       },
       "review3": {
@@ -402,9 +402,9 @@
       },
       "prometheus": {
         "badge": "방식 2",
-        "title": "Prometheus + Atlas",
+        "title": "플래너 + 실행자",
         "subtitle": "전략적 통제를 원할 때.",
-        "prometheusTitle": "Prometheus",
+        "prometheusTitle": "플래너",
         "prometheusDescription": "인터뷰를 진행하고, 컨텍스트를 조사하며, 상세한 YAML 계획을 생성합니다.",
         "atlasTitle": "Atlas",
         "atlasDescription": "계획을 실행하고, 하위 Agent에 위임하고, 웨이브를 관리하며, 진행 상황을 추적합니다.",
@@ -429,7 +429,7 @@
       "title": "핵심 루프",
       "features": {
         "prometheus": {
-          "feature": "Prometheus",
+          "feature": "플래닝 인터뷰",
           "purpose": "지능형 인터뷰로 의도 추출"
         },
         "metis": {
@@ -437,7 +437,7 @@
           "purpose": "버그가 되기 전에 모호함 포착"
         },
         "momus": {
-          "feature": "Momus",
+          "feature": "플랜 리뷰 게이트",
           "purpose": "실행 전 계획의 완성도 검증"
         },
         "orchestrator": {

--- a/packages/web/messages/zh.json
+++ b/packages/web/messages/zh.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "title": "Oh My OpenAgent",
-    "description": "最佳 Agent harness。遇见 Sisyphus：开箱即用的 Agent，像你一样编程。"
+    "description": "最佳 Agent harness。遇见 OmO：开箱即用、像你一样编程的智能体 harness。"
   },
   "nav": {
     "brand": "Oh My OpenAgent",
@@ -39,7 +39,7 @@
       "rail": {
         "wave1": {
           "index": "01",
-          "label": "Sisyphus 领队"
+          "label": "编排器领队"
         },
         "wave2": {
           "index": "02",
@@ -110,10 +110,10 @@
     "agents": {
       "eyebrow": "阵容",
       "title": "十一个智能体，一张图。",
-      "subtitle": "按波次调度的 11 个智能体有向图：Sisyphus 领队，Prometheus、Metis、Momus 负责规划与把关，执行者动手。点击图中的节点即可找到对应格子。",
+      "subtitle": "按波次调度的 11 个智能体有向图：编排器领队，规划器、缺口分析与计划评审负责把关，执行者动手。点击图中的节点即可找到对应格子。",
       "sisyphus": {
-        "name": "Sisyphus",
-        "role": "主编排者",
+        "name": "编排器",
+        "role": "主导智能体",
         "model": "Claude Opus 5 Max",
         "description": "读懂你的意图而非字面，动手前先摸清代码库，委派给专家并独立验证结果。中断的运行会从 boulder.json 记录的位置精确恢复。"
       },
@@ -123,7 +123,7 @@
         "model": "GPT 5.6 Sol Medium"
       },
       "prometheus": {
-        "name": "Prometheus",
+        "name": "规划器",
         "role": "战略规划者",
         "model": "Claude Fable 5.1 XHigh"
       },
@@ -133,8 +133,8 @@
         "model": "Claude Opus 5 High"
       },
       "momus": {
-        "name": "Momus",
-        "role": "计划评审",
+        "name": "计划评审",
+        "role": "评审关卡",
         "model": "GPT 6 Astra xHigh"
       },
       "atlas": {
@@ -158,7 +158,7 @@
         "model": "GPT 5.6 Luna Fast"
       },
       "sisyphusJunior": {
-        "name": "Sisyphus-Junior",
+        "name": "执行者",
         "role": "单任务执行者",
         "model": "Per-category"
       },
@@ -178,7 +178,7 @@
       "title": "先想，再做。",
       "subtitle": "规划和执行是两件事。规划者不写代码；执行者只跟随已通过两位评审的计划。",
       "prometheus": {
-        "name": "Prometheus",
+        "name": "规划器",
         "role": "战略规划者",
         "model": "Claude Fable 5.1 XHigh",
         "description": "访谈你，探索代码库，写出计划。从不写代码。",
@@ -192,7 +192,7 @@
         "features": ["缺失的需求", "未说明的假设"]
       },
       "momus": {
-        "name": "Momus",
+        "name": "计划评审",
         "role": "计划评审",
         "model": "GPT 6 Astra xHigh",
         "description": "只有计划站得住才批准，否则退回。",
@@ -285,7 +285,7 @@
         "author": "Arthur Guiot"
       },
       "review2": {
-        "text": "If Claude Code does in 7 days what a human does in 3 months, Sisyphus does it in 1 hour.",
+        "text": "If Claude Code does in 7 days what a human does in 3 months, OmO does it in 1 hour.",
         "author": "B, Quant Researcher"
       },
       "review3": {
@@ -402,9 +402,9 @@
       },
       "prometheus": {
         "badge": "方法 2",
-        "title": "Prometheus + Atlas",
+        "title": "规划器 + 执行器",
         "subtitle": "当你需要战略性控制时。",
-        "prometheusTitle": "Prometheus",
+        "prometheusTitle": "规划器",
         "prometheusDescription": "进行访谈、研究上下文并生成详细的 YAML 计划。",
         "atlasTitle": "Atlas",
         "atlasDescription": "执行计划，委派给子 Agent，管理波次并跟踪进度。",
@@ -429,7 +429,7 @@
       "title": "核心循环",
       "features": {
         "prometheus": {
-          "feature": "Prometheus",
+          "feature": "规划访谈",
           "purpose": "通过智能访谈提取意图"
         },
         "metis": {
@@ -437,7 +437,7 @@
           "purpose": "在歧义变成 Bug 之前捕获它们"
         },
         "momus": {
-          "feature": "Momus",
+          "feature": "计划评审关卡",
           "purpose": "在执行前验证计划完整性"
         },
         "orchestrator": {


### PR DESCRIPTION
## What

Replace the agent names Sisyphus, Prometheus and Momus with role words (orchestrator, planner, plan reviewer, worker) everywhere the public site renders them: hero rail, agents bento, orchestration ledger, manifesto sections, review quote, metadata description, web manifest, design showcase, 3D graph labels, DESIGN.md prose, e2e expectations. All four locales updated. Company name (Sisyphus Labs) and the X handle are unchanged. Docs pages keep the real agent identifiers because they document config keys.

## QA

- bun run format:check / lint / type-check: exit 0
- OMO_WEB_SHOWCASE=1 bun run build: exit 0
- bunx playwright test: see CI
- rg for the three names across components/app/messages (excluding keys, company, handle, docs): clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces internal agent names (Sisyphus, Prometheus, Momus, Sisyphus-Junior) with their role words (orchestrator, planner, plan reviewer, worker) everywhere the public site renders them: hero graph, agents bento, orchestration ledger, manifesto, review quote, metadata, web manifest, design showcase, and e2e expectations. All four locales are updated. The company name (Sisyphus Labs) and X handle stay unchanged, and docs pages keep the real identifiers because they document config keys. The metadata description now introduces "OmO" instead of "Sisyphus", the `sisyphus` keyword is removed from the page metadata, and the DAG camera toolbar buttons grow from 28px to 44px to meet the responsive QA hit-target requirement.

<sup>Written for commit 64623f77ee1eb2bf5e31d01a20df626019039662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

