### PR TITLE
test(ci): drop the duplicate npm-dist-tag-rollback entry from the job-summary allowlist

### DIFF
--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -59,7 +59,6 @@ const workflowExpectations = [
   { path: ".github/workflows/web-ci.yml", jobs: ["format-lint-typecheck-build"] },
   { path: ".github/workflows/web-deploy.yml", jobs: ["deploy"] },
   { path: ".github/workflows/windows-flake-soak.yml", jobs: ["soak"] },
-  { path: ".github/workflows/npm-dist-tag-rollback.yml", jobs: ["retag"] },
 ] as const satisfies readonly WorkflowExpectation[]
 
 function discoverWorkflowPaths(): readonly string[] {


### PR DESCRIPTION
## Summary

`dev` is red since #7730 merged: `script/ci-job-summary-workflow.test.ts` fails in `test (ubuntu-latest, 2/2)` on every PR based on `b5122f19d`, with

```
#given repository workflows #when inspected #then every step-based job writes a concise Markdown summary
expect(received).toEqual(expected)  - Expected - 1
```

`27ddc4d0d` (2026-09-04) had already registered `.github/workflows/npm-dist-tag-rollback.yml` at the end of `workflowExpectations`, and #7730 registered it again in sorted position, so the expected path list is one entry longer than the workflow directory listing that line 152 compares it against.

## Change

One line: remove the trailing duplicate and keep the entry in sorted position. No workflow or production code touched.

## Test plan

- [x] `bun test script/ci-job-summary-workflow.test.ts` on `dev@b5122f19d`: 3 pass / 1 fail before, 4 pass / 0 fail after.
- [x] Observed failing on three unrelated PRs opened today against current `dev` (#8019, #8021, #8022), same assertion each time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate `.github/workflows/npm-dist-tag-rollback.yml` entry from the `script/ci-job-summary-workflow.test.ts` allowlist so the job-summary assertion passes again on `dev`.

<sup>Written for commit 854d2e45837c3673ba5064167c3939f9a5c15660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

