### PR TITLE
feat(omo-opencode): show edition, latest version, and update command in doctor

### DIFF
--- a/packages/omo-opencode/src/cli/doctor/AGENTS.md
+++ b/packages/omo-opencode/src/cli/doctor/AGENTS.md
@@ -1,4 +1,4 @@
-# src/cli/doctor/ — Health Diagnostics (25 Check Files)
+# src/cli/doctor/ — Health Diagnostics (26 Check Files)
 
 **Generated:** 2026-08-10 / 38d268995
 
@@ -34,7 +34,9 @@ Registered by `getCodexCheckDefinitions()` (3): **CODEX** (critical, `checks/cod
 
 `checks/legacy-config-leftovers.ts` is not registered standalone; the Config aggregator invokes it.
 
-## SUPPORTING CHECK FILES (25 total)
+`checks/latest-version.ts` is not a check either: `runner.ts` runs `gatherEditionDistTags(target)` in parallel with the checks (npm dist-tags for `oh-my-openagent` / `lazycodex-ai`, 5s fetch timeout, `null` when unreachable) and `resolveLatestVersion()` picks the tag matching the installed channel. The result lands in `DoctorResult.latestVersion`, which the default formatter prints on the OK summary line together with the edition label and the per-edition update command (`framework/constants.ts` `EDITION_LABELS` / `UPDATE_COMMANDS`; `null` renders as `could not check`).
+
+## SUPPORTING CHECK FILES (26 total)
 
 ```
 checks/
@@ -61,6 +63,7 @@ checks/
 ├── telemetry.ts                           # Telemetry state
 ├── team-mode.ts                           # Team-mode dependencies
 ├── legacy-config-leftovers.ts             # Invoked by the Config aggregator, not registered
+├── latest-version.ts                      # Edition dist-tags fetch + channel pick for the summary line, not registered
 ├── codex.ts                               # Codex install (critical)
 ├── codex-components.ts                    # Codex plugin components
 └── codex-runtime-wrapper.ts               # Codex runtime wrapper bins
@@ -72,6 +75,7 @@ checks/
 doctor command
   → runner.ts: parallel check execution with 30s per-check timeout
   → checks/index.ts: getAllCheckDefinitions() (8) + getCodexCheckDefinitions() (3)
+  → checks/latest-version.ts: gatherEditionDistTags(target) runs alongside the checks
   → each check returns CheckResult: { name, status, message, details?, issues, duration? }
   → formatter.ts: render to stdout (text/status/json)
   → exit code: EXIT_CODES.SUCCESS (0) | EXIT_CODES.FAILURE (1)

--- a/packages/omo-opencode/src/cli/doctor/checks/index.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/index.ts
@@ -9,6 +9,7 @@ import { checkTelemetry } from "./telemetry"
 import { checkTeamMode } from "./team-mode"
 import { checkTuiPluginConfig } from "./tui-plugin-config"
 import { checkCodex, gatherCodexSummary } from "./codex"
+import { gatherEditionDistTags, resolveLatestVersion } from "./latest-version"
 import { CODEX_COMPONENTS_CHECK_ID, CODEX_COMPONENTS_CHECK_NAME, checkCodexComponents } from "./codex-components"
 import { checkCodexRuntimeWrapper } from "./codex-runtime-wrapper"
 
@@ -16,6 +17,7 @@ export type { CheckDefinition }
 export * from "./model-resolution-types"
 export { gatherSystemInfo, gatherToolsSummary }
 export { gatherCodexSummary }
+export { gatherEditionDistTags, resolveLatestVersion }
 
 export function getAllCheckDefinitions(): CheckDefinition[] {
   return [

--- a/packages/omo-opencode/src/cli/doctor/checks/latest-version.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/latest-version.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test"
+
+import type { NpmDistTags } from "../../config-manager/npm-dist-tags"
+import type { CodexDoctorSummary, SystemInfo } from "../framework/types"
+import { gatherEditionDistTags, resolveLatestVersion } from "./latest-version"
+
+function createSystemInfo(pluginVersion: string | null): SystemInfo {
+  return {
+    opencodeVersion: "1.0.200",
+    opencodePath: "/usr/local/bin/opencode",
+    pluginVersion,
+    loadedVersion: pluginVersion,
+    bunVersion: "1.2.0",
+    configPath: "/tmp/opencode.json",
+    configValid: true,
+    isLocalDev: false,
+  }
+}
+
+function createCodexSummary(overrides: Partial<CodexDoctorSummary> = {}): CodexDoctorSummary {
+  return {
+    codexPath: "/usr/local/bin/codex",
+    codexSource: "cli",
+    codexAppId: null,
+    marketplaceName: "sisyphuslabs",
+    pluginName: "omo",
+    pluginVersion: "5.0.0-beta.51",
+    pluginVersionStamped: true,
+    installerVersion: "5.0.0-beta.51",
+    packageName: "lazycodex-ai",
+    packageVersion: "5.0.0-beta.51",
+    pluginRoot: "/tmp/omo",
+    configPath: "/tmp/config.toml",
+    config: {
+      exists: true,
+      marketplaceConfigured: true,
+      pluginEnabled: true,
+      pluginsFeatureEnabled: true,
+      pluginHooksFeatureEnabled: true,
+      companionPluginEnabled: false,
+      companionLifecycleHookStateEvents: [],
+    },
+    linkedBins: ["omo"],
+    agents: ["plan"],
+    ...overrides,
+  }
+}
+
+describe("gatherEditionDistTags", () => {
+  it("fetches the oh-my-openagent dist-tags for the OpenCode edition", async () => {
+    //#given
+    const requested: string[] = []
+    const tags: NpmDistTags = { latest: "4.19.4", beta: "5.0.0-beta.51" }
+
+    //#when
+    const result = await gatherEditionDistTags("opencode", async (packageName) => {
+      requested.push(packageName)
+      return tags
+    })
+
+    //#then
+    expect(requested).toEqual(["oh-my-openagent"])
+    expect(result).toEqual(tags)
+  })
+
+  it("fetches the lazycodex-ai dist-tags for the Codex edition", async () => {
+    //#given
+    const requested: string[] = []
+
+    //#when
+    await gatherEditionDistTags("codex", async (packageName) => {
+      requested.push(packageName)
+      return { latest: "4.19.4" }
+    })
+
+    //#then
+    expect(requested).toEqual(["lazycodex-ai"])
+  })
+})
+
+describe("resolveLatestVersion", () => {
+  it("returns the beta tag when the installed OpenCode plugin is on the beta channel", () => {
+    //#given
+    const distTags: NpmDistTags = { latest: "4.19.4", beta: "5.0.0-beta.52" }
+
+    //#when
+    const latest = resolveLatestVersion({
+      target: "opencode",
+      systemInfo: createSystemInfo("5.0.0-beta.51"),
+      codex: undefined,
+      distTags,
+    })
+
+    //#then
+    expect(latest).toBe("5.0.0-beta.52")
+  })
+
+  it("returns the latest tag when the installed OpenCode plugin is a stable release", () => {
+    //#given
+    const distTags: NpmDistTags = { latest: "4.19.4", beta: "5.0.0-beta.52" }
+
+    //#when
+    const latest = resolveLatestVersion({
+      target: "opencode",
+      systemInfo: createSystemInfo("4.19.0"),
+      codex: undefined,
+      distTags,
+    })
+
+    //#then
+    expect(latest).toBe("4.19.4")
+  })
+
+  it("falls back to the latest tag when the installed channel has no dist-tag", () => {
+    //#given
+    const distTags: NpmDistTags = { latest: "4.19.4" }
+
+    //#when
+    const latest = resolveLatestVersion({
+      target: "opencode",
+      systemInfo: createSystemInfo("5.0.0-rc.1"),
+      codex: undefined,
+      distTags,
+    })
+
+    //#then
+    expect(latest).toBe("4.19.4")
+  })
+
+  it("returns null when the registry lookup failed", () => {
+    //#when
+    const latest = resolveLatestVersion({
+      target: "opencode",
+      systemInfo: createSystemInfo("5.0.0-beta.51"),
+      codex: undefined,
+      distTags: null,
+    })
+
+    //#then
+    expect(latest).toBeNull()
+  })
+
+  it("selects the Codex channel from the installed lazycodex-ai package version", () => {
+    //#given
+    const distTags: NpmDistTags = { latest: "4.19.4", beta: "5.0.0-beta.52" }
+
+    //#when
+    const latest = resolveLatestVersion({
+      target: "codex",
+      systemInfo: createSystemInfo("4.19.0"),
+      codex: createCodexSummary({ packageVersion: "5.0.0-beta.51" }),
+      distTags,
+    })
+
+    //#then
+    expect(latest).toBe("5.0.0-beta.52")
+  })
+
+  it("falls back to the Codex installer version when no distribution snapshot exists", () => {
+    //#given
+    const distTags: NpmDistTags = { latest: "4.19.4", beta: "5.0.0-beta.52" }
+
+    //#when
+    const latest = resolveLatestVersion({
+      target: "codex",
+      systemInfo: createSystemInfo("5.0.0-beta.51"),
+      codex: createCodexSummary({ packageVersion: null, installerVersion: "4.19.0" }),
+      distTags,
+    })
+
+    //#then
+    expect(latest).toBe("4.19.4")
+  })
+})

--- a/packages/omo-opencode/src/cli/doctor/checks/latest-version.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/latest-version.ts
@@ -1,0 +1,33 @@
+import { extractChannel } from "../../../hooks/auto-update-checker"
+import { fetchNpmDistTags, type NpmDistTags } from "../../config-manager/npm-dist-tags"
+import { EDITION_PACKAGE_NAMES } from "../framework/constants"
+import type { CodexDoctorSummary, DoctorTarget, SystemInfo } from "../framework/types"
+
+export type FetchDistTags = (packageName: string) => Promise<NpmDistTags | null>
+
+export interface LatestVersionInput {
+  target: DoctorTarget
+  systemInfo: SystemInfo
+  codex: CodexDoctorSummary | undefined
+  distTags: NpmDistTags | null
+}
+
+export function gatherEditionDistTags(
+  target: DoctorTarget,
+  fetchDistTags: FetchDistTags = fetchNpmDistTags
+): Promise<NpmDistTags | null> {
+  return fetchDistTags(EDITION_PACKAGE_NAMES[target])
+}
+
+function resolveInstalledVersion(input: LatestVersionInput): string | null {
+  if (input.target === "codex" && input.codex) {
+    return input.codex.packageVersion ?? input.codex.installerVersion
+  }
+  return input.systemInfo.pluginVersion
+}
+
+export function resolveLatestVersion(input: LatestVersionInput): string | null {
+  if (!input.distTags) return null
+  const channel = extractChannel(resolveInstalledVersion(input))
+  return input.distTags[channel] ?? input.distTags.latest ?? null
+}

--- a/packages/omo-opencode/src/cli/doctor/format-default.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/format-default.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { formatDefault } from "./framework/format-default"
 import { stripAnsi } from "./framework/format-shared"
-import type { DoctorResult } from "./framework/types"
+import type { CodexDoctorSummary, DoctorResult } from "./framework/types"
 
 function createBaseResult(): DoctorResult {
   return {
@@ -29,20 +29,64 @@ function createBaseResult(): DoctorResult {
     },
     summary: { total: 2, passed: 2, failed: 0, warnings: 0, skipped: 0, duration: 10 },
     exitCode: 0,
+    latestVersion: null,
+  }
+}
+
+function createCodexSummary(): CodexDoctorSummary {
+  return {
+    codexPath: "/usr/local/bin/codex",
+    codexSource: "cli",
+    codexAppId: null,
+    marketplaceName: "sisyphuslabs",
+    pluginName: "omo",
+    pluginVersion: "4.7.5",
+    pluginVersionStamped: true,
+    installerVersion: "4.7.5",
+    packageName: "lazycodex-ai",
+    packageVersion: "4.7.5",
+    pluginRoot: "/tmp/omo",
+    configPath: "/tmp/config.toml",
+    config: {
+      exists: true,
+      marketplaceConfigured: true,
+      pluginEnabled: true,
+      pluginsFeatureEnabled: true,
+      pluginHooksFeatureEnabled: true,
+      companionPluginEnabled: false,
+      companionLifecycleHookStateEvents: [],
+    },
+    linkedBins: ["omo"],
+    agents: ["plan"],
   }
 }
 
 describe("formatDefault", () => {
-  it("prints a single System OK line when no issues exist", () => {
+  it("prints the OpenCode edition, installed, latest, and update command when no issues exist", () => {
     //#given
     const result = createBaseResult()
+    result.latestVersion = "3.5.0"
 
     //#when
     const output = stripAnsi(formatDefault(result))
 
     //#then
-    expect(output).toContain("System OK (opencode 1.0.200")
+    expect(output).toContain("System OK · Edition: OpenCode · Installed: 3.4.0 · Latest: 3.5.0")
+    expect(output).toContain("Update: bunx oh-my-openagent install")
     expect(output).not.toContain("found:")
+  })
+
+  it("prints 'could not check' for Latest when the OpenCode registry lookup failed", () => {
+    //#given
+    const result = createBaseResult()
+    result.latestVersion = null
+
+    //#when
+    const output = stripAnsi(formatDefault(result))
+
+    //#then
+    expect(output).toContain("System OK · Edition: OpenCode · Installed: 3.4.0 · Latest: could not check")
+    expect(output).toContain("Update: bunx oh-my-openagent install")
   })
 
   it("prints numbered issue list when issues exist", () => {
@@ -78,41 +122,34 @@ describe("formatDefault", () => {
     expect(output).toContain("2. Loaded plugin is outdated")
   })
 
-  it("prints LazyCodex OK line for Codex doctor results", () => {
+  it("prints the Codex edition, installed, latest, and update command for Codex doctor results", () => {
     //#given
     const result = createBaseResult()
     result.target = "codex"
-    result.codex = {
-      codexPath: "/usr/local/bin/codex",
-      codexSource: "cli",
-      codexAppId: null,
-      marketplaceName: "sisyphuslabs",
-      pluginName: "omo",
-      pluginVersion: "4.7.5",
-      pluginVersionStamped: true,
-      installerVersion: "4.7.5",
-      packageName: "lazycodex-ai",
-      packageVersion: "4.7.5",
-      pluginRoot: "/tmp/omo",
-      configPath: "/tmp/config.toml",
-      config: {
-        exists: true,
-        marketplaceConfigured: true,
-        pluginEnabled: true,
-        pluginsFeatureEnabled: true,
-        pluginHooksFeatureEnabled: true,
-        companionPluginEnabled: false,
-        companionLifecycleHookStateEvents: [],
-      },
-      linkedBins: ["omo"],
-      agents: ["plan"],
-    }
+    result.codex = createCodexSummary()
+    result.latestVersion = "4.8.0"
 
     //#when
     const output = stripAnsi(formatDefault(result))
 
     //#then
-    expect(output).toContain("LazyCodex OK (codex /usr/local/bin/codex · omo 4.7.5 · lazycodex-ai 4.7.5)")
+    expect(output).toContain("LazyCodex OK · Edition: Codex · Installed: 4.7.5 · Latest: 4.8.0")
+    expect(output).toContain("Update: npx lazycodex-ai install --no-tui --codex-autonomous")
     expect(output).not.toContain("opencode")
+  })
+
+  it("prints 'could not check' for Latest when the Codex registry lookup failed", () => {
+    //#given
+    const result = createBaseResult()
+    result.target = "codex"
+    result.codex = createCodexSummary()
+    result.latestVersion = null
+
+    //#when
+    const output = stripAnsi(formatDefault(result))
+
+    //#then
+    expect(output).toContain("LazyCodex OK · Edition: Codex · Installed: 4.7.5 · Latest: could not check")
+    expect(output).toContain("Update: npx lazycodex-ai install --no-tui --codex-autonomous")
   })
 })

--- a/packages/omo-opencode/src/cli/doctor/formatter.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/formatter.test.ts
@@ -38,6 +38,7 @@ function createDoctorResult(): DoctorResult {
       duration: 12,
     },
     exitCode: 0,
+    latestVersion: "3.5.0",
   }
 }
 
@@ -102,7 +103,7 @@ function createCodexDoctorResult(): DoctorResult {
 
 describe("formatDoctorOutput", () => {
   describe("#given default mode", () => {
-    it("shows System OK when no issues", async () => {
+    it("shows the edition, installed, latest, and update command when no issues", async () => {
       //#given
       const result = createDoctorResult()
       const { formatDoctorOutput } = await import(`./framework/formatter?default-ok-${Date.now()}`)
@@ -111,7 +112,8 @@ describe("formatDoctorOutput", () => {
       const output = stripAnsi(formatDoctorOutput(result, "default"))
 
       //#then
-      expect(output).toContain("System OK (opencode 1.0.200 · oh-my-openagent 3.4.0)")
+      expect(output).toContain("System OK · Edition: OpenCode · Installed: 3.4.0 · Latest: 3.5.0")
+      expect(output).toContain("Update: bunx oh-my-openagent install")
     })
 
     it("shows issue count and details when issues exist", async () => {
@@ -279,6 +281,7 @@ describe("formatDoctorOutput", () => {
       expect(parsed.summary.total).toBe(2)
       expect(parsed.systemInfo.pluginVersion).toBe("3.4.0")
       expect(parsed.exitCode).toBe(0)
+      expect(parsed.latestVersion).toBe("3.5.0")
     })
   })
 })

--- a/packages/omo-opencode/src/cli/doctor/framework/constants.ts
+++ b/packages/omo-opencode/src/cli/doctor/framework/constants.ts
@@ -1,5 +1,6 @@
 import color from "picocolors"
 import { PUBLISHED_PACKAGE_NAME } from "../../../shared"
+import type { DoctorTarget } from "./types"
 
 export const SYMBOLS = {
   check: color.green("\u2713"),
@@ -50,3 +51,20 @@ export const MIN_OPENCODE_VERSION = "1.4.0"
 export const PACKAGE_NAME = PUBLISHED_PACKAGE_NAME
 
 export const OPENCODE_BINARIES = ["opencode", "opencode-desktop"] as const
+
+export const EDITION_LABELS: Record<DoctorTarget, string> = {
+  opencode: "OpenCode",
+  codex: "Codex",
+}
+
+export const EDITION_PACKAGE_NAMES: Record<DoctorTarget, string> = {
+  opencode: PUBLISHED_PACKAGE_NAME,
+  codex: "lazycodex-ai",
+}
+
+export const UPDATE_COMMANDS: Record<DoctorTarget, string> = {
+  opencode: `bunx ${PUBLISHED_PACKAGE_NAME} install`,
+  codex: "npx lazycodex-ai install --no-tui --codex-autonomous",
+}
+
+export const LATEST_UNAVAILABLE_TEXT = "could not check"

--- a/packages/omo-opencode/src/cli/doctor/framework/format-default.ts
+++ b/packages/omo-opencode/src/cli/doctor/framework/format-default.ts
@@ -1,8 +1,18 @@
 import color from "picocolors"
-import { PLUGIN_NAME } from "../../../shared"
 import type { DoctorResult } from "./types"
-import { SYMBOLS } from "./constants"
+import { SYMBOLS, EDITION_LABELS, UPDATE_COMMANDS, LATEST_UNAVAILABLE_TEXT } from "./constants"
 import { formatHeader, formatIssue } from "./format-shared"
+
+function formatOkSummary(result: DoctorResult, headline: string, installedVersion: string): string[] {
+  const target = result.target ?? "opencode"
+  const latest = result.latestVersion ?? LATEST_UNAVAILABLE_TEXT
+  return [
+    ` ${color.green(SYMBOLS.check)} ${color.green(
+      `${headline} · Edition: ${EDITION_LABELS[target]} · Installed: ${installedVersion} · Latest: ${latest}`
+    )}`,
+    `   Update: ${UPDATE_COMMANDS[target]}`,
+  ]
+}
 
 export function formatDefault(result: DoctorResult): string {
   const lines: string[] = []
@@ -13,21 +23,12 @@ export function formatDefault(result: DoctorResult): string {
 
   if (allIssues.length === 0) {
     if (result.target === "codex" && result.codex) {
-      const codex = result.codex.codexPath ?? result.codex.codexAppId ?? "unknown"
-      const pluginVer = result.codex.pluginVersion ?? "unknown"
-      const packageName = result.codex.packageName ?? "lazycodex-ai"
       const packageVer = result.codex.packageVersion ?? result.codex.installerVersion
-      lines.push(` ${color.green(SYMBOLS.check)} ${color.green(`LazyCodex OK (codex ${codex} · omo ${pluginVer} · ${packageName} ${packageVer})`)}`)
+      lines.push(...formatOkSummary(result, "LazyCodex OK", packageVer))
       return lines.join("\n")
     }
-    const opencodeVer = result.systemInfo.opencodeVersion ?? "unknown"
     const pluginVer = result.systemInfo.pluginVersion ?? "unknown"
-    lines.push(
-      ` ${color.green(SYMBOLS.check)} ${color.green(
-      `System OK (opencode ${opencodeVer} · oh-my-opencode ${pluginVer})`
-        .replace("oh-my-opencode", PLUGIN_NAME)
-      )}`
-    )
+    lines.push(...formatOkSummary(result, "System OK", pluginVer))
   } else {
     const issueCount = allIssues.filter((i) => i.severity === "error").length
     const warnCount = allIssues.filter((i) => i.severity === "warning").length

--- a/packages/omo-opencode/src/cli/doctor/framework/types.ts
+++ b/packages/omo-opencode/src/cli/doctor/framework/types.ts
@@ -72,6 +72,8 @@ export interface DoctorResult {
   exitCode: number
   target?: DoctorTarget
   codex?: CodexDoctorSummary
+  /** Latest published version on the installed channel; null when the registry lookup failed. */
+  latestVersion: string | null
 }
 
 export interface CodexConfigSummary {

--- a/packages/omo-opencode/src/cli/doctor/runner.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/runner.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, mock } from "bun:test"
 import type { CheckDefinition, CheckResult, DoctorResult, SystemInfo, ToolsSummary } from "./framework/types"
+import { gatherEditionDistTags, resolveLatestVersion } from "./checks/latest-version"
 
 function createSystemInfo(): SystemInfo {
   return {
@@ -29,12 +30,12 @@ function createPassResult(name: string): CheckResult {
   return { name, status: "pass", message: "ok", issues: [] }
 }
 
-function createDeferred(): {
-  promise: Promise<CheckResult>
-  resolve: (value: CheckResult) => void
+function createDeferred<T = CheckResult>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
 } {
-  let resolvePromise: (value: CheckResult) => void = () => {}
-  const promise = new Promise<CheckResult>((resolve) => {
+  let resolvePromise: (value: T) => void = () => {}
+  const promise = new Promise<T>((resolve) => {
     resolvePromise = resolve
   })
   return { promise, resolve: resolvePromise }
@@ -127,13 +128,15 @@ describe("runner", () => {
   })
 
   describe("runDoctor", () => {
-    it("starts all checks in parallel and returns collected result", async () => {
+    it("starts all checks and the registry lookup in parallel and returns collected result", async () => {
       //#given
       const startedChecks: string[] = []
+      const requestedUrls: string[] = []
       const deferredOne = createDeferred()
       const deferredTwo = createDeferred()
       const deferredThree = createDeferred()
       const deferredFour = createDeferred()
+      const deferredDistTags = createDeferred<Response>()
 
       const checks: CheckDefinition[] = [
         {
@@ -188,6 +191,7 @@ describe("runner", () => {
           duration: 0,
         },
         exitCode: 0,
+        latestVersion: null,
       }
 
       const formatDoctorOutputMock = mock((result: DoctorResult) => result.summary.total.toString())
@@ -197,6 +201,8 @@ describe("runner", () => {
         getAllCheckDefinitions: () => checks,
         gatherSystemInfo: async () => expectedResult.systemInfo,
         gatherToolsSummary: async () => expectedResult.tools,
+        gatherEditionDistTags,
+        resolveLatestVersion,
       }))
       mock.module("./framework/formatter", () => ({
         formatDoctorOutput: formatDoctorOutputMock,
@@ -206,6 +212,12 @@ describe("runner", () => {
       const logSpy = mock(() => {})
       const originalLog = console.log
       console.log = logSpy
+      const originalFetch = globalThis.fetch
+      globalThis.fetch = mock(async (input: string | URL | Request) => {
+        startedChecks.push("latest")
+        requestedUrls.push(String(input))
+        return deferredDistTags.promise
+      }) as unknown as typeof fetch
 
       const { runDoctor } = await import(`./runner?parallel=${Date.now()}`)
       const runPromise = runDoctor({ mode: "default" })
@@ -217,13 +229,17 @@ describe("runner", () => {
       deferredTwo.resolve(createPassResult("Configuration"))
       deferredThree.resolve(createPassResult("Tools"))
       deferredFour.resolve(createPassResult("Models"))
+      deferredDistTags.resolve(new Response(JSON.stringify({ latest: "3.5.0" }), { status: 200 }))
       const result = await runPromise
 
       //#then
       console.log = originalLog
-      expect(startedBeforeResolve.sort()).toEqual(["config", "models", "system", "tools"])
+      globalThis.fetch = originalFetch
+      expect(startedBeforeResolve.sort()).toEqual(["config", "latest", "models", "system", "tools"])
+      expect(requestedUrls).toEqual(["https://registry.npmjs.org/-/package/oh-my-openagent/dist-tags"])
       expect(result.results.length).toBe(4)
       expect(result.exitCode).toBe(0)
+      expect(result.latestVersion).toBe("3.5.0")
       expect(formatDoctorOutputMock).toHaveBeenCalledTimes(1)
       expect(formatJsonOutputMock).toHaveBeenCalledTimes(0)
     })

--- a/packages/omo-opencode/src/cli/doctor/runner.ts
+++ b/packages/omo-opencode/src/cli/doctor/runner.ts
@@ -1,5 +1,5 @@
 import type { DoctorOptions, DoctorResult, CheckDefinition, CheckResult, DoctorSummary } from "./framework/types"
-import { getAllCheckDefinitions, getCodexCheckDefinitions, gatherSystemInfo, gatherToolsSummary, gatherCodexSummary } from "./checks"
+import { getAllCheckDefinitions, getCodexCheckDefinitions, gatherSystemInfo, gatherToolsSummary, gatherCodexSummary, gatherEditionDistTags, resolveLatestVersion } from "./checks"
 import { EXIT_CODES } from "./framework/constants"
 import { formatDoctorOutput, formatJsonOutput } from "./framework/formatter"
 
@@ -51,6 +51,7 @@ function buildTimeoutResult(start: number, options: DoctorOptions): DoctorResult
     tools: { lspServers: [], astGrepCli: false, commentChecker: false, ghCli: { installed: false, authenticated: false, username: null }, mcpBuiltin: [], mcpUser: [] },
     summary: { total: 1, passed: 0, failed: 1, warnings: 0, skipped: 0, duration: Math.round(performance.now() - start) },
     exitCode: EXIT_CODES.FAILURE,
+    latestVersion: null,
   }
 
   if (options.json) {
@@ -74,6 +75,7 @@ export async function runDoctor(options: DoctorOptions): Promise<DoctorResult> {
     gatherSystemInfo(),
     gatherToolsSummary(),
     target === "codex" ? gatherCodexSummary() : Promise.resolve(undefined),
+    gatherEditionDistTags(target),
   ])
 
   let timer: ReturnType<typeof setTimeout> | undefined
@@ -85,9 +87,10 @@ export async function runDoctor(options: DoctorOptions): Promise<DoctorResult> {
   let systemInfo: Awaited<ReturnType<typeof gatherSystemInfo>>
   let tools: Awaited<ReturnType<typeof gatherToolsSummary>>
   let codex: Awaited<ReturnType<typeof gatherCodexSummary>> | undefined
+  let distTags: Awaited<ReturnType<typeof gatherEditionDistTags>>
 
   try {
-    ;[results, systemInfo, tools, codex] = await Promise.race([checksPromise, timeoutPromise])
+    ;[results, systemInfo, tools, codex, distTags] = await Promise.race([checksPromise, timeoutPromise])
   } catch (error) {
     clearTimeout(timer)
     if (error instanceof DoctorTimeoutError) {
@@ -110,6 +113,7 @@ export async function runDoctor(options: DoctorOptions): Promise<DoctorResult> {
     exitCode,
     target,
     codex,
+    latestVersion: resolveLatestVersion({ target, systemInfo, codex, distTags }),
   }
 
   if (options.json) {


### PR DESCRIPTION
## Summary

Refs #8049 (OpenCode and Codex halves; the Native half is a separate PR).

Beta users reported they could no longer tell from `doctor` which edition they run, whether a newer build exists, or which command updates it. The default `doctor` summary now answers all four questions on the success path, in the shape requested in the issue:

```
 ✓ System OK · Edition: OpenCode · Installed: 5.0.0-beta.51 · Latest: 5.0.0-beta.51
   Update: bunx oh-my-openagent install
```
```
 ✓ LazyCodex OK · Edition: Codex · Installed: 5.0.0-beta.51 · Latest: 5.0.0-beta.51
   Update: npx lazycodex-ai install --no-tui --codex-autonomous
```

When the npm registry is unreachable the line reads `Latest: could not check` instead of dropping the field.

## Root cause

- `packages/omo-opencode/src/cli/doctor/framework/format-default.ts:18-22` printed `System OK (opencode X · oh-my-openagent Y)` — installed version only, no edition, no latest, no update command. The Codex line at `:12-13` had the same gap.
- The only "latest" lookup lived inside the System check (`checks/system.ts:153-158`) and surfaced only as an issue when the loaded plugin was outdated, so an up-to-date user never saw a latest version at all. Codex had no latest lookup.
- `DoctorResult` (`framework/types.ts`) carried no latest-version field, so the formatter had nothing to print.

## Changes

- `checks/latest-version.ts` (new): `gatherEditionDistTags(target)` fetches the npm dist-tags of the edition's package (`oh-my-openagent` / `lazycodex-ai`) through the existing `fetchNpmDistTags` (5s `AbortSignal.timeout`, returns `null` on any failure). `resolveLatestVersion({ target, systemInfo, codex, distTags })` picks the tag for the installed channel via `extractChannel` (beta install -> `beta` tag, stable -> `latest`), falling back to `latest`, `null` when unreachable.
- `runner.ts`: the dist-tags fetch is a fifth member of the existing `Promise.all`, so it runs in parallel with the checks and stays under the 30s doctor budget; `DoctorResult.latestVersion` is attached (also `null` on the timeout result). Exit code is unaffected by the lookup.
- `framework/types.ts`: `DoctorResult.latestVersion: string | null` (also visible in `--json`).
- `framework/constants.ts`: `EDITION_LABELS`, `EDITION_PACKAGE_NAMES`, `UPDATE_COMMANDS`, `LATEST_UNAVAILABLE_TEXT`.
- `framework/format-default.ts`: shared `formatOkSummary` renders the summary line and a plain, copyable `Update:` line for both editions; the legacy `.replace("oh-my-opencode", PLUGIN_NAME)` path is gone.
- `AGENTS.md` (doctor): documents the new module and flow.
- Tests: `checks/latest-version.test.ts` (new), `format-default.test.ts`, `formatter.test.ts`, `runner.test.ts`.

Out of scope, noted for a follow-up: the issues path still prints `N issues found:` without the edition line, and `src/help/schema/doctor.ts` (Zod schema for `--json`) does not yet declare `latestVersion` (it already omits `target`/`codex`).

## Verification

Scoped test files and typecheck were run locally; the full suite was not run on this machine.

RED (tests written first, production untouched):

```
$ bun test src/cli/doctor/format-default.test.ts src/cli/doctor/formatter.test.ts src/cli/doctor/runner.test.ts src/cli/doctor/checks/latest-version.test.ts
Expected to contain: "System OK · Edition: OpenCode · Installed: 3.4.0 · Latest: 3.5.0"
Received: "\n oMoMoMoMo Doctor \n\n ✓ System OK (opencode 1.0.200 · oh-my-openagent 3.4.0)"
(fail) formatDefault > prints the OpenCode edition, installed, latest, and update command when no issues exist
(fail) formatDefault > prints 'could not check' for Latest when the OpenCode registry lookup failed
Expected to contain: "LazyCodex OK · Edition: Codex · Installed: 4.7.5 · Latest: 4.8.0"
Received: "\n oMoMoMoMo Doctor \n\n ✓ LazyCodex OK (codex /usr/local/bin/codex · omo 4.7.5 · lazycodex-ai 4.7.5)"
(fail) formatDefault > prints the Codex edition, installed, latest, and update command for Codex doctor results
(fail) formatDefault > prints 'could not check' for Latest when the Codex registry lookup failed
(fail) formatDoctorOutput > #given default mode > shows the edition, installed, latest, and update command when no issues
error: Cannot find module './checks/latest-version' from '.../runner.test.ts'
error: Cannot find module './latest-version' from '.../checks/latest-version.test.ts'
 12 pass
 7 fail
 2 errors
```

GREEN:

```
$ bun test src/cli/doctor/
 184 pass
 0 fail
Ran 184 tests across 29 files.

$ bun run typecheck   # packages/omo-opencode, tsgo --noEmit
exit 0

$ bun test src/shared/mock-module-lifecycle-audit.test.ts
 1 pass
```

Real surface (this machine has config issues, so the OK line is exercised via `--json`, which carries the same `latestVersion` the formatter prints):

```
$ bun run src/cli/index.ts doctor --json | jq -c '{target, installed: .systemInfo.pluginVersion, latestVersion}'
{"target":"opencode","installed":"5.0.0-beta.51","latestVersion":"5.0.0-beta.51"}

$ bun run src/cli/index.ts doctor --platform=codex --json | jq -c '{target, installed: (.codex.packageVersion // .codex.installerVersion), latestVersion}'
{"target":"codex","installed":"4.19.4","latestVersion":"4.19.4"}

$ HTTPS_PROXY=http://127.0.0.1:9 bun run src/cli/index.ts doctor --json | jq -c '{target, latestVersion}'
{"target":"opencode","latestVersion":null}
```

Rendered through `formatDoctorOutput` with a passing result (same code path the CLI takes after the runner):

```
 ✓ System OK · Edition: OpenCode · Installed: 5.0.0-beta.51 · Latest: 5.0.0-beta.51
   Update: bunx oh-my-openagent install
 ✓ System OK · Edition: OpenCode · Installed: 5.0.0-beta.51 · Latest: could not check
   Update: bunx oh-my-openagent install
 ✓ LazyCodex OK · Edition: Codex · Installed: 5.0.0-beta.51 · Latest: 5.0.0-beta.51
   Update: npx lazycodex-ai install --no-tui --codex-autonomous
 ✓ LazyCodex OK · Edition: Codex · Installed: 5.0.0-beta.51 · Latest: could not check
   Update: npx lazycodex-ai install --no-tui --codex-autonomous
```

Test-harness note: `mock.module("./checks")` in `runner.test.ts` rewrites the live export bindings of the modules that `./checks` re-exports (this is pre-existing for `gatherSystemInfo` / `gatherToolsSummary`). To keep `checks/latest-version.test.ts` deterministic in the same process, the runner test passes the real `gatherEditionDistTags` / `resolveLatestVersion` through the mock and stubs `globalThis.fetch` (restored by `test-setup.ts` after every test) instead of mocking the new functions.

## Ideal-state checklist

1. **Which edition, by name** — `Edition: OpenCode` / `Edition: Codex` on the summary line (`EDITION_LABELS`, selected by `DoctorResult.target`).
2. **Installed version** — `Installed: <v>` from `systemInfo.pluginVersion` (OpenCode) or `codex.packageVersion ?? codex.installerVersion` (Codex), same sources the old line used.
3. **Latest available version on the user's channel, or an explicit "could not check"** — `Latest: <v>` from the edition package's npm dist-tags, tag chosen by `extractChannel(installed)` (beta -> `beta`, stable -> `latest`); fetched on the success path too, bounded by the 5s fetch timeout inside the existing 30s doctor budget; `null` renders as `could not check`, never omitted.
4. **Exact update command on its own copyable line** — `Update: bunx oh-my-openagent install` (OpenCode) / `Update: npx lazycodex-ai install --no-tui --codex-autonomous` (Codex), plain text under the summary line.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`doctor` now reports the edition, installed version, latest release, and exact update command in the OK summary for both OpenCode and Codex. Previously the summary only showed the installed version, and the latest-version lookup only surfaced on the failure path when the plugin was outdated.

- Fetches npm dist-tags for `oh-my-openagent` / `lazycodex-ai` in parallel with the checks (5s timeout) and picks the tag matching the installed channel; `Latest: could not check` when the registry is unreachable.
- Adds `latestVersion` to `DoctorResult`, so `--json` output exposes it as well.
- Prints a plain, copyable `Update:` line under the summary for each edition.

<sup>Written for commit 94aac09a5a0cb2bcf4ef74c3f35f9adadbe9a11d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

