### PR TITLE
fix(omo-opencode): make the doctor fallback_models hint truthful

### DIFF
--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
@@ -3,6 +3,23 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
+import { REASONING_UNIFICATION_MIGRATION_ID } from "../../../config-migration"
+
+const FALLBACK_MODELS_FIXTURE = {
+  categories: {
+    deep: {
+      model: "openai/gpt-5.6-sol",
+      fallback_models: ["openai/gpt-5.6-terra"],
+    },
+  },
+  agents: {
+    explore: {
+      model: "openai/gpt-5.6-luna",
+      fallback_models: ["openai/gpt-5.6-terra"],
+    },
+  },
+}
+
 describe("deprecated reasoning keys check", () => {
   it("reports deprecated reasoning keys with exact file and key path", async () => {
     //#given a unified config containing deprecated reasoning keys
@@ -240,6 +257,112 @@ describe("deprecated reasoning keys check", () => {
         'Replace thinking with reasoning: "off" or provider_options.thinking, or run: oh-my-openagent config migrate',
       ])
       expect(result.message).toBe("2 deprecated config key(s) found")
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(testRootDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+    }
+  })
+
+  it("#given fallback_models and the reasoning unification marker #when the check runs #then the fix explains models[0] is the primary and does not advertise config migrate", async () => {
+    //#given a config that config migrate already processed (marker recorded) but which gained fallback_models afterwards
+    const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+    const originalHome = process.env.HOME
+    const originalCwd = process.cwd()
+    const testRootDir = mkdtempSync(join(tmpdir(), "omo-doctor-fallback-models-marked-"))
+    const projectDir = join(testRootDir, "project")
+    const configPath = join(testRootDir, ".omo", "omo.jsonc")
+
+    try {
+      mkdirSync(projectDir, { recursive: true })
+      mkdirSync(join(testRootDir, ".omo"), { recursive: true })
+      process.env.HOME = testRootDir
+      delete process.env.OPENCODE_CONFIG_DIR
+      writeFileSync(
+        configPath,
+        JSON.stringify(
+          {
+            ...FALLBACK_MODELS_FIXTURE,
+            _migrations: [REASONING_UNIFICATION_MIGRATION_ID],
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf-8",
+      )
+      process.chdir(projectDir)
+
+      //#when running the deprecated reasoning keys check
+      const { checkDeprecatedReasoningKeys } = await import("./deprecated-reasoning-keys")
+      const result = await checkDeprecatedReasoningKeys()
+
+      //#then the deprecated keys are still reported, the marker itself is not, and the fix is truthful
+      expect(result.status).toBe("warn")
+      expect(result.issues.map((issue) => issue.description)).toEqual([
+        `${configPath}: categories.deep.fallback_models`,
+        `${configPath}: agents.explore.fallback_models`,
+      ])
+      for (const issue of result.issues) {
+        expect(issue.fix).toContain("models: [<primary>, ...fallbacks]")
+        expect(issue.fix).toContain("first entry becomes the primary model")
+        expect(issue.fix).not.toContain("config migrate")
+      }
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(testRootDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+    }
+  })
+
+  it("#given fallback_models and no migration marker #when the check runs #then the fix still suggests config migrate", async () => {
+    //#given a config that config migrate has never processed
+    const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+    const originalHome = process.env.HOME
+    const originalCwd = process.cwd()
+    const testRootDir = mkdtempSync(join(tmpdir(), "omo-doctor-fallback-models-unmarked-"))
+    const projectDir = join(testRootDir, "project")
+    const configPath = join(testRootDir, ".omo", "omo.jsonc")
+
+    try {
+      mkdirSync(projectDir, { recursive: true })
+      mkdirSync(join(testRootDir, ".omo"), { recursive: true })
+      process.env.HOME = testRootDir
+      delete process.env.OPENCODE_CONFIG_DIR
+      writeFileSync(configPath, JSON.stringify(FALLBACK_MODELS_FIXTURE, null, 2) + "\n", "utf-8")
+      process.chdir(projectDir)
+
+      //#when running the deprecated reasoning keys check
+      const { checkDeprecatedReasoningKeys } = await import("./deprecated-reasoning-keys")
+      const result = await checkDeprecatedReasoningKeys()
+
+      //#then the fix explains the chain semantics and still offers the one-shot migration
+      expect(result.status).toBe("warn")
+      expect(result.issues.map((issue) => issue.description)).toEqual([
+        `${configPath}: categories.deep.fallback_models`,
+        `${configPath}: agents.explore.fallback_models`,
+      ])
+      for (const issue of result.issues) {
+        expect(issue.fix).toContain("first entry becomes the primary model")
+        expect(issue.fix).toEndWith(", or run: oh-my-openagent config migrate")
+      }
     } finally {
       process.chdir(originalCwd)
       rmSync(testRootDir, { recursive: true, force: true })

--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts
@@ -1,7 +1,9 @@
+import { hasMigrationMarker } from "@oh-my-opencode/omo-config-core"
 import { parse } from "jsonc-parser/lib/esm/main.js"
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 
+import { REASONING_UNIFICATION_MIGRATION_ID } from "../../../config-migration"
 import { CHECK_IDS, CHECK_NAMES } from "../framework/constants"
 import type { CheckResult, DoctorIssue } from "../framework/types"
 
@@ -10,8 +12,12 @@ const CANONICAL_REPLACEMENT = new Map([
   ["reasoningEffort", "reasoning"],
   ["thinking", 'reasoning: "off" or provider_options.thinking'],
   ["textVerbosity", "provider_options.textVerbosity"],
-  ["fallback_models", "models"],
+  // `models` is an ordered chain whose head is the primary, so a literal rename of a
+  // `fallback_models` list would promote the first fallback; the hint must say so.
+  ["fallback_models", "models: [<primary>, ...fallbacks] (the first entry becomes the primary model)"],
 ])
+
+const MIGRATE_SUFFIX = ", or run: oh-my-openagent config migrate"
 
 const TUNING_CONTAINERS = new Set(["agents", "categories", "models"])
 // Canonical migration output nests provider-native keys (thinking, textVerbosity) under these
@@ -26,7 +32,7 @@ function isHarnessBlock(key: string): boolean {
   return key.startsWith("[") && key.endsWith("]")
 }
 
-function collectIssues(configPath: string, value: unknown, prefix: string): DoctorIssue[] {
+function collectIssues(configPath: string, value: unknown, prefix: string, fixSuffix: string): DoctorIssue[] {
   if (!isRecord(value)) return []
   const issues: DoctorIssue[] = []
 
@@ -37,7 +43,7 @@ function collectIssues(configPath: string, value: unknown, prefix: string): Doct
       issues.push({
         title: "Deprecated config key",
         description: `${configPath}: ${path}`,
-        fix: `Replace ${key} with ${replacement}, or run: oh-my-openagent config migrate`,
+        fix: `Replace ${key} with ${replacement}${fixSuffix}`,
         severity: "warning",
         affects: [path],
       })
@@ -48,17 +54,24 @@ function collectIssues(configPath: string, value: unknown, prefix: string): Doct
     // A profile only scopes overrides; its own name is not part of the key path users edit.
     if (prefix.length === 0 && key === "profiles") {
       for (const profile of Object.values(child)) {
-        issues.push(...collectIssues(configPath, profile, ""))
+        issues.push(...collectIssues(configPath, profile, "", fixSuffix))
       }
       continue
     }
     if (key === "[opencode]") continue
     if (TUNING_CONTAINERS.has(key) || isHarnessBlock(key) || prefix.length > 0) {
-      issues.push(...collectIssues(configPath, child, path))
+      issues.push(...collectIssues(configPath, child, path, fixSuffix))
     }
   }
 
   return issues
+}
+
+// The reasoning-unification migration is one-shot: once its marker is recorded in the file,
+// `config migrate` answers "Nothing to migrate", so advertising it would send users in a loop.
+function migrateFixSuffix(parsed: unknown): string {
+  if (isRecord(parsed) && hasMigrationMarker(parsed, REASONING_UNIFICATION_MIGRATION_ID)) return ""
+  return MIGRATE_SUFFIX
 }
 
 function userConfigPaths(): readonly string[] {
@@ -75,7 +88,7 @@ export async function checkDeprecatedReasoningKeys(): Promise<CheckResult> {
     if (!existsSync(configPath)) continue
     scanned.push(configPath)
     const parsed: unknown = parse(readFileSync(configPath, "utf-8"))
-    issues.push(...collectIssues(configPath, parsed, ""))
+    issues.push(...collectIssues(configPath, parsed, "", migrateFixSuffix(parsed)))
   }
 
   return {


### PR DESCRIPTION
## Summary

Addresses the remaining part of #7521. The 4.19.4 contradiction the issue describes (doctor tells you to rename `fallback_models` → `models`, the plugin schema rejects `models`) is already closed on `dev` — `989636bc5` made the plugin's agent overrides accept `models`, and `ac85d1f3c` taught the doctor to skip the plugin-owned `[opencode]` block — but only in `5.0.0-beta.x`; `v4.19.4` (2026-08-01) was cut inside the window where the two sides disagreed and is still npm `latest`. I replayed the reporter's config against `validatePluginConfig` and the doctor check on `dev@4ec56b79d`: accepted and materialised.

What is still wrong on `dev` is the hint text itself:

1. It says "Replace fallback_models with models". `models` is an ordered chain whose head is the *primary*, so a literal rename of a `fallback_models` list silently promotes the first fallback to primary.
2. It unconditionally adds "or run: oh-my-openagent config migrate". That migration is deliberately one-shot (journaled via `hasMigrationMarker`) and is auto-applied at first plugin startup, so for anything edited afterwards it answers "Nothing to migrate" — the reporter's step 4.

## Changes (`packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.ts`, +19/−6)

- The `fallback_models` replacement reads `models: [<primary>, ...fallbacks] (the first entry becomes the primary model)`.
- The `config migrate` suggestion is appended only when the scanned file lacks the `2026-08-reasoning-unification` marker, using the existing `hasMigrationMarker` / `REASONING_UNIFICATION_MIGRATION_ID`. No schema or migration-engine change; the one-shot policy is untouched.

## Test plan

- [x] `deprecated-reasoning-keys.test.ts`: marker present → fix text explains that the first entry becomes the primary and does not mention `config migrate` (RED on `dev`: old string); no marker → still suggests `config migrate` (pins the scoped behaviour).
- [x] File 3 → 5 pass / 0 fail; `bun test packages/omo-opencode/src/cli/doctor/`: 176 pass / 0 fail (28 files). `bun run --cwd packages/omo-opencode typecheck` (tsgo): clean.

## Notes

Not a 4.x backport; the reporter's loop is resolved by upgrading to `5.0.0-beta`. Answered on the issue.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the doctor's `fallback_models` fix hint truthful so users don't lose their primary model or get sent in a loop.

- Updates the replacement text to `models: [<primary>, ...fallbacks]` and explains the first entry becomes the primary.
- Only suggests `config migrate` when the reasoning-unification migration marker is absent from the scanned file.

<sup>Written for commit 9b094392a26e123f39a36a1990a9f5227dd56576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

