### PR TITLE
fix(omo-opencode): preserve the flat assistant variant in the sibling continuation injectors

### DIFF
--- a/packages/omo-opencode/src/features/hook-message-injector/injector.test.ts
+++ b/packages/omo-opencode/src/features/hook-message-injector/injector.test.ts
@@ -53,6 +53,7 @@ function createMockClient(messages: Array<{
     model?: { providerID?: string; modelID?: string; variant?: string }
     providerID?: string
     modelID?: string
+    variant?: string
     tools?: Record<string, boolean>
     time?: { created?: number }
   }
@@ -98,6 +99,38 @@ describe("findNearestMessageWithFieldsFromSDK", () => {
       model: { providerID: "openai", modelID: "gpt-5" },
       tools: undefined,
     })
+  })
+
+  it("#given an assistant-shaped message with a flat variant #when resolving the nearest message #then the stored model keeps the variant", async () => {
+    // given
+    const mockClient = createMockClient([
+      { info: { agent: "sisyphus", providerID: "openai", modelID: "gpt-5.5", variant: "max" } },
+    ])
+
+    // when
+    const result = await findNearestMessageWithFieldsFromSDK(unsafeTestValue(mockClient), "ses_flat_variant")
+
+    // then
+    expect(result?.model).toEqual({ providerID: "openai", modelID: "gpt-5.5", variant: "max" })
+  })
+
+  it("#given a user-shaped message with a nested variant and a differing flat variant #when resolving the nearest message #then the nested variant wins", async () => {
+    // given
+    const mockClient = createMockClient([
+      {
+        info: {
+          agent: "sisyphus",
+          model: { providerID: "openai", modelID: "gpt-5.5", variant: "max" },
+          variant: "low",
+        },
+      },
+    ])
+
+    // when
+    const result = await findNearestMessageWithFieldsFromSDK(unsafeTestValue(mockClient), "ses_nested_variant")
+
+    // then
+    expect(result?.model).toEqual({ providerID: "openai", modelID: "gpt-5.5", variant: "max" })
   })
 
   it("returns nearest (most recent) message with all fields", async () => {

--- a/packages/omo-opencode/src/features/hook-message-injector/sdk-message-lookup.ts
+++ b/packages/omo-opencode/src/features/hook-message-injector/sdk-message-lookup.ts
@@ -20,6 +20,7 @@ export interface SDKMessage {
     }
     readonly providerID?: string
     readonly modelID?: string
+    readonly variant?: string
     readonly tools?: Record<string, ToolPermission>
     readonly time?: {
       readonly created?: number
@@ -38,7 +39,7 @@ function convertSDKMessageToStoredMessage(msg: SDKMessage): StoredMessage | null
 
   const providerID = info.model?.providerID ?? info.providerID
   const modelID = info.model?.modelID ?? info.modelID
-  const variant = info.model?.variant
+  const variant = info.model?.variant ?? info.variant
 
   if (!info.agent && !providerID && !modelID) {
     return null

--- a/packages/omo-opencode/src/hooks/atlas/recent-model-resolver.test.ts
+++ b/packages/omo-opencode/src/hooks/atlas/recent-model-resolver.test.ts
@@ -42,4 +42,33 @@ describe("resolveRecentPromptContextForSession", () => {
     expect(result.model).toEqual({ providerID: "openai", modelID: "gpt-5.4" })
     expect(result.tools).toEqual({ edit: true })
   })
+
+  test("#given a flat assistant message with a variant #when resolving recent prompt context #then the model keeps the variant", async () => {
+    // given
+    const ctx = unsafeTestValue<PluginInput>({
+      client: {
+        session: {
+          messages: mock(async () => ({
+            data: [
+              {
+                id: "m2",
+                info: {
+                  providerID: "openai",
+                  modelID: "gpt-5.5",
+                  variant: "max",
+                  time: { created: 2 },
+                },
+              },
+            ],
+          })),
+        },
+      },
+    })
+
+    // when
+    const result = await resolveRecentPromptContextForSession(ctx, "ses_atlas_flat")
+
+    // then
+    expect(result.model).toEqual({ providerID: "openai", modelID: "gpt-5.5", variant: "max" })
+  })
 })

--- a/packages/omo-opencode/src/hooks/atlas/recent-model-resolver.ts
+++ b/packages/omo-opencode/src/hooks/atlas/recent-model-resolver.ts
@@ -38,6 +38,7 @@ export async function resolveRecentPromptContextForSession(
         model?: ModelInfo
         modelID?: string
         providerID?: string
+        variant?: string
         tools?: Record<string, boolean | "allow" | "deny" | "ask">
         time?: { created?: number }
       }
@@ -66,7 +67,14 @@ export async function resolveRecentPromptContextForSession(
       }
 
       if (info?.providerID && info?.modelID) {
-        return { model: { providerID: info.providerID, modelID: info.modelID }, tools }
+        return {
+          model: {
+            providerID: info.providerID,
+            modelID: info.modelID,
+            ...(info.variant ? { variant: info.variant } : {}),
+          },
+          tools,
+        }
       }
     }
   } catch (error) {

--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.test.ts
@@ -277,4 +277,65 @@ describe("ralph-loop continuation prompt injector", () => {
     })
     expect(promptBody?.variant).toBe("max")
   })
