### PR TITLE
fix(omob): never prune a dev runtime a live process still executes

### DIFF
--- a/.omo/evidence/20260909-omob-prune-in-use/PLAN.md
+++ b/.omo/evidence/20260909-omob-prune-in-use/PLAN.md
@@ -1,0 +1,32 @@
+# omob: never prune a dev runtime that a live process is executing
+
+## Symptom
+Memorian gate in an omob session: `ENOENT ... /Users/yeongyu/.omo/binary-runtime/0.0.0-omob.749b777.eab8c4b/plugin/extensions/memorian-persona.md`.
+
+## Root cause
+`~/.local/bin/omob` (auto-update launcher) runs `build-omob.ts --if-changed --binary-only --keep 2` on every launch.
+When origin/dev or origin/main advanced, it rebuilt twice today (11:18, 11:23) and `pruneOmobRuntimes` deleted
+`0.0.0-omob.749b777.eab8c4b` while PIDs 84145 (since 09-08 23:37) and 54720 (since 09-09 01:17) were still executing
+`<that dir>/omo`. The compiled runtime reads persona assets lazily (`memory-core/src/recall/assets/assets.ts`
+`readFileSync(join(ASSETS_DIR, "memorian-persona.md"))`), so the first memorian judge after the prune hit ENOENT.
+Every other lazily-read asset (skills, personas, sidecars) has the same exposure.
+
+## Fix
+1. New `script/omob-runtime-prune.ts` (extracted: build-omob.ts is 413 pure LOC, over the ceiling):
+   - `PruneEntry`, `isOmobRuntimeDir`, `selectPruneEntries` moved unchanged.
+   - `planRuntimePrune(entries, keep, currentVersion, inUse)` excludes in-use runtimes before budgeting.
+   - `runtimesInUse(runtimeRoot, names, processCommands)`: a runtime is in use when any live process command
+     starts with `<runtimeRoot>/<name>/`.
+   - `listProcessCommands()`: `ps -axo command=` on POSIX, `Get-Process` paths on win32; typed
+     `ProcessListUnavailableError` when the listing fails.
+   - `pruneOmobRuntimes(keep, currentVersion)` moved; skips in-use dirs (logged) and skips pruning entirely when the
+     process list is unavailable (never delete blind).
+2. `build-omob.ts` imports `pruneOmobRuntimes` from the new module; prune tests move to `omob-runtime-prune.test.ts`.
+
+## Verification
+- RED: new tests fail before the module exists / before the inUse parameter exists.
+- GREEN: `bun test script/omob-runtime-prune.test.ts script/build-omob.test.ts` remotely (mengmotaMac or gorky).
+- Mutation: drop the inUse filter -> exclusion test fails while others pass.
+- Real surface: spawn a process from a fake `~/.omo/binary-runtime/0.0.0-omob.x.y/omo` under a temp HOME, run
+  `pruneOmobRuntimes` with keep=1 for a different current version -> the in-use dir survives, an idle one is deleted.
+- typecheck:script + biome on changed files.

