### PR TITLE
fix(omo-config-core): tolerate unrecognized keys the migration target already carries

### DIFF
--- a/.omo/evidence/20260910-migration-validation-drift/EVIDENCE.md
+++ b/.omo/evidence/20260910-migration-validation-drift/EVIDENCE.md
@@ -1,0 +1,57 @@
+# QA Evidence: migration validation tolerates pre-existing unrecognized keys
+
+Date: 2026-09-10
+Branch: fix/migration-validate-tolerate-existing-keys (worktree .local-ignore/wt-migration-validation-fix)
+
+## WHAT WAS TESTED
+
+Fix: `packages/omo-config-core/src/migration/commit.ts` `validateTarget()` now tolerates zod
+`unrecognized_keys` issues when every flagged key already exists at the same path in the
+migration target (matching `loadOmoConfig` loader semantics, which strips unknown keys with a
+diagnostic instead of dropping the layer). Unrecognized keys introduced by migration additions,
+unsafe keys (`__proto__`/`constructor`/`prototype`), and prototype-tampered documents stay
+fail-closed (`hasTamperedPrototype` moved to `src/internal/plain-object.ts`, shared with loader).
+
+1. Hermetic unit gate:
+   - `bun test packages/omo-config-core` -> 206 pass / 0 fail (33 files).
+   - New RED->GREEN test in `src/migration/merge-commit.test.ts`: target carrying
+     `agents.sisyphus.ultrawork/compaction` + `agents.hephaestus.allow_non_gpt_model` migrates
+     successfully and keeps the keys. RED proof: pre-fix run threw
+     `MigrationValidationError: ... Unrecognized keys: "ultrawork", "compaction" ...` at commit.ts:39.
+   - Pre-existing pinned test (transform-introduced `unsupported_key` still throws
+     "Migration validation failed") stayed GREEN.
+2. Typecheck: `tsgo --noEmit -p packages/omo-config-core/tsconfig.json` -> exit 0.
+3. Real-surface QA (`qa-before-after.txt`): drove the real startup entry
+   `runOpenCodeStartupMigration()` (packages/omo-opencode/src/startup-migration.ts, the exact
+   function create-plugin-module.ts calls at plugin load) against an isolated replica HOME at
+   /tmp/migration-schema-drift-qa/home containing a byte copy of the user's real ~/.omo/omo.jsonc
+   plus a synthetic legacy source .config/opencode/oh-my-openagent.jsonc. Run twice from the task
+   worktree: once with the fix `git stash`ed (BEFORE), once restored (AFTER).
+
+## WHAT WAS OBSERVED
+
+- BEFORE: error string identical to the user-reported startup warning:
+  `Migration validation failed ... agents.sisyphus: Unrecognized keys: "ultrawork", "compaction",
+  agents.hephaestus: Unrecognized key: "allow_non_gpt_model", agents.sisyphus-junior: ...`.
+- AFTER: `error: null`, both migration plans status `migrated`, `_migrations` markers written,
+  and all three unrecognized key groups (`ultrawork`, `compaction`, `allow_non_gpt_model`)
+  preserved verbatim in the target.
+- Isolation: replica HOME under /tmp only; the real ~/.omo and ~/.config were read (copy) but
+  never written. No opencode process spawned, so no session DB impact.
+
+## WHY IT IS ENOUGH
+
+- The warning the user sees is emitted by create-plugin-module.ts printing
+  `runOpenCodeStartupMigration().error`; the real-surface run reproduces that exact error pre-fix
+  and shows it gone post-fix through the same entry point.
+- Fail-closed behavior is pinned by the retained unit test (additions-introduced unknown keys
+  still throw) and by the shared `hasTamperedPrototype`/`isUnsafeObjectKey` guards, whose loader
+  coverage is unchanged.
+
+## WHAT WAS OMITTED
+
+- No full `opencode run` boot QA: the change lives in omo-config-core (harness-neutral) and the
+  affected surface is the startup-migration call, which was driven directly at function level;
+  the user's installed plugin is the published beta, not this worktree, so a local opencode boot
+  would not exercise the patched code anyway.
+- No secrets involved; the user config replica contains only model IDs and comments (no tokens).

