### PR TITLE
fix(lsp-daemon): clean a dead owner whose socket identity drifted after reboot

### DIFF
--- a/packages/lsp-daemon/src/ownership.ts
+++ b/packages/lsp-daemon/src/ownership.ts
@@ -141,9 +141,9 @@ async function validateExistingOwner(
 		}
 		if (ping) continue;
 		if (isProcessAlive(owner.pid)) throw new DaemonStartupDeferredError("owner_pid_live_unreachable");
+		// Compare the two file reads only: a live socket stat drifts across reboots (st_dev, tmpfs) while the pid is dead.
 		const reread = readDaemonOwner(paths);
-		const endpoint = endpointIdentity(owner.endpoint.path);
-		if (!reread || reread.nonce !== owner.nonce || !sameEndpoint(endpoint, owner.endpoint)) {
+		if (!reread || !sameOwner(reread, owner)) {
 			throw new DaemonStartupDeferredError("owner_changed_during_cleanup");
 		}
 		cleanupDeadOwner(paths, owner);

--- a/packages/lsp-daemon/test/auth-ownership.test.ts
+++ b/packages/lsp-daemon/test/auth-ownership.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import {
 	chmodSync,
 	existsSync,
@@ -21,7 +22,7 @@ import { callToolViaDaemon } from "../src/daemon-client.js";
 import { DaemonAlreadyRunningError, DaemonStartupDeferredError, startDaemonServer } from "../src/daemon-server.js";
 import { probeDaemon } from "../src/ensure-daemon.js";
 import { ensurePrivateDirectory } from "../src/ipc-protocol.js";
-import { readDaemonOwner, removeDaemonMetadataForOwner } from "../src/ownership.js";
+import { acquireStartupLease, readDaemonOwner, removeDaemonMetadataForOwner } from "../src/ownership.js";
 import { type DaemonPaths, daemonPaths, OMO_LSP_DAEMON_DIR } from "../src/paths.js";
 import { createLineDecoder, encodeJsonLine } from "../src/socket-jsonrpc.js";
 import { daemonTestPaths } from "./daemon-path-fixture.js";
@@ -69,6 +70,42 @@ function existingContext(root: string) {
 		installDecisionsPath: join(cwd, "install-decisions.json"),
 		capabilities: { installDecisionTool: true },
 	};
+}
+
+const DEAD_PID = 9_999_999;
+
+function writeDeadOwner(paths: DaemonPaths, endpoint: Record<string, unknown>): void {
+	mkdirSync(paths.dir, { recursive: true });
+	writeFileSync(paths.auth, "old-token", { mode: 0o600 });
+	writeFileSync(paths.owner, JSON.stringify({ pid: DEAD_PID, nonce: "dead", startedAt: "old", endpoint }), {
+		mode: 0o600,
+	});
+	writeFileSync(paths.pid, `${DEAD_PID}\n`, { mode: 0o600 });
+	writeFileSync(paths.endpoint, paths.socket, { mode: 0o600 });
+}
+
+// Leaves a real unix socket file behind the way a SIGKILLed daemon does: node
+// unlinks the path on a graceful close, so the listener must die uncleanly.
+async function leaveOrphanSocket(socketPath: string): Promise<void> {
+	mkdirSync(dirname(socketPath), { recursive: true });
+	const child = spawn(
+		process.execPath,
+		[
+			"-e",
+			"require('node:net').createServer().listen(process.argv[1], () => process.stdout.write('ready'))",
+			socketPath,
+		],
+		{ stdio: ["ignore", "pipe", "inherit"] },
+	);
+	await new Promise<void>((resolve, reject) => {
+		child.stdout.once("data", () => resolve());
+		child.once("error", reject);
+		child.once("exit", (code) => reject(new Error(`orphan socket child exited early with ${code}`)));
+	});
+	await new Promise<void>((resolve) => {
+		child.once("exit", () => resolve());
+		child.kill("SIGKILL");
+	});
 }
 
 function rawRequest(paths: DaemonPaths, token: string): Promise<Record<string, unknown>> {
@@ -267,6 +304,60 @@ describe("daemon IPC authentication and ownership", () => {
 
 		expect(readFileSync(paths.auth, "utf8").trim()).not.toBe("old-token");
 		expect(readDaemonOwner(paths)?.nonce).not.toBe("dead");
+	});
+
+	it("given a dead owner recorded with a unix endpoint whose socket file is gone when candidate starts then it cleans up and takes ownership", async () => {
+		if (process.platform === "win32") return;
+		const paths = tempPaths();
+		writeDeadOwner(paths, { kind: "unix", path: paths.socket, dev: 1, ino: 1 });
+		expect(existsSync(paths.socket)).toBe(false);
+
+		const server = await startDaemonServer(paths, { onIdleShutdown: () => {} });
+		openServers.push(server);
+
+		expect(readFileSync(paths.auth, "utf8").trim()).not.toBe("old-token");
+		expect(readDaemonOwner(paths)?.nonce).not.toBe("dead");
+		expect(readDaemonOwner(paths)?.pid).toBe(process.pid);
+		expect(existsSync(paths.socket)).toBe(true);
+	});
+
+	it("given a dead owner whose recorded socket device differs from the live orphan socket when candidate starts then it unlinks the orphan and takes ownership", async () => {
+		if (process.platform === "win32") return;
+		const paths = tempPaths();
+		mkdirSync(paths.dir, { recursive: true });
+		await leaveOrphanSocket(paths.socket);
+		const orphan = statSync(paths.socket);
+		expect(lstatSync(paths.socket).isSocket()).toBe(true);
+		writeDeadOwner(paths, { kind: "unix", path: paths.socket, dev: orphan.dev + 1, ino: orphan.ino });
+
+		const server = await startDaemonServer(paths, { onIdleShutdown: () => {} });
+		openServers.push(server);
+
+		expect(readFileSync(paths.auth, "utf8").trim()).not.toBe("old-token");
+		expect(readDaemonOwner(paths)?.nonce).not.toBe("dead");
+		expect(statSync(paths.socket).ino).not.toBe(orphan.ino);
+		expect(await probeDaemon(paths)).toBe(true);
+	});
+
+	it("given a dead owner when the owner file is rewritten by another writer during validation then startup defers and leaves the new owner untouched", async () => {
+		const paths = tempPaths();
+		writeDeadOwner(paths, { path: paths.socket });
+		const pingOwner = async () => {
+			writeFileSync(
+				paths.owner,
+				JSON.stringify({ pid: DEAD_PID - 1, nonce: "other", startedAt: "newer", endpoint: { path: paths.socket } }),
+				{ mode: 0o600 },
+			);
+			return null;
+		};
+
+		await expect(acquireStartupLease(paths, pingOwner)).rejects.toMatchObject({
+			code: "daemon_startup_deferred",
+			reason: "owner_changed_during_cleanup",
+		});
+		expect(readDaemonOwner(paths)?.nonce).toBe("other");
+		expect(readFileSync(paths.auth, "utf8").trim()).toBe("old-token");
+		expect(existsSync(paths.lock)).toBe(false);
 	});
 
 	it("given a stale close from an old owner when a new owner exists then winner metadata survives", async () => {

--- a/packages/lsp-daemon/test/auth-ownership.test.ts
+++ b/packages/lsp-daemon/test/auth-ownership.test.ts
@@ -335,7 +335,10 @@ describe("daemon IPC authentication and ownership", () => {
 
 		expect(readFileSync(paths.auth, "utf8").trim()).not.toBe("old-token");
 		expect(readDaemonOwner(paths)?.nonce).not.toBe("dead");
-		expect(statSync(paths.socket).ino).not.toBe(orphan.ino);
+		expect(readDaemonOwner(paths)?.pid).toBe(process.pid);
+		// A successful probe is the proof that the orphan was replaced: nothing listens on an orphan
+		// socket, and a listener cannot bind over an existing path. Inode inequality is not asserted
+		// because the filesystem may hand the new socket the unlinked orphan's inode number.
 		expect(await probeDaemon(paths)).toBe(true);
 	});
 


### PR DESCRIPTION
## Summary

Fixes #7827. After a reboot the pre-reboot daemon's `daemon.owner` survives because no clean `close()` ran. `validateExistingOwner` correctly proves the pid dead and the ping unanswered, but then stats the socket *now* and requires its dev/ino/presence to equal what the dead daemon recorded. That is false whenever `st_dev` changes across mounts (btrfs / overlay / dm) or the socket lived on tmpfs and is gone, so startup threw `owner_changed_during_cleanup` before `cleanupDeadOwner` on every attempt and the daemon never started until a periodic sweep happened to remove the metadata. The two-proxy race and PID reuse are not the cause: the `daemon.lock` lease is held across the window, and PID reuse produces a different reason.

## Changes

`packages/lsp-daemon/src/ownership.ts`
- The re-read guard in `validateExistingOwner` now compares the two owner-file reads with `sameOwner` (pid, nonce, recorded endpoint). Its purpose is to detect a concurrent writer of `daemon.owner`, and that is what it now checks. The live `endpointIdentity(owner.endpoint.path)` comparison against the persisted identity is dropped.
- `isProcessAlive`, the ping loop, the startup lease and `cleanupDeadOwner`'s `isSocket()` guard are unchanged.

## Test plan

- [x] New: dead owner whose recorded socket is gone (tmpfs trigger) → owner cleaned, startup proceeds. RED on `dev` (`DaemonStartupDeferredError: owner_changed_during_cleanup`), GREEN after.
- [x] New: dead owner with a real orphaned socket whose recorded identity is `dev+1` (st_dev-drift trigger) → orphan unlinked, startup proceeds. RED → GREEN.
- [x] New: owner file rewritten between the read and the re-read → still defers with `owner_changed_during_cleanup`; the new owner and lock state stay intact (GREEN before and after; pins the guard's real purpose).
- [x] Existing live-owner tests (`owner_pid_live_unreachable`, `DaemonAlreadyRunningError`) unchanged and passing.
- [x] `npm test` in `packages/lsp-daemon`: 22 files, 165 pass, 0 fail. `npm run typecheck`: clean. `npm run lint` reports only the pre-existing baseline findings (unchanged count); the added lines are lint-clean.

## Not covered

Which of the two reboot triggers the reporter hit is not distinguishable from the issue text (the socket was still present, which points at `st_dev` drift); both take the same branch. PID reuse making a dead owner look alive (`owner_pid_live_unreachable`) is a separate latent issue and is not touched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7827. After a reboot, a dead daemon's owner file could block startup forever because `validateExistingOwner` wrongly compared the recorded socket identity (`dev`/`ino`) against the live socket, which drifts across mounts or disappears if the socket was on tmpfs. The check now compares the two owner-file reads (pid, nonce, endpoint path) to detect a concurrent writer, which is its actual purpose. The pid-alive check, ping, startup lease, and `cleanupDeadOwner`'s socket guard are unchanged.

**Tests**
- Adds tests covering a deleted socket (tmpfs), a real orphan socket with drifted `st_dev`, and a concurrent owner-file rewrite.
- All existing live-owner tests still pass.

<sup>Written for commit ff6d74428e4e0e13b44383d0352424a179555b43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