--- a/.omo/evidence/20260909-omob-prune-in-use/QA.md
+++ b/.omo/evidence/20260909-omob-prune-in-use/QA.md
@@ -1,0 +1,37 @@
+# QA — omob runtime prune keeps in-use runtimes
+
+## What was tested
+1. Unit/contract: `bun test script/omob-runtime-prune.test.ts script/build-omob.test.ts` on mengmotaMac
+   (bun 1.4.0, detached worktree `/tmp/omob-prune-20260909` at 0d6ff537b + the 4 changed files, sha-verified
+   after pushTree, `bun install --frozen-lockfile` exit 0).
+2. Mutation: dropped `&& !inUse.has(entry.name)` from `planRuntimePrune` (grep confirmed 0 remaining
+   `inUse.has` in the mutant), re-ran the prune test file, restored the original (sha
+   38d6b713e1907bca5c7f927140b810c7e3540a92fcae209773c35d0d1a647960 matches local).
+3. Real surface (mengmotaHost, `bun /tmp/omob-live-qa.ts`, log in `live-process-qa.log`): temp runtime root with
+   two dev runtime dirs whose `omo` symlinks to the bun executable; a child is spawned from
+   `<root>/0.0.0-omob.live000.live000/omo` and its `ready` line awaited; then `pruneOmobRuntimes({keep:1,
+   currentVersion:<other>})` runs with the REAL `ps -axo command=` listing (no injected commands).
+4. `bun run typecheck:script` (tsgo) clean; `bunx biome check` on the 4 files exit 0.
+
+## What was observed
+1. GREEN: `26 pass / 0 fail / 57 expect()` across 2 files (`/tmp/omob-prune-green.log` on mengmotaMac).
+2. Mutant: `10 pass / 2 fail` — exactly the two tests that name the in-use guard failed
+   (`planRuntimePrune > never prunes a runtime a live process executes...`,
+   `pruneOmobRuntimes > deletes idle runtimes beyond the budget but keeps one a live process executes`); all
+   other tests still passed, so the failure is specific to the guard.
+3. Live: `pruned dev runtime 0.0.0-omob.idle000.idle000` + `kept in-use dev runtime 0.0.0-omob.live000.live000`;
+   `{"kept":["0.0.0-omob.live000.live000"],"liveExists":true,"idleExists":false}`.
+4. No type or lint findings.
+
+## Why it is enough
+The defect is "prune deletes a runtime a live process executes". The contract test locks the planner, the
+`runtimesInUse` tests lock whole-dir-name matching, the `listProcessCommands` test proves a live child shows
+up under its absolute exec path on this platform, and the live QA proves the composed function with the real
+process listing keeps the occupied dir while still retiring idle ones. The mutation shows the tests fail
+without the guard. `build-omob.ts` only changed its import and the call site; its remaining tests still pass.
+
+## What was omitted
+- Windows `Get-Process` path listing is implemented but not executed here (no Windows box in the compute pool);
+  the POSIX branch is the one every omob host uses today. Root `bun test` on the Windows CI lane runs the test
+  file, including the live-child `listProcessCommands` test.
+- No omob rebuild was run inside QA; the launcher path is exercised after merge (see summary).

--- a/.omo/evidence/20260909-omob-prune-in-use/ROOT-CAUSE.md
+++ b/.omo/evidence/20260909-omob-prune-in-use/ROOT-CAUSE.md
@@ -1,0 +1,28 @@
+# Root cause capture (mengmotaHost, 2026-09-09 11:3x KST)
+
+## Reported symptom
+```
+Memorian gate failed · session_create_failed
+ENOENT: no such file or directory, open '/Users/yeongyu/.omo/binary-runtime/0.0.0-omob.749b777.eab8c4b/plugin/extensions/memorian-persona.md'
+```
+
+## Observations
+- `ls ~/.omo/binary-runtime/` -> `0.0.0-omob.0d6ff53.096615a` (mtime 11:18) and `0.0.0-omob.0d6ff53.c7d812e` (mtime 11:23); NO `0.0.0-omob.749b777.eab8c4b`.
+- Both surviving omob runtimes DO carry `plugin/extensions/memorian-persona.md` (persona staging is correct).
+- `ps -axo pid,lstart,command | grep binary-runtime/0.0.0-omob`:
+  ```
+  84145 Tue Sep  8 23:37:11 2026  /Users/yeongyu/.omo/binary-runtime/0.0.0-omob.749b777.eab8c4b/omo
+  54720 Wed Sep  9 01:16:59 2026  /Users/yeongyu/.omo/binary-runtime/0.0.0-omob.749b777.eab8c4b/omo
+  ```
+  Two live sessions still execute from the deleted runtime dir.
+- `~/.local/bin/omob` is the auto-update launcher: it runs
+  `build-omob.ts --if-changed --binary-only ... --keep 2` on EVERY launch. Two upstream advances today
+  produced two rebuilds; each rebuild's `pruneOmobRuntimes(keep=2)` retired the oldest dev runtime by mtime,
+  which was the one the live sessions were running from.
+- `packages/memory-core/src/recall/assets/assets.ts` reads `memorian-persona.md` lazily
+  (`readFileSync(join(dirname(fileURLToPath(import.meta.url)), "memorian-persona.md"))`), so the first memorian
+  judge after the prune surfaced the ENOENT. Skills, other personas and sidecars are read the same way.
+
+## Conclusion
+Not a staging bug: the prune deleted a runtime that live processes still executed from. Fix = the prune must
+treat a runtime dir referenced by any live process command as in use and never delete it.

