### PR TITLE
test(senpi-task): make DAG concurrent-start race deterministic

### DIFF
--- a/packages/senpi-task/src/dag/manager.test.ts
+++ b/packages/senpi-task/src/dag/manager.test.ts
@@ -61,13 +61,20 @@ function runFiles(store: ReturnType<typeof createDagFileStore>): readonly string
   return fs.readdirSync(store.paths.runs).filter((entry) => entry.endsWith(".json"))
 }
 
-function raceWorkerSource(projectDir: string, prompt: string): string {
+function raceWorkerSource(projectDir: string, prompt: string, barrierDir: string): string {
   return [
     `const { createDagManager } = await import(${JSON.stringify(managerPath)})`,
     `const { createDagFileStore } = await import(${JSON.stringify(join(import.meta.dir, "store.ts"))})`,
-    `const { readSync } = await import("node:fs")`,
+    `const { existsSync, watch } = await import("node:fs")`,
     `const store = createDagFileStore({ project_dir: ${JSON.stringify(projectDir)} })`,
     `const dag = createDagManager({ store })`,
+    `const releasePath = ${JSON.stringify(join(barrierDir, "release"))}`,
+    `const waitForRelease = () => new Promise((resolve, reject) => {`,
+    `  const watcher = watch(${JSON.stringify(barrierDir)}, () => { if (existsSync(releasePath)) finish() })`,
+    `  const timeout = setTimeout(() => finish(new Error("timed out waiting for DAG race release")), 30_000)`,
+    `  const finish = (error) => { clearTimeout(timeout); watcher.close(); error === undefined ? resolve() : reject(error) }`,
+    `  if (existsSync(releasePath)) finish()`,
+    `})`,
     `const definition = {`,
     `  key: "release-plan",`,
     `  name: "release plan",`,
@@ -77,7 +84,7 @@ function raceWorkerSource(projectDir: string, prompt: string): string {
     `  ],`,
     `}`,
     `process.stdout.write("ready\\n")`,
-    `readSync(0, Buffer.alloc(1), 0, 1, null)`,
+    `await waitForRelease()`,
     `try {`,
     `  const started = await dag.start({ definition, parentSessionId: ${JSON.stringify(parentSessionId)}, rootSessionId: ${JSON.stringify(rootSessionId)} })`,
     `  process.stdout.write(JSON.stringify({ ok: true, reused: started.reused, runId: started.snapshot.runId }) + "\\n")`,
@@ -117,18 +124,20 @@ type RaceOutcome = {
 }
 
 async function raceStarts(projectDir: string, prompts: readonly string[]): Promise<readonly RaceOutcome[]> {
+  const barrierDir = join(projectDir, "race-barrier")
+  fs.mkdirSync(barrierDir)
   const children = prompts.map((prompt) => Bun.spawn(
-    [process.execPath, "-e", raceWorkerSource(projectDir, prompt)],
-    { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
+    [process.execPath, "-e", raceWorkerSource(projectDir, prompt, barrierDir)],
+    { stdout: "pipe", stderr: "pipe" },
   ))
   const readers = children.map((child) => lineReader(child.stdout))
   const errors = children.map((child) => new Response(child.stderr).text())
+  // Each child installs its filesystem watcher before publishing ready. The single release file is
+  // written only after both readiness signals, so the two starts cannot be serialized by the
+  // parent's sequential stdin writes on Windows.
   const ready = await Promise.all(readers.map((read) => read()))
   expect(ready).toEqual(prompts.map(() => "ready"))
-  for (const child of children) {
-    child.stdin.write("g")
-    child.stdin.flush()
-  }
+  fs.writeFileSync(join(barrierDir, "release"), "go")
   const outcomes = await Promise.all(readers.map(async (read) => JSON.parse(await read()) as RaceOutcome))
   const exits = await Promise.all(children.map((child) => child.exited))
   const stderr = await Promise.all(errors)


### PR DESCRIPTION
## Symptom

The Windows CI shard intermittently failed the concurrent-start case with:

> Expected length: 1
> Received length: 0

at `packages/senpi-task/src/dag/manager.test.ts:674:82` while asserting the `definition_conflict` outcome.

## Root cause

`raceStarts` released the children by writing one byte to each stdin pipe in sequence (`manager.test.ts` lines 126-130 on `origin/dev`). That was not a barrier: under Windows scheduling and runner process pressure, one child could be released and complete (or remain delayed in pipe delivery) before the other reached the start operation. The test therefore did not reliably exercise two starts from the same scheduling point, and its outcome depended on pipe delivery timing.

The DAG production lock is already the serialization boundary (`packages/senpi-task/src/dag/manager.ts:336`, via `packages/senpi-task/src/dag/store.ts:545`); no production code changed.

## Fix

Each child now installs a filesystem watcher on a shared barrier directory before reporting `ready`. After both `ready` signals are observed, the parent writes one durable `release` file. Both children await that file event before calling `dag.start`, making the release a true test-controlled barrier without polling or sequential stdin timing.

The regenerated Linux Senpi extension bundles are included as required by the repository CI check.

## Evidence

On gorky, with 32 CPU-busy-loop workers:

- `origin/dev` timing-assumption version: 26 failures / 74 passes across 100 concurrent invocations (five batches of 20); failures included test timeouts while the children remained unreleased.
- Fixed version: 40 passes / 0 failures across 40 concurrent invocations (two batches of 20).
- Fixed `packages/senpi-task/src/dag/manager.test.ts`: 24 passes / 0 failures.
- The fixed version also passed 20/20 serial repetitions under the same 32-worker CPU pressure.
- The mutation was the exact `origin/dev` helper restored with `git checkout -- packages/senpi-task/src/dag/manager.test.ts`; it reproduced the failure under parallel pressure. No test was skipped, loosened, or deleted.

Refs #6976

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the DAG concurrent-start race test in `senpi-task` so it no longer flakes on Windows CI. The old helper released children by writing to each stdin pipe in sequence; the new helper has both children watch a shared barrier directory and await a single release file written only after both ready signals.

**Bug Fixes**
- Adds a 30-second timeout to the barrier wait so a stuck child fails the test instead of hanging.

Refs #6976

<sup>Written for commit 7356ac65bd573e16a6db3041a7d3f8b9f8a5b542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

