### PR TITLE
fix(omo-native): inline css-tree data for compiled binaries (webfetch patch.json crash)

### DIFF
--- a/packages/omo-native/bin/lib/compile-safe-engine.js
+++ b/packages/omo-native/bin/lib/compile-safe-engine.js
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+
+/**
+ * Inlines the css-tree data that a compiled binary cannot resolve.
+ *
+ * css-tree loads `data/patch.json`, the three mdn-data dictionaries and its own
+ * `package.json` through `createRequire(import.meta.url)` at module scope. Bun's
+ * compiled filesystem serves no dynamic require, so every one of them throws
+ * from inside `/$bunfs/root/<binary>` (verified: relative JSON, bare mdn-data
+ * JSON and relative package.json all fail there). jsdom pulls css-tree in, so
+ * the first webfetch HTML conversion dies with
+ * `Cannot find module '../data/patch.json'` before any content is converted.
+ *
+ * Senpi inlines the same data before its own `build:binary`
+ * (scripts/prepare-bun-compile-assets.mjs), but that script is not part of the
+ * published package, so the installed engine is prepared here: the one hook both
+ * the release-binary build (omo-native postinstall) and the omob dev build
+ * (script/build-omob.ts swapSenpi) already run against the engine tree they are
+ * about to compile. jsdom's own `__dirname` reads survive bun compile and are
+ * deliberately left untouched.
+ */
+export function prepareCompileSafeEngine(senpiRoot) {
+  const cssTreeRoot = resolvePackageRoot(senpiRoot, "css-tree")
+  if (cssTreeRoot === undefined) return
+  inlineDataPatch(cssTreeRoot)
+  inlineMdnData(cssTreeRoot)
+  inlineVersion(cssTreeRoot)
+}
+
+function resolvePackageRoot(fromRoot, packageName) {
+  const nested = join(fromRoot, "node_modules", packageName)
+  if (existsSync(join(nested, "package.json"))) return nested
+  try {
+    return dirname(createRequire(join(fromRoot, "package.json")).resolve(`${packageName}/package.json`))
+  } catch {
+    return undefined
+  }
+}
+
+function serializeJsonFile(path) {
+  return JSON.stringify(JSON.parse(readFileSync(path, "utf8")), null, "\t")
+}
+
+function writeIfChanged(path, contents) {
+  if (!existsSync(path)) return
+  if (readFileSync(path, "utf8") === contents) return
+  writeFileSync(path, contents)
+}
+
+/**
+ * A file that matches neither the upstream source shape nor the already-inlined
+ * form is css-tree drift: failing here beats shipping a binary that only breaks
+ * once a user fetches a page.
+ */
+function inlineOnce(path, pattern, replacement, inlinedMarker, relativeName) {
+  if (!existsSync(path)) return
+  const source = readFileSync(path, "utf8")
+  const inlined = source.replace(pattern, () => replacement)
+  if (inlined !== source) {
+    writeFileSync(path, inlined)
+    return
+  }
+  if (!source.includes(inlinedMarker)) throw new Error(`omo-ai: unsupported Senpi ${relativeName}`)
+}
+
+function inlineDataPatch(cssTreeRoot) {
+  const patchJsonPath = join(cssTreeRoot, "data", "patch.json")
+  if (!existsSync(patchJsonPath)) return
+  const patch = `${serializeJsonFile(patchJsonPath)}\n`
+  writeIfChanged(join(cssTreeRoot, "lib", "data-patch.js"), `const patch = ${patch}\nexport default patch;\n`)
+  writeIfChanged(join(cssTreeRoot, "cjs", "data-patch.cjs"), `'use strict';\n\nmodule.exports = ${patch}`)
+}
+
+const CJS_MDN_REQUIRES =
+  "const mdnAtrules = require('mdn-data/css/at-rules.json');\nconst mdnProperties = require('mdn-data/css/properties.json');\nconst mdnSyntaxes = require('mdn-data/css/syntaxes.json');"
+const ESM_MDN_REQUIRES = `const require = createRequire(import.meta.url);\n${CJS_MDN_REQUIRES}`
+const MDN_INLINED_MARKER = "const mdnAtrules = {"
+
+function inlineMdnData(cssTreeRoot) {
+  const mdnCssRoot = resolveMdnCssRoot(cssTreeRoot)
+  if (mdnCssRoot === undefined) return
+  const constants = [
+    `const mdnAtrules = ${serializeJsonFile(join(mdnCssRoot, "at-rules.json"))};`,
+    `const mdnProperties = ${serializeJsonFile(join(mdnCssRoot, "properties.json"))};`,
+    `const mdnSyntaxes = ${serializeJsonFile(join(mdnCssRoot, "syntaxes.json"))};`,
+  ].join("\n")
+  inlineOnce(join(cssTreeRoot, "lib", "data.js"), ESM_MDN_REQUIRES, constants, MDN_INLINED_MARKER, "css-tree/lib/data.js")
+  inlineOnce(join(cssTreeRoot, "cjs", "data.cjs"), CJS_MDN_REQUIRES, constants, MDN_INLINED_MARKER, "css-tree/cjs/data.cjs")
+}
+
+function resolveMdnCssRoot(cssTreeRoot) {
+  const sibling = join(cssTreeRoot, "..", "mdn-data", "css")
+  if (existsSync(join(sibling, "at-rules.json"))) return sibling
+  try {
+    return dirname(createRequire(join(cssTreeRoot, "package.json")).resolve("mdn-data/css/at-rules.json"))
+  } catch {
+    return undefined
+  }
+}
+
+function inlineVersion(cssTreeRoot) {
+  const packageJsonPath = join(cssTreeRoot, "package.json")
+  if (!existsSync(packageJsonPath)) return
+  const { version } = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+  writeIfChanged(join(cssTreeRoot, "lib", "version.js"), `export const version = ${JSON.stringify(version)};\n`)
+  writeIfChanged(
+    join(cssTreeRoot, "cjs", "version.cjs"),
+    `'use strict';\n\nmodule.exports.version = ${JSON.stringify(version)};\n`,
+  )
+}

