### PR TITLE
fix(omo-senpi): stale session ctx + duplicate extension instance stall tool dispatch

### DIFF
--- a/packages/omo-senpi/src/components/memory/trigger-wiring.test.ts
+++ b/packages/omo-senpi/src/components/memory/trigger-wiring.test.ts
@@ -323,4 +323,70 @@ describe("reflection trigger wiring", () => {
     expect(launches).toHaveLength(1)
     expect(launches[0]?.trigger).toBe("step-count")
   })
+
+  test("#given a stale session ctx after replacement #when a run settles #then the error is swallowed and the host handler still resolves", async () => {
+    const base = await fixture({ stepCount: 1 })
+    const staleError = new Error(
+      "This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().",
+    )
+    const session: ReflectionTriggerSession = {
+      conversationId: "stale-conversation",
+      ledger: base.ledger,
+      engine: {
+        evaluate: async () => {
+          throw staleError
+        },
+      },
+    }
+    const pi = new FakeExtensionAPI()
+    const logs: Array<{ level: string; message: string; details?: unknown }> = []
+    createReflectionTriggerWiring({
+      resolveSession: () => session,
+      onLaunch: () => {
+        throw new Error("must not launch")
+      },
+      logger: {
+        info: (message, details) => logs.push({ level: "info", message, details }),
+        warn: (message, details) => logs.push({ level: "warn", message, details }),
+        error: (message, details) => logs.push({ level: "error", message, details }),
+      },
+    }).register(pi)
+
+    // Must resolve (not reject): the host awaits this handler before dispatching
+    // the next turn's tools, so a throw here stalls eval/bash/kill_bash.
+    await successfulSettle(pi)
+
+    expect(logs.filter((entry) => entry.level === "warn")).toEqual([])
+    expect(base.launches).toEqual([])
+  })
+
+  test("#given a stale session ctx #when a manual reflection is requested #then no warning is logged", async () => {
+    const staleError = new Error("This extension ctx is stale after session replacement or reload.")
+    const logs: Array<{ level: string; message: string; details?: unknown }> = []
+    const session: ReflectionTriggerSession = {
+      conversationId: "stale-conversation",
+      ledger: { pendingCompaction: false, configRestartNotified: false },
+      engine: {
+        evaluate: async () => {
+          throw staleError
+        },
+      },
+    }
+    const { wiring } = await fixture({ stepCount: 1 })
+    void wiring
+    const pi = new FakeExtensionAPI()
+    const manual = createReflectionTriggerWiring({
+      resolveSession: () => session,
+      logger: {
+        info: () => {},
+        warn: (message, details) => logs.push({ level: "warn", message, details }),
+        error: () => {},
+      },
+    })
+    manual.register(pi)
+    manual.requestManualReflection("stale-focus")
+    await manual.whenIdle()
+
+    expect(logs.filter((entry) => entry.level === "warn")).toEqual([])
+  })
 })

