### PR TITLE
feat(omo-native): print edition, latest version, and update command in doctor

### DIFF
--- a/packages/omo-native/bin/lib/doctor.js
+++ b/packages/omo-native/bin/lib/doctor.js
@@ -2,8 +2,67 @@ import { spawnSync } from "node:child_process"
 import { existsSync, readFileSync, statSync } from "node:fs"
 import { join } from "node:path"
 import { canonicalAgentDir } from "./agent-dir.js"
-import { packageManifest, packageRoot, readJson, resolveSenpi } from "./package-paths.js"
+import { packageManifest, packageRoot, readJson, resolveSenpi, updateTarget } from "./package-paths.js"
 import { needsSetupSuggestion } from "./setup-detect.js"
+
+const NPM_DIST_TAGS_URL = "https://registry.npmjs.org/-/package/omo-ai/dist-tags"
+const NPM_FETCH_TIMEOUT_MS = 5000
+
+// Doctor is called without await from the launcher and the compiled entry, so the
+// registry lookup has to finish before we print. A bounded child fetch keeps that
+// synchronous and turns any network failure into "could not check".
+
+export function installedDistTag(version) {
+  return typeof version === "string" && version.includes("beta") ? "beta" : "latest"
+}
+
+export function latestFromDistTags(distTags, version) {
+  if (distTags === null || distTags === undefined || typeof distTags !== "object") return "could not check"
+  const value = distTags[installedDistTag(version)]
+  return typeof value === "string" && value.length > 0 ? value : "could not check"
+}
+
+function distTagsFetchScript(url, timeoutMs) {
+  return `
+const url = ${JSON.stringify(url)};
+const timeout = ${Number(timeoutMs)};
+const ac = new AbortController();
+const timer = setTimeout(() => ac.abort(), timeout);
+fetch(url, { signal: ac.signal, headers: { accept: "application/json" } })
+  .then((res) => { if (!res.ok) throw new Error(String(res.status)); return res.text(); })
+  .then((text) => { JSON.parse(text); process.stdout.write(text); })
+  .catch(() => { process.exitCode = 1; })
+  .finally(() => { clearTimeout(timer); });
+`
+}
+
+export function fetchNpmDistTagsSync(options = {}) {
+  const spawn = options.spawn ?? spawnSync
+  const url = options.url ?? NPM_DIST_TAGS_URL
+  const timeoutMs = options.timeoutMs ?? NPM_FETCH_TIMEOUT_MS
+  try {
+    const result = spawn(process.execPath, ["-e", distTagsFetchScript(url, timeoutMs)], {
+      encoding: "utf8",
+      timeout: timeoutMs + 500,
+      windowsHide: true,
+      env: process.env,
+    })
+    if (result.error || result.status !== 0 || typeof result.stdout !== "string" || result.stdout.trim() === "") return null
+    const parsed = JSON.parse(result.stdout)
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function readDistTags(options) {
+  try {
+    if (Object.hasOwn(options, "fetchDistTags")) return options.fetchDistTags()
+    return fetchNpmDistTagsSync()
+  } catch {
+    return null
+  }
+}
 
 const artifacts = [
   ["plugin manifest", "plugin/package.json"],
@@ -289,7 +348,10 @@ export function runDoctor(inventory, args = [], options = {}) {
     }
   }
 
-  lines.push(`INFO omo ${packageManifest().version} (engine: senpi ${engineVersionOrUnresolved(senpi)})`)
+  const version = packageManifest().version
+  const latest = latestFromDistTags(readDistTags(options), version)
+  lines.push(`INFO omo · Edition: Native · Installed: ${version} (engine: senpi ${engineVersionOrUnresolved(senpi)}) · Latest: ${latest}`)
+  lines.push(`INFO Update: ${updateTarget().command}`)
   lines.push(...warningsForSettings())
   lines.push(...staleEngineReport(options))
   lines.push(...retiredPayloadReport(options))

--- a/packages/omo-native/test/doctor-edition.test.ts
+++ b/packages/omo-native/test/doctor-edition.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { cpSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import {
+  fetchNpmDistTagsSync,
+  latestFromDistTags,
+  runDoctor,
+} from "../bin/lib/doctor.js"
+import { packageManifest, updateTarget } from "../bin/lib/package-paths.js"
+
+const SOURCE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
+const roots: string[] = []
+const artifacts = [
+  ["plugin manifest", "plugin/package.json"],
+  ["extension", "plugin/extensions/omo.js"],
+  ["lsp-daemon runtime", "plugin/runtime/lsp-daemon/dist/cli.js"],
+  ["agent-toolkit runtime", "plugin/runtime/agent-toolkit/cli.js"],
+] as const
+
+type Fixture = { root: string; packageRoot: string; launcher: string; agentDir: string }
+type InstallLayout = "bun" | "npm"
+
+function writeFile(path: string, content = "fixture\n"): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+}
+
+function createFixture(installLayout: InstallLayout = "npm"): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "omo-doctor-edition-"))
+  roots.push(root)
+  const packagePath = installLayout === "bun"
+    ? join(root, "custom-bun", "install", "global", "node_modules", "omo-ai")
+    : join(root, "prefix", "lib", "node_modules", "omo-ai")
+  mkdirSync(packagePath, { recursive: true })
+  const packageRoot = realpathSync(packagePath)
+  cpSync(join(SOURCE_ROOT, "bin"), join(packageRoot, "bin"), { recursive: true })
+  writeFile(join(packageRoot, "package.json"), JSON.stringify({
+    name: "omo-ai",
+    version: "5.0.0-0.beta.51",
+    type: "module",
+    dependencies: { "@code-yeongyu/senpi": "2026.8.9" },
+  }))
+  const senpiRoot = join(packageRoot, "node_modules", "@code-yeongyu", "senpi")
+  writeFile(join(senpiRoot, "package.json"), JSON.stringify({
+    name: "@code-yeongyu/senpi",
+    version: "2026.8.9",
+    type: "module",
+    exports: { ".": "./dist/index.js" },
+  }))
+  writeFile(join(senpiRoot, "dist", "index.js"), "export const fixture = true\n")
+  writeFile(join(senpiRoot, "dist", "cli.js"), "process.exit(0)\n")
+  writeFile(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
+  for (const [, artifact] of artifacts) writeFile(join(packageRoot, artifact))
+  const agentDir = join(root, "agent")
+  mkdirSync(agentDir, { recursive: true })
+  return { root, packageRoot, launcher: join(packageRoot, "bin", "omo.js"), agentDir }
+}
+
+function run(fixture: Fixture, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(process.execPath, [fixture.launcher, "doctor"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      OMO_CODING_AGENT_DIR: fixture.agentDir,
+      SENPI_CODING_AGENT_DIR: fixture.agentDir,
+      OMO_RUNTIME: "node",
+      ...env,
+    },
+  })
+}
+
+function captureDoctor(options: Record<string, unknown> = {}): { stdout: string; exitCode: number | undefined } {
+  const output: string[] = []
+  const originalLog = console.log
+  const originalExitCode = process.exitCode
+  console.log = (value?: unknown) => { output.push(String(value)) }
+  process.exitCode = undefined
+  try {
+    runDoctor({ harnesses: [] }, [], {
+      list: () => [],
+      ...options,
+    })
+    return { stdout: output.join("\n"), exitCode: process.exitCode }
+  } finally {
+    console.log = originalLog
+    process.exitCode = originalExitCode ?? 0
+  }
+}
+
+function editionLine(stdout: string): string {
+  const line = stdout.split("\n").find((entry) => entry.startsWith("INFO omo · Edition:"))
+  if (line === undefined) throw new Error(`missing edition line in:\n${stdout}`)
+  return line
+}
+
+function lineAfter(stdout: string, line: string): string {
+  const lines = stdout.split("\n")
+  const index = lines.indexOf(line)
+  if (index < 0 || index + 1 >= lines.length) throw new Error(`no line after ${JSON.stringify(line)} in:\n${stdout}`)
+  return lines[index + 1] ?? ""
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("omo doctor edition summary", () => {
+  describe("#given a complete packaged installation", () => {
+    describe("#when diagnostics run", () => {
+      test("#then the summary names Native edition, the installed version with engine, and Latest", () => {
+        const distTags = { beta: "5.0.0-0.beta.99", latest: "4.9.0" }
+        const captured = captureDoctor({ fetchDistTags: () => distTags })
+        const version = packageManifest().version
+        const expectedLatest = latestFromDistTags(distTags, version)
+
+        expect(editionLine(captured.stdout)).toMatch(
+          new RegExp(`^INFO omo · Edition: Native · Installed: ${version.replaceAll(".", "\\.")} \\(engine: senpi .+\\) · Latest: ${expectedLatest.replaceAll(".", "\\.")}$`),
+        )
+      })
+
+      test("#then the update command is the next line and is copyable on its own", () => {
+        const captured = captureDoctor({ fetchDistTags: () => ({ beta: "5.0.0-0.beta.99", latest: "4.9.0" }) })
+        const summary = editionLine(captured.stdout)
+        expect(lineAfter(captured.stdout, summary)).toBe(`INFO Update: ${updateTarget().command}`)
+      })
+    })
+  })
+
+  describe("#given bun versus npm install layouts", () => {
+    test("#then an npm-managed install prints the npm update command", () => {
+      const fixture = createFixture("npm")
+      const result = run(fixture)
+      expect(result.status).toBe(0)
+      const summary = editionLine(result.stdout)
+      expect(summary).toMatch(/^INFO omo · Edition: Native · Installed: 5\.0\.0-0\.beta\.51 \(engine: senpi 2026\.8\.9\) · Latest: /)
+      expect(lineAfter(result.stdout, summary)).toBe("INFO Update: npm i -g omo-ai@beta")
+      expect(updateTarget(fixture.packageRoot).command).toBe("npm i -g omo-ai@beta")
+    })
+
+    test("#then a Bun-managed install prints the bun update command for that layout", () => {
+      const fixture = createFixture("bun")
+      const result = run(fixture)
+      expect(result.status).toBe(0)
+      const summary = editionLine(result.stdout)
+      expect(lineAfter(result.stdout, summary)).toBe(`INFO Update: ${updateTarget(fixture.packageRoot).command}`)
+      expect(updateTarget(fixture.packageRoot).manager).toBe("bun")
+    })
+  })
+
+  describe("#given the installed channel", () => {
+    test("#then a beta install reads the beta dist-tag", () => {
+      expect(latestFromDistTags({ beta: "5.0.0-0.beta.99", latest: "4.9.0" }, "5.0.0-0.beta.51")).toBe("5.0.0-0.beta.99")
+    })
+
+    test("#then a stable install reads the latest dist-tag", () => {
+      expect(latestFromDistTags({ beta: "5.0.0-0.beta.99", latest: "4.9.0" }, "5.0.0")).toBe("4.9.0")
+    })
+  })
+
+  describe("#given the registry cannot be reached", () => {
+    test("#then Latest is could not check and diagnostics still pass", () => {
+      const captured = captureDoctor({
+        fetchDistTags: () => {
+          throw new Error("ECONNREFUSED")
+        },
+      })
+      expect(editionLine(captured.stdout)).toContain("· Latest: could not check")
+      expect(captured.stdout).not.toMatch(/FAIL[^\n]*(latest|registry|npm|dist-tag)/i)
+    })
+
+    test("#then a refused registry fetch returns no dist-tags", () => {
+      const tags = fetchNpmDistTagsSync({
+        spawn: () => ({ status: 1, stdout: "", stderr: "ECONNREFUSED" }),
+      })
+      expect(tags).toBeNull()
+      expect(latestFromDistTags(tags, "5.0.0-0.beta.51")).toBe("could not check")
+    })
+  })
+
+  describe("#given the npm registry answers", () => {
+    test("#then dist-tags are read from registry.npmjs.org with a bounded timeout", () => {
+      const calls: Array<{ cmd: string; args: string[]; opts: { timeout?: number } }> = []
+      const tags = fetchNpmDistTagsSync({
+        spawn: (cmd: string, args: string[], opts: { timeout?: number }) => {
+          calls.push({ cmd, args, opts })
+          return { status: 0, stdout: JSON.stringify({ beta: "5.0.0-0.beta.99", latest: "4.9.0" }), stderr: "" }
+        },
+      })
+
+      expect(tags).toEqual({ beta: "5.0.0-0.beta.99", latest: "4.9.0" })
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.cmd).toBe(process.execPath)
+      expect(calls[0]?.args[0]).toBe("-e")
+      expect(calls[0]?.args[1]).toContain("registry.npmjs.org")
+      expect(calls[0]?.args[1]).toContain("omo-ai")
+      expect(calls[0]?.args[1]).toContain("dist-tags")
+      expect(calls[0]?.opts.timeout).toBeGreaterThan(0)
+      expect(calls[0]?.opts.timeout).toBeLessThanOrEqual(10_000)
+    })
+  })
+})

