### PR TITLE
test(omo-senpi): build live thread socket expectations from node:path

### DIFF
--- a/packages/omo-senpi/src/components/thread/live-surface.test.ts
+++ b/packages/omo-senpi/src/components/thread/live-surface.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
+import { join, resolve } from "node:path"
 import { createLiveThreadSurface, resolveThreadSocket } from "./live-surface"
 
+// Derived paths are built with node:path so the expectations hold under Windows separators too.
 describe("live thread socket discovery", () => {
   test("operator override wins", () => {
     expect(resolveThreadSocket({ SENPI_RPC_SOCKET: "/tmp/override.sock" })).toBe("/tmp/override.sock")
@@ -11,17 +13,17 @@ describe("live thread socket discovery", () => {
   test("#given brand and legacy RPC_SOCKET names #when several are set #then the brand name wins and blanks are skipped", () => {
     expect(resolveThreadSocket({ OMO_RPC_SOCKET: "/brand.sock", SENPI_RPC_SOCKET: "/legacy.sock", OMO_RPC_SOCKET_PATH: "/desktop.sock" })).toBe("/brand.sock")
     expect(resolveThreadSocket({ OMO_RPC_SOCKET: "  ", PI_RPC_SOCKET: "/pi.sock", OMO_RPC_SOCKET_PATH: "/desktop.sock" })).toBe("/pi.sock")
-    expect(resolveThreadSocket({ OMO_CODING_AGENT_DIR: "/configured" })).toBe("/configured/rpc/rpc.sock")
+    expect(resolveThreadSocket({ OMO_CODING_AGENT_DIR: "/configured" })).toBe(join(resolve("/configured"), "rpc", "rpc.sock"))
   })
   test("canonical and env branches resolve through resolveAgentHome", async () => {
     const { resolveAgentHome } = await import("../agent-home/resolve-agent-home")
-    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: (path) => path === "/h/.omo/agent/settings.json" })).toBe("/h/.omo/agent")
-    expect(resolveAgentHome({ env: { OMO_CODING_AGENT_DIR: "/configured" }, homeDir: "/h", exists: () => false })).toBe("/configured")
+    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: (path) => path === join("/h", ".omo", "agent", "settings.json") })).toBe(join("/h", ".omo", "agent"))
+    expect(resolveAgentHome({ env: { OMO_CODING_AGENT_DIR: "/configured" }, homeDir: "/h", exists: () => false })).toBe(resolve("/configured"))
   })
   test("resolveAgentHome supports flat and standalone fallback", async () => {
     const { resolveAgentHome } = await import("../agent-home/resolve-agent-home")
-    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: (path) => path === "/h/.omo/settings.json" })).toBe("/h/.omo")
-    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: () => false })).toBe("/h/.senpi/agent")
+    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: (path) => path === join("/h", ".omo", "settings.json") })).toBe(join("/h", ".omo"))
+    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: () => false })).toBe(join("/h", ".senpi", "agent"))
   })
   test("always constructs a surface when the socket is absent at registration", () => {
     expect(createLiveThreadSurface({} as never, { env: { SENPI_RPC_SOCKET: "/missing.sock" }, exists: () => false })).toBeDefined()


### PR DESCRIPTION
## Summary

`senpi-compatibility (windows-latest)` is red on `dev` at `efec42a81`
([run 34216613636 / job 102029836693](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/34216613636/job/102029836693))
and fails identically on #7958
([job 101995371039](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/34205881075/job/101995371039)).
The leg is not a required check, but `draft-release` needs every `senpi-compatibility` leg, so the red
leg skips the draft "next" release on each `dev` push.

Three tests in `packages/omo-senpi/src/components/thread/live-surface.test.ts` hard-code POSIX strings
both as expected values and inside the injected `exists` sentinel predicates, while `resolveAgentHome`
and `resolveThreadSocket` build paths with `node:path`. On Windows the predicates never match (the code
falls through to `\h\.senpi\agent`) and `resolve("/configured")` yields `D:\configured`. Production
behaviour is correct; the tests were platform-specific.

## Changes

`packages/omo-senpi/src/components/thread/live-surface.test.ts` (test only, +7/-5): derive the expected
values and the `exists` sentinel paths from the same `join` / `resolve` calls the code makes, matching
the idiom already used in `agent-home/resolve-agent-home.test.ts`. No test skipped, no matcher weakened,
no platform branch. On POSIX the computed values are byte-identical to the old literals.

## Test plan

- [x] `bun test packages/omo-senpi/src/components/thread/live-surface.test.ts`: 7 pass / 0 fail (Linux, bun 1.4.0).
- [x] `tsgo --noEmit -p packages/omo-senpi/tsconfig.json`: clean.
- [x] Windows behaviour reasoned from `path.win32` semantics for each of the three tests and cross-checked
      against the CI `Received` strings (`D:\configured\rpc\rpc.sock`, `\h\.senpi\agent` fallthrough).
      Not executed on a Windows host.
- [ ] CI note for maintainers: `script/ci-fast-path.mjs` does not classify this path as platform-sensitive,
      so this PR's own run skips the Windows senpi steps. Please apply `ci:full-matrix` so
      `senpi-compatibility (windows-latest)` actually runs here before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three tests in `packages/omo-senpi/src/components/thread/live-surface.test.ts` that hard-coded POSIX paths, which failed on `windows-latest` and blocked `draft-release` from running on each `dev` push.

The tests now build expected values and `exists` sentinel paths with the same `node:path` calls production code uses, so assertions hold on every OS. Production code is unchanged; on POSIX, computed paths match the old literals byte-for-byte.

**Rollout**
- Apply `ci:full-matrix` before merging so the Windows `senpi-compatibility` leg actually runs here.

<sup>Written for commit dd36dd46c946362b2b0dc8e5d03c2c80f2df35d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

