### PR TITLE
fix(background-agent): keep a task while a synchronous continuation is attached

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -267,6 +267,7 @@ export class BackgroundManager {
   private queuesByKey: Map<string, QueueItem[]> = new Map()
   private processingKeys: Set<string> = new Set()
   private completionTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+  private readonly syncAttachedSessions = new Set<string>()
   private completedTaskArchive: Map<string, BackgroundTask> = new Map()
   private completedTaskSummaries: Map<string, BackgroundTaskNotificationTask[]> = new Map()
   private idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
@@ -1167,6 +1168,22 @@ The fallback retry session is now created and can be inspected directly.
       }
     }
     return undefined
+  }
+
+  /**
+   * Marks a session as being polled by a run_in_background=false continuation so the
+   * completion cleanup timer neither drops the task nor deletes the session underneath it.
+   * The returned detach restarts the cleanup grace window once the waiter leaves.
+   */
+  attachSyncContinuation(sessionID: string): () => void {
+    this.syncAttachedSessions.add(sessionID)
+    return () => {
+      if (!this.syncAttachedSessions.delete(sessionID)) return
+      const task = this.findBySession(sessionID)
+      if (!task || !TERMINAL_BACKGROUND_TASK_STATUSES.has(task.status)) return
+      if (this.completionTimers.has(task.id)) return
+      this.scheduleTaskRemoval(task.id)
+    }
   }
 
   private resolveTaskAttemptBySession(sessionID: string): { task: BackgroundTask; attemptID?: string; isCurrent: boolean } | undefined {
@@ -2341,6 +2358,9 @@ The task was re-queued on a fallback model after a retryable failure.
       const task = this.tasks.get(taskId)
       if (!task) return
 
+      // A sync waiter is still polling this session; its detach re-arms removal.
+      if (task.sessionId && this.syncAttachedSessions.has(task.sessionId)) return
+
       if (task.parentSessionId) {
         const siblings = this.getTasksByParentSession(task.parentSessionId)
         const runningOrPendingSiblings = siblings.filter(
@@ -3185,6 +3205,7 @@ The task was re-queued on a fallback model after a retryable failure.
       clearTimeout(timer)
     }
     this.completionTimers.clear()
+    this.syncAttachedSessions.clear()
 
     for (const timer of this.idleDeferralTimers.values()) {
       clearTimeout(timer)

--- a/packages/omo-opencode/src/features/background-agent/task-removal-sync-attach.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/task-removal-sync-attach.test.ts
@@ -1,0 +1,231 @@
+import { tmpdir } from "node:os"
+import { afterEach, describe, expect, test } from "bun:test"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { TASK_CLEANUP_DELAY_MS } from "./constants"
+import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
+
+type FakeTimers = {
+  getDelay: (timer: ReturnType<typeof setTimeout>) => number | undefined
+  run: (timer: ReturnType<typeof setTimeout>) => Promise<void>
+  restore: () => void
+}
+
+let managerUnderTest: BackgroundManager | undefined
+let fakeTimers: FakeTimers | undefined
+
+afterEach(() => {
+  managerUnderTest?.shutdown()
+  fakeTimers?.restore()
+  managerUnderTest = undefined
+  fakeTimers = undefined
+})
+
+function createManager(): { manager: BackgroundManager; deleteCalls: string[] } {
+  const deleteCalls: string[] = []
+  const client = {
+    session: {
+      messages: async () => [],
+      status: async () => ({ data: {} }),
+      prompt: async () => ({}),
+      promptAsync: async () => ({}),
+      abort: async () => ({}),
+      delete: async (input: { path: { id: string } }) => {
+        deleteCalls.push(input.path.id)
+        return {}
+      },
+    },
+  }
+  const ctx: PluginInput = {
+    client: client as unknown as PluginInput["client"],
+    project: {} as PluginInput["project"],
+    directory: tmpdir(),
+    worktree: tmpdir(),
+    serverUrl: new URL("http://localhost"),
+    $: {} as PluginInput["$"],
+  }
+
+  const manager = new BackgroundManager({ pluginContext: ctx, config: undefined, enableParentSessionNotifications: false })
+  return { manager, deleteCalls }
+}
+
+function createCompletedTask(id: string, sessionId: string): BackgroundTask {
+  return {
+    id,
+    sessionId,
+    parentSessionId: "parent-1",
+    parentMessageId: "parent-message-id",
+    description: id,
+    prompt: `Prompt for ${id}`,
+    agent: "test-agent",
+    status: "completed",
+    startedAt: new Date("2026-03-11T00:00:00.000Z"),
+    completedAt: new Date("2026-03-11T00:01:00.000Z"),
+  }
+}
+
+function installFakeTimers(): FakeTimers {
+  const originalSetTimeout = globalThis.setTimeout
+  const originalClearTimeout = globalThis.clearTimeout
+  const callbacks = new Map<ReturnType<typeof setTimeout>, () => void | Promise<void>>()
+  const delays = new Map<ReturnType<typeof setTimeout>, number>()
+
+  globalThis.setTimeout = ((handler: Parameters<typeof setTimeout>[0], delay?: number, ...args: unknown[]): ReturnType<typeof setTimeout> => {
+    if (typeof handler !== "function") {
+      throw new Error("Expected function timeout handler")
+    }
+
+    const timer = originalSetTimeout(() => {}, 60_000)
+    originalClearTimeout(timer)
+    const callback = handler as (...callbackArgs: Array<unknown>) => void
+    callbacks.set(timer, () => callback(...args))
+    delays.set(timer, Math.max(0, delay ?? 0))
+    return timer
+  }) as typeof setTimeout
+
+  globalThis.clearTimeout = ((timer: ReturnType<typeof setTimeout>): void => {
+    callbacks.delete(timer)
+    delays.delete(timer)
+  }) as typeof clearTimeout
+
+  return {
+    getDelay(timer) {
+      return delays.get(timer)
+    },
+    async run(timer) {
+      const callback = callbacks.get(timer)
+      if (!callback) {
+        throw new Error(`Timer not found: ${String(timer)}`)
+      }
+
+      callbacks.delete(timer)
+      delays.delete(timer)
+      await callback()
+      for (let i = 0; i < 5; i += 1) {
+        await Promise.resolve()
+      }
+    },
+    restore() {
+      globalThis.setTimeout = originalSetTimeout
+      globalThis.clearTimeout = originalClearTimeout
+    },
+  }
+}
+
+function getTasks(manager: BackgroundManager): Map<string, BackgroundTask> {
+  return Reflect.get(manager, "tasks") as Map<string, BackgroundTask>
+}
+
+function getCompletionTimers(manager: BackgroundManager): Map<string, ReturnType<typeof setTimeout>> {
+  return Reflect.get(manager, "completionTimers") as Map<string, ReturnType<typeof setTimeout>>
+}
+
+function scheduleTaskRemovalForTest(manager: BackgroundManager, taskID: string): void {
+  const scheduleTaskRemoval = Reflect.get(manager, "scheduleTaskRemoval") as (taskId: string) => void
+  scheduleTaskRemoval.call(manager, taskID)
+}
+
+function getRequiredTimer(manager: BackgroundManager, taskID: string): ReturnType<typeof setTimeout> {
+  const timer = getCompletionTimers(manager).get(taskID)
+  expect(timer).toBeDefined()
+  if (timer === undefined) {
+    throw new Error(`Missing completion timer for ${taskID}`)
+  }
+
+  return timer
+}
+
+describe("BackgroundManager.scheduleTaskRemoval with an attached sync continuation", () => {
+  describe("#given a completed task whose cleanup timer is armed", () => {
+    test("#when a sync continuation is attached and the timer fires #then the task is kept and the session is not deleted", async () => {
+      // given
+      const { manager, deleteCalls } = createManager()
+      managerUnderTest = manager
+      fakeTimers = installFakeTimers()
+      const task = createCompletedTask("task-a", "ses_child")
+      getTasks(manager).set(task.id, task)
+      scheduleTaskRemovalForTest(manager, task.id)
+      const cleanupTimer = getRequiredTimer(manager, task.id)
+      expect(fakeTimers.getDelay(cleanupTimer)).toBe(TASK_CLEANUP_DELAY_MS)
+
+      // when
+      manager.attachSyncContinuation("ses_child")
+      await fakeTimers.run(cleanupTimer)
+
+      // then
+      expect(getTasks(manager).has(task.id)).toBe(true)
+      expect(manager.findBySession("ses_child")).toBe(task)
+      expect(deleteCalls).toEqual([])
+    })
+
+    test("#when the sync continuation detaches #then a fresh cleanup timer is armed and firing it removes the task and deletes the session once", async () => {
+      // given
+      const { manager, deleteCalls } = createManager()
+      managerUnderTest = manager
+      fakeTimers = installFakeTimers()
+      const task = createCompletedTask("task-a", "ses_child")
+      getTasks(manager).set(task.id, task)
+      scheduleTaskRemovalForTest(manager, task.id)
+      const detach = manager.attachSyncContinuation("ses_child")
+      await fakeTimers.run(getRequiredTimer(manager, task.id))
+      expect(getCompletionTimers(manager).has(task.id)).toBe(false)
+
+      // when
+      detach()
+
+      // then
+      const rearmedTimer = getRequiredTimer(manager, task.id)
+      expect(fakeTimers.getDelay(rearmedTimer)).toBe(TASK_CLEANUP_DELAY_MS)
+
+      // when
+      await fakeTimers.run(rearmedTimer)
+
+      // then
+      expect(getTasks(manager).has(task.id)).toBe(false)
+      expect(manager.findBySession("ses_child")).toBeUndefined()
+      expect(deleteCalls).toEqual(["ses_child"])
+    })
+
+    test("#when the sync continuation detaches before the timer fires #then the pending timer is left alone", async () => {
+      // given
+      const { manager, deleteCalls } = createManager()
+      managerUnderTest = manager
+      fakeTimers = installFakeTimers()
+      const task = createCompletedTask("task-a", "ses_child")
+      getTasks(manager).set(task.id, task)
+      scheduleTaskRemovalForTest(manager, task.id)
+      const originalTimer = getRequiredTimer(manager, task.id)
+
+      // when
+      const detach = manager.attachSyncContinuation("ses_child")
+      detach()
+
+      // then
+      expect(getCompletionTimers(manager).get(task.id)).toBe(originalTimer)
+
+      // when
+      await fakeTimers.run(originalTimer)
+
+      // then
+      expect(getTasks(manager).has(task.id)).toBe(false)
+      expect(deleteCalls).toEqual(["ses_child"])
+    })
+  })
+
+  describe("#given a session that is not tracked as a background task", () => {
+    test("#when a sync continuation attaches and detaches #then no cleanup timer is created", () => {
+      // given
+      const { manager, deleteCalls } = createManager()
+      managerUnderTest = manager
+      fakeTimers = installFakeTimers()
+
+      // when
+      const detach = manager.attachSyncContinuation("ses_sync_only")
+      detach()
+
+      // then
+      expect(getCompletionTimers(manager).size).toBe(0)
+      expect(deleteCalls).toEqual([])
+    })
+  })
+})

--- a/packages/omo-opencode/src/tools/delegate-task/sync-continuation.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-continuation.test.ts
@@ -1073,4 +1073,224 @@ describe("executeSyncContinuation - toast cleanup error paths", () => {
       ...TEAM_TOOL_DENIALS,
     })
   })
+
+  test("attaches the session to the background manager for the poll window and detaches after handback", async () => {
+    //#given - a background manager that tracks sync continuation attachment
+    const attachCalls: string[] = []
+    let detachCalls = 0
+    let attachedDuringPoll = false
+    const mockManager = {
+      attachSyncContinuation: (sessionID: string) => {
+        attachCalls.push(sessionID)
+        return () => {
+          detachCalls += 1
+        }
+      },
+    }
+    const mockClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+            {
+              info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn" },
+              parts: [{ type: "text", text: "Response" }],
+            },
+          ],
+        }),
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+        status: async () => ({
+          data: { ses_test: { type: "idle" } },
+        }),
+      },
+    }
+
+    const { executeSyncContinuation } = require("./sync-continuation")
+
+    const deps = {
+      pollSyncSession: async () => {
+        attachedDuringPoll = attachCalls.length === 1 && detachCalls === 0
+        return null
+      },
+      fetchSyncResult: async () => ({ ok: true as const, textContent: "Result" }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-123",
+      metadata: () => {},
+    }
+
+    const mockExecutorCtx = {
+      client: mockClient,
+      manager: mockManager,
+    }
+
+    const args = {
+      task_id: "ses_test_12345678",
+      prompt: "test prompt",
+      description: "test task",
+      load_skills: [],
+      run_in_background: false,
+    }
+
+    //#when
+    const result = await executeSyncContinuation(args, mockCtx, mockExecutorCtx, { sessionID: "parent-session", messageID: "parent-message" }, deps)
+
+    //#then - the manager must not delete the session while the poll is in flight
+    expect(result).toContain("Task continued and completed")
+    expect(attachCalls).toEqual(["ses_test_12345678"])
+    expect(attachedDuringPoll).toBe(true)
+    expect(detachCalls).toBe(1)
+  })
+
+  test("detaches from the background manager when pollSyncSession throws", async () => {
+    //#given
+    const attachCalls: string[] = []
+    let detachCalls = 0
+    const mockManager = {
+      attachSyncContinuation: (sessionID: string) => {
+        attachCalls.push(sessionID)
+        return () => {
+          detachCalls += 1
+        }
+      },
+    }
+    const mockClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+            {
+              info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn" },
+              parts: [{ type: "text", text: "Response" }],
+            },
+          ],
+        }),
+        prompt: async () => ({}),
+        promptAsync: async () => ({}),
+        status: async () => ({
+          data: { ses_test: { type: "idle" } },
+        }),
+      },
+    }
+
+    const { executeSyncContinuation } = require("./sync-continuation")
+
+    const deps = {
+      pollSyncSession: async () => {
+        throw new Error("Poll error")
+      },
+      fetchSyncResult: async () => ({ ok: true as const, textContent: "Result" }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-123",
+      metadata: () => {},
+    }
+
+    const mockExecutorCtx = {
+      client: mockClient,
+      manager: mockManager,
+    }
+
+    const args = {
+      task_id: "ses_test_12345678",
+      prompt: "test prompt",
+      description: "test task",
+      load_skills: [],
+      run_in_background: false,
+    }
+
+    //#when
+    let error: unknown = null
+    try {
+      await executeSyncContinuation(args, mockCtx, mockExecutorCtx, { sessionID: "parent-session", messageID: "parent-message" }, deps)
+    } catch (e) {
+      error = e
+    }
+
+    //#then
+    expect((error as Error).message).toBe("Poll error")
+    expect(attachCalls).toEqual(["ses_test_12345678"])
+    expect(detachCalls).toBe(1)
+  })
+
+  test("detaches from the background manager when the continuation prompt fails", async () => {
+    //#given
+    const attachCalls: string[] = []
+    let detachCalls = 0
+    const mockManager = {
+      attachSyncContinuation: (sessionID: string) => {
+        attachCalls.push(sessionID)
+        return () => {
+          detachCalls += 1
+        }
+      },
+    }
+    const mockClient = {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { id: "msg_001", role: "user", time: { created: 1000 } } },
+            {
+              info: { id: "msg_002", role: "assistant", time: { created: 2000 }, finish: "end_turn" },
+              parts: [{ type: "text", text: "Response" }],
+            },
+          ],
+        }),
+        prompt: async () => {
+          throw new Error("Session not found")
+        },
+        promptAsync: async () => {
+          throw new Error("Session not found")
+        },
+        status: async () => ({
+          data: { ses_test: { type: "idle" } },
+        }),
+      },
+    }
+
+    const { executeSyncContinuation } = require("./sync-continuation")
+
+    let pollCalled = false
+    const deps = {
+      pollSyncSession: async () => {
+        pollCalled = true
+        return null
+      },
+      fetchSyncResult: async () => ({ ok: true as const, textContent: "Result" }),
+    }
+
+    const mockCtx = {
+      sessionID: "parent-session",
+      callID: "call-123",
+      metadata: () => {},
+    }
+
+    const mockExecutorCtx = {
+      client: mockClient,
+      manager: mockManager,
+    }
+
+    const args = {
+      task_id: "ses_test_12345678",
+      prompt: "test prompt",
+      description: "test task",
+      load_skills: [],
+      run_in_background: false,
+    }
+
+    //#when
+    const result = await executeSyncContinuation(args, mockCtx, mockExecutorCtx, { sessionID: "parent-session", messageID: "parent-message" }, deps)
+
+    //#then
+    expect(result).toContain("Failed to send continuation prompt")
+    expect(pollCalled).toBe(false)
+    expect(attachCalls).toEqual(["ses_test_12345678"])
+    expect(detachCalls).toBe(1)
+  })
 })