+
+  test("#given the newest assistant message carries a flat variant #when injecting continuation prompt #then promptAsync receives the variant as a top-level field", async () => {
+    // given
+    let promptBody:
+      | {
+          model?: { providerID: string; modelID: string }
+          variant?: string
+        }
+      | undefined
+    const ctx = {
+      client: {
+        session: {
+          messages: async () => ({
+            data: [
+              {
+                info: {
+                  role: "user",
+                  agent: "sisyphus",
+                  model: { providerID: "openai", modelID: "gpt-5.5", variant: "max" },
+                },
+              },
+              {
+                info: {
+                  role: "assistant",
+                  finish: "stop",
+                  agent: "sisyphus",
+                  providerID: "openai",
+                  modelID: "gpt-5.5",
+                  variant: "max",
+                },
+              },
+            ],
+          }),
+          promptAsync: async (input: {
+            body: {
+              model?: { providerID: string; modelID: string }
+              variant?: string
+            }
+          }) => {
+            promptBody = input.body
+            return {}
+          },
+        },
+      },
+    }
+
+    // when
+    await injectContinuationPrompt(ctx as never, {
+      sessionID: "ses_ralph_flat_variant",
+      prompt: "continue",
+      directory: "/tmp/test",
+      apiTimeoutMs: 50,
+    })
+
+    // then
+    expect(promptBody?.model).toEqual({
+      providerID: "openai",
+      modelID: "gpt-5.5",
+    })
+    expect(promptBody?.variant).toBe("max")
+  })
 })

--- a/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.ts
+++ b/packages/omo-opencode/src/hooks/ralph-loop/continuation-prompt-injector.ts
@@ -19,6 +19,7 @@ type MessageInfo = {
 	model?: { providerID: string; modelID: string; variant?: string }
 	modelID?: string
 	providerID?: string
+	variant?: string
 	tools?: Record<string, boolean | "allow" | "deny" | "ask">
 }
 
