### PR TITLE
test(memory-core): end lock-holder fixtures on parent stdin EOF and await teardown

### DIFF
--- a/packages/memory-core/src/concurrency/two-process.test.ts
+++ b/packages/memory-core/src/concurrency/two-process.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { buildIdentityPaths, type MemoryIdentity } from "../identity"
+import { exitedWithin } from "../locks/process-liveness.test-support"
 import { ReflectionReservationStore, type ReservationResult } from "../reflection/reservation"
 import { realpathSync } from "node:fs"
 
@@ -14,6 +15,8 @@ const writerChildPath = fileURLToPath(new URL("./writer-child.ts", import.meta.u
 const reflectionChildPath = fileURLToPath(new URL("./reflection-child.ts", import.meta.url))
 const temporaryDirectories: string[] = []
 const liveChildren = new Set<ChildProcessWithoutNullStreams>()
+
+const TEARDOWN_GRACE_MS = 2_000
 
 type Exit = { readonly code: number | null; readonly signal: NodeJS.Signals | null }
 
@@ -144,7 +147,20 @@ async function assertTwentyLinearCommits(identity: MemoryIdentity): Promise<void
 }
 
 afterEach(async () => {
-  for (const child of liveChildren) child.kill("SIGKILL")
+  // Temp roots die only after every tracked child is confirmed exited: rm under a live lock
+  // holder strands it, and a fire-and-forget SIGKILL is not a confirmation.
+  const tracked = [...liveChildren]
+  liveChildren.clear()
+  for (const child of tracked) {
+    if (child.exitCode !== null || child.signalCode !== null) continue
+    child.kill("SIGTERM")
+    if (!(await exitedWithin(child, TEARDOWN_GRACE_MS))) {
+      child.kill("SIGKILL")
+      if (!(await exitedWithin(child, TEARDOWN_GRACE_MS))) {
+        throw new Error(`tracked child pid ${String(child.pid)} survived SIGTERM and SIGKILL teardown`)
+      }
+    }
+  }
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })))
 })
 