--- a/packages/omo-native/bin/senpi-patch.mjs
+++ b/packages/omo-native/bin/senpi-patch.mjs
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { createRequire } from "node:module"
 import { fileURLToPath } from "node:url"
+import { prepareCompileSafeEngine } from "./lib/compile-safe-engine.js"
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const require = createRequire(join(packageRoot, "package.json"))
@@ -42,3 +43,5 @@ if (belowFloor) {
     claudeCodeSource.replace(claudeCodeVersionPattern, `const claudeCodeVersion = "${claudeCodeVersionFloor}";`),
   )
 }
+
+prepareCompileSafeEngine(senpiRoot)

--- a/packages/omo-native/test/compile-safe-engine.test.ts
+++ b/packages/omo-native/test/compile-safe-engine.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import { prepareCompileSafeEngine } from "../bin/lib/compile-safe-engine.js"
+
+const PACKAGE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
+const PATCH_SCRIPT = join(PACKAGE_ROOT, "bin", "senpi-patch.mjs")
+const CSS_TREE_VERSION = "3.2.1"
+const PATCH_DATA = { atrules: { charset: { prelude: "<string>" } }, properties: { color: { syntax: "<color>" } } }
+const AT_RULES = { "@media": { syntax: "@media <media-query-list> { <rule-list> }" } }
+const PROPERTIES = { color: { syntax: "<color>" } }
+const SYNTAXES = { color: { syntax: "<rgb()> | <hex-color>" } }
+
+const roots: string[] = []
+
+function write(path: string, contents: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, contents)
+}
+
+function createEngine(): string {
+  const root = mkdtempSync(join(tmpdir(), "omo-compile-safe-"))
+  roots.push(root)
+  write(join(root, "package.json"), JSON.stringify({ name: "@code-yeongyu/senpi", version: "2026.9.9-2", type: "module" }))
+  const cssTree = join(root, "node_modules", "css-tree")
+  write(join(cssTree, "package.json"), JSON.stringify({ name: "css-tree", version: CSS_TREE_VERSION, type: "module" }))
+  write(join(cssTree, "data", "patch.json"), JSON.stringify(PATCH_DATA))
+  write(
+    join(cssTree, "lib", "data-patch.js"),
+    "import { createRequire } from 'module';\n\nconst require = createRequire(import.meta.url);\nconst patch = require('../data/patch.json');\n\nexport default patch;\n",
+  )
+  write(
+    join(cssTree, "cjs", "data-patch.cjs"),
+    "'use strict';\n\nconst patch = require('../data/patch.json');\n\nconst patch$1 = patch;\n\nmodule.exports = patch$1;\n",
+  )
+  write(
+    join(cssTree, "lib", "data.js"),
+    "import { createRequire } from 'module';\nimport patch from './data-patch.js';\n\nconst require = createRequire(import.meta.url);\nconst mdnAtrules = require('mdn-data/css/at-rules.json');\nconst mdnProperties = require('mdn-data/css/properties.json');\nconst mdnSyntaxes = require('mdn-data/css/syntaxes.json');\n\nexport default { mdnAtrules, mdnProperties, mdnSyntaxes, patch };\n",
+  )
+  write(
+    join(cssTree, "cjs", "data.cjs"),
+    "'use strict';\n\nconst dataPatch = require('./data-patch.cjs');\n\nconst mdnAtrules = require('mdn-data/css/at-rules.json');\nconst mdnProperties = require('mdn-data/css/properties.json');\nconst mdnSyntaxes = require('mdn-data/css/syntaxes.json');\n\nmodule.exports = { mdnAtrules, mdnProperties, mdnSyntaxes, dataPatch };\n",
+  )
+  write(
+    join(cssTree, "lib", "version.js"),
+    "import { createRequire } from 'module';\n\nconst require = createRequire(import.meta.url);\n\nexport const { version } = require('../package.json');\n",
+  )
+  write(join(cssTree, "cjs", "version.cjs"), "'use strict';\n\nconst { version } = require('../package.json');\n\nexports.version = version;\n")
+  const mdnCss = join(root, "node_modules", "mdn-data", "css")
+  write(join(root, "node_modules", "mdn-data", "package.json"), JSON.stringify({ name: "mdn-data", version: "2.27.1" }))
+  write(join(mdnCss, "at-rules.json"), JSON.stringify(AT_RULES))
+  write(join(mdnCss, "properties.json"), JSON.stringify(PROPERTIES))
+  write(join(mdnCss, "syntaxes.json"), JSON.stringify(SYNTAXES))
+  return root
+}
+
+function cssTreeFile(root: string, ...segments: string[]): string {
+  return readFileSync(join(root, "node_modules", "css-tree", ...segments), "utf8")
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("compile-safe engine preparation", () => {
+  describe("#given an engine whose css-tree resolves its data through createRequire", () => {
+    describe("#when the engine is prepared for bun compile", () => {
+      test("#then no css-tree module reaches for a file at runtime", () => {
+        const root = createEngine()
+        prepareCompileSafeEngine(root)
+        for (const relative of [
+          ["lib", "data-patch.js"],
+          ["cjs", "data-patch.cjs"],
+          ["lib", "data.js"],
+          ["cjs", "data.cjs"],
+          ["lib", "version.js"],
+          ["cjs", "version.cjs"],
+        ]) {
+          const source = cssTreeFile(root, ...relative)
+          expect(source).not.toContain("require('../data/patch.json')")
+          expect(source).not.toContain("require('mdn-data/css/at-rules.json')")
+          expect(source).not.toContain("require('../package.json')")
+        }
+      })
+
+      test("#then the inlined modules still expose the exact upstream data", async () => {
+        const root = createEngine()
+        prepareCompileSafeEngine(root)
+        const cssTree = join(root, "node_modules", "css-tree")
+        const dataPatch = await import(pathToFileURL(join(cssTree, "lib", "data-patch.js")).href)
+        expect(dataPatch.default).toEqual(PATCH_DATA)
+        const data = await import(pathToFileURL(join(cssTree, "lib", "data.js")).href)
+        expect(data.default.mdnAtrules).toEqual(AT_RULES)
+        expect(data.default.mdnProperties).toEqual(PROPERTIES)
+        expect(data.default.mdnSyntaxes).toEqual(SYNTAXES)
+        expect(data.default.patch).toEqual(PATCH_DATA)
+        const version = await import(pathToFileURL(join(cssTree, "lib", "version.js")).href)
+        expect(version.version).toBe(CSS_TREE_VERSION)
+      })
+    })
+
+    describe("#when the preparation runs a second time", () => {
+      test("#then every prepared file stays byte-identical", () => {
+        const root = createEngine()
+        prepareCompileSafeEngine(root)
+        const first = cssTreeFile(root, "lib", "data.js")
+        const firstPatch = cssTreeFile(root, "cjs", "data-patch.cjs")
+        prepareCompileSafeEngine(root)
+        expect(cssTreeFile(root, "lib", "data.js")).toBe(first)
+        expect(cssTreeFile(root, "cjs", "data-patch.cjs")).toBe(firstPatch)
+      })
+    })
+  })
+
+  describe("#given a css-tree whose data module matches no known shape", () => {
+    describe("#when the engine is prepared", () => {
+      test("#then preparation fails loud instead of shipping a broken binary", () => {
+        const root = createEngine()
+        write(join(root, "node_modules", "css-tree", "lib", "data.js"), "export default {};\n")
+        expect(() => prepareCompileSafeEngine(root)).toThrow("omo-ai: unsupported Senpi css-tree/lib/data.js")
+      })
+    })
+  })
+
+  describe("#given an engine that does not bundle css-tree", () => {
+    describe("#when the engine is prepared", () => {
+      test("#then preparation is a no-op", () => {
+        const root = createEngine()
+        rmSync(join(root, "node_modules", "css-tree"), { recursive: true, force: true })
+        expect(() => prepareCompileSafeEngine(root)).not.toThrow()
+      })
+    })
+  })
+
+  describe("#given the patch script runs as postinstall does", () => {
+    describe("#when the installed engine still resolves css-tree data dynamically", () => {
+      test("#then the script prepares css-tree along with the pi-ai floor", () => {
+        const root = createEngine()
+        write(
+          join(root, "node_modules", "@earendil-works", "pi-ai", "dist", "api", "anthropic-messages.js"),
+          'const claudeCodeVersion = "2.1.251";\n',
+        )
+        const result = spawnSync("node", [PATCH_SCRIPT], {
+          encoding: "utf8",
+          env: { ...process.env, OMO_SENPI_PATCH_ROOT: root },
+        })
+        expect(result.stderr).toBe("")
+        expect(result.status).toBe(0)
+        expect(cssTreeFile(root, "lib", "data-patch.js")).not.toContain("createRequire")
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- New `packages/omo-native/bin/lib/compile-safe-engine.js`: rewrites the installed engine's `css-tree` so `lib/data-patch.js`, `cjs/data-patch.cjs`, `lib/data.js`, `cjs/data.cjs`, `lib/version.js` and `cjs/version.cjs` carry their JSON inline instead of resolving `../data/patch.json`, `mdn-data/css/*.json` and `../package.json` through `createRequire(import.meta.url)` at module scope.
- `bin/senpi-patch.mjs` calls it after the existing pi-ai floor patch. That hook already runs on both compile paths: the release-binary build (omo-native `postinstall` before `script/build-omo-binary.ts` in `publish-platform.yml`) and the omob dev build (`script/build-omob.ts` `swapSenpi`).
- New `test/compile-safe-engine.test.ts` (6 tests) against a synthetic engine root.

## Why

In every compiled omo binary the first webfetch HTML conversion (`format: markdown` / `text`) died with

```
Cannot find module '../data/patch.json'
Require stack:
- /$bunfs/root/omo-darwin-arm64
```

Bun's compiled filesystem serves no dynamic require. A 3-line probe compiled with the release flags shows all three css-tree specifiers fail from `/$bunfs/root`: relative JSON, bare `mdn-data/...` JSON, relative `package.json`. The sidecar `node_modules/{css-tree,mdn-data,source-map-js}` embedded next to the executable cannot satisfy a require that is evaluated from inside `$bunfs`.

Senpi inlines the same data before its own `build:binary` (`scripts/prepare-bun-compile-assets.mjs`), but that script is not part of the published package (`files`: dist/docs/examples/vendor/CHANGELOG), so the engine omo installs is not compile-safe. The npm/node install path was never affected: it keeps `node_modules` on disk.

## Observed behaviour (real shipped surface, identical command)

`<omo> -p --no-session --mode json --tools webfetch --provider opengateway --model anthropic/claude-haiku-4-5 --thinking off "Call the webfetch tool exactly once with url https://example.com and format \"markdown\" ... reply with only the page's H1 text."`

| binary | `tool_execution_end` |
|---|---|
| **before** `0.0.0-omob.f2a9880.2b6a886` (current dev) | `"Cannot find module '../data/patch.json'\nRequire stack:\n- /$bunfs/root/omo-darwin-arm64"`, `isError: true` |
| **after** `0.0.0-omob.a900abe.90b2535` (this branch, unmodified `build-omob.ts` pipeline) | `"# Example Domain\n\nThis domain is for use in documentation examples..."`, `converted: true`, `isError: false`; final reply `Example Domain` |

`format: html` returns the raw body without touching jsdom, which is why the crash only shows on markdown/text conversion.

## QA / evidence

Evidence dir (local, gitignored): `.omo/evidence/20260910-webfetch-csstree-bunfs/` — `QA.md` plus the two JSON event captures above.

- Compiled probe importing the engine's `webfetch/content.js`: pre-fix reproduces the error byte-for-byte; post-fix `MARKDOWN_OK 2599` / `TEXT_OK 2557`.
- Counterfactual: css-tree fixed + jsdom left upstream still converts, so jsdom's `__dirname` stylesheet read and `require.resolve("./xhr-sync-worker.js")` survive bun compile and are deliberately untouched.
- Unit tests on mengmotaMac (bunshin mesh): 11 pass / 0 fail across the new file and the existing `senpi-patch.test.ts`.
- Mutations: wiring call removed → 1 fail; module body neutered → 3 fail; JSON serializer forced to `{}` → exactly the data-equality test fails. Every assertion has a mutation that kills it.
- Idempotency on the real installed engine: second run leaves every css-tree `.js`/`.cjs` byte-identical.
- `bun install` 1.4.2 runs a workspace package's `postinstall` (scratch workspace, marker file written), so the release lane is covered.
- `bunx tsc -p packages/omo-native/tsconfig.json --noEmit` clean; LSP clean; pure LOC 78 / 144 / 43.

## Residual risk / follow-ups

- A css-tree that changes the shape of `lib/data.js` / `cjs/data.cjs` fails the install/build loud (`omo-ai: unsupported Senpi css-tree/lib/data.js`) instead of shipping a broken binary; the other files are rewritten wholesale from `data/patch.json` and `package.json`.
- Already-published beta binaries (through beta.51) keep the crash until the next omo release.
- Follow-up (senpi): make the published package compile-safe upstream (run the css-tree inlining during publish staging) so every consumer that compiles the engine gets it without a patch hook.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes webfetch crashing in compiled omo binaries by inlining `css-tree`'s JSON data before bundling. Previously the first webfetch HTML conversion (markdown/text) in a compiled binary failed with `Cannot find module '../data/patch.json'` because Bun's compiled filesystem can't resolve dynamic requires. Now the engine's `css-tree` modules carry their dictionaries and version inline before compile, so conversions succeed. The npm install path is unaffected.

**Side effects**
- Already-published compiled binaries (through beta.51) keep the crash until the next omo release.
- A `css-tree` release that changes its data module shape fails the build loud (`omo-ai: unsupported Senpi css-tree/lib/data.js`) instead of shipping a broken binary.

<sup>Written for commit a900abea63b1587cad65bb5ce2fae88fcdf12ddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