--- a/packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts
@@ -109,6 +109,7 @@ export async function executeSyncContinuation(
     throw new Error("task_id is required to continue a sync task")
   }
   cancelSyncSessionDeletion(continuationID)
+  const detachFromManager = executorCtx.manager?.attachSyncContinuation?.(continuationID)
   const taskId = `resume_sync_${continuationID.slice(0, 8)}`
   const startTime = new Date()
 
@@ -189,6 +190,7 @@ export async function executeSyncContinuation(
        toastManager.removeTask(taskId)
      }
      const errorMessage = promptError instanceof Error ? promptError.message : String(promptError)
+     detachFromManager?.()
      scheduleSyncSessionDeletion(client, continuationID)
      return `Failed to send continuation prompt: ${errorMessage}\n\nTask ID: ${continuationID}`
    }
@@ -269,6 +271,7 @@ ${buildTaskMetadataBlock({
      }
      // Every terminal continuation path must restore the cleanup grace timer,
      // including prompt/poll failures after revival cancelled the old timer.
+     detachFromManager?.()
      scheduleSyncSessionDeletion(client, continuationID)
    }
 }


### PR DESCRIPTION
## Summary

Fixes #7929. A background task that finished and was later continued with `run_in_background=false` had two deletion timers on one child session that did not know about each other. `BackgroundManager.scheduleTaskRemoval` (10 minutes after completion) fired in the middle of the synchronous poll, dropped the task from `tasks` and called `session.delete`; the sync poller then 404-looped until its inactivity deadline, and a later `run_in_background=true` resume failed with `Task not found for session`. Only `resume()` disarmed the manager's timer; the sync continuation path never did, it only re-armed its own `pendingDeletionTimers`.