--- a/.omo/evidence/20260910-migration-validation-drift/qa-before-after.txt
+++ b/.omo/evidence/20260910-migration-validation-drift/qa-before-after.txt
@@ -1,0 +1,21 @@
+=== BEFORE (unfixed, git stash of fix) ===
+$ HOME=/tmp/migration-schema-drift-qa/home bun /tmp/migration-schema-drift-qa/run.ts
+{
+  "error": "Migration validation failed for /tmp/migration-schema-drift-qa/home/.omo/omo.jsonc: agents.sisyphus: Unrecognized keys: \"ultrawork\", \"compaction\", agents.hephaestus: Unrecognized key: \"allow_non_gpt_model\", agents.sisyphus-junior: Unrecognized keys: \"ultrawork\", \"compaction\"",
+  "statuses": [],
+  "migratedFrom": []
+}
+
+=== AFTER (fixed) ===
+$ HOME=/tmp/migration-schema-drift-qa/home bun /tmp/migration-schema-drift-qa/run.ts
+{
+  "error": null,
+  "statuses": [
+    { "status": "migrated", "diagnostics": ["skipped: $schema legacy=... kept=..."] },
+    { "status": "migrated", "diagnostics": [] }
+  ],
+  "migratedFrom": ["/private/tmp/migration-schema-drift-qa/home/.config/opencode/oh-my-openagent.jsonc"]
+}
+
+=== target agents keys preserved after migration ===
+{"hasUltrawork":true,"hasCompaction":true,"hasAllowNonGpt":true,"migrations":"\"_migrations\": [\n    \"2026-07-opencode-config-unification\",\n    \"2026-08-reasoning-unification\"\n  ]"}

--- a/packages/omo-config-core/src/internal/plain-object.ts
+++ b/packages/omo-config-core/src/internal/plain-object.ts
@@ -12,3 +12,11 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
     Object.prototype.toString.call(value) === "[object Object]"
   )
 }
+
+export function hasTamperedPrototype(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some((entry) => hasTamperedPrototype(entry))
+  if (typeof value !== "object" || value === null) return false
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) return true
+  return Object.values(value).some((entry) => hasTamperedPrototype(entry))
+}

--- a/packages/omo-config-core/src/loader/loader.ts
+++ b/packages/omo-config-core/src/loader/loader.ts
@@ -1,6 +1,7 @@
 import { parse, printParseErrorCode } from "jsonc-parser/lib/esm/main.js"
 import type * as z from "zod"
 
+import { hasTamperedPrototype } from "../internal/plain-object"
 import { OmoConfigLayerSchema, OmoConfigSchema, resolveOmoTaskSettings, type OmoConfig } from "../schema"
 import { isUnsafeObjectKey, mergeOmoConfigRecords } from "./merge"
 import { resolveOmoConfigPaths } from "./paths"
@@ -88,14 +89,6 @@ function unrecognizedKeyIssues(issues: readonly z.core.$ZodIssue[]): readonly Un
 function hasUnsafeUnrecognizedKey(parsed: unknown, issues: readonly UnrecognizedKeyIssue[]): boolean {
   if (issues.some((issue) => issue.keys.some((key) => isUnsafeObjectKey(key)))) return true
   return hasTamperedPrototype(parsed)
-}
-
-function hasTamperedPrototype(value: unknown): boolean {
-  if (Array.isArray(value)) return value.some((entry) => hasTamperedPrototype(entry))
-  if (!isRecord(value)) return false
-  const prototype = Object.getPrototypeOf(value)
-  if (prototype !== Object.prototype && prototype !== null) return true
-  return Object.values(value).some((entry) => hasTamperedPrototype(entry))
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/omo-config-core/src/migration/commit.ts
+++ b/packages/omo-config-core/src/migration/commit.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join, resolve } from "node:path"
-import { isPlainObject } from "../internal/plain-object"
+import { hasTamperedPrototype, isPlainObject, isUnsafeObjectKey } from "../internal/plain-object"
 import { parseJsoncSafe } from "../internal/jsonc-parse"
 import { toPosixPath } from "../internal/posix-path"
 import { resolveHomeDir } from "../loader"
