### PR TITLE
test: isolate nested timeout probe from CI reporter

### DIFF
--- a/script/ci-test-timeout.test.ts
+++ b/script/ci-test-timeout.test.ts
@@ -29,7 +29,13 @@ describe("per-file test timeout budget", () => {
           "",
         ].join("\n"))
       }
-      const run = (...extra: string[]) => spawnSync(process.execPath, ["test", ...extra, dir], { cwd: repoRoot, encoding: "utf8" })
+      // The parent runs in GitHub Actions, but the probe's captured output must not use Bun's
+      // GitHub log-group reporter. Bun 1.4.x sends the grouped test output to stderr after the
+      // initial header on CI, and Windows can return the sync capture at that split point.
+      const probeEnv = { ...process.env }
+      delete probeEnv.CI
+      delete probeEnv.GITHUB_ACTIONS
+      const run = (...extra: string[]) => spawnSync(process.execPath, ["test", ...extra, dir], { cwd: repoRoot, encoding: "utf8", env: probeEnv })
       const explicit = run("--timeout", "20000")
       expect(`${explicit.stdout}${explicit.stderr}`).toMatch(/\b2 pass\b/)
       expect(`${explicit.stdout}${explicit.stderr}`).not.toMatch(/timed out after 5000ms/)


### PR DESCRIPTION
## Symptom
On Windows CI, the timeout contract test intermittently received only the truncated nested-child output:

> `bun test v1.4.2 (744846f84)\n\n::group::C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\omo-timeout-budget-INV8AU\\probe\\a.test.ts:`

The assertion then could not find `2 pass`.

## Root cause
The probe inherits the parent GitHub Actions environment. Bun 1.4.x enables its GitHub log-group reporter when `GITHUB_ACTIONS`/`CI` is set, writing the initial `bun test` header to stdout and grouped test output/summary to stderr. On Windows, the synchronous nested capture can be observed at that stream split, ending after the `::group::` header. This is in `script/ci-test-timeout.test.ts:32-38`; the probe itself has no child timeout and uses `spawnSync`, so this is reporter/capture behavior rather than the timeout contract under test.

## Fix
Remove `CI` and `GITHUB_ACTIONS` only from the nested probe child environment. The child therefore uses plain Bun output, while the parent test still runs under CI and continues to assert the real `--timeout 20000` multi-file contract.

## Evidence
- Bun 1.4.2 on gorky with `GITHUB_ACTIONS=true CI=true`: captured stdout was only `bun test v1.4.2 (744846f84)`; captured stderr contained the `::group::` framing, both passes, and `2 pass`.
- Existing test: 10/10 on gorky/Linux (Bun 1.4.2).
- Fixed test: 10/10 on gorky/Linux (Bun 1.4.2) with the CI environment still set for the parent.
- Mutation using a racy first-stdout-chunk read: observed only `bun test v1.4.2 (744846f84)` and `containsPass: false`.

Refs #6976


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the nested timeout probe in the CI test so it no longer gets truncated output from Bun's GitHub log-group reporter on Windows.

- Removes `CI` and `GITHUB_ACTIONS` from the probe's environment so it uses plain test output; the parent test still runs under CI and asserts the real `--timeout 20000` contract.

<sup>Written for commit f27abed3566f0672855c48f4dbb703d26b1c7527. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