--- a/script/agent-command-string-audit.allowlist.json
+++ b/script/agent-command-string-audit.allowlist.json
@@ -32,6 +32,7 @@
     "packages/omo-native/test/bun-bin-shim.test.ts: /bin/omo x8",
     "packages/omo-native/test/bun-runtime-decision.test.ts: /bin/omo",
     "packages/omo-native/test/bun-runtime.test.ts: /bin/omo",
+    "packages/omo-native/test/doctor-edition.test.ts: omo doctor",
     "packages/omo-native/test/doctor-stale-engines.test.ts: omo doctor x3",
     "packages/omo-native/test/doctor.test.ts: omo doctor x2",
     "packages/omo-opencode/src/cli/doctor/checks/codex-components.test.ts: omo doctor",


### PR DESCRIPTION
## Summary

Native `omo doctor` did not answer the four questions beta users asked in Discord (#8049): which edition this is, what is installed, what is latest on their channel, and the exact command that updates *this* install.

This change is the Native half. Doctor now prints:

```
INFO omo · Edition: Native · Installed: 5.0.0-0.beta.51 (engine: senpi …) · Latest: <v|could not check>
INFO Update: <updateTarget().command>
```

Latest comes from the npm `omo-ai` dist-tag that matches the installed channel (`beta` vs `latest`), with a 5s bounded fetch. Offline or a refused registry becomes `could not check` instead of omitting the field. The update line reuses `updateTarget()` (bun global layout vs npm) and does not change that helper.

## Root cause

`packages/omo-native/bin/lib/doctor.js:280` (pre-change) printed only `INFO omo <version> (engine: senpi <v>)`. The copyable update command lived only on `omo update` (`bin/lib/launcher.js:156-160` via `updateTarget()` in `bin/lib/package-paths.js`). Nothing fetched the channel's latest version.

## Changes

- `packages/omo-native/bin/lib/doctor.js`: edition/installed/latest summary line, next-line `INFO Update:`, sync npm dist-tags fetch with timeout, `could not check` on failure.
- `packages/omo-native/test/doctor-edition.test.ts`: failing-first coverage for the new lines, bun-vs-npm update command, beta-vs-latest channel, and the offline branch.

`updateTarget()` semantics are unchanged. `packages/omo-opencode` is untouched.

## Verification

RED (tests before production change):

```
bun test --timeout 20000 packages/omo-native/test/doctor-edition.test.ts

SyntaxError: Export named 'fetchNpmDistTagsSync' not found in module
'.../packages/omo-native/bin/lib/doctor.js'.

 0 pass
 1 fail
 1 error
```

GREEN (after the doctor.js change):

```
bun test --timeout 20000 packages/omo-native/test/doctor-edition.test.ts
 9 pass
 0 fail
EXIT:0

env OMO_CODING_AGENT_DIR= SENPI_CODING_AGENT_DIR= PI_CODING_AGENT_DIR= \
  bun test --timeout 20000 \
  packages/omo-native/test/doctor.test.ts \
  packages/omo-native/test/doctor-stale-engines.test.ts \
  packages/omo-native/test/doctor-retired-payload.test.ts
 36 pass
 0 fail

tsgo --noEmit -p packages/omo-native/tsconfig.json
TYPECHECK:0
```

## Ideal-state checklist

1. **Edition + installed + latest on the summary line** — `INFO omo · Edition: Native · Installed: <v> (engine: senpi …) · Latest: <v|could not check>`. Covered by the in-process summary test and the npm-layout spawn shape assertion.
2. **Update command on the next line** — `INFO Update: <updateTarget().command>` immediately after the summary. Covered by the "next line" test.
3. **Latest from the matching npm dist-tag, bounded timeout, offline = could not check** — `beta` vs `latest` from the installed version; fetch hits `registry.npmjs.org/-/package/omo-ai/dist-tags` with a 5s timeout; refused fetch returns null → `could not check`.
4. **Failing-first tests** — new lines, bun-vs-npm update line, offline branch in `packages/omo-native/test/doctor-edition.test.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Native `omo doctor` now prints the edition, installed version, latest available on the channel, and the copyable update command — the four questions beta users asked in #8049. Previously it only printed the installed version, and the update command lived only on `omo update`.

- The latest version comes from the npm dist-tag matching the installed channel (`beta` vs `latest`) via a 5s bounded fetch, falling back to `could not check` when the registry is unreachable.
- The update line reuses `updateTarget()`, whose semantics are unchanged; `packages/omo-opencode` is untouched.
- Test coverage for the new lines and the offline branch is added in `doctor-edition.test.ts`, with the command-audit allowlist updated for the new `omo doctor` invocation.

<sup>Written for commit 9ab721daa0eb1696c761fd2d2eae56fedd607fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