@@ -32,10 +32,36 @@ function markerValue(target: Readonly<Record<string, unknown>>, migrationId: str
   return hasMigrationMarker(target, migrationId) ? value : [...value, migrationId]
 }
 
-function validateTarget(targetPath: string, document: Readonly<Record<string, unknown>>): void {
+function containerInTarget(target: Readonly<Record<string, unknown>>, path: readonly string[]): Record<string, unknown> | null {
+  let container: Record<string, unknown> = target
+  for (const segment of path) {
+    const next = container[segment]
+    if (!isPlainObject(next)) return null
+    container = next
+  }
+  return container
+}
+
+/**
+ * Mirrors loader semantics: unrecognized keys the user already carries in the target are tolerated
+ * (the loader strips them with a diagnostic instead of dropping the layer), while keys the migration
+ * additions introduce, unsafe keys, and prototype tampering stay fail-closed.
+ */
+function validateTarget(targetPath: string, document: Readonly<Record<string, unknown>>, target: Readonly<Record<string, unknown>>): void {
   const result = OmoConfigSchema.safeParse(document)
   if (result.success) return
-  const detail = result.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")
+  const blocking = result.error.issues.filter((issue) => {
+    if (issue.code !== "unrecognized_keys") return true
+    if (issue.keys.some((key) => isUnsafeObjectKey(key))) return true
+    const path = issue.path.map((segment) => String(segment))
+    const container = containerInTarget(target, path)
+    return container === null || issue.keys.some((key) => !Object.prototype.hasOwnProperty.call(container, key))
+  })
+  if (blocking.length === 0) {
+    if (!hasTamperedPrototype(document)) return
+    throw new MigrationValidationError(targetPath, "the document contains prototype tampering")
+  }
+  const detail = blocking.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")
   throw new MigrationValidationError(targetPath, detail)
 }
 
@@ -85,7 +111,7 @@ export function prepareTargetWrite(input: {
   const merged = mergeWithoutClobber(input.target, input.additions)
   const marker = markerValue(input.target, input.migrationId, input.targetPath)
   const document = { ...merged.merged, _migrations: marker }
-  validateTarget(input.targetPath, document)
+  validateTarget(input.targetPath, document, input.target)
   const edits = [...collectMigrationEdits(merged.additions), { path: ["_migrations"], value: marker }]
   return { diagnostics: merged.diagnostics, document, edits }
 }
@@ -98,7 +124,7 @@ export function prepareTargetReplacement(input: {
 }): PreparedTargetWrite {
   const marker = markerValue(input.target, input.migrationId, input.targetPath)
   const document = { ...input.document, _migrations: marker }
-  validateTarget(input.targetPath, document)
+  validateTarget(input.targetPath, document, input.target)
   const edits: { path: readonly string[]; value: unknown }[] = []
   for (const key of Object.keys(input.target)) {
     if (key !== "_migrations" && !Object.prototype.hasOwnProperty.call(input.document, key)) {

--- a/packages/omo-config-core/src/migration/merge-commit.test.ts
+++ b/packages/omo-config-core/src/migration/merge-commit.test.ts
@@ -132,4 +132,34 @@ describe("runMigration", () => {
     expect(fileSystem.existsSync(migrationFixture.sourcePath)).toBe(true)
     expect(fileSystem.existsSync("/home/alice/.omo/.migration-journal.json")).toBe(false)
   })
+
+  test("#given a target carrying harness-specific agent keys #when migrating #then validation tolerates keys already present in the target", () => {
+    // given
+    const fileSystem = new MemoryMigrationFileSystem()
+    fileSystem.files.set(migrationFixture.sourcePath, `{"task":{"default_concurrency":3}}`)
+    fileSystem.files.set(
+      migrationFixture.targetPath,
+      `{"agents":{"sisyphus":{"ultrawork":{"model":"x"},"compaction":{"model":"y"}},"hephaestus":{"allow_non_gpt_model":true}}}`,
+    )
+
+    // when
+    const result = runMigration({
+      env: migrationFixture.env,
+      fileSystem,
+      id: "legacy-task",
+      pid: 100,
+      sources: [{ path: migrationFixture.sourcePath }],
+      targetPath: migrationFixture.targetPath,
+      transform: () => ({ task: { default_concurrency: 3 } }),
+    })
+
+    // then
+    expect(result.status).toBe("migrated")
+    const target = parseFile(fileSystem, migrationFixture.targetPath)
+    expect(target["agents"]).toEqual({
+      sisyphus: { ultrawork: { model: "x" }, compaction: { model: "y" } },
+      hephaestus: { allow_non_gpt_model: true },
+    })
+    expect(target["_migrations"]).toEqual(["legacy-task"])
+  })
 })


### PR DESCRIPTION
## What changed

`validateTarget()` in `packages/omo-config-core/src/migration/commit.ts` no longer rejects unrecognized keys that the migration target already carries. It now mirrors `loadOmoConfig` loader semantics: an unrecognized key pre-existing at the same path in the target is tolerated (the loader strips unknown keys with a diagnostic instead of dropping the layer), while unrecognized keys introduced by migration additions, unsafe keys (`__proto__`/`constructor`/`prototype`), and prototype-tampered documents stay fail-closed. `hasTamperedPrototype` moved from `loader/loader.ts` to `internal/plain-object.ts` for reuse.

## Why

Users who legitimately configure harness-specific agent keys in `~/.omo/omo.jsonc` (e.g. `agents.sisyphus.ultrawork`, `agents.sisyphus.compaction`, `agents.hephaestus.allow_non_gpt_model` - all accepted by the OpenCode plugin's AgentOverridesSchema at runtime) hit a strict-schema rejection in the migration validator. Every opencode startup printed:

```
[config-migration] legacy configuration changes were not applied: Migration validation failed for ~/.omo/omo.jsonc: agents.sisyphus: Unrecognized keys: "ultrawork", "compaction", agents.hephaestus: Unrecognized key: "allow_non_gpt_model", ...
```

and no legacy migration could ever complete on such machines. The migration validator was stricter than the loader that consumes the same file.

## QA / evidence

- New RED->GREEN unit test (`merge-commit.test.ts`): target carrying the three key groups migrates successfully and preserves them. Pre-fix it threw the exact user-reported error.
- Pinned fail-closed test (transform-introduced `unsupported_key` still throws) stays green.
- `bun test packages/omo-config-core`: 206 pass / 0 fail. `tsgo --noEmit -p packages/omo-config-core/tsconfig.json`: clean.
- Real-surface before/after: drove `runOpenCodeStartupMigration()` (the exact startup entry) against an isolated replica HOME containing a byte copy of a real user `~/.omo/omo.jsonc` plus a synthetic legacy source. Before: the user-reported error verbatim. After: `error: null`, both plans migrated, keys preserved, `_migrations` markers written. Captured in `.omo/evidence/20260910-migration-validation-drift/`.

## Residual risk

Low: validation is only loosened for keys already present in the user's own target file; additions-introduced unknown keys and all prototype-pollution guards remain blocking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes migration validation so `~/.omo/omo.jsonc` files with harness-specific agent keys (e.g. `agents.sisyphus.ultrawork`, `agents.hephaestus.allow_non_gpt_model`) no longer block legacy migrations. `validateTarget()` now mirrors the loader: unrecognized keys already present in the target pass, while keys introduced by migration additions, unsafe keys, and prototype tampering still fail. Previously every startup printed a config-migration warning and no migration could complete on affected machines.

**Behavior**
- Tolerated keys are preserved verbatim in the migrated target file.
- Fail-closed paths (additions-introduced unknown keys, unsafe keys, prototype tampering) are unchanged.

<sup>Written for commit 9ca3443b53638e1bd6cd35a65fd218d5672ff2cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

