### PR TITLE
fix(team-mode): spawn members in their worktree directory

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.test.ts
@@ -299,6 +299,20 @@ describe("tryFallbackRetry", () => {
       expect(retryInput?.sessionPermission).toEqual(QUESTION_DENIED_SESSION_PERMISSION)
     })
 
+    test("retry input preserves task.cwd", async () => {
+      const args = createDefaultArgs({
+        teamRunId: "team-run-1",
+        onSessionCreated: mock(async () => {}),
+        cwd: "/lead-fix-1",
+      })
+
+      await tryFallbackRetry(args)
+
+      const key = `${args.task.model!.providerID}/${args.task.model!.modelID}`
+      const retryInput = args.queuesByKey.get(key)?.[0]?.input
+      expect(retryInput?.cwd).toBe("/lead-fix-1")
+    })
+
     test("finalizes the failed attempt, creates a new pending attempt, and enqueues its explicit attemptID", async () => {
       const args = createDefaultArgs({
         status: "running",

--- a/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
+++ b/packages/omo-opencode/src/features/background-agent/fallback-retry-handler.ts
@@ -224,6 +224,7 @@ export async function tryFallbackRetry(args: {
     sessionPermission: task.sessionPermission,
     category: task.category,
     isUnstableAgent: task.isUnstableAgent,
+    cwd: task.cwd,
     onSessionCreated: task.onSessionCreated,
   }
 

--- a/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager-session-permission.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import type { PluginInput } from "@opencode-ai/plugin"
 
 import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
 
 describe("BackgroundManager session permission", () => {
@@ -120,5 +121,127 @@ describe("BackgroundManager session permission", () => {
         { permission: "question", action: "deny", pattern: "*" },
       ],
     })
+  })
+})
+
+describe("BackgroundManager child session directory", () => {
+  function createRecordingClient() {
+    const createCalls: Array<Record<string, unknown>> = []
+    const promptCalls: Array<Record<string, unknown>> = []
+    const client = {
+      session: {
+        get: async () => ({ data: { directory: "/parent" } }),
+        create: async (input: Record<string, unknown>) => {
+          createCalls.push(input)
+          return { data: { id: "ses_child" } }
+        },
+        promptAsync: async (input: Record<string, unknown>) => {
+          promptCalls.push(input)
+          return {}
+        },
+        abort: async () => ({}),
+      },
+    }
+    return { client, createCalls, promptCalls }
+  }
+
+  test("uses input.cwd for the child session create and prompt directory", async () => {
+    // given
+    const { client, createCalls, promptCalls } = createRecordingClient()
+    const manager = new BackgroundManager({ pluginContext: unsafeTestValue<PluginInput>({ client, directory: tmpdir() }) })
+
+    // when
+    await manager.launch({
+      description: "Test task",
+      prompt: "Do something",
+      agent: "explore",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+      cwd: "/parent-fix-1",
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    manager.shutdown()
+
+    // then
+    expect(createCalls).toHaveLength(1)
+    expect(createCalls[0]?.query).toEqual({ directory: "/parent-fix-1" })
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0]?.query).toEqual({ directory: "/parent-fix-1" })
+  })
+
+  test("falls back to the parent directory when cwd is absent", async () => {
+    // given
+    const { client, createCalls, promptCalls } = createRecordingClient()
+    const manager = new BackgroundManager({ pluginContext: unsafeTestValue<PluginInput>({ client, directory: tmpdir() }) })
+
+    // when
+    await manager.launch({
+      description: "Test task",
+      prompt: "Do something",
+      agent: "explore",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    manager.shutdown()
+
+    // then
+    expect(createCalls).toHaveLength(1)
+    expect(createCalls[0]?.query).toEqual({ directory: "/parent" })
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0]?.query).toEqual({ directory: "/parent" })
+  })
+
+  test("persists cwd on the task record", async () => {
+    // given
+    const { client } = createRecordingClient()
+    const manager = new BackgroundManager({ pluginContext: unsafeTestValue<PluginInput>({ client, directory: tmpdir() }) })
+
+    // when
+    const task = await manager.launch({
+      description: "Test task",
+      prompt: "Do something",
+      agent: "explore",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+      cwd: "/parent-fix-1",
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    manager.shutdown()
+
+    // then
+    expect(task.cwd).toBe("/parent-fix-1")
+  })
+
+  test("resume prompts the continuation in the task cwd", async () => {
+    // given
+    const { client, promptCalls } = createRecordingClient()
+    const manager = new BackgroundManager({ pluginContext: unsafeTestValue<PluginInput>({ client, directory: tmpdir() }) })
+    const tasks = unsafeTestValue<{ tasks: Map<string, BackgroundTask> }>(manager).tasks
+    tasks.set("bg_worktree", {
+      id: "bg_worktree",
+      sessionId: "ses_worktree",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+      description: "Worktree member",
+      prompt: "Do something",
+      agent: "explore",
+      status: "completed",
+      cwd: "/parent-fix-1",
+    })
+
+    // when
+    await manager.resume({
+      sessionId: "ses_worktree",
+      prompt: "continue",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent_2",
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    manager.shutdown()
+
+    // then
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0]?.query).toEqual({ directory: "/parent-fix-1" })
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -628,6 +628,7 @@ export class BackgroundManager {
         sessionPermission: input.sessionPermission,
         attemptCount: 0,
         category: input.category,
+        cwd: input.cwd,
         onSessionCreated: input.onSessionCreated,
       }
       const firstAttempt = startAttempt(task, input.model)
@@ -775,7 +776,8 @@ export class BackgroundManager {
       return null
     })
     const parentDirectory = parentSession?.data?.directory ?? this.directory
-    log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${parentDirectory}`)
+    const childDirectory = input.cwd ?? parentDirectory
+    log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${childDirectory}`)
 
     const createResult = await this.client.session.create({
       body: {
@@ -793,7 +795,7 @@ export class BackgroundManager {
           : {}),
       } as Record<string, unknown>,
       query: {
-        directory: parentDirectory,
+        directory: childDirectory,
       },
     })
 
@@ -853,7 +855,7 @@ export class BackgroundManager {
 
     if (task.retryNotification) {
       const attemptNumber = boundAttempt.attemptNumber
-      const retrySessionUrl = buildLocalSessionUrl(parentDirectory, sessionID)
+      const retrySessionUrl = buildLocalSessionUrl(childDirectory, sessionID)
       const previousAttempt = getPreviousAttempt(task, boundAttempt.attemptId)
       const failedSessionID = previousAttempt?.sessionId ?? task.retryNotification.previousSessionID
       const failedSessionLine = failedSessionID
@@ -960,7 +962,7 @@ The fallback retry session is now created and can be inspected directly.
     promptWithRetryInDirectory(this.client, {
       path: { id: sessionID },
       body: promptBody,
-    }, parentDirectory).catch(async (error) => {
+    }, childDirectory).catch(async (error) => {
       // Retry with fallback agent if the original agent was unregistered (e.g., after a model switch)
       if (isAgentNotFoundError(error) && input.agent !== FALLBACK_AGENT) {
         log("[background-agent] Agent not found, retrying with fallback agent", {
@@ -987,7 +989,7 @@ The fallback retry session is now created and can be inspected directly.
           await promptWithRetryInDirectory(this.client, {
             path: { id: sessionID },
             body: fallbackBody,
-          }, parentDirectory)
+          }, childDirectory)
           task.agent = FALLBACK_AGENT
           return
         } catch (retryError) {
@@ -1430,7 +1432,7 @@ The fallback retry session is now created and can be inspected directly.
           })(),
           parts: [createInternalAgentTextPart(input.prompt)],
         },
-        query: { directory: this.directory },
+        query: { directory: existingTask.cwd ?? this.directory },
       },
     }).then((promptResult) => {
       if (promptResult.status === "failed") {

--- a/packages/omo-opencode/src/features/background-agent/spawner.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner.test.ts
@@ -665,6 +665,69 @@ describe("background-agent spawner fallback model promotion", () => {
     expect(promptCalls[0]?.query).toEqual({ directory: "/parent/dir" })
   })
 
+  test("creates and prompts the child in input.cwd", async () => {
+    // given
+    const getCalls: Array<Record<string, unknown>> = []
+    const createCalls: Array<Record<string, unknown>> = []
+    const promptCalls: Array<Record<string, unknown>> = []
+
+    const client = {
+      session: {
+        get: async (input: Record<string, unknown>) => {
+          getCalls.push(input)
+          return { data: { directory: "/parent/dir" } }
+        },
+        create: async (input: Record<string, unknown>) => {
+          createCalls.push(input)
+          return { data: { id: "ses_child_cwd" } }
+        },
+        promptAsync: async (input: Record<string, unknown>) => {
+          promptCalls.push(input)
+          return {}
+        },
+      },
+    }
+
+    const task = createTask({
+      description: "Test task",
+      prompt: "Do work",
+      agent: "sisyphus-junior",
+      parentSessionId: "ses_parent",
+      parentMessageId: "msg_parent",
+      cwd: "/parent/dir-fix-1",
+    })
+
+    const item = {
+      task,
+      input: {
+        description: task.description,
+        prompt: task.prompt,
+        agent: task.agent,
+        parentSessionId: task.parentSessionId,
+        parentMessageId: task.parentMessageId,
+        cwd: task.cwd,
+      },
+    }
+
+    // when
+    await startTask(item as never, {
+      client: client as never,
+      directory: "/fallback",
+      concurrencyManager: { release: () => {} } as never,
+      tmuxEnabled: false,
+      onTaskError: () => {},
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // then
+    expect(task.cwd).toBe("/parent/dir-fix-1")
+    expect(getCalls).toEqual([{ path: { id: "ses_parent" }, query: { directory: "/fallback" } }])
+    expect(createCalls).toHaveLength(1)
+    expect(createCalls[0]?.query).toEqual({ directory: "/parent/dir-fix-1" })
+    expect(promptCalls).toHaveLength(1)
+    expect(promptCalls[0]?.query).toEqual({ directory: "/parent/dir-fix-1" })
+  })
+
   test("strips leading zwsp from prompt body agent before promptAsync", async () => {
     //#given
     const promptCalls: Array<{ body?: { agent?: string } }> = []

--- a/packages/omo-opencode/src/features/background-agent/spawner.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner.ts
@@ -52,7 +52,8 @@ export async function startTask(
     return null
   })
   const parentDirectory = parentSession?.data?.directory ?? directory
-  log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${parentDirectory}`)
+  const childDirectory = input.cwd ?? parentDirectory
+  log(`[background-agent] Parent dir: ${parentSession?.data?.directory}, using: ${childDirectory}`)
 
   const createResult = await client.session.create({
     body: {
@@ -60,7 +61,7 @@ export async function startTask(
       ...(input.sessionPermission ? { permission: input.sessionPermission } : {}),
     } as Record<string, unknown>,
     query: {
-      directory: parentDirectory,
+      directory: childDirectory,
     },
   }).catch((error: unknown) => {
     concurrencyManager.release(concurrencyKey)
@@ -119,7 +120,7 @@ export async function startTask(
   const promptChain = promptWithRetryInDirectory(client, {
     path: { id: sessionID },
     body: promptBody,
-  }, parentDirectory).catch(async (error) => {
+  }, childDirectory).catch(async (error) => {
     if (isAgentNotFoundError(error) && input.agent !== FALLBACK_AGENT) {
       log("[background-agent] Agent not found, retrying with fallback agent", {
         original: input.agent,
@@ -136,7 +137,7 @@ export async function startTask(
         await promptWithRetryInDirectory(client, {
           path: { id: sessionID },
           body: fallbackBody,
-        }, parentDirectory)
+        }, childDirectory)
         task.agent = FALLBACK_AGENT
         return
       } catch (retryError) {

--- a/packages/omo-opencode/src/features/background-agent/spawner/task-record.ts
+++ b/packages/omo-opencode/src/features/background-agent/spawner/task-record.ts
@@ -20,6 +20,7 @@ export function buildTaskRecord(input: LaunchInput, id: string, queuedAt: Date):
     sessionPermission: input.sessionPermission,
     category: input.category,
     isUnstableAgent: input.isUnstableAgent,
+    cwd: input.cwd,
     onSessionCreated: input.onSessionCreated,
   }
 }

--- a/packages/omo-opencode/src/features/background-agent/types.ts
+++ b/packages/omo-opencode/src/features/background-agent/types.ts
@@ -79,6 +79,8 @@ export interface BackgroundTask {
   isUnstableAgent?: boolean
   /** Category used for this task (e.g., 'quick', 'visual-engineering') */
   category?: string
+  /** Directory the child session is created and prompted in; defaults to the parent session directory */
+  cwd?: string
   onSessionCreated?: (sessionId: string) => void | Promise<void>
   /** Pending retry notification details for the next spawned retry session */
   retryNotification?: {
@@ -128,6 +130,8 @@ export interface LaunchInput {
   skillContent?: string
   category?: string
   sessionPermission?: SessionPermissionRule[]
+  /** Directory the child session is created and prompted in; defaults to the parent session directory */
+  cwd?: string
   onSessionCreated?: (sessionId: string) => void | Promise<void>
   /** User tool overrides (ask/allow/deny) from category or agent config. Merged into launchTools before hardcoded restrictions. */
   userPermission?: Record<string, "ask" | "allow" | "deny">

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.test.ts
@@ -298,6 +298,47 @@ describe("createTeamRun", () => {
     expect(await pathExists(path.resolve(baseDir, "./worktrees/member-2"))).toBe(false)
   })
 
+  test("passes the resolved worktree path as cwd to launch", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-worktree-cwd-"))
+    temporaryDirectories.push(baseDir)
+    let launchCount = 0
+    const { manager, launchMock } = createManager(baseDir, async () => ({ id: `task-${++launchCount}`, sessionId: `session-${launchCount}`, status: "running" } as BackgroundTask))
+    const spec = createSpec(2, true)
+
+    // when
+    await createTeamRun(spec, "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+
+    // then
+    expect(launchMock).toHaveBeenCalledTimes(2)
+    const launchInputs = launchMock.mock.calls.map((call) => call[0] as LaunchInput)
+    for (const member of spec.members) {
+      const expectedWorktree = path.resolve(baseDir, member.worktreePath!)
+      const launchInput = launchInputs.find((input) => input.description.endsWith(`/${member.name}`))
+      expect(launchInput?.cwd).toBe(expectedWorktree)
+      expect(launchInput?.prompt).toContain(`Worktree: ${expectedWorktree}`)
+    }
+  })
+
+  test("omits cwd when the member has no worktree", async () => {
+    // given
+    const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-no-worktree-cwd-"))
+    temporaryDirectories.push(baseDir)
+    let launchCount = 0
+    const { manager, launchMock } = createManager(baseDir, async () => ({ id: `task-${++launchCount}`, sessionId: `session-${launchCount}`, status: "running" } as BackgroundTask))
+    const spec = createSpec(2, false)
+
+    // when
+    await createTeamRun(spec, "lead-session", createContext(baseDir, manager), createConfig(baseDir), manager)
+
+    // then
+    expect(launchMock).toHaveBeenCalledTimes(2)
+    for (const call of launchMock.mock.calls) {
+      const launchInput = call[0] as LaunchInput
+      expect("cwd" in launchInput).toBe(false)
+    }
+  })
+
   test("returns the existing runtime on repeated calls with the same spec and lead session", async () => {
     // given
     const baseDir = await mkdtemp(path.join(tmpdir(), "team-runtime-idempotent-"))

--- a/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
+++ b/packages/omo-opencode/src/features/team-mode/team-runtime/create.ts
@@ -205,6 +205,7 @@ export async function createTeamRun(
             skillContent: resolvedMember.systemContent,
             category: member.kind === "category" ? member.category : undefined,
             sessionPermission: QUESTION_DENIED_SESSION_PERMISSION,
+            ...(resource.worktreePath ? { cwd: resource.worktreePath } : {}),
             onSessionCreated: async (sessionId) => {
               registerTeamSession(sessionId, {
                 teamRunId: runtimeState.teamRunId,


### PR DESCRIPTION
## Summary

Addresses #7788. Team Mode resolves a member's sibling worktree path (`team-runtime/create.ts`) but only ever injected it into the member's prompt text. The child session itself was created and prompted in the lead session's directory: `LaunchInput` had no cwd field and `BackgroundManager.startTask` hard-coded `query.directory` to the parent directory for both `session.create` and the prompt. Team messaging was already the other half of the story and routes member prompts with `directory: recipientMember.worktreePath ?? directory`; spawning was the inconsistent half.

## Changes

`features/background-agent/types.ts`
- Optional `cwd` on `LaunchInput` and `BackgroundTask`: the directory the child session is created and prompted in; defaults to the parent session directory.

`features/background-agent/manager.ts`, `spawner.ts`, `spawner/task-record.ts`
- `childDirectory = input.cwd ?? parentDirectory` is used for `session.create`, `buildLocalSessionUrl` and both `promptWithRetryInDirectory` calls; `resume()` prompts with `existingTask.cwd ?? this.directory`. The record keeps `cwd` so retries inherit it. The spawner twin mirrors the same logic so it does not drift from the live path.

`features/background-agent/fallback-retry-handler.ts`
- The fallback retry input carries `cwd: task.cwd`.

`features/team-mode/team-runtime/create.ts`
- Passes `cwd: resource.worktreePath` into `launch` when the member has a worktree; members without one are unchanged.

Every other `launch` caller passes no `cwd`, so their behaviour is identical to before.

## Test plan

- [x] 8 new tests, RED on unpatched `dev` (6 fail: `session.create` received `{ directory: "/parent" }` instead of the worktree; `launchInput.cwd` undefined) → GREEN after: `manager-session-permission.test.ts` (child create + prompt use `input.cwd`; fallback to parent when absent; `resume()` uses the task cwd), `spawner.test.ts`, `fallback-retry-handler.test.ts` (retry input preserves `task.cwd`), `team-runtime/create.test.ts` (worktree path passed as `cwd`; omitted without a worktree).
- [x] `bun test packages/omo-opencode/src/features/background-agent packages/omo-opencode/src/features/team-mode`: 1060 pass, 1 pre-existing skip, 0 fail.
- [x] `bun run --cwd packages/omo-opencode typecheck` (tsgo): clean. Senpi extension bundles unchanged after a rebuild.

## Not covered

This is the OmO-side plumbing only. Whether the LSP error in the issue disappears depends on OpenCode creating a per-directory plugin instance (and therefore a worktree-rooted `lsp` MCP) for a child session created with `directory=<worktree>`; that cannot be verified in this repository, which is why this says "addresses" rather than "fixes". Poller, abort and session-existence checks still address the child through the plugin directory and are left as they were.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes team-mode spawning so member sessions run in their own worktree directory, addressing #7788. Previously sessions were created and prompted in the lead directory; now team members with worktrees pass their worktree path as `cwd`.

**Bug Fixes**

- Adds an optional `cwd` to `LaunchInput` and `BackgroundTask`, defaulting to the parent directory, and threads it through session creation, prompting, fallback retries, and resumes.
- Only team members with worktrees set it; other launch callers keep the parent directory default.
- Whether the LSP error disappears depends on OpenCode creating a per-directory plugin instance, so this addresses rather than fixes the issue.

<sup>Written for commit d32c3e5ba6654a4dbba24f7eccf1b2c04b9b3bf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