--- a/packages/omo-senpi/src/components/memory/trigger-wiring.ts
+++ b/packages/omo-senpi/src/components/memory/trigger-wiring.ts
@@ -71,7 +71,11 @@ export function createReflectionTriggerWiring(options: ReflectionTriggerWiringOp
   function track(task: () => Promise<void>): void {
     const promise = task()
       .catch((error: unknown) => {
-        options.logger?.warn("omo-senpi memory reflection trigger failed", { error: describe(error) })
+        // Same rationale as the agent_settled handler: a stale ctx is expected
+        // after session replacement, not a failure worth surfacing.
+        if (!isStaleSessionContext(error)) {
+          options.logger?.warn("omo-senpi memory reflection trigger failed", { error: describe(error) })
+        }
       })
       .finally(() => {
         inFlight.delete(promise)
@@ -122,7 +126,12 @@ export function createReflectionTriggerWiring(options: ReflectionTriggerWiringOp
           }
           await evaluateAndLaunch(session, { kind: "settled", success: true })
         } catch (error: unknown) {
-          options.logger?.warn("omo-senpi memory reflection trigger failed", { error: describe(error) })
+          // A stale session ctx means this turn is already gone (session replaced
+          // or reloaded mid-flight). Swallow it silently: reflection is best-effort
+          // and must never break the host's tool dispatch for subsequent turns.
+          if (!isStaleSessionContext(error)) {
+            options.logger?.warn("omo-senpi memory reflection trigger failed", { error: describe(error) })
+          }
         }
       })
 
@@ -196,4 +205,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * The senpi host throws when an extension uses a ctx captured before a session
+ * replacement or reload ("This extension ctx is stale after session replacement
+ * or reload..."). Reflection is fire-and-forget observability: a stale ctx means
+ * the turn it belonged to is already gone, so the settle is skipped instead of
+ * surfacing an error that can stall the host's tool dispatch chain.
+ */
+export function isStaleSessionContext(error: unknown): boolean {
+  const message = describe(error)
+  return message.includes("stale after session replacement or reload")
 }

--- a/packages/omo-senpi/src/extension/compose.test.ts
+++ b/packages/omo-senpi/src/extension/compose.test.ts
@@ -28,6 +28,9 @@ class ReloadingFakeExtensionAPI extends FakeExtensionAPI {
 
 afterEach(() => {
   jest.useRealTimers()
+  // The duplicate-instance guard is process-wide: reset between tests so each
+  // case starts as the first (winning) instance.
+  delete (globalThis as Record<string, unknown>).__omoSenpiActiveInstance
 })
 
 function createRecordingLogger(): ComponentLogger & { entries: Array<{ level: string; message: string; details?: unknown }> } {
@@ -373,5 +376,49 @@ describe("composeOmoSenpiExtension", () => {
 
     // then
     expect(alphaCalls).toStrictEqual([["alpha ready"], ["alpha detail", { count: 1 }]])
+  })
+
+  it("#given a second omo extension instance in the same process #when composed #then it stands down without registering anything", async () => {
+    // given the first instance already won
+    const first = new FakeExtensionAPI()
+    const firstLogger = createRecordingLogger()
+    await composeOmoSenpiExtension(
+      [
+        {
+          name: "alpha",
+          register(api) {
+            api.registerTool({ name: "alpha_tool" })
+          },
+        },
+      ],
+      { logger: firstLogger },
+    )(first)
+    expect(first.tools.map((tool) => tool.name)).toEqual(["alpha_tool"])
+
+    // when a second instance (dev plugin + launcher bundle) activates
+    const second = new FakeExtensionAPI()
+    const secondLogger = createRecordingLogger()
+    await composeOmoSenpiExtension(
+      [
+        {
+          name: "alpha",
+          register(api) {
+            api.registerTool({ name: "alpha_tool" })
+          },
+        },
+      ],
+      { logger: secondLogger },
+    )(second)
+
+    // then it registers nothing and warns once
+    expect(second.tools).toEqual([])
+    expect(second.flags).toEqual([])
+    expect(secondLogger.entries).toContainEqual({
+      level: "warn",
+      message: "omo-senpi duplicate extension instance detected; standing down",
+      details: {
+        hint: "two omo extensions are loaded in this senpi process (e.g. a local dev plugin in senpi settings packages plus the omo launcher's bundled extension); remove one",
+      },
+    })
   })
 })

--- a/packages/omo-senpi/src/extension/compose.ts
+++ b/packages/omo-senpi/src/extension/compose.ts
@@ -79,6 +79,18 @@ export function composeOmoSenpiExtension(
       return
     }
 
+    // Two omo extensions in one senpi process (e.g. a local dev plugin in senpi
+    // settings packages plus the omo launcher's bundled extension) fight over
+    // tool registration and session ctx. The FIRST instance wins; later ones
+    // stand down entirely so the winner owns tool dispatch alone.
+    // See: config-watch's per-component guard only covers config, not tools.
+    if (markOmoSenpiActive()) {
+      logger.warn("omo-senpi duplicate extension instance detected; standing down", {
+        hint: "two omo extensions are loaded in this senpi process (e.g. a local dev plugin in senpi settings packages plus the omo launcher's bundled extension); remove one",
+      })
+      return
+    }
+
     pi.registerFlag("omo-senpi-disabled", {
       type: "boolean",
       default: false,
@@ -164,4 +176,19 @@ export function composeOmoSenpiExtension(
 
 function componentDisabledFlag(name: string): string {
   return `omo-senpi-${name}-disabled`
+}
+
+// Process-wide single-winner guard: the first omo-senpi extension instance to
+// activate in this senpi process owns tool dispatch. module state is shared per
+// process, so a second bundled copy (dev plugin + launcher bundle) sees the
+// flag and stands down before registering anything.
+declare global {
+  // eslint-disable-next-line no-var
+  var __omoSenpiActiveInstance: boolean | undefined
+}
+
+function markOmoSenpiActive(): boolean {
+  if (globalThis.__omoSenpiActiveInstance === true) return true
+  globalThis.__omoSenpiActiveInstance = true
+  return false
 }


### PR DESCRIPTION
## Symptom (Orca desktop)

Every process-spawning tool call (eval, bash, kill_bash, bash_output) renders as a DSML block but never returns. read_file works intermittently. Each user utterance only bumps the <memory_notice> recall count. New sessions show the same symptom. Reproduced in both Orca app sessions and terminal `omo -p`.

Environment: Orca 1.4.197, omo v5.0.0-beta.53, senpi 2026.9.10-2, macOS 26.5.1 (M4 Mac mini).

## Root cause 1: stale session ctx in reflection settle path (fixed)

After a session replacement or reload, the senpi host rejects extension ctx captured before the switch:

> This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().

The reflection wiring's `agent_settled` handler awaited `engine.evaluate()` with that stale ctx (`packages/omo-senpi/src/components/memory/trigger-wiring.ts`). The throw stalls the host's tool dispatch chain. Reproduced locally: `omo -p` prints the DSML block, then `memory reflection launch failed { error: stale... }` and exits without a tool result.

Fix: reflection is fire-and-forget observability, so a stale ctx (turn already gone) is skipped silently in both the settled handler and the manual `track()` path via new `isStaleSessionContext()` helper. Other errors still warn as before.

## Root cause 2: duplicate omo extension instance in one senpi process (fixed)

The default local-path install registers a dev plugin in senpi settings `packages` (e.g. `~/.local/src/oh-my-openagent/packages/omo-senpi/plugin`), while the omo launcher ALSO loads its bundled extension. Two live omo instances in one senpi process fight over tool registration and session ctx. `config-watch` already stands down per-component, but every other component stays live on both sides.

Log signature:

> omo config-watch superseded by another omo extension instance; standing down ... two omo extensions are loaded in this senpi process (e.g. a local dev plugin in senpi settings packages plus the omo launcher's bundled extension); remove one

In my case TWO stale checkouts were registered at once (`~/.local/src/oh-my-openagent` in senpi settings + `~/.local/src/omo-empty-response-recovery` in omo settings), both weeks out of date. Removing both made `superseded` disappear — but tool calls still stalled intermittently, which led to root cause 3.

Fix: process-wide single-winner guard in `composeOmoSenpiExtension` (`packages/omo-senpi/src/extension/compose.ts`) — the first instance to activate wins, later ones return before registering anything. `globalThis` flag is shared per process even across separate bundles.

## Root cause 3 (reported, NOT fixed here): deepseek-v4-flash emits fullwidth DSML delimiters

After fixing 1+2, terminal `omo -p` with `openai-codex/gpt-5.6-luna` works. But Orca app sessions using `deepseek-v4-flash` (opencode-zen provider) still stall: the model emits DSML delimiters with FULLWIDTH pipes:

> <｜｜DSML｜｜ calls>   (U+FF5C FULLWIDTH VERTICAL LINE)

instead of:

> <||DSML|| calls>   (U+007C ASCII)

The host does not recognize the fullwidth form as a tool call, so it renders as plain text and nothing executes. Note the model keeps ASCII everywhere else (JS code, quotes) — only the DSML delimiters get CJK-width treatment, as if the model treats them as markdown-like adornments. Other reporters use GPT/Claude-family models, which is likely why this only surfaces on deepseek-v4-flash (+ possibly other CJK-heavy tokenizers).

Suggested follow-ups for maintainers:
- normalize fullwidth `｜` (U+FF5C) to ASCII `|` in the DSML parser, or
- add an explicit halfwidth-only instruction to the tool-call format prompt.

Happy to implement either on direction.

## Tests

- `bun test src/components/memory/trigger-wiring.test.ts src/extension/compose.test.ts`: 36 pass, 0 fail (3 new tests: stale-ctx settle, stale-ctx manual, duplicate-instance stand-down)
- `tsc --noEmit`: clean