--- a/.omo/evidence/20260909-omob-prune-in-use/live-process-qa.log
+++ b/.omo/evidence/20260909-omob-prune-in-use/live-process-qa.log
@@ -1,0 +1,4 @@
+$ bun /tmp/omob-live-qa.ts (mengmotaHost, real ps listing, child spawned from <root>/0.0.0-omob.live000.live000/omo)
+pruned dev runtime 0.0.0-omob.idle000.idle000
+kept in-use dev runtime 0.0.0-omob.live000.live000
+{"kept":["0.0.0-omob.live000.live000"],"liveExists":true,"idleExists":false,"childPid":21850}

--- a/script/build-omob.test.ts
+++ b/script/build-omob.test.ts
@@ -12,8 +12,6 @@ import {
 	hostTargetFor,
 	packSoleSenpiTarball,
 	parseOmobArgs,
-	planRuntimePrune,
-	selectPruneEntries,
 } from "./build-omob"
 
 function tempDir(prefix: string): string {
@@ -73,58 +71,6 @@ describe("deriveOmobAiVersion", () => {
 		expect(deriveOmobAiVersion("c6e7dd7fb0f993336ed61c62acc5d55c6ada8bfc", "7fd18dfeec7a7db89a983b2c3cb90835b8c3c5f7")).toBe(
 			"0.0.0-omob.c6e7dd7.7fd18df",
 		)
-	})
-})
-
-describe("selectPruneEntries", () => {
-	const entries = [
-		{ name: "0.0.0-omob.aaaaaaa.bbbbbbb", mtimeMs: 3 },
-		{ name: "0.0.0-omob.ccccccc.ddddddd", mtimeMs: 1 },
-		{ name: "0.0.0-omob.eeeeeee.fffffff", mtimeMs: 2 },
-		{ name: "5.0.0-0.beta.39", mtimeMs: 0 },
-		{ name: "0.0.0-omob.1111111.2222222", mtimeMs: 5 },
-	]
-
-	test("keeps the newest dev runtimes and never touches release runtimes", () => {
-		expect(selectPruneEntries(entries, 2)).toEqual(["0.0.0-omob.ccccccc.ddddddd", "0.0.0-omob.eeeeeee.fffffff"])
-	})
-
-	test("keeps everything below the budget", () => {
-		expect(selectPruneEntries(entries, 3)).toEqual(["0.0.0-omob.ccccccc.ddddddd"])
-		expect(selectPruneEntries(entries, 4)).toEqual([])
-	})
-})
-
-describe("planRuntimePrune", () => {
-	const entries = [
-		{ name: "0.0.0-omob.cur0000.cur0000", mtimeMs: 5 },
-		{ name: "0.0.0-omob.aaaaaaa.bbbbbbb", mtimeMs: 3 },
-		{ name: "0.0.0-omob.ccccccc.ddddddd", mtimeMs: 1 },
-		{ name: "0.0.0-omob.eeeeeee.fffffff", mtimeMs: 2 },
-		{ name: "5.0.0-0.beta.40", mtimeMs: 0 },
-	]
-
-	test("reserves a slot for the version being built and prunes the rest oldest-first", () => {
-		expect(planRuntimePrune(entries, 2, "0.0.0-omob.cur0000.cur0000")).toEqual([
-			"0.0.0-omob.ccccccc.ddddddd",
-			"0.0.0-omob.eeeeeee.fffffff",
-		])
-	})
-
-	test("never counts the current version against the budget even when its dir is absent", () => {
-		const withoutCurrent = entries.filter((entry) => !entry.name.includes("cur0000"))
-		expect(planRuntimePrune(withoutCurrent, 2, "0.0.0-omob.cur0000.cur0000")).toEqual([
-			"0.0.0-omob.ccccccc.ddddddd",
-			"0.0.0-omob.eeeeeee.fffffff",
-		])
-	})
-
-	test("keep=1 leaves only the version being built", () => {
-		expect(planRuntimePrune(entries, 1, "0.0.0-omob.cur0000.cur0000")).toEqual([
-			"0.0.0-omob.ccccccc.ddddddd",
-			"0.0.0-omob.eeeeeee.fffffff",
-			"0.0.0-omob.aaaaaaa.bbbbbbb",
-		])
 	})
 })
 

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -12,6 +12,7 @@ import { dirname, join, resolve } from "node:path"
 import { versionLines, type OmoBuildInfo } from "../packages/omo-native/build-info"
 import { RELEASE_BINARY_TARGETS } from "./build-omo-binary"
 import { installOmobLauncher, isCurrentOmobBuild } from "./omob-launcher"