--- a/packages/memory-core/src/concurrency/writer-child.ts
+++ b/packages/memory-core/src/concurrency/writer-child.ts
@@ -98,7 +98,17 @@ async function locked<T>(operation: () => Promise<T>): Promise<T> {
 
     if (mode === "kill-holder" && acquisition === 2) {
       process.stdout.write("kill-ready\n")
-      await new Promise<never>(() => {})
+      // Hold the lock until the parent SIGKILLs this process. The parent owns our stdin pipe (it
+      // spawns us with a piped stdin, already resumed above), so if the parent dies first the
+      // kernel closes it and we exit here like a crashed owner - deliberately skipping the
+      // release in `finally`. Never park on a bare unsettled promise: Bun does not exit on an
+      // unsettled top-level await, it busy-polls a handle-less loop at one full core (#7335).
+      await new Promise<void>((resolve) => {
+        process.stdin.once("end", resolve)
+        process.stdin.once("close", resolve)
+        process.stdin.once("error", resolve)
+      })
+      process.exit(0)
     }
     return await operation()
   } finally {

--- a/packages/memory-core/src/locks/process-liveness.test-support.ts
+++ b/packages/memory-core/src/locks/process-liveness.test-support.ts
@@ -1,0 +1,135 @@
+// Bounded liveness primitives for tests that spawn real lock-holder processes: zombie-aware pid
+// probes, pid-file readers for foreign (non-child) writers, bounded child-termination waits, and
+// identity-guarded fail-safe kills so a failed assertion can never leak a spawned process.
+//
+// Ported from omo-senpi's process-liveness.test-support: memory-core cannot import from omo-senpi
+// (dependency direction), so the primitives the lock tests need live here.
+
+import { execFileSync } from "node:child_process"
+import type { ChildProcess } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { readFile } from "node:fs/promises"
+
+/**
+ * Resolves true once the child TERMINATED (`exit`, or the later `close`), false once `boundMs`
+ * elapsed. Deliberately NOT gated on stdio close alone: `close` lags `exit` indefinitely when a
+ * descendant inherited the child's stdio fds, and teardown must never stall - or report a false
+ * "survived teardown" - behind pipes that carry no liveness of their own.
+ */
+export function exitedWithin(child: ChildProcess, boundMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true)
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => settle(false), boundMs)
+    function settle(exited: boolean): void {
+      clearTimeout(timer)
+      child.off("exit", onDone)
+      child.off("close", onDone)
+      resolve(exited)
+    }
+    function onDone(): void {
+      settle(true)
+    }
+    child.once("exit", onDone)
+    child.once("close", onDone)
+  })
+}
+
+export function pidAlive(pid: number): boolean {
+  if (process.platform === "linux") {
+    try {
+      const statLine = readFileSync(`/proc/${String(pid)}/stat`, "utf8")
+      const stateIndex = statLine.lastIndexOf(")") + 2
+      // Z = zombie: exited but unreaped; signal liveness still succeeds against it.
+      if (statLine.slice(stateIndex, stateIndex + 1) === "Z") return false
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return false
+      // Unreadable /proc entry: fall through to signal liveness.
+    }
+  }
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // ESRCH means the process is gone; anything else (EPERM, ...) means it still exists.
+    if (error instanceof Error && "code" in error && error.code === "ESRCH") return false
+    return true
+  }
+}
+
+export type ProcessIdentity = Readonly<{ pid: number; command: string }>
+
+function commandForPid(pid: number): string | null {
+  try {
+    if (process.platform === "linux") return readFileSync(`/proc/${String(pid)}/cmdline`, "utf8").replaceAll("\0", " ").trim()
+    if (process.platform === "win32") {
+      const out = execFileSync("powershell", ["-NoProfile", "-NonInteractive", "-Command", `(Get-CimInstance Win32_Process -Filter "ProcessId=${String(pid)}").CommandLine`], { encoding: "utf8" }).trim()
+      return out === "" ? null : out
+    }
+    return execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf8" }).trim()
+  } catch {
+    return null
+  }
+}
+
+/** Snapshots a live process's command identity; null when the pid is gone or unreadable. */
+export function captureIdentity(pid: number): ProcessIdentity | null {
+  const command = commandForPid(pid)
+  return command === null ? null : { pid, command }
+}
+
+export function identityMatches(identity: ProcessIdentity): boolean {
+  const command = commandForPid(identity.pid)
+  return command !== null && command === identity.command
+}
+
+/** Resolves true once the pid is provably terminal (dead, zombie, or reused by another command), false once `boundMs` elapsed. */
+export function pidTerminalWithin(identity: ProcessIdentity, boundMs: number): Promise<boolean> {
+  // Watching /proc/<pid> cannot detect termination: a zombie keeps its /proc entry present (and
+  // procfs does not deliver reliable fs events), so a watcher can sleep through the death it
+  // waits for. The zombie-aware liveness probe is the only correct oracle on every platform.
+  return probeUntil(() => !identityMatches(identity) || !pidAlive(identity.pid), boundMs)
+}
+
+/**
+ * Bounded condition probe: resolves true once `condition` holds, false once `boundMs` elapsed.
+ * This is the sanctioned fallback for waiting on FOREIGN processes/files, where no OS-level
+ * event exists. It is never an ordering oracle: callers assert on the condition outcome, not on
+ * elapsed time.
+ */
+export async function probeUntil(condition: () => boolean | Promise<boolean>, boundMs: number, intervalMs = 25): Promise<boolean> {
+  const deadline = Date.now() + boundMs
+  for (;;) {
+    if (await condition()) return true
+    if (Date.now() >= deadline) return false
+    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs))
+  }
+}
+
+/** Reads a pid file written by a foreign helper once it appears, without requiring the process to still be alive. */
+export async function readPidFileWhenWritten(path: string, boundMs: number): Promise<number> {
+  let pid: number | null = null
+  const found = await probeUntil(async () => {
+    try {
+      const raw = Number((await readFile(path, "utf8")).trim())
+      if (Number.isInteger(raw) && raw > 0) {
+        pid = raw
+        return true
+      }
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error
+    }
+    return false
+  }, boundMs)
+  if (!found || pid === null) throw new Error(`pid file never appeared: ${path}`)
+  return pid
+}
+
+/** SIGKILL only when the target still has the command identity captured at registration. */
+export function killIfAlive(identity: ProcessIdentity): void {
+  if (!identityMatches(identity)) return
+  try {
+    process.kill(identity.pid, "SIGKILL")
+  } catch (error) {
+    if (pidAlive(identity.pid)) throw error
+  }
+}