## Changes

`packages/omo-opencode/src/features/background-agent/manager.ts`
- `attachSyncContinuation(sessionID)` registers a session as being polled by a synchronous waiter. The removal timer callback returns early for attached sessions. The returned detach removes the registration and, if the task is still terminal with no live cleanup timer, re-arms `scheduleTaskRemoval`, so the 10-minute grace window restarts once the waiter leaves instead of being skipped. The set is cleared on shutdown.

`packages/omo-opencode/src/tools/delegate-task/sync-continuation.ts`
- `executeSyncContinuation` attaches on entry and detaches on every terminal path (prompt-failure return and the final `finally`). Optional-chained, so callers without a manager keep today's behaviour.

No leak is introduced: detach is unconditional in `finally`, and the poll itself is bounded by the parent abort signal and the poller's 30-minute inactivity deadline.

## Test plan

- [x] New `task-removal-sync-attach.test.ts` (fake timers, mocked client): an attached session survives the removal timer with no `session.delete`; detach re-arms a `TASK_CLEANUP_DELAY_MS` timer that then removes the task and deletes the session exactly once; detach before the timer fires leaves the pending timer alone; an untracked session creates no timer.
- [x] `sync-continuation.test.ts`: attach is called with the continuation session id at entry and detach runs on success, on a `pollSyncSession` throw, and on prompt failure.
- [x] RED on unpatched `dev`: 7 fail (`manager.attachSyncContinuation is not a function`, attach never called); GREEN after: 23 pass in the two files.
- [x] `bun test packages/omo-opencode/src/features/background-agent packages/omo-opencode/src/tools/delegate-task`: 1262 pass, 0 fail.
- [x] `bun run --cwd packages/omo-opencode typecheck` (tsgo): clean. Senpi extension bundles unchanged after a rebuild.

## Not covered

The poller's 404 loop and `pruneStaleTasksAndNotifications` (30 minutes after original completion, when other tasks are running) do not consult the attach set; both are pre-existing and left as follow-ups.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where a completed background task resumed with `run_in_background=false` could be dropped by the manager's 10-minute cleanup timer mid-poll, causing a 404 loop and "Task not found" errors on later resumes. The sync continuation now registers its session with the background manager for the poll window so cleanup waits, and restarts the cleanup timer when the waiter leaves.

- `BackgroundManager.attachSyncContinuation` marks a session as being polled synchronously; the removal timer skips attached sessions, and detaching re-arms the 10-minute removal window.
- `executeSyncContinuation` attaches on entry and detaches on every terminal path, so callers without a manager keep existing behavior.

<sup>Written for commit 2bc89b6320e43a973915e4f640134e0d6a947568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

