### PR TITLE
test(script): fix omob Windows CI portability

### DIFF
--- a/.omo/evidence/20260909-omob-windows-tests/posix-test.log
+++ b/.omo/evidence/20260909-omob-windows-tests/posix-test.log
@@ -1,0 +1,104 @@
+bun test v1.4.0 (34cbb9a40)
+
+script/omob-refresh.test.ts:
+[test-setup] vendored lsp-daemon dist missing; building once via `npm ci && npm run build`...
+npm warn install-scripts 1 package has install scripts not yet covered by allowScripts:
+npm warn install-scripts   fsevents@2.3.3 (install: (install scripts present))
+npm warn install-scripts
+npm warn install-scripts Run `npm install-scripts ls` to review, or `npm install-scripts approve <pkg>` to allow.
+(pass) omob refresh integration > #given an ordinary managed install #when ordinary install repeats #then auto-refresh remains installed [3699.51ms]
+(pass) omob refresh integration > #given an installed build #when same refresh runs #then only the authoritative pair can launch [4051.26ms]
+(pass) omob refresh integration > #given an installed build #when changed refresh runs #then only the authoritative pair can launch [5037.19ms]
+(pass) omob refresh integration > #given an installed build #when failure refresh runs #then only the authoritative pair can launch [33375.11ms]
+(pass) omob refresh integration > #given an installed build #when network refresh runs #then only the authoritative pair can launch [13504.10ms]
+(pass) omob refresh integration > #given an installed build #when feature refresh runs #then only the authoritative pair can launch [9815.63ms]
+(pass) omob refresh integration > #given an installed build #when locked refresh runs #then only the authoritative pair can launch [8542.71ms]
+
+script/omob-launcher.test.ts:
+(pass) omob mainline launcher > #given ordinary installation #when defaults are parsed #then the managed launcher is retained [0.40ms]
+(pass) omob mainline launcher > #given mainline refresh flags #when parsed #then startup refresh is supported [0.18ms]
+(pass) omob mainline launcher > #given explicit feature refs #when building directly #then only explicit launcher installation rejects them [0.16ms]
+(pass) omob mainline launcher > #given an incompletely written cache claim #when another updater starts #then it cannot steal the lock [1.60ms]
+(pass) omob mainline launcher > #given a same SHA pair #when cache is checked #then rebuild is false [350.13ms]
+(pass) omob mainline launcher > #given a changed SHA pair #when cache is checked #then rebuild is true [276.63ms]
+(pass) omob mainline launcher > #given a signaled executable #when launched #then the launcher preserves the signal [734.24ms]
+(pass) omob mainline launcher > #given successful refresh #when launched #then args and exit status reach the refreshed executable [1282.78ms]
+(pass) omob mainline launcher > #given failed refresh #when launched #then the previous binary survives without launching [672.39ms]
+
+script/build-omob.test.ts:
+(pass) parseOmobArgs > defaults to the latest tracked refs and the host target [0.57ms]
+(pass) parseOmobArgs > accepts ref overrides and keep counts [0.47ms]
+(pass) parseOmobArgs > rejects unknown flags [0.26ms]
+(pass) parseOmobArgs > maps host platforms onto release targets [0.18ms]
+(pass) deriveOmobAiVersion > embeds both short shas in the dev version [0.20ms]
+(pass) acquireCacheLock > #given a free cache #when the lock is taken #then it records this pid and releases [7.58ms]
+(pass) acquireCacheLock > #given a live holder #when a second build starts #then it fails fast naming the holder and lock [8.00ms]
+(pass) acquireCacheLock > #given a lock left by a dead process #when a build starts #then the stale lock is reclaimed [29.48ms]
+(pass) acquireCacheLock > #given a released lock #when release is called again #then it stays a no-op [5.55ms]
+(pass) packSoleSenpiTarball > #given a decoy tarball from a previous version #when packing #then the decoy is gone and the fresh one is returned [4.40ms]
+(pass) packSoleSenpiTarball > #given a pack that produces nothing #when packing #then it throws [24.17ms]
+(pass) packSoleSenpiTarball > #given a pack that produces two tarballs #when packing #then it throws naming both [16.70ms]
+(pass) packSoleSenpiTarball > #given non-tarball residue #when packing #then only .tgz files are considered [8.98ms]
+Cloning into '/var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/omob-submodule-XVjhVd/cache/omo'...
+Submodule 'upstreams/skill' (file:///var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/omob-submodule-XVjhVd/sub.git) registered for path 'upstreams/skill'
+Cloning into '/private/var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/omob-submodule-XVjhVd/cache/omo/upstreams/skill'...
+Submodule path 'upstreams/skill': checked out '9b88a460334eb2b875419c2c88625e87e5115248'
+Note: switching to 'origin/dev'.
+
+You are in 'detached HEAD' state. You can look around, make experimental
+changes and commit them, and you can discard any commits you make in this
+state without impacting any branches by switching back to a branch.
+
+If you want to create a new branch to retain commits you create, you may
+do so (now or later) by using -c with the switch command. Example:
+
+  git switch -c <new-branch-name>
+
+Or undo this operation with:
+
+  git switch -
+
+Turn off this advice by setting config variable advice.detachedHead to false
+
+HEAD is now at 15d9408 bump submodule to v2
+HEAD is now at 15d9408 bump submodule to v2
+Submodule path 'upstreams/skill': checked out '9b88a460334eb2b875419c2c88625e87e5115248'
+Previous HEAD position was 15d9408 bump submodule to v2
+HEAD is now at 9261138 pin submodule at v1
+HEAD is now at 9261138 pin submodule at v1
+From file:///var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/omob-submodule-XVjhVd/sub
+ * branch            7b6421b2536976a30748709f77ac112a074a1a77 -> FETCH_HEAD
+Submodule path 'upstreams/skill': checked out '7b6421b2536976a30748709f77ac112a074a1a77'
+Previous HEAD position was 9261138 pin submodule at v1
+HEAD is now at 15d9408 bump submodule to v2
+HEAD is now at 15d9408 bump submodule to v2
+Submodule path 'upstreams/skill': checked out '9b88a460334eb2b875419c2c88625e87e5115248'
+Previous HEAD position was 15d9408 bump submodule to v2
+HEAD is now at 9261138 pin submodule at v1
+HEAD is now at 9261138 pin submodule at v1
+From file:///var/folders/nj/hqfr8ndn5q56cqw7jqgbrck40000gn/T/omob-submodule-XVjhVd/sub
+ * branch            7b6421b2536976a30748709f77ac112a074a1a77 -> FETCH_HEAD
+Submodule path 'upstreams/skill': checked out '7b6421b2536976a30748709f77ac112a074a1a77'
+(pass) ensureCacheClone submodule ordering > #given a ref whose submodule pointer moved #when the cache checks it out #then submodule content matches that ref [14075.73ms]
+
+script/omob-runtime-prune.test.ts:
+(pass) selectPruneEntries > keeps the newest dev runtimes and never touches release runtimes [0.31ms]
+(pass) selectPruneEntries > keeps everything below the budget [0.16ms]
+(pass) planRuntimePrune > reserves a slot for the version being built and prunes the rest oldest-first [0.15ms]
+(pass) planRuntimePrune > never counts the current version against the budget even when its dir is absent [6.46ms]
+(pass) planRuntimePrune > keep=1 leaves only the version being built [0.32ms]
+(pass) planRuntimePrune > never prunes a runtime a live process executes, without charging it to the budget [0.14ms]
+(pass) runtimesInUse > marks a runtime in use when a process command starts with its provisioned executable [0.23ms]
+(pass) runtimesInUse > matches whole directory names, not string prefixes [0.11ms]
+(pass) runtimesInUse > reports nothing when no process runs from the runtime root [0.11ms]
+(pass) listProcessCommands > includes a live child spawned by absolute executable path [915.66ms]
+pruned dev runtime 0.0.0-omob.mid0000.mid0000
+pruned dev runtime 0.0.0-omob.new0000.new0000
+kept in-use dev runtime 0.0.0-omob.old0000.old0000
+(pass) pruneOmobRuntimes > deletes idle runtimes beyond the budget but keeps one a live process executes [56.54ms]
+(pass) pruneOmobRuntimes > is a no-op when the runtime root does not exist [6.35ms]
+
+ 42 pass
+ 0 fail
+ 125 expect() calls
+Ran 42 tests across 4 files. [103.03s]

--- a/.omo/evidence/20260909-omob-windows-tests/qa.md
+++ b/.omo/evidence/20260909-omob-windows-tests/qa.md
@@ -1,0 +1,22 @@
+# Omob Windows test portability QA
+
+## Root cause and scope
+PR #7991 intentionally resolves cache/install paths and installs a POSIX auto-update launcher only on supported hosts. Dev run https://github.com/code-yeongyu/oh-my-openagent/actions/runs/34302507008 failed 13 Windows shard-2 tests because their path expectations omitted Windows drive resolution and their executable fixtures assumed POSIX shebang/signal support.
+
+Only test code changes: resolved default/feature path expectations; explicit Windows gates for five shell-backed launcher cases and the seven-case POSIX refresh integration suite. Parsing, host targeting, locks, tarball selection, version derivation, submodule ordering and runtime-prune coverage remain enabled on Windows. The prune child fixture now uses a subscribed stdin/stdout handshake and bounded exit cleanup instead of a 30-second lifetime that could expire during process enumeration.
+
+Production builder, launcher and prune behavior are unchanged. Existing docs already distinguish Windows bare-binary installs from macOS/Linux POSIX launchers, so no user documentation or adapter bundle regeneration is needed.
+
+## Pre-commit observations
+- `bun install --frozen-lockfile --ignore-scripts`: exit 0, 595 packages installed; lockfile unchanged.
+- `bun run typecheck:script`: exit 0, no compiler diagnostics, including all four omob test files.
+- Language-server diagnostics were requested for all four changed files. The existing language-server session reports unresolved Node built-ins/process globals despite the successful configured Bun-typed compiler check; these environment diagnostics were not suppressed or repaired by changing project configuration.
+- Real builder CLI smoke via Bun/spawnSync: invalid flag rejected with exit 1 and the expected argument error before any cache/build side effect.
+- `git diff --check`: exit 0.
+- Bunshin round trip to mengmotaMac: Darwin arm64, Bun 1.4.0; the task's remote directory did not exist before use.
+
+## Remaining gates at initial push
+The user's required order is push, remote checkout/regression, then PR full-matrix CI. Remote test counts and run URL will be recorded after those gates execute. No local `bun test` was run. Windows cannot be proven by the local host; no simulated-platform result is presented as Windows execution.
+
+## Coverage and omissions
+This is test portability, not a shipped runtime change. The remote integration invokes the real parser, git/cache state, builder CLI and installed POSIX launcher; its existing compiler/package boundary fixture avoids building the full engine. Full repository build, adapter compatibility, typechecks and actual Windows execution are CI gates. No live model/harness session is needed for an unchanged adapter. No credentials, environment dumps, or secret-bearing logs are included.

--- a/.omo/evidence/20260909-omob-windows-tests/qa.md
+++ b/.omo/evidence/20260909-omob-windows-tests/qa.md
@@ -15,8 +15,17 @@ Production builder, launcher and prune behavior are unchanged. Existing docs alr
 - `git diff --check`: exit 0.
 - Bunshin round trip to mengmotaMac: Darwin arm64, Bun 1.4.0; the task's remote directory did not exist before use.
 
-## Remaining gates at initial push
-The user's required order is push, remote checkout/regression, then PR full-matrix CI. Remote test counts and run URL will be recorded after those gates execute. No local `bun test` was run. Windows cannot be proven by the local host; no simulated-platform result is presented as Windows execution.
+## Remote POSIX regression
+Machine: mengmotaMac via bunshin, Darwin arm64, Bun 1.4.0. Fresh branch clone at b92d0f09f55067226d0de28577fca941c47227ac; dependencies installed with `bun install --frozen-lockfile --ignore-scripts`.
+
+Command: `bun test script/build-omob.test.ts script/omob-launcher.test.ts script/omob-refresh.test.ts script/omob-runtime-prune.test.ts`
+
+Observed in one execution: **42 pass, 0 fail, 125 expect() calls, 4 files, 103.03 seconds**, exit 0. This includes real git submodule transitions, ordinary repeated installation, same/changed SHA refresh, compile/network/lock failure handling, feature-checkout preservation, argv/exit/signal propagation and live-process enumeration. Exact captured test output is in `posix-test.log`.
+
+Remote cleanup used `rm -rf /tmp/omob-win-fix-20260909` followed by `test ! -e /tmp/omob-win-fix-20260909`; exit 0, receipt: `REMOVED /tmp/omob-win-fix-20260909 on mengmotaMac`.
+
+## CI gate
+PR https://github.com/code-yeongyu/oh-my-openagent/pull/7996 targets dev and carries `ci:full-matrix`. Full-matrix CI is pending at this evidence commit; final run URL and per-job conclusions will be recorded in the PR's Verification section after completion. No local `bun test` was run. Windows cannot be proven by the local host; no simulated-platform result is presented as Windows execution.
 
 ## Coverage and omissions
 This is test portability, not a shipped runtime change. The remote integration invokes the real parser, git/cache state, builder CLI and installed POSIX launcher; its existing compiler/package boundary fixture avoids building the full engine. Full repository build, adapter compatibility, typechecks and actual Windows execution are CI gates. No live model/harness session is needed for an unchanged adapter. No credentials, environment dumps, or secret-bearing logs are included.

--- a/script/build-omob.test.ts
+++ b/script/build-omob.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 import {
 	acquireCacheLock,
 	deriveOmobAiVersion,
@@ -32,8 +32,8 @@ describe("parseOmobArgs", () => {
 		expect(parsed.name).toBe("omob")
 		expect(parsed.keep).toBe(2)
 		expect(parsed.target).toBe("darwin-arm64")
-		expect(parsed.installDir).toBe(join("/home/dev", ".local", "bin"))
-		expect(parsed.cacheDir).toBe(join("/home/dev", ".cache", "omob"))
+		expect(parsed.installDir).toBe(resolve(join("/home/dev", ".local", "bin")))
+		expect(parsed.cacheDir).toBe(resolve(join("/home/dev", ".cache", "omob")))
 		expect(parsed.skipFetch).toBe(false)
 		expect(parsed.skipInstall).toBe(false)
 	})

--- a/script/omob-launcher.test.ts
+++ b/script/omob-launcher.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 import * as builder from "./build-omob"
 
 describe("omob mainline launcher", () => {
@@ -18,7 +18,7 @@ describe("omob mainline launcher", () => {
 		const args = ["--omo-ref", "origin/feature", "--senpi-ref", "origin/experiment"]
 		const feature = builder.parseOmobArgs([...args, "--name", "omob-feature"], "darwin", "arm64", "/home/dev")
 		expect(feature.omoRef).toBe("origin/feature")
-		expect(feature.cacheDir).toBe("/home/dev/.cache/omob-feature")
+		expect(feature.cacheDir).toBe(resolve(join("/home/dev", ".cache", "omob-feature")))
 		expect(() => builder.parseOmobArgs(args, "darwin", "arm64", "/home/dev")).toThrow()
 		expect(() => builder.parseOmobArgs([...args, "--launcher"], "darwin", "arm64", "/home/dev")).toThrow()
 		expect(builder.parseOmobArgs([], "darwin", "arm64", "/home/dev").omoRef).toBe("origin/dev")
@@ -33,7 +33,8 @@ describe("omob mainline launcher", () => {
 	})
 
 	for (const changed of [false, true]) {
-		test(`#given a ${changed ? "changed" : "same"} SHA pair #when cache is checked #then rebuild is ${changed}`, () => {
+		// The launcher is a POSIX shell script, disabled by default on win32 by parseOmobArgs.
+		test.skipIf(process.platform === "win32")(`#given a ${changed ? "changed" : "same"} SHA pair #when cache is checked #then rebuild is ${changed}`, () => {
 			const root = mkdtempSync(join(tmpdir(), "omob-pair-"))
 			try {
 				const current = builder.isCurrentOmobBuild
@@ -50,7 +51,8 @@ describe("omob mainline launcher", () => {
 		})
 	}
 
-	test("#given a signaled executable #when launched #then the launcher preserves the signal", () => {
+	// The launcher is a POSIX shell script, disabled by default on win32 by parseOmobArgs.
+	test.skipIf(process.platform === "win32")("#given a signaled executable #when launched #then the launcher preserves the signal", () => {
 		const root = mkdtempSync(join(tmpdir(), "omob-signal-"))
 		try {
 			const options = builder.parseOmobArgs(["--cache-dir", join(root, "cache"), "--install-dir", join(root, "bin")], "darwin", "arm64", root)
@@ -67,7 +69,8 @@ describe("omob mainline launcher", () => {
 	})
 
 	for (const fail of [false, true]) {
-		test(`#given ${fail ? "failed" : "successful"} refresh #when launched #then ${fail ? "the previous binary survives without launching" : "args and exit status reach the refreshed executable"}`, () => {
+		// The launcher is a POSIX shell script, disabled by default on win32 by parseOmobArgs.
+		test.skipIf(process.platform === "win32")(`#given ${fail ? "failed" : "successful"} refresh #when launched #then ${fail ? "the previous binary survives without launching" : "args and exit status reach the refreshed executable"}`, () => {
 			const root = mkdtempSync(join(tmpdir(), "omob-launcher-"))
 			try {
 				const install = builder.installOmobLauncher

--- a/script/omob-refresh.test.ts
+++ b/script/omob-refresh.test.ts
@@ -72,7 +72,8 @@ function fixture() {
 	return { root, omo, senpi, cache, builds, env, options, git, run, ordinary, binary: join(cache, "bin", "omob") }
 }
 
-describe("omob refresh integration", () => {
+// The launcher is a POSIX shell script, disabled by default on win32 by parseOmobArgs.
+describe.skipIf(process.platform === "win32")("omob refresh integration", () => {
 	test("#given an ordinary managed install #when ordinary install repeats #then auto-refresh remains installed", () => {
 		const f = fixture()
 		try {

--- a/script/omob-runtime-prune.test.ts
+++ b/script/omob-runtime-prune.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test"
 import { spawn } from "node:child_process"
+import { once } from "node:events"
 import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join, sep } from "node:path"
@@ -85,17 +86,17 @@ describe("runtimesInUse", () => {
 
 describe("listProcessCommands", () => {
 	test("includes a live child spawned by absolute executable path", async () => {
-		const child = spawn(process.execPath, ["-e", "console.log('ready'); setTimeout(() => {}, 30_000)"], { stdio: ["ignore", "pipe", "ignore"] })
+		const child = spawn(process.execPath, ["-e", "process.stdin.once('data', () => console.log('ready')); process.stdin.resume()"], { stdio: ["pipe", "pipe", "ignore"] })
 		try {
-			await new Promise<void>((resolve, reject) => {
-				child.stdout.once("data", () => resolve())
-				child.once("error", reject)
-				child.once("exit", (code) => reject(new Error(`child exited early with ${code}`)))
-			})
+			const ready = once(child.stdout, "data", { signal: AbortSignal.timeout(5_000) })
+			child.stdin.write("start\n")
+			await ready
 			const commands = listProcessCommands()
 			expect(commands.some((command) => command.startsWith(process.execPath))).toBe(true)
 		} finally {
+			const exited = once(child, "exit", { signal: AbortSignal.timeout(5_000) })
 			child.kill()
+			await exited
 		}
 	})
 })


### PR DESCRIPTION
## Summary
Fix Windows omob test portability without changing the builder or launcher behavior. Keep platform-neutral coverage enabled on Windows and explicitly limit shell-backed fixtures to supported hosts.

## Root cause
PR #7991 intentionally resolves cache/install directories and uses a POSIX shell auto-update launcher on macOS/Linux. Dev CI run [34302507008](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/34302507008) reported 13 failures in Windows shard 2: two non-host-correct path assertions and POSIX executable/launcher fixtures that Windows cannot execute. The ordinary PR fast path did not execute Windows steps without `ci:full-matrix`.

## Changes
- Compare default and feature cache/install paths with host `resolve(join(...))` semantics.
- Gate only the five shell-backed SHA-pair/signal/refresh launcher cases and the seven-case refresh integration suite on Windows, with explicit POSIX explanations.
- Keep argument parsing, host targets, cache locks, tarball packing, version derivation, submodule ordering and runtime-prune tests enabled on Windows.
- Keep the prune process fixture alive through a stdin/stdout handshake, rather than a fixed lifetime, and await cleanup with a bounded timeout.
- Record scoped QA under `.omo/evidence/20260909-omob-windows-tests/`, as required by AGENTS.md.

## Verification
- `bun run typecheck:script`: passed.
- Real builder CLI invalid-argument smoke: passed, exit 1 before cache/build work.
- `git diff --check`: passed.
- Remote POSIX regression on **mengmotaMac**, Darwin arm64, Bun 1.4.0: `bun test script/build-omob.test.ts script/omob-launcher.test.ts script/omob-refresh.test.ts script/omob-runtime-prune.test.ts` passed once: **42 pass, 0 fail, 125 expect() calls, 4 files, 103.03 seconds**. Tested code commit: `b92d0f09f55067226d0de28577fca941c47227ac`; the subsequent commit adds QA evidence only.
- Remote directory cleanup: `rm -rf /tmp/omob-win-fix-20260909` followed by `test ! -e /tmp/omob-win-fix-20260909`, exit 0. Receipt: `REMOVED /tmp/omob-win-fix-20260909 on mengmotaMac`.
- Full-matrix [CI run 34305060026](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/34305060026), attempt 1, head `97e7d15719f1c6d5fbd5c1c6991e6d1faa101c71`: **completed, success**. `ci:full-matrix` is present and the Windows test steps actually executed. Run-level audit: **20 jobs, 18 success, 2 expected push-only skips, 0 non-completed jobs, 0 failures**.
- Windows shard 2 logs confirm all four platform-neutral launcher cases, host-resolved parsing and live process enumeration passed; exactly the 12 shell-backed omob cases were skipped. Root remainder: 5717 pass, 0 fail; serial quarantine: 94 pass, 0 fail.
- Also inspected completed dev run [34304421158](https://github.com/code-yeongyu/oh-my-openagent/actions/runs/34304421158) at `73f0ddd14`: the same 13 omob failures only, no additional prune or unrelated failing jobs. Prune child-lifetime hardening removes a timing risk rather than claiming a reproduced Windows prune defect.
- No local `bun test` execution; no production code changes. Configured script typecheck passed; local language-server module-resolution diagnostics are documented in the QA evidence rather than suppressed.

| CI job | Conclusion |
| --- | --- |
| test (windows-latest, 1/2) | success |
| test (windows-latest, 2/2) | success |
| test (ubuntu-latest, 1/2) | success |
| test (ubuntu-latest, 2/2) | success |
| test (macos-latest, 1/2) | success |
| test (macos-latest, 2/2) | success |
| senpi-compatibility (windows-latest) | success |
| senpi-compatibility (ubuntu-latest) | success |
| senpi-compatibility (macos-latest) | success |
| codex-compatibility (windows-latest, platform) | success |
| codex-compatibility (ubuntu-latest, full) | success |
| codex-compatibility (macos-latest, platform) | success |
| typecheck | success |
| build | success |
| ci-mode | success |
| block-master-pr | success |
| lazycodex-published-smoke | success |
| omo-ai-payload-check | success |
| draft-release | skipped (push-only) |
| auto-commit-schema | skipped (push-only) |