--- a/packages/memory-core/src/locks/subprocess-contention.test.ts
+++ b/packages/memory-core/src/locks/subprocess-contention.test.ts
@@ -83,7 +83,20 @@ async function createFixture(): Promise<{ directory: string; lockPath: string; c
 }
 
 afterEach(async () => {
-  for (const child of children) child.kill("SIGKILL")
+  // Temp directories die only after every tracked child is confirmed exited: rm under a live
+  // holder strands it, and a fire-and-forget SIGKILL is not a confirmation.
+  const tracked = [...children]
+  children.clear()
+  for (const child of tracked) {
+    if (child.exitCode !== null || child.signalCode !== null) continue
+    child.kill("SIGTERM")
+    if (!(await exitedWithin(child, TEARDOWN_GRACE_MS))) {
+      child.kill("SIGKILL")
+      if (!(await exitedWithin(child, TEARDOWN_GRACE_MS))) {
+        throw new Error(`tracked lock holder pid ${String(child.pid)} survived SIGTERM and SIGKILL teardown`)
+      }
+    }
+  }
   await Promise.all(temporaryDirectories.splice(0).map(async (directory) => {
     await rm(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })
   }))

--- a/packages/memory-core/src/locks/subprocess-contention.test.ts
+++ b/packages/memory-core/src/locks/subprocess-contention.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import type { ChildProcessWithoutNullStreams } from "node:child_process"
+import type { ChildProcess, ChildProcessWithoutNullStreams } from "node:child_process"
 import { spawn } from "node:child_process"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -7,16 +7,40 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { LockContentionError, acquireLock, createLockRecord, releaseLock } from "./index"
+import {
+  type ProcessIdentity,
+  captureIdentity,
+  exitedWithin,
+  killIfAlive,
+  pidAlive,
+  pidTerminalWithin,
+  readPidFileWhenWritten,
+} from "./process-liveness.test-support"
 
 const workerPath = fileURLToPath(new URL("./subprocess-worker.ts", import.meta.url))
 const temporaryDirectories: string[] = []
-const children = new Set<ChildProcessWithoutNullStreams>()
+const children = new Set<ChildProcess>()
 
-function spawnWorker(args: string[]): ChildProcessWithoutNullStreams {
-  const child = spawn(process.execPath, [workerPath, ...args], { stdio: ["pipe", "pipe", "pipe"] })
+const READY_TIMEOUT_MS = 10_000
+const EXIT_TIMEOUT_MS = 5_000
+const TEARDOWN_GRACE_MS = 2_000
+
+function track<T extends ChildProcess>(child: T): T {
   children.add(child)
   child.once("exit", () => children.delete(child))
   return child
+}
+
+function spawnWorker(args: string[]): ChildProcessWithoutNullStreams {
+  return track(spawn(process.execPath, [workerPath, ...args], { stdio: ["pipe", "pipe", "pipe"] }))
+}
+
+async function killAndAwait(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  child.kill("SIGKILL")
+  if (!(await exitedWithin(child, TEARDOWN_GRACE_MS))) {
+    throw new Error(`child pid ${String(child.pid)} survived SIGKILL for ${String(TEARDOWN_GRACE_MS)}ms`)
+  }
 }
 
 function waitForOutput(child: ChildProcessWithoutNullStreams, expected: string): Promise<void> {
@@ -125,4 +149,141 @@ describe("real subprocess lock contention", () => {
     holder.kill("SIGKILL")
     await exitPromise
   }, 10_000)
+})
+
+describe("subprocess lock holder lifecycle", () => {
+  // A hold-mode worker must never outlive the parent that owns its stdin: an orphaned holder
+  // parked on an unsettled top-level await busy-polls one core under Bun forever (#7335).
+
+  test("#given a hold-mode worker that reported entered #when the parent ends its stdin #then the worker exits by itself within the bound", async () => {
+    // #given
+    const fixture = await createFixture()
+    const holder = spawnWorker(["hold", fixture.lockPath, fixture.counterPath, fixture.logPath, "orphan"])
+    try {
+      await waitForOutput(holder, "entered\n")
+      const exit = waitForExit(holder)
+
+      // #when
+      holder.stdin.end()
+
+      // #then
+      expect(await exit).toEqual({ code: 0, signal: null })
+    } finally {
+      await killAndAwait(holder)
+    }
+  }, 30_000)
+
+  test("#given a wrapper that spawns the hold-mode worker and SIGKILLs itself once entered #when the wrapper dies #then the ORIGINAL worker is terminal within the bound", async () => {
+    // #given: a wrapper that spawns the real worker with a wrapper-owned stdin pipe, records the
+    // worker's own pid once it holds the lock, waits for this test to acknowledge that it has
+    // snapshotted the worker's identity, then SIGKILLs itself. The test observes THAT original
+    // worker (pid + command identity), never a substitute process.
+    const fixture = await createFixture()
+    const workerPidPath = path.join(fixture.directory, "worker.pid")
+    const wrapperPath = path.join(fixture.directory, "abrupt-wrapper.mjs")
+    await writeFile(wrapperPath, `
+import { spawn } from "node:child_process"
+import { writeFileSync } from "node:fs"
+const worker = spawn(
+  process.execPath,
+  [process.env.WORKER_PATH, "hold", process.env.LOCK_PATH, process.env.COUNTER_PATH, process.env.LOG_PATH, "abrupt"],
+  { stdio: ["pipe", "pipe", "ignore"] },
+)
+let entered = false
+let acknowledged = false
+const dieOnceArmed = () => { if (entered && acknowledged) process.kill(process.pid, "SIGKILL") }
+worker.stdout.on("data", (chunk) => {
+  if (!chunk.toString().includes("entered\\n")) return
+  writeFileSync(process.env.WORKER_PID_PATH, String(worker.pid))
+  entered = true
+  dieOnceArmed()
+})
+process.stdin.on("data", () => { acknowledged = true; dieOnceArmed() })
+process.stdin.on("end", () => process.kill(process.pid, "SIGKILL"))
+process.stdin.resume()
+`, "utf8")
+    const wrapper = track(spawn(process.execPath, [wrapperPath], {
+      stdio: ["pipe", "ignore", "ignore"],
+      env: {
+        ...process.env,
+        WORKER_PATH: workerPath,
+        LOCK_PATH: fixture.lockPath,
+        COUNTER_PATH: fixture.counterPath,
+        LOG_PATH: fixture.logPath,
+        WORKER_PID_PATH: workerPidPath,
+      },
+    }))
+    // Subscribe to the wrapper's death BEFORE it can fire: the wrapper SIGKILLs itself in the
+    // same tick it reads the acknowledgement, so listening only afterwards would miss the event.
+    const wrapperExit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("wrapper did not terminate after worker readiness")), READY_TIMEOUT_MS)
+      wrapper.once("exit", (code, signal) => {
+        clearTimeout(timer)
+        resolve({ code, signal })
+      })
+    })
+    let workerIdentity: ProcessIdentity | null = null
+    let workerPid: number | null = null
+    try {
+      workerPid = await readPidFileWhenWritten(workerPidPath, READY_TIMEOUT_MS)
+      // The wrapper is still alive here (it dies only after our acknowledgement) and holds the
+      // worker's stdin open, so the worker is alive too; the snapshot doubles as the fail-safe's
+      // PID-reuse guard.
+      workerIdentity = captureIdentity(workerPid)
+      expect(workerIdentity).not.toBeNull()
+      if (workerIdentity === null) throw new Error("unreachable")
+
+      // #when
+      wrapper.stdin?.write("ack\n")
+      const exit = await wrapperExit
+      // Windows reports no POSIX signal for a killed process: termination itself is the
+      // contract, the signal is the POSIX-only corroboration.
+      if (process.platform !== "win32") expect(exit.signal).toBe("SIGKILL")
+
+      // #then: the ORIGINAL worker is terminal on every platform. Termination is awaited with a
+      // zombie-aware liveness probe against the captured identity rather than asserted from a
+      // single point-in-time probe, because the worker's death trails the wrapper's by a beat.
+      expect(await pidTerminalWithin(workerIdentity, EXIT_TIMEOUT_MS)).toBe(true)
+    } finally {
+      await killAndAwait(wrapper)
+      // Identity-guarded: never signal a pid that has since been reused by another process.
+      if (workerIdentity !== null) killIfAlive(workerIdentity)
+      else if (workerPid !== null && pidAlive(workerPid)) throw new Error(`worker pid ${String(workerPid)} is alive but its identity was never captured`)
+    }
+  }, 30_000)
+
+  // The two tests below run back to back on purpose: the first leaves a live holder for the
+  // file-level afterEach to tear down, the second observes what that teardown left behind.
+  let teardownProbe: ChildProcessWithoutNullStreams | null = null
+
+  test("#given a hold-mode worker still holding the lock when its test ends #when the test returns #then it is handed to afterEach", async () => {
+    // #given
+    const fixture = await createFixture()
+    const holder = spawnWorker(["hold", fixture.lockPath, fixture.counterPath, fixture.logPath, "teardown"])
+    await waitForOutput(holder, "entered\n")
+
+    // #when: the test returns without killing the holder.
+    teardownProbe = holder
+
+    // #then
+    expect(holder.exitCode).toBeNull()
+    expect(holder.signalCode).toBeNull()
+  }, 30_000)
+
+  test("#given the holder handed to afterEach #when afterEach has run #then no tracked child remains alive", async () => {
+    const holder = teardownProbe
+    teardownProbe = null
+    try {
+      // #given
+      expect(holder).not.toBeNull()
+      if (holder === null) throw new Error("unreachable")
+
+      // #then: teardown awaited the exit (exitCode or signalCode is set) and untracked the child
+      // before this test started, so a subsequent rm can never strand a live holder.
+      expect(holder.exitCode !== null || holder.signalCode !== null).toBe(true)
+      expect(children.has(holder)).toBe(false)
+    } finally {
+      if (holder !== null) await killAndAwait(holder)
+    }
+  }, 30_000)
 })