@@ -103,7 +104,11 @@ export async function injectContinuationPrompt(
 				model =
 					info.model ??
 					(info.providerID && info.modelID
-						? { providerID: info.providerID, modelID: info.modelID }
+						? {
+							providerID: info.providerID,
+							modelID: info.modelID,
+							...(info.variant ? { variant: info.variant } : {}),
+						}
 						: undefined)
 				tools = info.tools
 				break

--- a/packages/omo-opencode/src/hooks/unstable-agent-babysitter/index.test.ts
+++ b/packages/omo-opencode/src/hooks/unstable-agent-babysitter/index.test.ts
@@ -342,6 +342,58 @@ describe("unstable-agent-babysitter hook", () => {
     expect(payload.body?.variant).toBe("max")
   })
 
+  test("#given the main session's newest assistant message carries a flat variant #when injecting a babysitter reminder #then promptAsync receives the variant as a top-level field", async () => {
+    // given
+    setMainSession("main-1")
+    const promptCalls: Array<{ input: unknown }> = []
+    const ctx = createMockPluginInput({
+      messagesBySession: {
+        "main-1": [
+          {
+            info: {
+              role: "user",
+              agent: "sisyphus",
+              model: { providerID: "openai", modelID: "gpt-5.5", variant: "max" },
+            },
+          },
+          {
+            info: {
+              role: "assistant",
+              finish: "stop",
+              agent: "sisyphus",
+              providerID: "openai",
+              modelID: "gpt-5.5",
+              variant: "max",
+            },
+          },
+        ],
+        "bg-1": [
+          { info: { role: "assistant" }, parts: [{ type: "thinking", thinking: "deep thought" }] },
+        ],
+      },
+      promptCalls,
+    })
+    const backgroundManager = createBackgroundManager([createTask()])
+    const hook = createUnstableAgentBabysitterHook(ctx, {
+      backgroundManager,
+      config: { timeout_ms: 120000 },
+    })
+
+    // when
+    await hook.event({ event: { type: "session.idle", properties: { sessionID: "main-1" } } })
+
+    // then
+    expect(promptCalls.length).toBe(1)
+    const payload = promptCalls[0].input as {
+      body?: {
+        model?: { providerID: string; modelID: string }
+        variant?: string
+      }
+    }
+    expect(payload.body?.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+    expect(payload.body?.variant).toBe("max")
+  })
+
   test("#given the main session has a fresh user message #when it becomes idle #then babysitter does not inject a reminder", async () => {
     // given
     const originalNow = Date.now

--- a/packages/omo-opencode/src/hooks/unstable-agent-babysitter/task-message-analyzer.ts
+++ b/packages/omo-opencode/src/hooks/unstable-agent-babysitter/task-message-analyzer.ts
@@ -10,6 +10,7 @@ type MessageInfo = {
   model?: { providerID: string; modelID: string; variant?: string }
   providerID?: string
   modelID?: string
+  variant?: string
   tools?: Record<string, boolean | "allow" | "deny" | "ask">
 }
 
@@ -45,6 +46,7 @@ export function getMessageInfo(value: unknown): MessageInfo | undefined {
     model,
     providerID: typeof info.providerID === "string" ? info.providerID : undefined,
     modelID: typeof info.modelID === "string" ? info.modelID : undefined,
+    variant: typeof info.variant === "string" ? info.variant : undefined,
     tools: isRecord(info.tools)
       ? Object.entries(info.tools).reduce<Record<string, boolean | "allow" | "deny" | "ask">>((acc, [key, value]) => {
           if (

--- a/packages/omo-opencode/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
+++ b/packages/omo-opencode/src/hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts
@@ -69,7 +69,15 @@ async function resolveMainSessionTarget(
       const info = getMessageInfo(messages[i])
       if (info?.agent || info?.model || (info?.providerID && info?.modelID)) {
         agent = agent ?? info?.agent
-        model = info?.model ?? (info?.providerID && info?.modelID ? { providerID: info.providerID, modelID: info.modelID } : undefined)
+        model =
+          info?.model ??
+          (info?.providerID && info?.modelID
+            ? {
+                providerID: info.providerID,
+                modelID: info.modelID,
+                ...(info.variant ? { variant: info.variant } : {}),
+              }
+            : undefined)
         tools = resolveInheritedPromptTools(sessionID, info?.tools) ?? tools
         break
       }


### PR DESCRIPTION
## Summary

Fixes #7462 — the remaining part. The reported path (the todo-continuation enforcer's `resolve-message-info.ts`) was already fixed in `ca87be2f1`, but the same hand-rolled normalisation exists in four sibling injectors and each still drops the variant.

opencode stores user messages with a nested `info.model = { providerID, modelID, variant }` but assistant messages with flat `info.providerID / modelID / variant`. Every auto-continuation injector rebuilds the model as `info.model ?? { providerID, modelID }`, forgetting the third flat field on the assistant message that the backwards scan almost always lands on. Because `variant` is then sent as a separate top-level `promptAsync` body field derived from `model.variant`, the injected turn goes out without `reasoning_effort` / `verbosity`, which changes the provider's cache key and invalidates the whole cached prefix (the report's 99% → 2% cache hit). The SDK types do not declare `variant` on messages, so the type checker cannot catch it. All four sites confirmed RED on `dev@4ec56b79d`.

## Changes (+28/−4 production)

Same idiom the maintainer accepted in `ca87be2f1` and #7698 — read the variant from either message shape and spread it only when present, so output is byte-identical when no variant exists:

- `features/hook-message-injector/sdk-message-lookup.ts` — the enforcer's own fallback lookup (also used by atlas): `info.model?.variant ?? info.variant`.
- `hooks/ralph-loop/continuation-prompt-injector.ts` — flat rebuild spreads `variant`.
- `hooks/atlas/recent-model-resolver.ts` — returned model carries `variant`.
- `hooks/unstable-agent-babysitter/unstable-agent-babysitter-hook.ts` + `task-message-analyzer.ts` — the narrowed `getMessageInfo` never copied a flat `variant`, so the hook's spread alone would still yield `undefined`; both are covered.

No shared helper (a `resolveMessageModel(info)` across five call sites with different local types is a follow-up refactor, not a bug fix) and `json-message-lookup.ts` is untouched.

## Test plan

- [x] One `#given … #when … #then …` case per site, RED on `dev` → GREEN: `injector.test.ts` (flat assistant variant preserved by `findNearestMessageWithFieldsFromSDK`, plus a nested-vs-flat control pinning that the nested value wins), `recent-model-resolver.test.ts`, `continuation-prompt-injector.test.ts` and `index.test.ts` for the babysitter (both assert `promptAsync` receives `variant` as a top-level field).
- [x] Four target directories 420 → 425 pass / 0 fail; `hooks/todo-continuation-enforcer/` unchanged at 146 pass; combined 571 pass / 0 fail. `bun run --cwd packages/omo-opencode typecheck` (tsgo): clean.
- [x] Existing `toEqual({ providerID, modelID })` assertions stay green because the spread adds nothing when the variant is absent.

## Relationship to #7463

#7463 (@AceRothstein71) identified the flat-assistant shape first; its `resolve-message-info.ts` / `types.ts` hunks have since landed via `ca87be2f1`, and its remaining `sdk-message-lookup.ts` hunk is the same one-line change included here. It has been waiting on a rebase since Aug 31 with its author having paused work; if it is rebased first I will drop the overlapping hunk from this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the last #7462 gap: four auto-continuation injectors rebuild the model from assistant-shaped messages without carrying the flat `variant` field over, so the injected turn goes out without `reasoning_effort`/`verbosity` and the provider cache key changes (cache hits dropped from 99% to 2%). Each injector now reads `variant` from either the nested or flat message shape and only adds it when present, so output is byte-identical when there is no variant.

**Changes**
- `hook-message-injector/sdk-message-lookup.ts` falls back to `info.variant` when the nested `model.variant` is absent.
- The ralph-loop continuation injector, atlas recent-model resolver, and babysitter hook spread the flat `variant` when rebuilding `{ providerID, modelID }`.
- `task-message-analyzer.ts` copies the flat `variant` through its narrowed `getMessageInfo` so the babysitter hook can use it.
- New tests cover the flat-assistant case at each site; the nested `model.variant` still wins when both are present.

<sup>Written for commit cf45e33555d6eb46011125c87dc32375061551b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

