### PR TITLE
fix(omob): refresh canonical mainline before every managed launch

### DIFF
--- a/docs/reference/omob-dev-binary.md
+++ b/docs/reference/omob-dev-binary.md
@@ -1,13 +1,14 @@
 # omob — dev binary from the latest commits
 
-`omob` builds a single-file bun-compiled binary from the freshest tracked
-commits — senpi `origin/main` + omo `origin/dev` — and installs it as
-`omob` next to your regular `omo`. It exists to test a commit pair
-end-to-end without cutting a release.
+`omob` builds a single-file Bun-compiled binary from senpi `origin/main` and
+omo `origin/dev`. On macOS and Linux, the ordinary install places an auto-update
+launcher at `~/.local/bin/omob` and its executable at `~/.cache/omob/bin/omob`.
+It tests the current mainline commit pair end-to-end without cutting a release.
 
 ```bash
 bun run omob                       # latest origin/main + origin/dev
-bun run omob --senpi-ref origin/feat/x --omo-ref abc1234   # omo refs must already contain the omob build-info support
+bun run omob --name omob-feature --senpi-ref origin/feat/x --omo-ref abc1234
+# Explicit feature builds use a separate name and require build-info support.
 bun run omob --skip-install        # build only, into ~/.cache/omob/out
 ```
 
@@ -22,4 +23,20 @@ Behavior:
   are pruned (keep 2 by default, `--keep N`). Release runtimes are never touched.
 - `~/.omo` sessions/settings/auth are shared with a regular `omo` install on
   purpose: omob is the same product built from fresher commits.
-- Rebuild to update: `bun run omob` (the `update` hint inside omob says so).
+- Every managed launch visibly checks both canonical upstream refs before running.
+  The same pair skips dependency installation and compilation, checking provenance
+  from the executable itself rather than trusting a metadata sidecar. A changed
+  pair builds before launch. Running `bun run omob` again retains this launcher.
+- The builder and source clones live in the managed cache, not the caller's
+  checkout. A feature checkout is never reset or used as the default source.
+  Named feature builds default to their own cache (for example
+  `~/.cache/omob-feature`) so they cannot replace the managed mainline builder.
+- Fetch/build failures stop launch with a nonzero status and leave the previous
+  executable intact. Installation uses atomic rename. Concurrent updates share the
+  existing cache lock and fail fast rather than interleave builds; retry after
+  the active update finishes. Runtime arguments, exit status and signals pass
+  through the launcher's final `exec`.
+- Bun and Git must remain on `PATH`. `--binary-only` explicitly requests a bare
+  executable instead of a launcher; the launcher uses this internally to refresh
+  its cached executable. Windows retains the bare-binary installation path.
+  `--launcher` explicitly requests the managed POSIX installation.

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -6,15 +6,13 @@
 // runtime dir are namespaced by the commit pair.
 
 import { spawnSync } from "node:child_process"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, chmodSync, renameSync, cpSync } from "node:fs"
-import { homedir, tmpdir } from "node:os"
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, chmodSync, renameSync, cpSync } from "node:fs"
+import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
-import { parseBuildInfo, versionLines, type OmoBuildInfo } from "../packages/omo-native/build-info"
+import { versionLines, type OmoBuildInfo } from "../packages/omo-native/build-info"
 import { RELEASE_BINARY_TARGETS } from "./build-omo-binary"
