### PR TITLE
fix(ci): drop the duplicated workflow summary expectation

### DIFF
--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -59,7 +59,6 @@ const workflowExpectations = [
   { path: ".github/workflows/web-ci.yml", jobs: ["format-lint-typecheck-build"] },
   { path: ".github/workflows/web-deploy.yml", jobs: ["deploy"] },
   { path: ".github/workflows/windows-flake-soak.yml", jobs: ["soak"] },
-  { path: ".github/workflows/npm-dist-tag-rollback.yml", jobs: ["retag"] },
 ] as const satisfies readonly WorkflowExpectation[]
 
 function discoverWorkflowPaths(): readonly string[] {


### PR DESCRIPTION
dev is red on `script/ci-job-summary-workflow.test.ts`: `workflowExpectations` lists `.github/workflows/npm-dist-tag-rollback.yml` twice, so the expected array no longer equals discovery output.

#7730 (merge b5122f19d, current dev HEAD) appended the entry while 6d14bcec7 had already added it in its grouped position. This removes the appended copy and leaves the grouped one, restoring `5793 pass / 0 fail` on that suite. Test-fixture only; no runtime change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `ci-job-summary-workflow` test on `dev` by removing a duplicate `.github/workflows/npm-dist-tag-rollback.yml` entry from `workflowExpectations`, so the expected workflow list again matches discovery output.

- Test-fixture only; no runtime change.

<sup>Written for commit a2114af7cd55263b7b49bad8f412b98ab3474dbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

