### PR TITLE
fix(build): embed shared-session workers in compiled OmO wrappers

### DIFF
--- a/script/build-omo-binary.ts
+++ b/script/build-omo-binary.ts
@@ -25,6 +25,7 @@ import { tmpdir } from "node:os"
 import { dirname, join, relative, resolve, sep } from "node:path"
 import { fileURLToPath } from "node:url"
 import ptyFixture from "./release-binary-pty-fixture.json"
+import { senpiWorkerCompileArgs } from "./senpi-worker-compile"
 import { parseBuildInfo, type OmoBuildInfo } from "../packages/omo-native/build-info"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -639,6 +640,7 @@ export async function buildReleaseBinary(
           "--no-compile-autoload-bunfig",
           `--asset=${stageDir}`,
           compileEntry,
+          ...senpiWorkerCompileArgs(repoRoot),
           "--outfile",
           binaryPath,
         ],

--- a/script/build-omo-binary.ts
+++ b/script/build-omo-binary.ts
@@ -635,6 +635,7 @@ export async function buildReleaseBinary(
           "build",
           "--compile",
           `--target=${target.bunTarget}`,
+          "--minify-whitespace",
           "--compile-autoload-package-json",
           "--no-compile-autoload-dotenv",
           "--no-compile-autoload-bunfig",

--- a/script/senpi-worker-compile.test.ts
+++ b/script/senpi-worker-compile.test.ts
@@ -17,7 +17,7 @@ test("#given a worker engine #when compiled and relocated #then two workers star
     writeFileSync(entry, `import { Worker } from "node:worker_threads";
 const path = typeof SENPI_RPC_SESSION_WORKER_ENTRY === "string" ? SENPI_RPC_SESSION_WORKER_ENTRY : "./src/modes/rpc/session-worker.ts";
 await Promise.all([1, 2].map(() => new Promise((resolve, reject) => {
-  const worker = new Worker(path);
+  const worker = new Worker(new URL(path, import.meta.url));
   worker.once("error", reject);
   worker.once("message", async (message) => { await worker.terminate(); resolve(message); });
 })));

--- a/script/senpi-worker-compile.test.ts
+++ b/script/senpi-worker-compile.test.ts
@@ -1,17 +1,26 @@
 import { expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { senpiWorkerCompileArgs } from "./senpi-worker-compile"
 
-test("#given a worker engine #when compiled and relocated #then two workers start without source files", () => {
+test.each(["directory", "bun-link", "external-link"])("#given a %s worker engine #when compiled and relocated #then two workers start without source files", (layout) => {
   const scratch = mkdtempSync(join(tmpdir(), "omo-worker-compile-"))
   try {
     // given: mirror the published engine layout and compile-time worker contract.
-    const root = join(scratch, "source")
-    const worker = join(root, "node_modules/@code-yeongyu/senpi/dist/modes/rpc/session-worker.js")
-    mkdirSync(dirname(worker), { recursive: true })
+    const buildRoot = join(scratch, "build")
+    const root = join(buildRoot, "source")
+    const packagePath = join(root, "node_modules/@code-yeongyu/senpi")
+    const physicalPackage = layout === "directory" ? packagePath : layout === "bun-link"
+      ? join(root, "node_modules/.bun/senpi/node_modules/@code-yeongyu/senpi")
+      : join(buildRoot, "engine")
+    mkdirSync(join(physicalPackage, "dist/modes/rpc"), { recursive: true })
+    if (layout !== "directory") {
+      mkdirSync(dirname(packagePath), { recursive: true })
+      symlinkSync(physicalPackage, packagePath, "junction")
+    }
+    const worker = join(packagePath, "dist/modes/rpc/session-worker.js")
     writeFileSync(worker, `import { parentPort } from "node:worker_threads"; parentPort.postMessage("ready");`)
     const entry = join(root, "entry.ts")
     writeFileSync(entry, `import { Worker } from "node:worker_threads";
@@ -30,7 +39,7 @@ console.log("two-workers-ready");`)
     mkdirSync(relocated)
     const moved = join(relocated, process.platform === "win32" ? "omo.exe" : "omo")
     renameSync(binary, moved)
-    rmSync(root, { recursive: true })
+    rmSync(buildRoot, { recursive: true })
     const result = spawnSync(moved, [], { cwd: relocated, encoding: "utf8", timeout: 10_000 })
     // then
     expect(result.status, result.stderr).toBe(0)

--- a/script/senpi-worker-compile.test.ts
+++ b/script/senpi-worker-compile.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { senpiWorkerCompileArgs } from "./senpi-worker-compile"
+
+test("#given a worker engine #when compiled and relocated #then two workers start without source files", () => {
+  const scratch = mkdtempSync(join(tmpdir(), "omo-worker-compile-"))
+  try {
+    // given: mirror the published engine layout and compile-time worker contract.
+    const root = join(scratch, "source")
+    const worker = join(root, "node_modules/@code-yeongyu/senpi/dist/modes/rpc/session-worker.js")
+    mkdirSync(dirname(worker), { recursive: true })
+    writeFileSync(worker, `import { parentPort } from "node:worker_threads"; parentPort.postMessage("ready");`)
+    const entry = join(root, "entry.ts")
+    writeFileSync(entry, `import { Worker } from "node:worker_threads";
+const path = typeof SENPI_RPC_SESSION_WORKER_ENTRY === "string" ? SENPI_RPC_SESSION_WORKER_ENTRY : "./src/modes/rpc/session-worker.ts";
+await Promise.all([1, 2].map(() => new Promise((resolve, reject) => {
+  const worker = new Worker(path);
+  worker.once("error", reject);
+  worker.once("message", async (message) => { await worker.terminate(); resolve(message); });
+})));
+console.log("two-workers-ready");`)
+    const binary = join(scratch, process.platform === "win32" ? "omo.exe" : "omo")
+    // when: use the same args as the release builder, then remove the entire source.
+    const built = spawnSync(process.execPath, ["build", "--compile", entry, ...senpiWorkerCompileArgs(root), "--outfile", binary], { cwd: root, encoding: "utf8", timeout: 30_000 })
+    expect(built.status, built.stderr).toBe(0)
+    const relocated = join(scratch, "relocated")
+    mkdirSync(relocated)
+    const moved = join(relocated, process.platform === "win32" ? "omo.exe" : "omo")
+    renameSync(binary, moved)
+    rmSync(root, { recursive: true })
+    const result = spawnSync(moved, [], { cwd: relocated, encoding: "utf8", timeout: 10_000 })
+    // then
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout.trim()).toBe("two-workers-ready")
+  } finally {
+    rmSync(scratch, { recursive: true, force: true })
+  }
+}, 45_000)
+
+test("#given a pre-worker engine #when resolving compile args #then the legacy graph stays unchanged", () => {
+  const root = mkdtempSync(join(tmpdir(), "omo-worker-legacy-"))
+  try {
+    expect(senpiWorkerCompileArgs(root)).toEqual([])
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/script/senpi-worker-compile.ts
+++ b/script/senpi-worker-compile.ts
@@ -1,0 +1,14 @@
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+
+/** Bun entry names are relative to --root, not to the relocated executable's cwd. */
+export function senpiWorkerCompileArgs(repoRoot: string): string[] {
+  const worker = "node_modules/@code-yeongyu/senpi/dist/modes/rpc/session-worker.js"
+  // Older pinned engines do not have a shared-session worker.
+  if (!existsSync(join(repoRoot, worker))) return []
+  return [
+    `--root=${repoRoot}`,
+    `--define=SENPI_RPC_SESSION_WORKER_ENTRY=${JSON.stringify(`./${worker}`)}`,
+    join(repoRoot, worker),
+  ]
+}

--- a/script/senpi-worker-compile.ts
+++ b/script/senpi-worker-compile.ts
@@ -1,14 +1,24 @@
-import { existsSync } from "node:fs"
-import { join } from "node:path"
+import { existsSync, realpathSync } from "node:fs"
+import { dirname, isAbsolute, join, relative, sep } from "node:path"
 
 /** Bun entry names are relative to --root, not to the relocated executable's cwd. */
 export function senpiWorkerCompileArgs(repoRoot: string): string[] {
-  const worker = "node_modules/@code-yeongyu/senpi/dist/modes/rpc/session-worker.js"
+  const candidate = join(repoRoot, "node_modules/@code-yeongyu/senpi/dist/modes/rpc/session-worker.js")
   // Older pinned engines do not have a shared-session worker.
-  if (!existsSync(join(repoRoot, worker))) return []
+  if (!existsSync(candidate)) return []
+  const entry = realpathSync(candidate)
+  let root = realpathSync(repoRoot)
+  let worker = relative(root, entry)
+  if (isAbsolute(worker)) throw new Error("The wrapper and session worker must share a filesystem root")
+  // Bun embeds the physical entry name, including .bun store paths. Linked
+  // development engines outside the repo need a root containing both entries.
+  while (worker.startsWith(`..${sep}`)) {
+    root = dirname(root)
+    worker = relative(root, entry)
+  }
   return [
-    `--root=${repoRoot}`,
-    `--define=SENPI_RPC_SESSION_WORKER_ENTRY=${JSON.stringify(`./${worker}`)}`,
-    join(repoRoot, worker),
+    `--root=${root}`,
+    `--define=SENPI_RPC_SESSION_WORKER_ENTRY=${JSON.stringify(`./${worker.split(sep).join("/")}`)}`,
+    entry,
   ]
 }


### PR DESCRIPTION
## Summary

Include Senpi's shared-session worker in the actual compiled OmO wrapper. The worker path is now tied to an explicit Bun compile root and passed through Senpi's `SENPI_RPC_SESSION_WORKER_ENTRY` build-time contract. The Senpi runtime half is in https://github.com/code-yeongyu/senpi/pull/1499.

Older pinned engines without a session-worker module retain their existing compile graph. This does not change the engine dependency pin, generated JS, runtime environment overrides, or production installations. Based on dev `771b83c298db7d68f5c15accbb771b7dfd86f18a`, preserving #7969 and #7978.

## Changes

- Resolve the published `dist/modes/rpc/session-worker.js` as an additional compile entry.
- Supply an explicit `--root` and matching embedded entry name to Senpi; embedding a worker without matching its runtime path is insufficient.
- Exercise two real Bun workers after relocating a compiled fixture and deleting its complete source tree.

## QA and evidence

All builds/tests ran on approved `mengmotaMac` through Bunshin, using Bun 1.4.2 / macOS arm64. Local commands were source/git/orchestration only.

- `bun run typecheck:script`: passed.
- `bun test script/senpi-worker-compile.test.ts script/build-omo-binary.test.ts script/build-omo-native.test.ts`: **37 passed, 0 failed, 0 skipped in the complete invocation**. Earlier attempts exposed missing source-checkout packaging prerequisites (vendor/ and generated ast-grep skill); those inputs were supplied, not hidden by test edits.
- The real `script/build-omo-binary.ts --target darwin-arm64` pipeline built the plugin, staged 1,183 sidecars, verified embedding and the existing 150 MiB budget, and produced a 151,044,978-byte executable.
- That executable was relocated outside source and driven through shared RPC: two simultaneous sessions, distinct durable identities, real memory/task/LSP registration, requester control, B surviving A close, and both shutdown hooks. Disposable HOME/agent/memory/LSP paths and a loopback dummy model only; owned runtime resources were cleaned.
- Causal RED: even with the new worker compile entry present, the old Senpi runtime still failed `open_session` with `Cannot find module './src/modes/rpc/session-worker.ts'`. The repaired Senpi runtime with the same compile arguments and staged payload passed. The full builder with the latest candidate plugin then passed independently.

Retained evidence: `/tmp/st_01a08205-evidence/remote/` (`st_01a08205-wrapper-red*.log`, `st_01a08205-wrapper-seam-green*.log`, `st_01a08205-wrapper-green.log`, `st_01a08205-omo-full-build.log`, `st_01a08205-omo-build-tests-complete.log`). Source input manifest: `/tmp/st_01a08205-omo-manifest.json`. Final repair handoff: `/tmp/ulw-host-worker-isolation-20260908-result.md`.

## Limits

The actual wrapper was wired to the candidate Senpi dist and its dependency graph in an isolated build tree; the published dependency version has not been bumped. This proves packaging, initialization and RPC lifecycle, not real-provider execution or delegated-task completion. The separate Senpi Node bundle-builder still has its documented three baseline build errors; neither Node dist nor this Bun wrapper result is substituted for that failed gate.

No merge, deployment, or production operation is part of this repair lane.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embeds Senpi's shared-session worker in compiled OmO binaries so the worker path resolves at runtime instead of failing with `Cannot find module './src/modes/rpc/session-worker.ts'`. Older pinned engines without the worker module still compile with the same graph.

- Adds `--root`, a `SENPI_RPC_SESSION_WORKER_ENTRY` define, and `--minify-whitespace` to the Bun compile step, embedding the worker and keeping the binary within the 150 MiB budget.
- Adds tests that compile a binary with the worker, relocate it, delete the source tree, and start two workers; pre-worker engines keep the legacy compile graph.
- No changes to dependency pins, generated JS, or production installations.

<sup>Written for commit 1698c8aa0f098d5b74480656e7375c0bcb2e96f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