--- a/packages/memory-core/src/locks/subprocess-worker.ts
+++ b/packages/memory-core/src/locks/subprocess-worker.ts
@@ -43,8 +43,24 @@ if (mode === "gated-increment") {
   await increment()
   await releaseLock(lockPath, record)
 } else if (mode === "hold") {
-  process.stdin.resume()
-  await new Promise<never>(() => {})
+  // Hold the lock for as long as the parent lives, then exit WITHOUT releasing so the marker is
+  // left behind exactly like a crashed owner (the recovery tests depend on that). The parent must
+  // spawn this worker with a piped stdin it keeps open: EOF/close/error on that pipe - including
+  // the kernel closing it on abrupt parent death - is the only exit path. Never park on a bare
+  // unsettled promise here: Bun does not exit on an unsettled top-level await, it busy-polls a
+  // handle-less event loop at one full core, which is how orphaned holders spun forever (#7335).
+  await new Promise<void>((resolve) => {
+    const done = (): void => {
+      // A still-open stdin would keep the loop alive after the wait resolves; drop it so exit is
+      // unconditional on every ownership-loss path.
+      process.stdin.destroy()
+      resolve()
+    }
+    process.stdin.once("end", done)
+    process.stdin.once("close", done)
+    process.stdin.once("error", done)
+    process.stdin.resume()
+  })
 } else {
   await releaseLock(lockPath, record)
   throw new Error(`unknown subprocess worker mode: ${mode}`)


### PR DESCRIPTION
## Summary

Addresses the remaining part of #7335. The Senpi `hold-lock` fixture the issue names was already fixed on `dev` by #7404 and #7479 (its lifecycle regression is green on HEAD and leaves no orphans). The identical pre-fix shape survives in memory-core's test fixtures: `locks/subprocess-worker.ts` `hold` mode and `concurrency/writer-child.ts` `kill-holder` mode both parked on `await new Promise<never>(() => {})` and relied entirely on the parent test's `afterEach` SIGKILL, which never runs if the `bun test` worker is itself killed.

Why that spins a core rather than idling: Bun, unlike Node (which exits with code 13), keeps a process with an unsettled top-level await alive and, once the event loop has no live handle, busy-polls. Measured with Bun 1.4.2 while investigating: ~265 CPU ticks per 3 s for the pre-fix shape (and for memory-core's `hold` mode after stdin EOF), 0 ticks for a timer keep-alive, immediate exit for the current event-driven Senpi fixture.

## Changes (test fixtures and tests only; no lock semantics change, no production code)

- `subprocess-worker.ts` `hold` mode and `writer-child.ts` `kill-holder` mode park on the parent-owned stdin pipe (`end` / `close` / `error`, destroying stdin in the resolver) — the same wait shape as the merged Senpi fixture — so a holder idles on a live handle while held and exits on its own when the parent dies, on Linux, macOS and Windows. No PPID polling, no wall-clock timeout (both add nondeterminism the merged fix deliberately removed). `releaseLock` is intentionally *not* called on this path: the "SIGKILLed holder is recovered" tests depend on the marker being left behind like a crashed owner; `writer-child` exits explicitly for the same reason instead of falling into its `finally`.
- `subprocess-contention.test.ts` and `two-process.test.ts`: ordered, bounded teardown (SIGTERM → await ≤2 s → SIGKILL → await ≤2 s → throw if still alive → then `rm`), replacing fire-and-forget kills.
- New `locks/process-liveness.test-support.ts`: `exitedWithin` and identity-guarded pid probes ported from the Senpi support file (memory-core cannot import from omo-senpi).

## Test plan

- [x] New lifecycle tests in `subprocess-contention.test.ts`, RED on `dev` → GREEN: a hold-mode holder exits by itself within 5 s after the parent ends its stdin (RED: `timed out waiting for child exit`); a wrapper that spawns the holder and SIGKILLs itself leaves the *original* worker terminal within 5 s (RED: orphan survives with ppid 1); after teardown every tracked child has `exitCode` or `signalCode` set (RED: old `afterEach` never awaited). Termination is asserted on every platform; POSIX signal details only off-Windows. Every test kills and awaits its children in `finally`, and the wrapper kills itself on its own stdin EOF so a dead test runner still takes the tree down.
- [x] `bun test packages/memory-core/src/locks/ packages/memory-core/src/concurrency/`: 26 pass / 0 fail; the lifecycle file run 5× consecutively 7/7 each time; `pgrep` for the fixture scripts empty after every run. `bun run --cwd packages/memory-core typecheck` (tsgo): clean.

## Housekeeping (not in this PR)

#7335 itself can be closed once this lands (the Senpi part is #7404 / #7479); #7342 is superseded by those; #7883 (a six-line await for the Windows-only control-socket race in the merged lifecycle test) was closed unmerged on 2026-09-07 and may be worth reopening.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory-core's lock-holder test fixtures so an orphaned holder no longer busy-polls a core forever under Bun (#7335). The fixtures used to park on an unsettled top-level await and rely on the parent's SIGKILL; they now wait on the parent-owned stdin pipe and exit on their own when the parent dies.

- Both fixture modes wait on stdin `end`/`close`/`error` and exit without releasing the lock, leaving the marker behind like a crashed owner.
- Teardown in `subprocess-contention.test.ts` and `two-process.test.ts` now SIGTERMs, waits up to 2s, SIGKILLs, waits up to 2s, then throws, before removing temp dirs.
- New `locks/process-liveness.test-support.ts` adds bounded, zombie-aware pid probes ported from `omo-senpi`.
- New lifecycle tests in `subprocess-contention.test.ts` fail on `dev` (orphan survives) and pass here.
- Callers must spawn these fixtures with a piped stdin they keep open; all current call sites already do.

<sup>Written for commit b3f417157359a9c2b7e402c4ab2939d6d6e0ef15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

