### PR TITLE
fix(omo-opencode): wait out task store lock contention

### DIFF
--- a/packages/omo-opencode/src/features/claude-tasks/AGENTS.md
+++ b/packages/omo-opencode/src/features/claude-tasks/AGENTS.md
@@ -30,7 +30,7 @@ interface Task {
 | File | Purpose |
 |------|---------|
 | `types.ts` | Task interface + status types |
-| `storage.ts` | `readJsonSafe()`, `writeJsonAtomic()`, `acquireLock()`, `generateTaskId()` |
+| `storage.ts` | `readJsonSafe()`, `writeJsonAtomic()`, `acquireLock()` (async, bounded wait), `generateTaskId()` |
 | `index.ts` | Barrel exports |
 
 ## STORAGE
@@ -38,5 +38,10 @@ interface Task {
 - Location: `.omo/tasks/` directory
 - Format: JSON files, one per task
 - Atomic writes: temp file → rename
-- Locking: file-based lock for concurrent access
+- Locking: file-based lock for concurrent access. `acquireLock()` is async and waits out ordinary
+  contention with jittered retry (default 5s budget, override with `OMO_TASK_LOCK_WAIT_TIMEOUT_MS`);
+  it reports `acquired: false` only once that budget is exhausted. A lock older than 30s is reclaimed
+  as stale regardless of the wait budget.
+- Critical section: only the atomic task-file write is done under the lock; Todo API sync happens
+  after release
 - Sync: Changes pushed to OpenCode Todo API after each update

--- a/packages/omo-opencode/src/features/claude-tasks/storage.test.ts
+++ b/packages/omo-opencode/src/features/claude-tasks/storage.test.ts
@@ -468,12 +468,12 @@ describe("acquireLock", () => {
     }
   })
 
-  test("acquires lock when no lock exists", () => {
+  test("acquires lock when no lock exists", async () => {
     //#given
     const dirPath = TEST_DIR_ABS
 
     //#when
-    const lock = acquireLock(dirPath)
+    const lock = await acquireLock(dirPath)
 
     //#then
     expect(lock.acquired).toBe(true)
@@ -483,13 +483,13 @@ describe("acquireLock", () => {
     lock.release()
   })
 
-  test("fails to acquire lock when fresh lock exists", () => {
+  test("fails to acquire lock when fresh lock exists and no wait budget is given", async () => {
     //#given
     const dirPath = TEST_DIR
-    const firstLock = acquireLock(dirPath)
+    const firstLock = await acquireLock(dirPath)
 
     //#when
-    const secondLock = acquireLock(dirPath)
+    const secondLock = await acquireLock(dirPath, { waitTimeoutMs: 0 })
 
     //#then
     expect(secondLock.acquired).toBe(false)
@@ -498,7 +498,46 @@ describe("acquireLock", () => {
     firstLock.release()
   })
 
-  test("acquires lock when stale lock exists (>30s)", () => {
+  test("acquires a lock released while waiting within the bound", async () => {
+    //#given
+    const dirPath = TEST_DIR
+    const firstLock = await acquireLock(dirPath)
+
+    //#when
+    // acquireLock runs its first attempt synchronously, so the lock is still held when it fails;
+    // releasing here can only be observed by a retry.
+    const pendingLock = acquireLock(dirPath, { waitTimeoutMs: 2000, retryDelayMs: 5 })
+    firstLock.release()
+    const secondLock = await pendingLock
+
+    //#then
+    expect(secondLock.acquired).toBe(true)
+
+    //#cleanup
+    secondLock.release()
+  })
+
+  test("reports failure only after the wait bound is exhausted", async () => {
+    //#given
+    const dirPath = TEST_DIR
+    const holder = await acquireLock(dirPath)
+    const waitTimeoutMs = 60
+
+    //#when
+    const startedAt = Date.now()
+    const contender = await acquireLock(dirPath, { waitTimeoutMs, retryDelayMs: 5 })
+    const elapsed = Date.now() - startedAt
+
+    //#then
+    expect(contender.acquired).toBe(false)
+    expect(elapsed).toBeGreaterThanOrEqual(waitTimeoutMs)
+    expect(existsSync(join(dirPath, ".lock"))).toBe(true)
+
+    //#cleanup
+    holder.release()
+  })
+
+  test("acquires lock when stale lock exists (>30s)", async () => {
     //#given
     const dirPath = TEST_DIR
     const lockPath = join(dirPath, ".lock")
@@ -506,7 +545,7 @@ describe("acquireLock", () => {
     writeFileSync(lockPath, JSON.stringify({ timestamp: staleTimestamp }), "utf-8")
 
     //#when
-    const lock = acquireLock(dirPath)
+    const lock = await acquireLock(dirPath)
 
     //#then
     expect(lock.acquired).toBe(true)
@@ -515,10 +554,26 @@ describe("acquireLock", () => {
     lock.release()
   })
 
-  test("release removes lock file", () => {
+  test("reclaims a stale lock without spending the wait bound", async () => {
     //#given
     const dirPath = TEST_DIR
-    const lock = acquireLock(dirPath)
+    const lockPath = join(dirPath, ".lock")
+    writeFileSync(lockPath, JSON.stringify({ id: "crashed", timestamp: Date.now() - 31000 }), "utf-8")
+
+    //#when
+    const lock = await acquireLock(dirPath, { waitTimeoutMs: 0 })
+
+    //#then
+    expect(lock.acquired).toBe(true)
+
+    //#cleanup
+    lock.release()
+  })
+
+  test("release removes lock file", async () => {
+    //#given
+    const dirPath = TEST_DIR
+    const lock = await acquireLock(dirPath)
     const lockPath = join(dirPath, ".lock")
 
     //#when
@@ -528,10 +583,10 @@ describe("acquireLock", () => {
     expect(existsSync(lockPath)).toBe(false)
   })
 
-  test("release is safe to call multiple times", () => {
+  test("release is safe to call multiple times", async () => {
     //#given
     const dirPath = TEST_DIR
-    const lock = acquireLock(dirPath)
+    const lock = await acquireLock(dirPath)
 
     //#when
     lock.release()

--- a/packages/omo-opencode/src/features/claude-tasks/storage.ts
+++ b/packages/omo-opencode/src/features/claude-tasks/storage.ts
@@ -89,7 +89,35 @@ export function writeJsonAtomic(filePath: string, data: unknown): void {
   }
 }
 
+// A crashed holder is reclaimed on age alone, and this threshold stays independent of the wait
+// bound below so a wedged lock never costs a writer more than one stale check.
 const STALE_LOCK_THRESHOLD_MS = 30000
+// The critical section is a single atomic JSON write, so ordinary contention clears in
+// microseconds; this budget only has to outlast a burst of parallel writers.
+const DEFAULT_LOCK_WAIT_TIMEOUT_MS = 5000
+const DEFAULT_LOCK_RETRY_DELAY_MS = 10
+const MAX_LOCK_RETRY_DELAY_MS = 50
+
+export interface AcquireLockOptions {
+  waitTimeoutMs?: number
+  retryDelayMs?: number
+}
+
+export function resolveLockWaitTimeoutMs(): number {
+  const raw = process.env.OMO_TASK_LOCK_WAIT_TIMEOUT_MS?.trim()
+  if (!raw) return DEFAULT_LOCK_WAIT_TIMEOUT_MS
+
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_LOCK_WAIT_TIMEOUT_MS
+
+  return parsed
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
 
 export function generateTaskId(): string {
   return `T-${randomUUID()}`
@@ -103,9 +131,14 @@ export function listTaskFiles(config: Partial<OhMyOpenCodeConfig> = {}): string[
     .map((f) => f.replace('.json', ''))
 }
 
-export function acquireLock(dirPath: string): { acquired: boolean; release: () => void } {
+export async function acquireLock(
+  dirPath: string,
+  options: AcquireLockOptions = {},
+): Promise<{ acquired: boolean; release: () => void }> {
   const lockPath = join(dirPath, ".lock")
   const lockId = randomUUID()
+  const waitTimeoutMs = options.waitTimeoutMs ?? resolveLockWaitTimeoutMs()
+  const baseRetryDelayMs = options.retryDelayMs ?? DEFAULT_LOCK_RETRY_DELAY_MS
 
   const createLock = (timestamp: number) => {
     writeFileSync(lockPath, JSON.stringify({ id: lockId, timestamp }), {
@@ -114,9 +147,8 @@ export function acquireLock(dirPath: string): { acquired: boolean; release: () =
     })
   }
 
-  const isStale = () => {
+  const isStale = (lockContent: string) => {
     try {
-      const lockContent = readFileSync(lockPath, "utf-8")
       const lockData = JSON.parse(lockContent)
       const lockAge = Date.now() - lockData.timestamp
       return lockAge > STALE_LOCK_THRESHOLD_MS
@@ -124,6 +156,30 @@ export function acquireLock(dirPath: string): { acquired: boolean; release: () =
       ignoreClaudeTaskStorageError(error)
       return true
     }
+  }
+
+  const reclaimStaleLock = () => {
+    let snapshot: string
+    try {
+      snapshot = readFileSync(lockPath, "utf-8")
+    } catch (error) {
+      ignoreClaudeTaskStorageError(error)
+      // The lock vanished between the failed create and this read: nothing to reclaim, retry now.
+      return true
+    }
+
+    if (!isStale(snapshot)) return false
+
+    try {
+      // Re-read guards the gap between staleness detection and removal so a lock another writer
+      // acquired in the meantime is never deleted.
+      if (readFileSync(lockPath, "utf-8") !== snapshot) return false
+      unlinkSync(lockPath)
+    } catch (error) {
+      ignoreClaudeTaskStorageError(error)
+      // Ignore cleanup errors
+    }
+    return true
   }
 
   const tryAcquire = () => {
@@ -139,17 +195,31 @@ export function acquireLock(dirPath: string): { acquired: boolean; release: () =
     }
   }
 
+  const nextDelayMs = (attempt: number, deadline: number) => {
+    const cap = Math.max(MAX_LOCK_RETRY_DELAY_MS, baseRetryDelayMs)
+    const step = Math.min(baseRetryDelayMs * 2 ** attempt, cap)
+    // Jitter keeps a burst of parallel writers from retrying in lockstep.
+    const jittered = step / 2 + Math.random() * (step / 2)
+    return Math.max(1, Math.min(jittered, deadline - Date.now()))
+  }
+
   ensureDir(dirPath)
 
-  let acquired = tryAcquire()
-  if (!acquired && isStale()) {
-    try {
-      unlinkSync(lockPath)
-    } catch (error) {
-      ignoreClaudeTaskStorageError(error)
-      // Ignore cleanup errors
+  const deadline = Date.now() + waitTimeoutMs
+  let acquired = false
+  for (let attempt = 0; ; attempt++) {
+    if (tryAcquire()) {
+      acquired = true
+      break
     }
-    acquired = tryAcquire()
+    // Stale reclaim runs on every pass, so a crashed holder is cleared as soon as it ages out
+    // instead of consuming the whole wait budget.
+    if (reclaimStaleLock() && tryAcquire()) {
+      acquired = true
+      break
+    }
+    if (Date.now() >= deadline) break
+    await delay(nextDelayMs(attempt, deadline))
   }
 
   if (!acquired) {

--- a/packages/omo-opencode/src/tools/task/task-create.ts
+++ b/packages/omo-opencode/src/tools/task/task-create.ts
@@ -65,12 +65,13 @@ async function handleCreate(
   try {
     const validatedArgs = TaskCreateInputSchema.parse(args);
     const taskDir = getTaskDir(config);
-    const lock = acquireLock(taskDir);
+    const lock = await acquireLock(taskDir);
 
     if (!lock.acquired) {
-      return JSON.stringify({ error: "task_lock_unavailable" });
+      return JSON.stringify({ error: "task_lock_unavailable", retryable: true });
     }
 
+    let validatedTask: TaskObject;
     try {
       const taskId = generateTaskId();
       const task: TaskObject = {
@@ -87,20 +88,22 @@ async function handleCreate(
         threadID: context.sessionID,
       };
 
-      const validatedTask = TaskObjectSchema.parse(task);
+      validatedTask = TaskObjectSchema.parse(task);
       writeJsonAtomic(join(taskDir, `${taskId}.json`), validatedTask);
-
-      await syncTaskTodoUpdate(ctx, validatedTask, context.sessionID);
-
-      return JSON.stringify({
-        task: {
-          id: validatedTask.id,
-          subject: validatedTask.subject,
-        },
-      });
     } finally {
       lock.release();
     }
+
+    // Todo sync talks to the OpenCode session API and needs no mutual exclusion, so it runs
+    // outside the critical section to keep the hold window at one atomic write.
+    await syncTaskTodoUpdate(ctx, validatedTask, context.sessionID);
+
+    return JSON.stringify({
+      task: {
+        id: validatedTask.id,
+        subject: validatedTask.subject,
+      },
+    });
   } catch (error) {
     if (error instanceof Error && error.message.includes("Required")) {
       return JSON.stringify({

--- a/packages/omo-opencode/src/tools/task/task-lock-concurrency.test.ts
+++ b/packages/omo-opencode/src/tools/task/task-lock-concurrency.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, readdirSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { acquireLock } from "../../features/claude-tasks/storage"
+import { createTaskCreateTool } from "./task-create"
+import { createTaskUpdateTool } from "./task-update"
+import type { TaskObject } from "./types"
+
+const TEST_SESSION_ID = "test-session-concurrency"
+const TEST_ABORT_CONTROLLER = new AbortController()
+const TEST_CONTEXT = {
+  sessionID: TEST_SESSION_ID,
+  messageID: "test-message-concurrency",
+  agent: "test-agent",
+  abort: TEST_ABORT_CONTROLLER.signal,
+}
+const CONCURRENT_WRITERS = 8
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: () => void = () => {}
+  const promise = new Promise<void>((resolveFn) => {
+    resolve = resolveFn
+  })
+  return { promise, resolve }
+}
+
+function listTaskIds(dir: string): string[] {
+  return readdirSync(dir)
+    .filter((name) => name.startsWith("T-") && name.endsWith(".json"))
+    .map((name) => name.replace(".json", ""))
+}
+
+describe("task tool lock contention", () => {
+  let testDir = ""
+  let config: { sisyphus: { tasks: { storage_path: string } } }
+  const originalWaitTimeout = process.env.OMO_TASK_LOCK_WAIT_TIMEOUT_MS
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "omo-task-lock-"))
+    config = { sisyphus: { tasks: { storage_path: testDir } } }
+  })
+
+  afterEach(() => {
+    if (originalWaitTimeout === undefined) {
+      delete process.env.OMO_TASK_LOCK_WAIT_TIMEOUT_MS
+    } else {
+      process.env.OMO_TASK_LOCK_WAIT_TIMEOUT_MS = originalWaitTimeout
+    }
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  test("persists every task when task_create calls run concurrently", async () => {
+    //#given
+    const tool = createTaskCreateTool(config)
+
+    //#when
+    const results = await Promise.all(
+      Array.from({ length: CONCURRENT_WRITERS }, (_, index) =>
+        tool.execute({ subject: `Concurrent task ${index}` }, TEST_CONTEXT),
+      ),
+    )
+
+    //#then
+    const parsed = results.map((result) => JSON.parse(result) as { task?: { id: string }; error?: string })
+    expect(parsed.filter((result) => result.error !== undefined)).toEqual([])
+    expect(new Set(parsed.map((result) => result.task?.id)).size).toBe(CONCURRENT_WRITERS)
+    expect(listTaskIds(testDir).length).toBe(CONCURRENT_WRITERS)
+  })
+
+  test("persists concurrent task_create and task_update calls against one list", async () => {
+    //#given
+    const createTool = createTaskCreateTool(config)
+    const updateTool = createTaskUpdateTool(config)
+    const seededId = "T-seeded-task"
+    const seeded: TaskObject = {
+      id: seededId,
+      subject: "Seeded task",
+      description: "",
+      status: "pending",
+      blocks: [],
+      blockedBy: [],
+      threadID: TEST_SESSION_ID,
+    }
+    await Bun.write(join(testDir, `${seededId}.json`), JSON.stringify(seeded))
+
+    //#when
+    const results = await Promise.all([
+      ...Array.from({ length: 4 }, (_, index) => createTool.execute({ subject: `Mixed task ${index}` }, TEST_CONTEXT)),
+      ...Array.from({ length: 4 }, (_, index) =>
+        updateTool.execute({ id: seededId, description: `Update ${index}` }, TEST_CONTEXT),
+      ),
+    ])
+
+    //#then
+    const errors = results.map((result) => JSON.parse(result) as { error?: string }).filter((r) => r.error !== undefined)
+    expect(errors).toEqual([])
+    expect(listTaskIds(testDir).length).toBe(5)
+  })
+
+  test("marks task_lock_unavailable retryable when the wait bound is exhausted", async () => {
+    //#given
+    process.env.OMO_TASK_LOCK_WAIT_TIMEOUT_MS = "50"
+    const createTool = createTaskCreateTool(config)
+    const updateTool = createTaskUpdateTool(config)
+    const holder = await acquireLock(testDir, { waitTimeoutMs: 0 })
+    expect(holder.acquired).toBe(true)
+
+    //#when
+    const createResult = JSON.parse(await createTool.execute({ subject: "Blocked task" }, TEST_CONTEXT))
+    const updateResult = JSON.parse(await updateTool.execute({ id: "T-seeded-task", subject: "Blocked" }, TEST_CONTEXT))
+
+    //#then
+    expect(createResult).toEqual({ error: "task_lock_unavailable", retryable: true })
+    expect(updateResult).toEqual({ error: "task_lock_unavailable", retryable: true })
+
+    //#cleanup
+    holder.release()
+  })
+
+  test("releases the task lock before syncing todos", async () => {
+    //#given
+    process.env.OMO_TASK_LOCK_WAIT_TIMEOUT_MS = "80"
+    const enteredSync = deferred()
+    const finishSync = deferred()
+    const ctx = {
+      client: {
+        session: {
+          todo: async () => {
+            enteredSync.resolve()
+            await finishSync.promise
+            return { data: [] }
+          },
+        },
+      },
+    } as unknown as PluginInput
+    const syncingTool = createTaskCreateTool(config, ctx)
+    const plainTool = createTaskCreateTool(config)
+
+    //#when
+    const syncing = syncingTool.execute({ subject: "Task holding todo sync" }, TEST_CONTEXT)
+    await enteredSync.promise
+    const secondResult = JSON.parse(await plainTool.execute({ subject: "Task during todo sync" }, TEST_CONTEXT))
+
+    //#then
+    expect(secondResult.error).toBeUndefined()
+    expect(secondResult.task.subject).toBe("Task during todo sync")
+
+    //#cleanup
+    finishSync.resolve()
+    await syncing
+  })
+})

--- a/packages/omo-opencode/src/tools/task/task-update.ts
+++ b/packages/omo-opencode/src/tools/task/task-update.ts
@@ -2,6 +2,7 @@ import type { PluginInput } from "@opencode-ai/plugin";
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import { join } from "path";
 import type { OhMyOpenCodeConfig } from "../../config/schema";
+import type { TaskObject, TaskUpdateInput } from "./types";
 import { TaskObjectSchema, TaskUpdateInputSchema } from "./types";
 import {
   getTaskDir,
@@ -68,6 +69,52 @@ Properly managed dependencies enable maximum parallel execution.`,
   });
 }
 
+function applyTaskUpdate(taskPath: string, input: TaskUpdateInput): TaskObject | null {
+  const task = readJsonSafe(taskPath, TaskObjectSchema);
+
+  if (!task) {
+    return null;
+  }
+
+  if (input.subject !== undefined) {
+    task.subject = input.subject;
+  }
+  if (input.description !== undefined) {
+    task.description = input.description;
+  }
+  if (input.status !== undefined) {
+    task.status = input.status;
+  }
+  if (input.activeForm !== undefined) {
+    task.activeForm = input.activeForm;
+  }
+  if (input.owner !== undefined) {
+    task.owner = input.owner;
+  }
+
+  if (input.addBlocks) {
+    task.blocks = [...new Set([...task.blocks, ...input.addBlocks])];
+  }
+
+  if (input.addBlockedBy) {
+    task.blockedBy = [...new Set([...task.blockedBy, ...input.addBlockedBy])];
+  }
+
+  if (input.metadata !== undefined) {
+    task.metadata = { ...task.metadata, ...input.metadata };
+    Object.keys(task.metadata).forEach((key) => {
+      if (task.metadata?.[key] === null) {
+        delete task.metadata[key];
+      }
+    });
+  }
+
+  const updatedTask = TaskObjectSchema.parse(task);
+  writeJsonAtomic(taskPath, updatedTask);
+
+  return updatedTask;
+}
+
 async function handleUpdate(
   args: Record<string, unknown>,
   config: Partial<OhMyOpenCodeConfig>,
@@ -82,64 +129,28 @@ async function handleUpdate(
     }
 
     const taskDir = getTaskDir(config);
-    const lock = acquireLock(taskDir);
+    const lock = await acquireLock(taskDir);
 
     if (!lock.acquired) {
-      return JSON.stringify({ error: "task_lock_unavailable" });
+      return JSON.stringify({ error: "task_lock_unavailable", retryable: true });
     }
 
+    let updatedTask: TaskObject | null = null;
     try {
-      const taskPath = join(taskDir, `${taskId}.json`);
-      const task = readJsonSafe(taskPath, TaskObjectSchema);
-
-      if (!task) {
-        return JSON.stringify({ error: "task_not_found" });
-      }
-
-      if (validatedArgs.subject !== undefined) {
-        task.subject = validatedArgs.subject;
-      }
-      if (validatedArgs.description !== undefined) {
-        task.description = validatedArgs.description;
-      }
-      if (validatedArgs.status !== undefined) {
-        task.status = validatedArgs.status;
-      }
-      if (validatedArgs.activeForm !== undefined) {
-        task.activeForm = validatedArgs.activeForm;
-      }
-      if (validatedArgs.owner !== undefined) {
-        task.owner = validatedArgs.owner;
-      }
-
-      const addBlocks = args.addBlocks as string[] | undefined;
-      if (addBlocks) {
-        task.blocks = [...new Set([...task.blocks, ...addBlocks])];
-      }
-
-      const addBlockedBy = args.addBlockedBy as string[] | undefined;
-      if (addBlockedBy) {
-        task.blockedBy = [...new Set([...task.blockedBy, ...addBlockedBy])];
-      }
-
-      if (validatedArgs.metadata !== undefined) {
-        task.metadata = { ...task.metadata, ...validatedArgs.metadata };
-        Object.keys(task.metadata).forEach((key) => {
-          if (task.metadata?.[key] === null) {
-            delete task.metadata[key];
-          }
-        });
-      }
-
-      const validatedTask = TaskObjectSchema.parse(task);
-      writeJsonAtomic(taskPath, validatedTask);
-
-      await syncTaskTodoUpdate(ctx, validatedTask, context.sessionID);
-
-      return JSON.stringify({ task: validatedTask });
+      updatedTask = applyTaskUpdate(join(taskDir, `${taskId}.json`), validatedArgs);
     } finally {
       lock.release();
     }
+
+    if (!updatedTask) {
+      return JSON.stringify({ error: "task_not_found" });
+    }
+
+    // Todo sync talks to the OpenCode session API and needs no mutual exclusion, so it runs
+    // outside the critical section to keep the hold window at one read-modify-write.
+    await syncTaskTodoUpdate(ctx, updatedTask, context.sessionID);
+
+    return JSON.stringify({ task: updatedTask });
   } catch (error) {
     if (error instanceof Error && error.message.includes("Required")) {
       return JSON.stringify({


### PR DESCRIPTION
## Summary

Concurrent `task_create` / `task_update` calls against one task list lost writes and returned
`{"error":"task_lock_unavailable"}` on ordinary contention (#6157). The task-store lock was a single
exclusive-create attempt with no wait, so any writer that lost the race was told the lock was
unavailable and its task was silently never written — the reporter saw 3 of 4 concurrent creates
succeed, leaving the planner with an incomplete list while every individual call looked handled.

This PR makes the lock wait out ordinary contention within a bounded budget, shrinks the hold window
to the atomic file write, and marks the exhausted-budget error retryable. Measured on the real tool
implementations with 32 concurrent `task_create` calls against one list: **before 1 task file + 31
`task_lock_unavailable` errors, after 32 task files + 0 errors (31 ms)**.

Closes #6157

## Root cause

- `packages/omo-opencode/src/features/claude-tasks/storage.ts:106-115` (pre-change) —
  `acquireLock()` wrote `.lock` with `flag: "wx"` exactly once and returned `{ acquired: false }` on
  `EEXIST`. No retry, no backoff, no wait: staleness was the only escape hatch, so a lock that was
  merely *held* produced an instant failure.
- `packages/omo-opencode/src/tools/task/task-create.ts:46-48` and
  `packages/omo-opencode/src/tools/task/task-update.ts:62-64` (pre-change) surfaced that as
  `{"error":"task_lock_unavailable"}` with nothing marking it transient.
- `packages/omo-opencode/src/tools/task/task-create.ts:63` (pre-change) held the lock across
  `await syncTaskTodoUpdate()`, an OpenCode session API round trip, widening the contention window
  far beyond the file write it needed to protect.

## Changes

`packages/omo-opencode/src/features/claude-tasks/storage.ts`

- `acquireLock(dirPath, options?)` is now `async` and retries inside a bounded budget with jittered
  exponential backoff (10 ms base, 50 ms cap, half-jitter) until the deadline.
- Budget defaults to 5 s, overridable process-wide with `OMO_TASK_LOCK_WAIT_TIMEOUT_MS` and per call
  with `{ waitTimeoutMs, retryDelayMs }` (used by the tests to stay fast and deterministic).
- Stale reclaim keeps its own `STALE_LOCK_THRESHOLD_MS = 30000` and now runs on *every* retry pass,
  so it never depends on, or consumes, the wait budget.
- Reclaim re-reads the lock body immediately before `unlinkSync` and skips removal if the content
  changed, so a lock another writer acquired after the staleness check is never deleted (issue's
  "Possible fix direction" bullet 4).

`packages/omo-opencode/src/tools/task/task-create.ts`, `.../task-update.ts`

- `await acquireLock(...)`; on exhaustion return `{ error: "task_lock_unavailable", retryable: true }`.
- Critical section is now the atomic task-file write only; `syncTaskTodoUpdate()` runs after
  `lock.release()`. In `task-update` the read-modify-write moved into `applyTaskUpdate()` so the
  locked region is a single call and `task_not_found` is decided after release.

Tests / docs

- New `packages/omo-opencode/src/tools/task/task-lock-concurrency.test.ts`: 8 genuinely concurrent
  `task_create` calls via `Promise.all` on the real filesystem against one list; a mixed
  concurrent create+update batch; the retryable-error contract; and a test that pins todo sync
  outside the critical section by gating `client.session.todo` and creating a second task while the
  first is still inside sync.
- `packages/omo-opencode/src/features/claude-tasks/storage.test.ts`: existing `acquireLock` tests
  awaited; new tests for "lock released while waiting is acquired", "failure only after the bound
  elapses" (asserts `elapsed >= waitTimeoutMs`), and "stale lock reclaimed with `waitTimeoutMs: 0`".
- `packages/omo-opencode/src/features/claude-tasks/AGENTS.md` documents the new lock semantics.

No other call site exists: `acquireLock` from this module is used only by these two tools
(`task-get` / `task-list` are readers of atomically renamed files).

## Verification

RED first, against the unmodified `dev` code (`453e33c55`):

```
$ bun test packages/omo-opencode/src/tools/task/task-lock-concurrency.test.ts \
           packages/omo-opencode/src/features/claude-tasks/storage.test.ts

expect(received).toEqual(expected)
- []
+ [
+   { "error": "task_lock_unavailable" },   (x7)
+ ]
(fail) task tool lock contention > persists every task when task_create calls run concurrently
(fail) task tool lock contention > persists concurrent task_create and task_update calls against one list
(fail) task tool lock contention > marks task_lock_unavailable retryable when the wait bound is exhausted
(fail) task tool lock contention > releases the task lock before syncing todos
(fail) acquireLock > acquires a lock released while waiting within the bound
(fail) acquireLock > reports failure only after the wait bound is exhausted
 30 pass
 6 fail
```

GREEN after the fix:

```
$ bun test packages/omo-opencode/src/tools/task/ packages/omo-opencode/src/features/claude-tasks/
(pass) task tool lock contention > persists every task when task_create calls run concurrently [10.96ms]
(pass) task tool lock contention > persists concurrent task_create and task_update calls against one list [10.49ms]
(pass) task tool lock contention > marks task_lock_unavailable retryable when the wait bound is exhausted [103.47ms]
(pass) task tool lock contention > releases the task lock before syncing todos [1.08ms]
(pass) acquireLock > acquires a lock released while waiting within the bound [5.61ms]
(pass) acquireLock > reports failure only after the wait bound is exhausted [62.57ms]
(pass) acquireLock > reclaims a stale lock without spending the wait bound [0.60ms]
 144 pass
 0 fail
Ran 144 tests across 9 files.
```

Typecheck:

```
$ tsgo --noEmit -p packages/omo-opencode/tsconfig.json
(exit 0)
```

Real-surface QA — the actual `createTaskCreateTool` / `createTaskUpdateTool` factories driven with
32 concurrent creates followed by 32 concurrent updates against one temp-dir list:

```
before (dev 453e33c55)                    after (this branch)
{                                         {
  "concurrentCalls": 32,                    "concurrentCalls": 32,
  "createErrors": 31,                       "createErrors": 0,
  "uniqueCreatedIds": 1,                    "uniqueCreatedIds": 32,
  "concurrentUpdateErrors": 0,              "concurrentUpdateErrors": 0,
  "taskFilesOnDisk": 1,                     "taskFilesOnDisk": 32,
  "taskFilesInProgress": 1,                 "taskFilesInProgress": 32,
  "lockFileLeftBehind": false,              "lockFileLeftBehind": false,
  "elapsedMs": 3                            "elapsedMs": 31
}                                         }
```

The full `bun test` suite was not run on the authoring machine (scoped files + typecheck locally);
CI covers it on this PR.

## Ideal-state checklist

1. **Normal contention is invisible to the caller** — `acquireLock` retries with jittered
   exponential backoff until a bounded deadline (default 5 s); a lock released within the bound is
   acquired. Pinned by `acquireLock > acquires a lock released while waiting within the bound` (the
   release happens after `acquireLock`'s synchronous first attempt has already failed, so only a
   retry can observe it) and by the 8-way concurrent `task_create` test.
2. **`task_lock_unavailable` is reserved for genuine exhaustion and is explicitly retryable** —
   returned only when `Date.now() >= deadline`, as `{ error: "task_lock_unavailable", retryable: true }`
   from both tools. Pinned by `marks task_lock_unavailable retryable when the wait bound is
   exhausted` and by `reports failure only after the wait bound is exhausted`
   (`elapsed >= waitTimeoutMs`).
3. **The hold window is minimal** — the lock covers only the atomic write (`writeJsonAtomic`, plus
   the read-modify-write in `applyTaskUpdate`); `syncTaskTodoUpdate()` runs after `lock.release()`.
   Pinned by `releases the task lock before syncing todos`, which gates `client.session.todo` open
   and completes a second `task_create` while the first call is still inside sync.
4. **A stale lock is still reclaimed, independently of the wait bound** —
   `STALE_LOCK_THRESHOLD_MS` stays 30 s and reclaim runs on every retry pass, before the deadline
   check, so it works even with a zero budget. Pinned by `reclaims a stale lock without spending the
   wait bound` (`waitTimeoutMs: 0`). Reclaim is also content-guarded against deleting a lock taken
   in the meantime.
5. **Regression coverage uses genuinely concurrent writers** — `Promise.all` over N real
   `task_create` executions against one list on the real filesystem, asserting all N tasks exist on
   disk with unique ids and no error; plus a mixed concurrent create+update batch. Captured failing
   on the old code first (7 of 8 creates lost), which is exactly the reported failure mode.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `omo-opencode` task store lock contention so concurrent `task_create` and `task_update` calls against one task list no longer lose writes or return spurious `task_lock_unavailable` errors. The lock now waits out ordinary contention within a bounded budget and only covers the atomic file write. Closes #6157.

**Lock behavior**
- `acquireLock()` is async and retries with jittered exponential backoff until a deadline (5s default, overridable via `OMO_TASK_LOCK_WAIT_TIMEOUT_MS` or per-call options).
- Exhausting the budget returns `{ error: "task_lock_unavailable", retryable: true }` from both tools.
- Stale-lock reclaim keeps its own 30s threshold and runs on every retry pass, re-reading the lock body before unlinking so a lock re-acquired meanwhile is never deleted.

**Lock coverage**
- The lock now covers only the atomic task-file write; todo sync runs after release, with the update path's read-modify-write moved into `applyTaskUpdate()`.
- Concurrency tests use genuinely parallel `task_create` calls on the real filesystem, plus mixed create+update batches.

<sup>Written for commit c6e738fbee2f26bfa4340dde30ed1fd86a517f78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

