### PR TITLE
perf(omob): reuse senpi artifacts by commit

### DIFF
--- a/script/build-omob.test.ts
+++ b/script/build-omob.test.ts
@@ -13,6 +13,7 @@ import {
 	hostTargetFor,
 	packSoleSenpiTarball,
 	parseOmobArgs,
+	resolveCachedSenpiPackage,
 } from "./build-omob"
 import { planRuntimePrune, selectPruneEntries } from "./omob-runtime-prune"
 
@@ -190,6 +191,24 @@ describe("packSoleSenpiTarball", () => {
 				writeFileSync(join(tarballDir, "pkg-1.0.0.tgz"), "x")
 			})
 			expect(name).toBe("pkg-1.0.0.tgz")
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true })
+		}
+	})
+})
+
+describe("resolveCachedSenpiPackage", () => {
+	test("#given a cache manifest for one commit #when resolving another commit #then it never reuses the package", () => {
+		const cacheDir = tempDir("omob-artifact-cache-")
+		try {
+			const artifactRoot = join(cacheDir, "artifacts", "senpi", "aaa1111", "install", "node_modules", "@code-yeongyu", "senpi")
+			mkdirSync(artifactRoot, { recursive: true })
+			writeFileSync(
+				join(cacheDir, "artifacts", "senpi", "aaa1111", "manifest.json"),
+				JSON.stringify({ commit: "aaa1111", packageRoot: artifactRoot, tarballName: "senpi.tgz" }),
+			)
+			expect(resolveCachedSenpiPackage(cacheDir, "bbb2222")).toBeUndefined()
+			expect(resolveCachedSenpiPackage(cacheDir, "aaa1111")).toBe(artifactRoot)
 		} finally {
 			rmSync(cacheDir, { recursive: true, force: true })
 		}

--- a/script/build-omob.ts
+++ b/script/build-omob.ts
@@ -241,7 +241,44 @@ export function packSoleSenpiTarball(tarballDir: string, pack: () => void): stri
 	return tarballs[0] as string
 }
 
-function buildSenpiPackage(senpiDir: string, cacheDir: string): string {
+interface SenpiArtifactCache {
+	readonly commit: string
+	readonly packageRoot: string
+	readonly tarballName: string
+}
+
+function senpiArtifactCachePath(cacheDir: string, commit: string): string {
+	return join(cacheDir, "artifacts", "senpi", commit, "manifest.json")
+}
+
+function readSenpiArtifactCache(cacheDir: string, commit: string): string | undefined {
+	const manifestPath = senpiArtifactCachePath(cacheDir, commit)
+	if (!existsSync(manifestPath)) return undefined
+	try {
+		const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Partial<SenpiArtifactCache>
+		if (manifest.commit !== commit || typeof manifest.packageRoot !== "string" || !existsSync(manifest.packageRoot)) return undefined
+		return manifest.packageRoot
+	} catch {
+		return undefined
+	}
+}
+
+function writeSenpiArtifactCache(cacheDir: string, artifact: SenpiArtifactCache): void {
+	const manifestPath = senpiArtifactCachePath(cacheDir, artifact.commit)
+	mkdirSync(dirname(manifestPath), { recursive: true })
+	writeFileSync(manifestPath, `${JSON.stringify(artifact, undefined, "\t")}\n`)
+}
+
+export function resolveCachedSenpiPackage(cacheDir: string, commit: string): string | undefined {
+	return readSenpiArtifactCache(cacheDir, commit)
+}
+
+function buildSenpiPackage(senpiDir: string, cacheDir: string, commit: string): string {
+	const cached = readSenpiArtifactCache(cacheDir, commit)
+	if (cached !== undefined) {
+		console.error(`[omob] reusing senpi artifact ${commit}`)
+		return cached
+	}
 	run("bun", ["install"], senpiDir)
 	materializeNestedLockDeps(senpiDir)
 	run("bun", ["run", "build:bun"], senpiDir)
@@ -253,13 +290,15 @@ function buildSenpiPackage(senpiDir: string, cacheDir: string): string {
 	)
 	// Isolated production install: the tarball plus its registry deps, resolved under
 	// a dedicated root so the resulting tree can be dropped into omo's node_modules.
-	const installRoot = join(cacheDir, "senpi-install")
+	const installRoot = join(cacheDir, "artifacts", "senpi", commit, "install")
 	rmSync(installRoot, { recursive: true, force: true })
 	mkdirSync(installRoot, { recursive: true })
-	writeFileSync(join(installRoot, "package.json"), `${JSON.stringify({ private: true, dependencies: { "@code-yeongyu/senpi": `file:../tarballs/${tarballName}` } }, undefined, "\t")}\n`)
+	writeFileSync(join(installRoot, "package.json"), `${JSON.stringify({ private: true, dependencies: { "@code-yeongyu/senpi": `file:${resolve(tarballDir, tarballName)}` } }, undefined, "\t")}\n`)
 	run("bun", ["install", "--production", "--ignore-scripts"], installRoot)
 	nestHoistedDeps(installRoot)
-	return join(installRoot, "node_modules", "@code-yeongyu", "senpi")
+	const packageRoot = join(installRoot, "node_modules", "@code-yeongyu", "senpi")
+	writeSenpiArtifactCache(cacheDir, { commit, packageRoot, tarballName })
+	return packageRoot
 }
 
 /** Moves the isolated install's hoisted deps under the senpi package, mirroring the published nested layout. */
@@ -381,7 +420,7 @@ async function runBuild(options: OmobOptions): Promise<number> {
 	console.error(`[omob] building: omo ${omoInfo.commit} + senpi ${senpiInfo.commit}`)
 	ensureCacheClone(senpiUrl, senpi.directory, options.senpiRef, true)
 	ensureCacheClone(omoUrl, omo.directory, options.omoRef, true)
-	const builtSenpiRoot = buildSenpiPackage(senpi.directory, options.cacheDir)
+	const builtSenpiRoot = buildSenpiPackage(senpi.directory, options.cacheDir, senpiInfo.commit)
 	// The omo prepare chain materializes gitignored plugin/skills from the shared-skills
 	// upstream submodules; a caller's OMO_SKIP_MATERIALIZE=1 would skip that and break the
 	// build, so the dev-binary install always runs the full materialization.


### PR DESCRIPTION
## Summary
Cache the isolated senpi production artifact by exact senpi commit in the omob cache. A valid manifest and existing package root are required; malformed, missing, or different-commit entries fall back to the full build.

## Measurements
Measured on mengmotaHost (M4 Pro, 14 cores, Bun 1.4.2), darwin-arm64:

| Scenario | Result | Change vs 56.43s baseline | Evidence |
|---|---:|---:|---|
| Existing warm baseline | 56.43s | — | /tmp/omob-timing-2026-09-10T04-15-23.log |
| First run after merged senpi provenance changed | 49.12s | 12.9% faster | /tmp/omob-final-cachehit-20260910.log |
| Same omo/senpi pair, senpi artifact cache hit | 16.92s | 70.0% faster | /tmp/omob-final-cachehit-second-20260910.log |
| Senpi tsc build phase | 16.7s | — | baseline evidence |
| Senpi tsgo build phase | 4.85s | 71.0% faster | senpi PR #1536 |

The final 16.92s run printed the exact reuse message for senpi commit 90b2535b0c04559de9802229cc8279c6a2c2cb6, proving the cache-hit branch was exercised. The resulting binary was 127,928,178 bytes with 1,192 embedded sidecar files.

## QA
- bun test script/build-omob.test.ts --timeout 120000: 15 pass, 0 fail.
- bunx tsc --noEmit -p script/tsconfig.json: pass in a real dependency-installed worktree.
- Senpi PR #1536: 24 successful checks including Windows RPC, native prebuilds, workspace tests, three coding-agent shards, static checks, and Check and test aggregate.

Related: #8044; senpi #1536