### PR TITLE
test(omo-senpi): build live-surface path expectations with node:path

### DIFF
--- a/packages/omo-senpi/src/components/thread/live-surface.test.ts
+++ b/packages/omo-senpi/src/components/thread/live-surface.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { join, resolve } from "node:path"
 import { createLiveThreadSurface, resolveThreadSocket } from "./live-surface"
 
 describe("live thread socket discovery", () => {
@@ -11,17 +12,19 @@ describe("live thread socket discovery", () => {
   test("#given brand and legacy RPC_SOCKET names #when several are set #then the brand name wins and blanks are skipped", () => {
     expect(resolveThreadSocket({ OMO_RPC_SOCKET: "/brand.sock", SENPI_RPC_SOCKET: "/legacy.sock", OMO_RPC_SOCKET_PATH: "/desktop.sock" })).toBe("/brand.sock")
     expect(resolveThreadSocket({ OMO_RPC_SOCKET: "  ", PI_RPC_SOCKET: "/pi.sock", OMO_RPC_SOCKET_PATH: "/desktop.sock" })).toBe("/pi.sock")
-    expect(resolveThreadSocket({ OMO_CODING_AGENT_DIR: "/configured" })).toBe("/configured/rpc/rpc.sock")
+    expect(resolveThreadSocket({ OMO_CODING_AGENT_DIR: "/configured" })).toBe(join(resolve("/configured"), "rpc", "rpc.sock"))
   })
   test("canonical and env branches resolve through resolveAgentHome", async () => {
     const { resolveAgentHome } = await import("../agent-home/resolve-agent-home")
-    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: (path) => path === "/h/.omo/agent/settings.json" })).toBe("/h/.omo/agent")
-    expect(resolveAgentHome({ env: { OMO_CODING_AGENT_DIR: "/configured" }, homeDir: "/h", exists: () => false })).toBe("/configured")
+    const canonical = join("/h", ".omo", "agent")
+    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: (path) => path === join(canonical, "settings.json") })).toBe(canonical)
+    expect(resolveAgentHome({ env: { OMO_CODING_AGENT_DIR: "/configured" }, homeDir: "/h", exists: () => false })).toBe(resolve("/configured"))
   })
   test("resolveAgentHome supports flat and standalone fallback", async () => {
     const { resolveAgentHome } = await import("../agent-home/resolve-agent-home")
-    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: (path) => path === "/h/.omo/settings.json" })).toBe("/h/.omo")
-    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: () => false })).toBe("/h/.senpi/agent")
+    const flat = join("/h", ".omo")
+    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: (path) => path === join(flat, "settings.json") })).toBe(flat)
+    expect(resolveAgentHome({ env: {}, homeDir: "/h", exists: () => false })).toBe(join("/h", ".senpi", "agent"))
   })
   test("always constructs a surface when the socket is absent at registration", () => {
     expect(createLiveThreadSurface({} as never, { env: { SENPI_RPC_SOCKET: "/missing.sock" }, exists: () => false })).toBeDefined()


### PR DESCRIPTION
## Summary

`packages/omo-senpi/src/components/thread/live-surface.test.ts` pinned POSIX strings for paths that the resolver builds with `node:path`: on Windows `resolveAgentHome` answers `resolve("/configured")` = `D:\configured` and `join` produces backslashes, so three cases fail deterministically in `senpi-compatibility (windows-latest)` on every dev run since 8bd0c35b3 (runs 34225459048, 34238561557, 34247222257 - same three failures each time). That red leg blocks the omo release gate.

Expected values are now built with the same `join`/`resolve` calls the resolver uses; POSIX results are byte-identical, so ubuntu/macos coverage is unchanged.

## Evidence

- RED: dev CI run 34247222257, job `senpi-compatibility (windows-latest)`: `Expected: "/configured/rpc/rpc.sock" Received: "D:\configured\rpc\rpc.sock"` plus the two `resolveAgentHome` cases (`2991 pass, 3 fail`).
- GREEN: this PR's `senpi-compatibility (windows-latest)` leg.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `omo-senpi` live-surface tests so they pass on Windows by building expected paths with the same `node:path` calls the resolver uses, instead of pinned POSIX strings.

- Replaces hardcoded `/configured/rpc/rpc.sock` and `/h/.omo/agent` style expectations with `join`/`resolve` results, matching resolver behavior on all platforms.
- POSIX output is byte-identical, so Ubuntu and macOS coverage is unchanged.

<sup>Written for commit 2697f9e7688a2e70a41602490f31248a64be07b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

