### PR TITLE
fix(memory): say recall is passive in the memory notice

### DIFF
--- a/packages/omo-senpi/src/components/memory/prompt.ts
+++ b/packages/omo-senpi/src/components/memory/prompt.ts
@@ -102,7 +102,7 @@ function renderMemoryNotice(
 ): string {
   return [
     "<memory_notice>",
-    `- ${previousMessageCount} previous messages between you and the user are stored in recall memory`,
+    `- ${previousMessageCount} previous messages are indexed in recall memory; relevant ones arrive on their own as <recalled-memory>, so there is no recall tool to look for`,
     ...(nudgeTurns === undefined
       ? []
       : [`- ${nudgeTurns} ${MEMORY_NUDGE_METADATA_TOKEN}. Save durable facts now, or decide nothing qualifies.`]),


### PR DESCRIPTION
## Summary

The memory notice described recall as a store the model could query, so models spent a tool-search round trip hunting for a `recall` tool that does not exist. Recall is passive: the kibitzer lane injects `<recalled-memory>` on its own.

Fixes #8066

## Changes

- `components/memory/prompt.ts`: the notice now says the indexed messages surface on their own as `<recalled-memory>` and that there is no recall tool to look for.

## QA & Evidence

- **What was tested:** rendered notice read back from the prompt path, plus `bun test packages/omo-senpi/src/components/memory/prompt.test.ts recall-notice.test.ts`.
- **Observed result:** the notice line reads `- N previous messages are indexed in recall memory; relevant ones arrive on their own as <recalled-memory>, so there is no recall tool to look for`; `37 pass, 0 fail`.
- **Why sufficient:** this is a prose-only change with no machine consumer - the notice's `customType` and delivery are already pinned by the existing tests, which stay green. Pinning the sentence itself with a grep would be pretend-coverage.

## Risks & Residuals

- Wording only; no code path, no schema, no delivery change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8066 by rewording the memory notice so models stop wasting a tool-search round trip hunting for a `recall` tool that doesn't exist. The notice now says relevant indexed messages arrive on their own as `<recalled-memory>`; watch out for a stray `packages/omo-senpi/node_modules` symlink added here that should be removed before merging.

<sup>Written for commit 469d3f724d1dd306277d33b93fd3fcfba2c02285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

