### PR TITLE
test(omo-native): canonicalize the doctor fixture root with realpathSync.native on Windows

### DIFF
--- a/packages/omo-native/test/doctor-edition.test.ts
+++ b/packages/omo-native/test/doctor-edition.test.ts
@@ -35,7 +35,10 @@ function createFixture(installLayout: InstallLayout = "npm"): Fixture {
     ? join(root, "custom-bun", "install", "global", "node_modules", "omo-ai")
     : join(root, "prefix", "lib", "node_modules", "omo-ai")
   mkdirSync(packagePath, { recursive: true })
-  const packageRoot = realpathSync(packagePath)
+  // realpathSync.native returns the long canonical name on Windows (GetFinalPathNameByHandle); the JS
+  // realpath keeps 8.3 aliases such as RUNNER~1, while the child resolves its own import.meta.url to the
+  // long form, so the two spellings of one directory would disagree in the Update: line.
+  const packageRoot = realpathSync.native(packagePath)
   cpSync(join(SOURCE_ROOT, "bin"), join(packageRoot, "bin"), { recursive: true })
   writeFile(join(packageRoot, "package.json"), JSON.stringify({
     name: "omo-ai",


### PR DESCRIPTION
## Summary

`packages/omo-native/test/doctor-edition.test.ts` fails on `windows-latest` only (`test (windows-latest, 2/2)` on dev-derived heads, e.g. run 34457617582):

```
Expected: "INFO Update: bun add --cwd "C:/Users/RUNNER~1/AppData/Local/Temp/omo-doctor-edition-xkQ1k0/custom-bun/install/global/node_modules/omo-ai" -g omo-ai@beta"
Received: "INFO Update: bun add --cwd "C:/Users/runneradmin/AppData/Local/Temp/omo-doctor-edition-xkQ1k0/custom-bun/install/global/node_modules/omo-ai" -g omo-ai@beta"
```

This is a test-only defect introduced with #8055 (the Native `doctor` edition summary). The product output is correct; the test's expected value is spelled with a Windows 8.3 short name.

## Root cause

`createFixture` canonicalizes the fixture directory with `realpathSync(packagePath)`. The JS `realpath` implementation keeps 8.3 aliases (`RUNNER~1`) because they are legal canonical path components. The child `omo doctor` process derives its own package root from `fileURLToPath(import.meta.url)` (`package-paths.js:5`), which the runtime resolves to the long form (`runneradmin`). Two spellings of one directory disagree only in the `Update:` line, which embeds the path verbatim.

This did not surface on the PR because the CI `test` matrix runs the Windows shards only with the `ci:full-matrix` label; the first real Windows execution was post-merge on `dev`.

## Changes

- `createFixture` uses `realpathSync.native`, which on Windows returns the long canonical name via `GetFinalPathNameByHandle` — the same spelling the child sees. No assertion is loosened; the expected and received values are now derived from the same canonical form.

## Verification

- macOS: `bun test packages/omo-native/test/doctor-edition.test.ts` — all tests pass (no POSIX regression; `realpathSync.native` and `realpathSync` agree there).
- Windows: this PR carries `ci:full-matrix` so `test (windows-latest, 2/2)` runs on the PR itself. RED is the dev-derived failure above; GREEN is this PR's Windows shard.

## Ideal-state checklist

1. The test compares the child's real output against a value canonicalized the same way the child canonicalizes — no pinned short names, no regex loosening.
2. Windows coverage runs on the PR, not only after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `doctor` edition test failing on Windows by canonicalizing the fixture root with `realpathSync.native` instead of `realpathSync`. The JS `realpath` kept Windows 8.3 short names (`RUNNER~1`) in the expected value, while the child `omo doctor` process resolves its own path to the long form (`runneradmin`), so the two spellings disagreed in the `Update:` line. The change makes the expected value use the same canonical form the child produces; no assertions are loosened and there's no POSIX impact.

<sup>Written for commit 2f87af1280e50707876d09fc86d2f75df2091494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