+import { pruneOmobRuntimes } from "./omob-runtime-prune"
 export { installOmobLauncher, isCurrentOmobBuild } from "./omob-launcher"
 
 export interface OmobOptions {
@@ -99,34 +100,6 @@ export function parseOmobArgs(argv: readonly string[], platform: string, arch: s
 
 export function deriveOmobAiVersion(omoCommit: string, senpiCommit: string): string {
 	return `0.0.0-omob.${omoCommit.slice(0, 7)}.${senpiCommit.slice(0, 7)}`
-}
-
-export interface PruneEntry {
-	readonly name: string
-	readonly mtimeMs: number
-}
-
-const OMOB_RUNTIME_PREFIX = "0.0.0-omob."
-
-export function isOmobRuntimeDir(name: string): boolean {
-	return name.startsWith(OMOB_RUNTIME_PREFIX)
-}
-
-/**
- * Prune plan for a build about to provision `currentVersion`: that version owns one
- * of the `keep` slots (whether or not its dir exists yet), so only `keep - 1` OTHER
- * dev runtimes survive. Release runtimes are never touched.
- */
-export function planRuntimePrune(entries: readonly PruneEntry[], keep: number, currentVersion: string): string[] {
-	const others = entries.filter((entry) => entry.name !== currentVersion)
-	return selectPruneEntries(others, Math.max(0, keep - 1))
-}
-
-/** Names of dev runtime dirs to delete: omob dirs beyond the newest `keep`. Release runtimes are never touched. */
-export function selectPruneEntries(entries: readonly PruneEntry[], keep: number): string[] {
-	const omob = entries.filter((entry) => isOmobRuntimeDir(entry.name))
-	const sorted = omob.slice().sort((left, right) => right.mtimeMs - left.mtimeMs)
-	return sorted.slice(Math.max(0, keep)).reverse().map((entry) => entry.name)
 }
 
 function run(command: string, args: readonly string[], cwd: string, env: NodeJS.ProcessEnv = process.env): void {
@@ -358,19 +331,6 @@ function swapSenpi(omoDir: string, builtSenpiRoot: string): void {
 	run("bun", [join("packages", "omo-native", "bin", "senpi-patch.mjs")], omoDir, { ...process.env, OMO_SENPI_PATCH_ROOT: target })
 }
 
-function pruneOmobRuntimes(keep: number, currentVersion: string): void {
-	const runtimeRoot = join(homedir(), ".omo", "binary-runtime")
-	if (!existsSync(runtimeRoot)) return
-	const entries: PruneEntry[] = readdirSync(runtimeRoot).map((name) => {
-		const stats = statSync(join(runtimeRoot, name))
-		return { name, mtimeMs: stats.mtimeMs }
-	})
-	for (const name of planRuntimePrune(entries, keep, currentVersion)) {
-		rmSync(join(runtimeRoot, name), { recursive: true, force: true })
-		console.log(`pruned dev runtime ${name}`)
-	}
-}
-
 function installBinary(binaryPath: string, installDir: string, name: string): string {
 	mkdirSync(installDir, { recursive: true })
 	const destination = join(installDir, name)
@@ -465,7 +425,7 @@ async function runBuild(options: OmobOptions): Promise<number> {
 	}
 	// Pruning is only safe once the new binary is in place: a --skip-install run would
 	// otherwise delete the runtime a still-installed (possibly running) omob depends on.
-	if (!options.skipInstall) pruneOmobRuntimes(options.keep, omoAiVersion)
+	if (!options.skipInstall) pruneOmobRuntimes({ runtimeRoot: join(homedir(), ".omo", "binary-runtime"), keep: options.keep, currentVersion: omoAiVersion })
 	// versionLines is the single formatter for provenance output; --version, doctor, the
 	// startup banner and this summary must never drift apart.
 	console.log(versionLines(buildInfo).join("\n"))

--- a/script/omob-runtime-prune.test.ts
+++ b/script/omob-runtime-prune.test.ts
@@ -1,0 +1,138 @@
+// Contract tests for script/omob-runtime-prune.ts.
+
+import { describe, expect, test } from "bun:test"
+import { spawn } from "node:child_process"
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, sep } from "node:path"
+import { listProcessCommands, planRuntimePrune, pruneOmobRuntimes, runtimesInUse, selectPruneEntries } from "./omob-runtime-prune"
+
+describe("selectPruneEntries", () => {
+	const entries = [
+		{ name: "0.0.0-omob.aaaaaaa.bbbbbbb", mtimeMs: 3 },
+		{ name: "0.0.0-omob.ccccccc.ddddddd", mtimeMs: 1 },
+		{ name: "0.0.0-omob.eeeeeee.fffffff", mtimeMs: 2 },
+		{ name: "5.0.0-0.beta.39", mtimeMs: 0 },
+		{ name: "0.0.0-omob.1111111.2222222", mtimeMs: 5 },
+	]
+
+	test("keeps the newest dev runtimes and never touches release runtimes", () => {
+		expect(selectPruneEntries(entries, 2)).toEqual(["0.0.0-omob.ccccccc.ddddddd", "0.0.0-omob.eeeeeee.fffffff"])
+	})
+
+	test("keeps everything below the budget", () => {
+		expect(selectPruneEntries(entries, 3)).toEqual(["0.0.0-omob.ccccccc.ddddddd"])
+		expect(selectPruneEntries(entries, 4)).toEqual([])
+	})
+})
+
+describe("planRuntimePrune", () => {
+	const entries = [
+		{ name: "0.0.0-omob.cur0000.cur0000", mtimeMs: 5 },
+		{ name: "0.0.0-omob.aaaaaaa.bbbbbbb", mtimeMs: 3 },
+		{ name: "0.0.0-omob.ccccccc.ddddddd", mtimeMs: 1 },
+		{ name: "0.0.0-omob.eeeeeee.fffffff", mtimeMs: 2 },
+		{ name: "5.0.0-0.beta.40", mtimeMs: 0 },
+	]
+	const current = "0.0.0-omob.cur0000.cur0000"
+
+	test("reserves a slot for the version being built and prunes the rest oldest-first", () => {
+		expect(planRuntimePrune(entries, 2, current)).toEqual(["0.0.0-omob.ccccccc.ddddddd", "0.0.0-omob.eeeeeee.fffffff"])
+	})
+
+	test("never counts the current version against the budget even when its dir is absent", () => {
+		const withoutCurrent = entries.filter((entry) => !entry.name.includes("cur0000"))
+		expect(planRuntimePrune(withoutCurrent, 2, current)).toEqual(["0.0.0-omob.ccccccc.ddddddd", "0.0.0-omob.eeeeeee.fffffff"])
+	})
+
+	test("keep=1 leaves only the version being built", () => {
+		expect(planRuntimePrune(entries, 1, current)).toEqual([
+			"0.0.0-omob.ccccccc.ddddddd",
+			"0.0.0-omob.eeeeeee.fffffff",
+			"0.0.0-omob.aaaaaaa.bbbbbbb",
+		])
+	})
+
+	test("never prunes a runtime a live process executes, without charging it to the budget", () => {
+		const inUse = new Set(["0.0.0-omob.ccccccc.ddddddd"])
+		expect(planRuntimePrune(entries, 2, current, inUse)).toEqual(["0.0.0-omob.eeeeeee.fffffff"])
+		expect(planRuntimePrune(entries, 1, current, inUse)).toEqual(["0.0.0-omob.eeeeeee.fffffff", "0.0.0-omob.aaaaaaa.bbbbbbb"])
+	})
+})
+
+describe("runtimesInUse", () => {
+	const runtimeRoot = join(sep, "home", "dev", ".omo", "binary-runtime")
+	const names = ["0.0.0-omob.aaaaaaa.bbbbbbb", "0.0.0-omob.aaaaaaa.bbbbbbb2", "0.0.0-omob.ccccccc.ddddddd", "5.0.0-beta.40"]
+
+	test("marks a runtime in use when a process command starts with its provisioned executable", () => {
+		const commands = [
+			`${join(runtimeRoot, "0.0.0-omob.aaaaaaa.bbbbbbb", "omo")}`,
+			`${join(runtimeRoot, "5.0.0-beta.40", "omo")} --resume abc`,
+			"/usr/bin/ps -axo command=",
+		]
+		expect([...runtimesInUse(runtimeRoot, names, commands)].sort()).toEqual(["0.0.0-omob.aaaaaaa.bbbbbbb", "5.0.0-beta.40"])
+	})
+
+	test("matches whole directory names, not string prefixes", () => {
+		const commands = [`${join(runtimeRoot, "0.0.0-omob.aaaaaaa.bbbbbbb2", "omo")}`]
+		expect([...runtimesInUse(runtimeRoot, names, commands)]).toEqual(["0.0.0-omob.aaaaaaa.bbbbbbb2"])
+	})
+
+	test("reports nothing when no process runs from the runtime root", () => {
+		expect(runtimesInUse(runtimeRoot, names, ["/usr/bin/ps", join(sep, "elsewhere", "omo")]).size).toBe(0)
+	})
+})
+
+describe("listProcessCommands", () => {
+	test("includes a live child spawned by absolute executable path", async () => {
+		const child = spawn(process.execPath, ["-e", "console.log('ready'); setTimeout(() => {}, 30_000)"], { stdio: ["ignore", "pipe", "ignore"] })
+		try {
+			await new Promise<void>((resolve, reject) => {
+				child.stdout.once("data", () => resolve())
+				child.once("error", reject)
+				child.once("exit", (code) => reject(new Error(`child exited early with ${code}`)))
+			})
+			const commands = listProcessCommands()
+			expect(commands.some((command) => command.startsWith(process.execPath))).toBe(true)
+		} finally {
+			child.kill()
+		}
+	})
+})
+
+describe("pruneOmobRuntimes", () => {
+	function runtimeFixture(): { readonly root: string; readonly dir: (name: string) => string } {
+		const root = mkdtempSync(join(tmpdir(), "omob-prune-"))
+		const dir = (name: string): string => join(root, name)
+		for (const [name, mtimeMs] of [
+			["0.0.0-omob.old0000.old0000", 1],
+			["0.0.0-omob.mid0000.mid0000", 2],
+			["0.0.0-omob.new0000.new0000", 3],
+			["5.0.0-beta.40", 0],
+		] as const) {
+			mkdirSync(dir(name), { recursive: true })
+			writeFileSync(join(dir(name), "omo"), "#!/bin/sh\n")
+			utimesSync(dir(name), mtimeMs, mtimeMs)
+		}
+		return { root, dir }
+	}
+
+	test("deletes idle runtimes beyond the budget but keeps one a live process executes", () => {
+		const { root, dir } = runtimeFixture()
+		try {
+			const processCommands = [`${join(dir("0.0.0-omob.old0000.old0000"), "omo")} --resume x`]
+			const kept = pruneOmobRuntimes({ runtimeRoot: root, keep: 1, currentVersion: "0.0.0-omob.cur0000.cur0000", processCommands })
+			expect(existsSync(dir("0.0.0-omob.old0000.old0000"))).toBe(true)
+			expect(existsSync(dir("0.0.0-omob.mid0000.mid0000"))).toBe(false)
+			expect(existsSync(dir("0.0.0-omob.new0000.new0000"))).toBe(false)
+			expect(existsSync(dir("5.0.0-beta.40"))).toBe(true)
+			expect(kept).toEqual(["0.0.0-omob.old0000.old0000"])
+		} finally {
+			rmSync(root, { recursive: true, force: true })
+		}
+	})
+
+	test("is a no-op when the runtime root does not exist", () => {
+		expect(pruneOmobRuntimes({ runtimeRoot: join(tmpdir(), "omob-prune-missing-" + process.pid), keep: 1, currentVersion: "x", processCommands: [] })).toEqual([])
+	})
+})

--- a/script/omob-runtime-prune.ts
+++ b/script/omob-runtime-prune.ts
@@ -1,0 +1,110 @@
+// script/omob-runtime-prune.ts
+// Retires old omob dev runtimes under ~/.omo/binary-runtime. A compiled omob re-execs from its
+// provisioned runtime dir and reads plugin assets (skills, personas, sidecars) lazily, so a
+// runtime that any live process still executes from must survive every prune.
+
+import { spawnSync } from "node:child_process"
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs"
+import { join, sep } from "node:path"
+
+export interface PruneEntry {
+	readonly name: string
+	readonly mtimeMs: number
+}
+
+const OMOB_RUNTIME_PREFIX = "0.0.0-omob."
+
+export function isOmobRuntimeDir(name: string): boolean {
+	return name.startsWith(OMOB_RUNTIME_PREFIX)
+}
+
+/**
+ * Prune plan for a build about to provision `currentVersion`: that version owns one of the
+ * `keep` slots (whether or not its dir exists yet), so only `keep - 1` OTHER idle dev runtimes
+ * survive. In-use runtimes are neither deleted nor charged to the budget. Release runtimes are
+ * never touched.
+ */
+export function planRuntimePrune(entries: readonly PruneEntry[], keep: number, currentVersion: string, inUse: ReadonlySet<string> = new Set()): string[] {
+	const idle = entries.filter((entry) => entry.name !== currentVersion && !inUse.has(entry.name))
+	return selectPruneEntries(idle, Math.max(0, keep - 1))
+}
+
+/** Names of dev runtime dirs to delete: omob dirs beyond the newest `keep`. Release runtimes are never touched. */
+export function selectPruneEntries(entries: readonly PruneEntry[], keep: number): string[] {
+	const omob = entries.filter((entry) => isOmobRuntimeDir(entry.name))
+	const sorted = omob.slice().sort((left, right) => right.mtimeMs - left.mtimeMs)
+	return sorted.slice(Math.max(0, keep)).reverse().map((entry) => entry.name)
+}
+
+/** Runtime dir names whose provisioned executable is the image of a live process. */
+export function runtimesInUse(runtimeRoot: string, names: readonly string[], processCommands: readonly string[]): ReadonlySet<string> {
+	const inUse = new Set<string>()
+	for (const name of names) {
+		const executablePrefix = join(runtimeRoot, name) + sep
+		if (processCommands.some((command) => command.startsWith(executablePrefix))) inUse.add(name)
+	}
+	return inUse
+}
+
+export class ProcessListUnavailableError extends Error {
+	constructor(
+		readonly command: string,
+		readonly reason: string,
+	) {
+		super(`process list unavailable via ${command}: ${reason}`)
+		this.name = "ProcessListUnavailableError"
+	}
+}
+
+/** Command line of every live process, executable path first. */
+export function listProcessCommands(platform: NodeJS.Platform = process.platform): readonly string[] {
+	const command = platform === "win32" ? "powershell" : "ps"
+	const args = platform === "win32" ? ["-NoProfile", "-Command", "Get-Process | ForEach-Object { $_.Path }"] : ["-axo", "command="]
+	const result = spawnSync(command, args, { encoding: "utf8" })
+	if (result.error !== undefined) throw new ProcessListUnavailableError(command, result.error.message)
+	if (result.status !== 0) throw new ProcessListUnavailableError(command, `exit ${result.status ?? result.signal ?? "unknown"}`)
+	return result.stdout
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+}
+
+export interface PruneRequest {
+	readonly runtimeRoot: string
+	readonly keep: number
+	readonly currentVersion: string
+	readonly processCommands?: readonly string[]
+}
+
+/**
+ * Deletes idle dev runtimes beyond the budget and returns the in-use dev runtimes it kept.
+ * When the process list cannot be read, nothing is deleted: pruning blind is how a running
+ * session loses its plugin assets.
+ */
+export function pruneOmobRuntimes(request: PruneRequest): string[] {
+	if (!existsSync(request.runtimeRoot)) return []
+	const entries: PruneEntry[] = readdirSync(request.runtimeRoot).map((name) => ({
+		name,
+		mtimeMs: statSync(join(request.runtimeRoot, name)).mtimeMs,
+	}))
+	let processCommands: readonly string[]
+	try {
+		processCommands = request.processCommands ?? listProcessCommands()
+	} catch (error) {
+		if (!(error instanceof ProcessListUnavailableError)) throw error
+		console.warn(`skipped dev runtime prune: ${error.message}`)
+		return []
+	}
+	const inUse = runtimesInUse(
+		request.runtimeRoot,
+		entries.map((entry) => entry.name),
+		processCommands,
+	)
+	for (const name of planRuntimePrune(entries, request.keep, request.currentVersion, inUse)) {
+		rmSync(join(request.runtimeRoot, name), { recursive: true, force: true })
+		console.log(`pruned dev runtime ${name}`)
+	}
+	const kept = [...inUse].filter(isOmobRuntimeDir).sort()
+	for (const name of kept) console.log(`kept in-use dev runtime ${name}`)
+	return kept
+}


### PR DESCRIPTION
## What
`build-omob.ts` pruned dev runtimes under `~/.omo/binary-runtime` purely by mtime (`--keep 2`). The omob auto-update launcher rebuilds on every launch once `origin/dev`/`origin/main` move, so two upstream advances in one morning retired `0.0.0-omob.749b777.eab8c4b` while two live sessions (started 09-08 23:37 and 09-09 01:17) were still executing `<that dir>/omo`. The compiled runtime reads plugin assets lazily, so the next memorian judge failed:

```
Memorian gate failed · session_create_failed
ENOENT: no such file or directory, open '~/.omo/binary-runtime/0.0.0-omob.749b777.eab8c4b/plugin/extensions/memorian-persona.md'
```

## Why / how
- Extracted the prune unit into `script/omob-runtime-prune.ts` (`build-omob.ts` was already 413 pure LOC; net -44 lines there).
- `runtimesInUse(runtimeRoot, names, processCommands)`: a runtime dir is in use when any live process command starts with `<runtimeRoot>/<name>/`. `listProcessCommands()` = `ps -axo command=` (POSIX) / `Get-Process` paths (win32), typed `ProcessListUnavailableError` on failure.
- `planRuntimePrune(..., inUse)` neither deletes an in-use runtime nor charges it to the keep budget; release runtimes remain untouched. If the process list cannot be read, nothing is pruned (never prune blind).
- `pruneOmobRuntimes` now takes a typed `PruneRequest` (runtime root injected) and returns the in-use runtimes it kept, logging `kept in-use dev runtime <name>`.

## Observed behavior / QA (evidence: `.omo/evidence/20260909-omob-prune-in-use/`)
- `bun test script/omob-runtime-prune.test.ts script/build-omob.test.ts` on mengmotaMac (bun 1.4.0, fresh detached worktree at 0d6ff537b + these files, sha-verified): **26 pass / 0 fail / 57 expect()**.
- Mutation: removing `&& !inUse.has(entry.name)` -> **exactly the 2 guard tests fail, 10 still pass**; original restored (sha verified).
- Live surface (mengmotaHost): child spawned from `<tmp>/0.0.0-omob.live000.live000/omo`, real `ps` listing, `keep: 1` for a different current version -> idle dir pruned, occupied dir kept (`live-process-qa.log`).
- `bun run typecheck:script` clean; `biome check` on the 4 files exit 0.

## Residual risk
- Windows `Get-Process` branch is implemented but only exercised by the Windows CI lane (the live-child `listProcessCommands` test runs there too); every omob host today is POSIX.
- In-use runtimes are retired on a later build once their processes exit, so disk use can grow while old sessions stay alive — intended.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the omob runtime prune from deleting dev runtimes that live processes still execute from. Pruning by mtime alone previously removed a runtime dir out from under running sessions, so the next memorian judge failed with an ENOENT on a lazily-read plugin asset.

- Moves prune logic into `script/omob-runtime-prune.ts` and trims `build-omob.ts` under its size ceiling.
- Marks a runtime in use when a live process command starts with `<runtimeRoot>/<name>/`, detected via `ps` on POSIX and `Get-Process` paths on Windows.
- In-use runtimes are neither deleted nor charged against the keep budget.
- Skips pruning entirely when the process list cannot be read.
- Retires in-use runtimes on later builds once their processes exit, so disk usage can grow while old sessions stay alive.
- The Windows process listing is implemented but only exercised by the Windows CI lane; every omob host today is POSIX.

<sup>Written for commit 5f12a02c27efa0d7aa4c2e3ae8454acb2149ba8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/7994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