-
-const scriptDir = dirname(fileURLToPath(import.meta.url))
-const repoRoot = resolve(scriptDir, "..")
+import { installOmobLauncher, isCurrentOmobBuild } from "./omob-launcher"
+export { installOmobLauncher, isCurrentOmobBuild } from "./omob-launcher"
 
 export interface OmobOptions {
 	readonly senpiRef: string
@@ -27,6 +25,8 @@ export interface OmobOptions {
 	readonly senpiUrl: string
 	readonly skipFetch: boolean
 	readonly skipInstall: boolean
+	readonly ifChanged: boolean
+	readonly launcher: boolean
 }
 
 export function hostTargetFor(platform: string, arch: string): string {
@@ -39,10 +39,13 @@ export function hostTargetFor(platform: string, arch: string): string {
 const DEFAULT_SENPI_URL = "https://github.com/code-yeongyu/senpi.git"
 
 export function parseOmobArgs(argv: readonly string[], platform: string, arch: string, homeDir: string): OmobOptions {
-	const options: { senpiRef?: string; omoRef?: string; cacheDir?: string; installDir?: string; name?: string; target?: string; senpiUrl?: string; keep?: number; skipFetch: boolean; skipInstall: boolean } = {
+	const options: { senpiRef?: string; omoRef?: string; cacheDir?: string; installDir?: string; name?: string; target?: string; senpiUrl?: string; keep?: number; skipFetch: boolean; skipInstall: boolean; ifChanged: boolean; launcher: boolean; binaryOnly: boolean } = {
 		senpiUrl: undefined,
 		skipFetch: false,
 		skipInstall: false,
+		ifChanged: false,
+		launcher: false,
+		binaryOnly: false,
 	}
 	for (let index = 0; index < argv.length; index += 1) {
 		const argument = argv[index]
@@ -62,21 +65,35 @@ export function parseOmobArgs(argv: readonly string[], platform: string, arch: s
 			options.skipFetch = true
 		} else if (argument === "--skip-install") {
 			options.skipInstall = true
+		} else if (argument === "--if-changed") {
+			options.ifChanged = true
+		} else if (argument === "--launcher") {
+			options.launcher = true
+		} else if (argument === "--binary-only") {
+			options.binaryOnly = true
 		} else {
 			throw new Error(`unknown argument: ${argument}`)
 		}
 	}
+	if (options.launcher && (options.binaryOnly || options.skipInstall)) throw new Error("--launcher conflicts with --binary-only and --skip-install")
+	const launcher = options.launcher || (!options.binaryOnly && !options.skipInstall && platform !== "win32" && (options.name ?? "omob") === "omob")
+	const mainline = (options.omoRef ?? "origin/dev") === "origin/dev" && (options.senpiRef ?? "origin/main") === "origin/main" && (options.senpiUrl ?? DEFAULT_SENPI_URL) === DEFAULT_SENPI_URL
+	if (!mainline && (launcher || (!options.skipInstall && (options.name ?? "omob") === "omob"))) {
+		throw new Error("the managed omob name requires origin/dev + origin/main; use --name omob-feature or --skip-install for feature builds")
+	}
 	return {
 		senpiRef: options.senpiRef ?? "origin/main",
 		omoRef: options.omoRef ?? "origin/dev",
-		cacheDir: options.cacheDir ?? join(homeDir, ".cache", "omob"),
-		installDir: options.installDir ?? join(homeDir, ".local", "bin"),
+		cacheDir: resolve(options.cacheDir ?? join(homeDir, ".cache", options.name ?? (mainline ? "omob" : "omob-feature"))),
+		installDir: resolve(options.installDir ?? join(homeDir, ".local", "bin")),
 		name: options.name ?? "omob",
 		target: options.target ?? hostTargetFor(platform, arch),
 		keep: options.keep ?? 2,
 		senpiUrl: options.senpiUrl ?? DEFAULT_SENPI_URL,
 		skipFetch: options.skipFetch,
 		skipInstall: options.skipInstall,
+		ifChanged: options.ifChanged || launcher,
+		launcher,
 	}
 }
 
@@ -154,15 +171,22 @@ export function acquireCacheLock(cacheDir: string, pid: number = process.pid): C
 		claim()
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error
-		const holder = Number.parseInt(readFileSync(path, "utf8").trim(), 10)
-		if (Number.isFinite(holder) && holder !== pid && processIsAlive(holder)) {
-			throw new Error(
-				`another omob build is running (pid ${holder}); lock: ${path}. Wait for it to finish, or remove the lock if that process is gone.`,
-			)
+		// Serialize stale-owner reclamation too: two contenders must not unlink
+		// a fresh claim after both observed the same dead owner.
+		const reclaim = `${path}.reclaim`
+		mkdirSync(reclaim)
+		try {
+			if (existsSync(path)) {
+				const holder = Number.parseInt(readFileSync(path, "utf8").trim(), 10)
+				if (!Number.isInteger(holder) || holder <= 0 || processIsAlive(holder)) {
+					throw new Error(`another omob build is running (pid ${holder}); lock: ${path}. Wait for it to finish; an incomplete claim must not be stolen.`)
+				}
+				rmSync(path)
+			}
+			claim()
+		} finally {
+			rmSync(reclaim, { recursive: true })
 		}
-		// Stale lock: the owner died without releasing it.
-		rmSync(path, { force: true })
-		claim()
 	}
 	let released = false
 	const release = (): void => {
@@ -177,22 +201,25 @@ export function acquireCacheLock(cacheDir: string, pid: number = process.pid): C
 	return { path, release }
 }
 
-export function ensureCacheClone(url: string, directory: string, ref: string, skipFetch: boolean): { readonly directory: string; readonly commit: string } {
+export function ensureCacheClone(url: string, directory: string, ref: string, skipFetch: boolean, checkout = true): { readonly directory: string; readonly commit: string } {
 	mkdirSync(dirname(directory), { recursive: true })
 	if (!existsSync(join(directory, ".git"))) {
 		// --recurse-submodules bootstraps the submodules; the post-reset sync below is the
 		// single place that points them at the requested ref, on this and every later run.
 		run("git", ["clone", "--recurse-submodules", "--shallow-submodules", url, directory], dirname(directory))
 	}
+	const actualUrl = runCaptured("git", ["config", "--get", "remote.origin.url"], directory)
+	if (actualUrl !== url) throw new Error(`cache origin mismatch at ${directory}: expected ${url}, found ${actualUrl}`)
 	if (!skipFetch) {
 		// A plain `origin/<branch>` narrows the fetch to that one refspec. Anything else —
 		// a raw SHA, or a revision expression such as `origin/dev~1` — is not a refspec git
 		// can fetch, so fall back to fetching every branch and resolving locally.
 		const branch = ref.startsWith("origin/") ? ref.slice("origin/".length) : ""
 		const isPlainBranch = branch !== "" && !/[~^:@\\]|\.\.|^-/.test(branch)
-		const fetchArgs = isPlainBranch ? ["--prune", "origin", branch] : ["--prune", "origin"]
+		const fetchArgs = isPlainBranch ? ["--prune", "origin", `+refs/heads/${branch}:refs/remotes/origin/${branch}`] : ["--prune", "origin"]
 		run("git", ["fetch", ...fetchArgs], directory)
 	}
+	if (!checkout) return { directory, commit: runCaptured("git", ["rev-parse", `${ref}^{commit}`], directory) }
 	// A cache checkout must land on the exact ref tree: drop leftovers from a previous
 	// ref (tracked deletions, staged swaps). `clean -ffd` deliberately omits `-x`, so
 	// ignored build outputs and node_modules survive for cache reuse.
@@ -213,8 +240,8 @@ interface CommitInfo {
 }
 
 function readCommitInfo(directory: string, ref: string): CommitInfo {
-	const commit = runCaptured("git", ["rev-parse", "HEAD"], directory)
-	const committedAt = runCaptured("git", ["log", "-1", "--format=%cI"], directory)
+	const commit = runCaptured("git", ["rev-parse", `${ref}^{commit}`], directory)
+	const committedAt = runCaptured("git", ["log", "-1", "--format=%cI", ref], directory)
 	const rawBranch = runCaptured("git", ["rev-parse", "--abbrev-ref", ref], directory).trim()
 	const branch = (rawBranch === "HEAD" || rawBranch === "" ? ref : rawBranch).replace(/^origin\//, "")
 	return { commit, committedAt, branch }
@@ -370,8 +397,10 @@ async function main(argv: readonly string[]): Promise<number> {
 
 async function runBuild(options: OmobOptions): Promise<number> {
 	const senpiUrl = options.senpiUrl ?? DEFAULT_SENPI_URL
-	const senpi = ensureCacheClone(senpiUrl, join(options.cacheDir, "senpi"), options.senpiRef, options.skipFetch)
-	const omo = ensureCacheClone(runCaptured("git", ["remote", "get-url", "origin"], repoRoot), join(options.cacheDir, "omo"), options.omoRef, options.skipFetch)
+	const omoUrl = "https://github.com/code-yeongyu/oh-my-openagent.git"
+	console.error(`[omob] checking ${options.omoRef} + ${options.senpiRef}`)
+	const senpi = ensureCacheClone(senpiUrl, join(options.cacheDir, "senpi"), options.senpiRef, options.skipFetch, false)
+	const omo = ensureCacheClone(omoUrl, join(options.cacheDir, "omo"), options.omoRef, options.skipFetch, false)
 
 	const senpiInfo = readCommitInfo(senpi.directory, options.senpiRef)
 	const omoInfo = readCommitInfo(omo.directory, options.omoRef)
@@ -381,6 +410,15 @@ async function runBuild(options: OmobOptions): Promise<number> {
 		engine: { commit: senpiInfo.commit, committedAt: senpiInfo.committedAt, branch: senpiInfo.branch },
 	}
 
+	const installDir = options.launcher ? join(options.cacheDir, "bin") : options.installDir
+	if (options.ifChanged && !options.skipInstall && isCurrentOmobBuild(join(installDir, options.name), buildInfo, options.target)) {
+		console.error(`[omob] current: omo ${omoInfo.commit} + senpi ${senpiInfo.commit}; no build needed`)
+		if (options.launcher) installOmobLauncher(options)
+		return 0
+	}
+	console.error(`[omob] building: omo ${omoInfo.commit} + senpi ${senpiInfo.commit}`)
+	ensureCacheClone(senpiUrl, senpi.directory, options.senpiRef, true)
+	ensureCacheClone(omoUrl, omo.directory, options.omoRef, true)
 	const builtSenpiRoot = buildSenpiPackage(senpi.directory, options.cacheDir)
 	// The omo prepare chain materializes gitignored plugin/skills from the shared-skills
 	// upstream submodules; a caller's OMO_SKIP_MATERIALIZE=1 would skip that and break the
@@ -421,7 +459,8 @@ async function runBuild(options: OmobOptions): Promise<number> {
 	const result = { binaryPath, size: statSync(binaryPath).size }
 
 	if (!options.skipInstall) {
-		const installed = installBinary(result.binaryPath, options.installDir, options.name)
+		const installed = installBinary(result.binaryPath, installDir, options.name)
+		if (options.launcher) console.error(`[omob] installed launcher ${installOmobLauncher(options)}`)
 		console.log(`installed ${installed} (${result.size} bytes)`)
 	}
 	// Pruning is only safe once the new binary is in place: a --skip-install run would

--- a/script/omob-launcher.test.ts
+++ b/script/omob-launcher.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import * as builder from "./build-omob"
+
+describe("omob mainline launcher", () => {
+	test("#given ordinary installation #when defaults are parsed #then the managed launcher is retained", () => {
+		expect(builder.parseOmobArgs([], "darwin", "arm64", "/home/dev").launcher).toBe(true)
+	})
+
+	test("#given mainline refresh flags #when parsed #then startup refresh is supported", () => {
+		expect(() => builder.parseOmobArgs(["--if-changed", "--launcher"], "darwin", "arm64", "/home/dev")).not.toThrow()
+	})
+
+	test("#given explicit feature refs #when building directly #then only explicit launcher installation rejects them", () => {
+		const args = ["--omo-ref", "origin/feature", "--senpi-ref", "origin/experiment"]
+		const feature = builder.parseOmobArgs([...args, "--name", "omob-feature"], "darwin", "arm64", "/home/dev")
+		expect(feature.omoRef).toBe("origin/feature")
+		expect(feature.cacheDir).toBe("/home/dev/.cache/omob-feature")
+		expect(() => builder.parseOmobArgs(args, "darwin", "arm64", "/home/dev")).toThrow()
+		expect(() => builder.parseOmobArgs([...args, "--launcher"], "darwin", "arm64", "/home/dev")).toThrow()
+		expect(builder.parseOmobArgs([], "darwin", "arm64", "/home/dev").omoRef).toBe("origin/dev")
+	})
+
+	test("#given an incompletely written cache claim #when another updater starts #then it cannot steal the lock", () => {
+		const root = mkdtempSync(join(tmpdir(), "omob-lock-incomplete-"))
+		try {
+			writeFileSync(join(root, ".lock"), "")
+			expect(() => builder.acquireCacheLock(root)).toThrow()
+		} finally { rmSync(root, { recursive: true, force: true }) }
+	})
+
+	for (const changed of [false, true]) {
+		test(`#given a ${changed ? "changed" : "same"} SHA pair #when cache is checked #then rebuild is ${changed}`, () => {
+			const root = mkdtempSync(join(tmpdir(), "omob-pair-"))
+			try {
+				const current = builder.isCurrentOmobBuild
+				expect(typeof current).toBe("function")
+				const binary = join(root, "omob")
+				const info = { command: "omob", omo: { commit: "a".repeat(40), committedAt: "2026-09-09T00:00:00Z", branch: "dev" }, engine: { commit: "b".repeat(40), committedAt: "2026-09-09T00:00:00Z", branch: "main" } }
+				writeFileSync(binary, `#!/bin/sh\nprintf '%s\\n' 'omob dev build' 'omo   ${info.omo.commit} ${info.omo.committedAt} (dev)' 'senpi ${info.engine.commit} ${info.engine.committedAt} (main)'\n`, { mode: 0o755 })
+				const requested = changed ? { ...info, engine: { ...info.engine, commit: "c".repeat(40) } } : info
+				writeFileSync(`${binary}.build.json`, JSON.stringify({ buildInfo: requested }))
+				expect(current(binary, requested, builder.hostTargetFor(process.platform, process.arch))).toBe(!changed)
+				rmSync(binary)
+				expect(current(binary, requested, builder.hostTargetFor(process.platform, process.arch))).toBe(false)
+			} finally { rmSync(root, { recursive: true, force: true }) }
+		})
+	}
+
+	test("#given a signaled executable #when launched #then the launcher preserves the signal", () => {
+		const root = mkdtempSync(join(tmpdir(), "omob-signal-"))
+		try {
+			const options = builder.parseOmobArgs(["--cache-dir", join(root, "cache"), "--install-dir", join(root, "bin")], "darwin", "arm64", root)
+			const tools = join(root, "tools")
+			mkdirSync(tools)
+			mkdirSync(join(options.cacheDir, "bin"), { recursive: true })
+			writeFileSync(join(tools, "bun"), "#!/bin/sh\nexit 0\n", { mode: 0o755 })
+			writeFileSync(join(options.cacheDir, "bin", "omob"), "#!/bin/sh\nkill -TERM $$\n", { mode: 0o755 })
+			builder.installOmobLauncher(options)
+			const result = spawnSync(join(options.installDir, "omob"), [], { env: { ...process.env, PATH: `${tools}:${process.env.PATH}` } })
+			expect(result.signal).toBe("SIGTERM")
+			expect(result.status).toBeNull()
+		} finally { rmSync(root, { recursive: true, force: true }) }
+	})
+
+	for (const fail of [false, true]) {
+		test(`#given ${fail ? "failed" : "successful"} refresh #when launched #then ${fail ? "the previous binary survives without launching" : "args and exit status reach the refreshed executable"}`, () => {
+			const root = mkdtempSync(join(tmpdir(), "omob-launcher-"))
+			try {
+				const install = builder.installOmobLauncher
+				expect(typeof install).toBe("function")
+				const options = builder.parseOmobArgs(["--cache-dir", join(root, "cache space"), "--install-dir", join(root, "bin")], "darwin", "arm64", root)
+				const fakeBin = join(root, "tools")
+				mkdirSync(fakeBin)
+				const binaryDir = join(options.cacheDir, "bin")
+				mkdirSync(binaryDir, { recursive: true })
+				const binary = join(binaryDir, "omob")
+				const previous = '#!/bin/sh\nprintf "stale launched\\n"\n'
+				writeFileSync(binary, previous, { mode: 0o755 })
+				const receipt = join(root, "refresh-args")
+				writeFileSync(join(fakeBin, "bun"), `#!/bin/sh\nprintf '%s\\n' "$@" > '${receipt}'\n${fail ? "exit 29" : `printf '%s\\n' '#!/bin/sh' 'printf "<%s>\\n" "$@"' 'exit 37' > '${binary}'` }\n`, { mode: 0o755 })
+				install(options)
+				const result = spawnSync(join(options.installDir, options.name), ["a b", "", "--flag", "$(echo unsafe)"], { encoding: "utf8", env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` } })
+				expect(result.status).toBe(fail ? 29 : 37)
+				expect(result.stdout).toBe(fail ? "" : "<a b>\n<>\n<--flag>\n<$(echo unsafe)>\n")
+				expect(readFileSync(receipt, "utf8").split("\n")).toContain("--if-changed")
+				if (fail) expect(readFileSync(binary, "utf8")).toBe(previous)
+			} finally {
+				rmSync(root, { recursive: true, force: true })
+			}
+		})
+	}
+})

--- a/script/omob-launcher.ts
+++ b/script/omob-launcher.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { versionLines, type OmoBuildInfo } from "../packages/omo-native/build-info"
+import type { OmobOptions } from "./build-omob"
+
+export function isCurrentOmobBuild(binary: string, info: OmoBuildInfo, target: string): boolean {
+	const host = `${process.platform === "win32" ? "windows" : process.platform}-${process.arch}`
+	if (target !== host || !existsSync(binary)) return false
+	// Read provenance from the executable, not a sidecar that can outlive a failed install.
+	const result = spawnSync(binary, ["--version"], { encoding: "utf8", timeout: 30_000 })
+	return result.status === 0 && result.stdout.trim() === versionLines(info).join("\n")
+}
+
+export function installOmobLauncher(options: OmobOptions): string {
+	if (process.platform === "win32") throw new Error("the omob auto-update launcher requires a POSIX shell")
+	const quote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`
+	const binDir = join(options.cacheDir, "bin")
+	const args = [join(options.cacheDir, "omo", "script", "build-omob.ts"), "--if-changed", "--binary-only", "--cache-dir", options.cacheDir, "--install-dir", binDir, "--name", options.name, "--target", options.target, "--keep", String(options.keep)]
+	const destination = join(options.installDir, options.name)
+	const temporary = `${destination}.tmp-${process.pid}`
+	mkdirSync(options.installDir, { recursive: true })
+	writeFileSync(temporary, `#!/bin/sh\n# Refresh must succeed before the engine can claim to be current.\nbun ${args.map(quote).join(" ")} >&2\nstatus=$?\n[ "$status" -eq 0 ] || exit "$status"\nexec ${quote(join(binDir, options.name))} "$@"\n`, { mode: 0o755 })
+	renameSync(temporary, destination)
+	return destination
+}

--- a/script/omob-refresh.test.ts
+++ b/script/omob-refresh.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { installOmobLauncher, parseOmobArgs } from "./build-omob"
+
+const builder = resolve(import.meta.dir, "build-omob.ts")
+const canonical = "https://github.com/code-yeongyu/oh-my-openagent.git"
+
+// Replace only the expensive package/compiler boundary. Git, cache selection,
+// update decisions, installs and the installed launcher all run the real code.
+const compiler = `#!/usr/bin/env node
+const fs = require('node:fs'), path = require('node:path'), cp = require('node:child_process');
+const args = process.argv.slice(2), cwd = process.cwd();
+if (args[0]?.endsWith('/script/build-omob.ts')) {
+ const result = cp.spawnSync(process.env.OMOB_TEST_BUN, [process.env.OMOB_TEST_BUILDER, ...args.slice(1)], {stdio:'inherit'});
+ process.exit(result.status ?? 1);
+}
+if (args.includes('script/build-omo-binary.ts')) {
+ fs.appendFileSync(process.env.OMOB_TEST_BUILDS, 'compile\\n');
+ if (process.env.OMOB_TEST_FAIL === '1') process.exit(23);
+ const info = JSON.parse(args[args.indexOf('--build-info')+1]);
+ const version = [info.command+' dev build', 'omo   '+info.omo.commit+' '+info.omo.committedAt+' ('+info.omo.branch+')', 'senpi '+info.engine.commit+' '+info.engine.committedAt+' ('+info.engine.branch+')'].join('\\n');
+ const out = args[args.indexOf('--out-dir')+1], target = args[args.indexOf('--target')+1];
+ fs.mkdirSync(out,{recursive:true});
+ fs.writeFileSync(path.join(out,'omo-'+target), '#!/usr/bin/env node\\nif(process.argv[2]==="--version") console.log('+JSON.stringify(version)+'); else {console.log(JSON.stringify(process.argv.slice(2))); process.exit(17)}\\n', {mode:0o755});
+} else if (args[0] === 'pm') {
+ fs.writeFileSync(path.join(args[args.indexOf('--destination')+1],'senpi.tgz'),'fixture');
+} else if (args[0] === 'install') {
+ fs.mkdirSync(path.join(cwd,'node_modules'),{recursive:true});
+ if (path.basename(cwd)==='senpi-install') {
+  const pkg=path.join(cwd,'node_modules/@code-yeongyu/senpi');
+  fs.mkdirSync(pkg,{recursive:true}); fs.writeFileSync(path.join(pkg,'package.json'),'{}');
+ }
+}
+`
+
+function fixture() {
+	const root = mkdtempSync(join(tmpdir(), "omob-refresh-"))
+	const omo = join(root, "upstream-omo"), senpi = join(root, "upstream-senpi")
+	const cache = join(root, "cache"), tools = join(root, "tools"), builds = join(root, "builds")
+	const env = { ...process.env, PATH: `${tools}:${process.env.PATH}`, OMOB_TEST_BUN: process.execPath, OMOB_TEST_BUILDER: builder, OMOB_TEST_BUILDS: builds,
+		GIT_CONFIG_COUNT: "5", GIT_CONFIG_KEY_0: "user.name", GIT_CONFIG_VALUE_0: "Test", GIT_CONFIG_KEY_1: "user.email", GIT_CONFIG_VALUE_1: "test@example.com",
+		GIT_CONFIG_KEY_2: `url.file://${omo}.insteadOf`, GIT_CONFIG_VALUE_2: canonical, GIT_CONFIG_KEY_3: "protocol.file.allow", GIT_CONFIG_VALUE_3: "always", GIT_CONFIG_KEY_4: `url.file://${senpi}.insteadOf`, GIT_CONFIG_VALUE_4: "https://github.com/code-yeongyu/senpi.git" }
+	const git = (cwd: string, args: string[]) => {
+		const result = spawnSync("git", args, { cwd, env, encoding: "utf8" })
+		if (result.status !== 0) throw new Error(result.stderr)
+		return result.stdout.trim()
+	}
+	for (const [repo, branch] of [[omo, "dev"], [senpi, "main"]]) {
+		mkdirSync(join(repo, "scripts"), { recursive: true })
+		mkdirSync(join(repo, "packages", "coding-agent"), { recursive: true })
+		writeFileSync(join(repo, "packages", "coding-agent", "package.json"), '{}')
+		writeFileSync(join(repo, "package-lock.json"), '{"packages":{}}')
+		writeFileSync(join(repo, "scripts", "prepare-senpi-bundled-workspaces.mjs"), "")
+		git(repo, ["init", "-q", "-b", branch])
+		git(repo, ["add", "."])
+		git(repo, ["commit", "-qm", "initial"])
+	}
+	mkdirSync(cache)
+	git(root, ["clone", "-q", canonical, join(cache, "omo")])
+	git(omo, ["switch", "-qc", "feature"])
+	writeFileSync(join(omo, "uncommitted"), "keep me")
+	mkdirSync(tools)
+	writeFileSync(join(tools, "bun"), compiler, { mode: 0o755 })
+	writeFileSync(builds, "")
+	const options = parseOmobArgs(["--cache-dir", cache, "--install-dir", join(root, "install")], process.platform, process.arch, root)
+	const args = [builder, "--if-changed", "--binary-only", "--cache-dir", cache, "--install-dir", join(cache, "bin")]
+	const run = (extraEnv = {}) => spawnSync(process.execPath, args, { env: { ...env, ...extraEnv }, encoding: "utf8", timeout: 30_000 })
+	const ordinary = () => spawnSync(process.execPath, [builder, "--cache-dir", cache, "--install-dir", options.installDir], { env, encoding: "utf8", timeout: 30_000 })
+	return { root, omo, senpi, cache, builds, env, options, git, run, ordinary, binary: join(cache, "bin", "omob") }
+}
+
+describe("omob refresh integration", () => {
+	test("#given an ordinary managed install #when ordinary install repeats #then auto-refresh remains installed", () => {
+		const f = fixture()
+		try {
+			const first = f.ordinary()
+			expect({ status: first.status, error: first.stderr }).toMatchObject({ status: 0 })
+			const repeated = f.ordinary()
+			expect({ status: repeated.status, error: repeated.stderr }).toMatchObject({ status: 0 })
+			expect(readFileSync(join(f.options.installDir, "omob"), "utf8").split("\n")[0]).toBe("#!/bin/sh")
+			expect(readFileSync(f.builds, "utf8")).toBe("compile\n")
+		} finally { rmSync(f.root, { recursive: true, force: true }) }
+	}, 60_000)
+
+	for (const scenario of ["same", "changed", "failure", "network", "feature", "locked"] as const) {
+		test(`#given an installed build #when ${scenario} refresh runs #then only the authoritative pair can launch`, () => {
+			const f = fixture()
+			try {
+				const first = f.run()
+				expect({ status: first.status, error: first.stderr }).toMatchObject({ status: 0 })
+				const previous = readFileSync(f.binary)
+				if (scenario === "changed" || scenario === "failure") {
+					writeFileSync(join(f.senpi, "new-commit"), "new")
+					f.git(f.senpi, ["add", "."])
+					f.git(f.senpi, ["commit", "-qm", "advance"])
+				}
+				if (scenario === "network") rmSync(f.senpi, { recursive: true, force: true })
+				if (scenario === "locked") writeFileSync(join(f.cache, ".lock"), `${process.pid}\n`)
+				installOmobLauncher(f.options)
+				const result = spawnSync(join(f.options.installDir, "omob"), ["a b", "", "--flag"], { encoding: "utf8", timeout: 30_000, env: { ...f.env, OMOB_TEST_FAIL: scenario === "failure" ? "1" : "0" } })
+				if (scenario === "failure" || scenario === "network" || scenario === "locked") {
+					expect(result.status).not.toBe(0)
+					expect(result.stdout).toBe("")
+					expect(readFileSync(f.binary)).toEqual(previous)
+				} else {
+					expect({ status: result.status, error: result.stderr }).toMatchObject({ status: 17 })
+					expect(JSON.parse(result.stdout)).toEqual(["a b", "", "--flag"])
+					expect(readFileSync(f.builds, "utf8")).toBe(scenario === "changed" ? "compile\ncompile\n" : "compile\n")
+					const version = spawnSync(f.binary, ["--version"], { encoding: "utf8" })
+					expect(version.stdout).toContain(f.git(f.senpi, ["rev-parse", "main"]))
+				}
+				expect(f.git(f.omo, ["branch", "--show-current"])).toBe("feature")
+				expect(readFileSync(join(f.omo, "uncommitted"), "utf8")).toBe("keep me")
+			} finally { rmSync(f.root, { recursive: true, force: true }) }
+		}, 60_000)
+	}
+})


### PR DESCRIPTION
## Summary

Ordinary `bun run omob` now installs a managed POSIX launcher rather than a bare executable that never updates again. Each launch checks canonical omo `origin/dev` and senpi `origin/main`, rebuilds before launch when either SHA changes, and otherwise takes a no-build path. A network/build failure stops launch without replacing the last good executable or calling it current.

## Changes

- Keep the builder in the managed cache and the executable at `<cache>/bin/omob`; the installed shell launcher contains no task-worktree dependency and finishes with `exec`.
- Read cache provenance from the executable's `--version`, not a potentially stale/spoofed sidecar. Unchanged SHAs avoid checkout, submodule synchronization, installation and compilation.
- Fix canonical remote-ref fetching and reject unexpected cache origins. Named feature builds get separate caches and cannot silently replace the managed mainline name.
- Reuse the existing exclusive cache lock, including serialized stale-owner reclamation and rejection of incompletely written claims. Concurrent updates fail fast instead of interleaving.
- Keep ordinary repeated installation managed; `--binary-only` is explicit and used internally. Document the POSIX launcher and retained Windows bare-binary path.

## QA and evidence

All test/build commands ran remotely through Bunshin on mengmotaMac, Bun 1.4.0. No local `bun test` or build was run.

Evidence ledger: `.omo/evidence/20260909-omob-mainline/README.md` in the task worktree (retained local artifacts, not committed secrets or generated binaries).

- Failing-first: `red.json` records assertion failures for missing startup support before production edits. `red-ordinary.json` records ordinary reinstall producing a bare executable and default launcher=false; `red-lock.json` records stealing an incomplete lock; `red-feature-cache.json` records named feature builds sharing the main cache. Each was captured before its fix.
- `bun test script/build-omob.test.ts script/omob-launcher.test.ts script/omob-refresh.test.ts script/build-omo-binary.test.ts && bun run typecheck:script`: **63 pass, 0 fail, 0 skip, 188 assertions**. Real built binary supplied to the existing size gate. `green-complete.json`.
- Final focused rerun after named-cache isolation: **35 pass, 0 fail, 113 assertions**, script typecheck passed. `green-feature-isolated.json`.
- Integration tests use real Git repositories, production fetch/selection/lock/install behavior and the installed shell launcher. Only dependency packaging/compilation is replaced at the subprocess boundary. Cases cover same-pair no compile, changed-pair compile-before-launch, failed build/network preserving old bytes without launching, concurrent-lock rejection, caller feature-checkout isolation, repeated ordinary install, args/status and final-exec SIGTERM fidelity.
- Real native build: **131,163,890 bytes**, **1,188 embedded sidecars**, successful build on canonical omo `1ee26636fa686f864b7ba752f236bb59ef8a241b` and senpi `096615afeb833c5aaff538c6d41f61aafc579e9f`. `build-mainline.json`.
- Real pre-merge launcher QA: ordinary install plus two launcher `--version` executions each visibly reported checking/current/no build needed and printed matching full dev/main provenance. `qa-real-premerge.json`. For this pre-merge QA only, the changed updater files were copied into the task-owned cache; the final installation will use merged cache source.
- LSP diagnostics: no diagnostics on all changed TypeScript files. `git diff --check` passed.

## Risks and residuals

The launcher needs Bun, Git and a POSIX shell; Windows retains the existing bare-binary installation behavior. Update serialization is fail-fast, not a waiting queue. The first expanded test run lacked generated skill payloads because the remote source transfer used `bun install --ignore-scripts`; restoring the real build's generated payloads resolved that environment failure without changing/skipping tests.

Post-merge canonical rebuild, mengmotaHost installation, event-driven xterm capture and remote cleanup are release acceptance tasks, not claimed complete by this pre-merge PR description. Self-review only as explicitly requested; no autonomous review panel.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes omob so a managed launch always checks the canonical mainline and rebuilds when the commit pair changes, instead of running a stale executable forever. The installed launcher refreshes via `--binary-only` before exec, and a failed refresh preserves the last good binary.

Behavior:
- Launcher reads provenance from the executable's `--version` output, not a sidecar, so a failed install can't masquerade as current.
- Named feature builds get their own cache (e.g., `~/.cache/omob-feature`) and cannot replace the managed mainline build.
- Concurrent updates fail fast instead of interleaving; an incomplete lock claim is never stolen.
- `--launcher` and `--binary-only` are explicit; Windows keeps bare-binary installation. The launcher requires Bun and Git on `PATH`.

<sup>Written for commit 7e429a8e663a718da9cd91298cfa0f6009ba019f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

