### PR TITLE
fix(senpi-task): reject tool-call narration as completion

### DIFF
--- a/packages/senpi-task/src/runners/in-process/child-handle-outcome.test.ts
+++ b/packages/senpi-task/src/runners/in-process/child-handle-outcome.test.ts
@@ -97,6 +97,22 @@ function emptyTextEnd(): ChildSessionEvent {
 }
 
 describe("createChildHandle turn outcomes", () => {
+  test('#given completion "turn" and a terminating tool call with narration #when the prompt settles #then the policy completes with empty text', async () => {
+    const fake = createEmittingSession()
+    const handle = createChildHandle({
+      taskId: "task-1",
+      session: fake.session,
+      promptText: "judge",
+      completion: "turn",
+    })
+
+    fake.lastText.value = "The cap has been reached."
+    fake.emit(narratedToolUseEnd(fake.lastText.value))
+    fake.resolvePrompt()
+
+    expect(await handle.waitForIdle()).toEqual({ status: "completed", finalResponse: "" })
+  })
+
   test("#given narration attached to an unfinished tool call #when the prompt settles without a later assistant response #then the narration is not accepted as the final response", async () => {
     const fake = createEmittingSession()
     const handle = createChildHandle({ taskId: "task-1", session: fake.session, promptText: "finish the work" })

--- a/packages/senpi-task/src/runners/in-process/child-handle-outcome.test.ts
+++ b/packages/senpi-task/src/runners/in-process/child-handle-outcome.test.ts
@@ -75,6 +75,20 @@ function toolUseEnd(): ChildSessionEvent {
   }
 }
 
+function narratedToolUseEnd(text: string): ChildSessionEvent {
+  return {
+    type: "message_end",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "text", text },
+        { type: "toolCall", id: "c1", name: "bash", arguments: {} },
+      ],
+      stopReason: "toolUse",
+    },
+  }
+}
+
 function emptyTextEnd(): ChildSessionEvent {
   return {
     type: "message_end",
@@ -83,6 +97,23 @@ function emptyTextEnd(): ChildSessionEvent {
 }
 
 describe("createChildHandle turn outcomes", () => {
+  test("#given narration attached to an unfinished tool call #when the prompt settles without a later assistant response #then the narration is not accepted as the final response", async () => {
+    const fake = createEmittingSession()
+    const handle = createChildHandle({ taskId: "task-1", session: fake.session, promptText: "finish the work" })
+
+    fake.lastText.value = "Running the bounded wait:"
+    fake.emit(narratedToolUseEnd(fake.lastText.value))
+    fake.resolvePrompt()
+
+    expect(await handle.waitForIdle()).toEqual({
+      status: "error",
+      failure: {
+        kind: "child-turn-failed",
+        message: "child turn ended after a tool call without a terminal assistant response",
+      },
+    })
+  })
+
   test('#given completion "turn" and a toolUse message_end followed by a stop message_end with an empty text part #when the prompt resolves #then the outcome is completed with empty finalResponse', async () => {
     const fake = createEmittingSession()
     const handle = createChildHandle({ taskId: "task-1", session: fake.session, promptText: "judge", completion: "turn" })

--- a/packages/senpi-task/src/runners/in-process/child-handle-restored.test.ts
+++ b/packages/senpi-task/src/runners/in-process/child-handle-restored.test.ts
@@ -6,6 +6,7 @@ type FakeSessionControls = {
   readonly session: ChildSession
   readonly followUpCalls: string[]
   readonly lastText: { value: string | undefined }
+  readonly messages: { value: readonly unknown[] | undefined }
   promptCalls: () => number
   resolvePrompt: () => void
 }
@@ -15,10 +16,14 @@ type FakeSessionControls = {
 function createFakeSession(sessionId = "restored-session-1"): FakeSessionControls {
   const followUpCalls: string[] = []
   const lastText = { value: undefined as string | undefined }
+  const messages = { value: undefined as readonly unknown[] | undefined }
   const counters = { promptCalls: 0 }
   let settle: (() => void) | undefined
   const session: ChildSession = {
     sessionId,
+    get messages() {
+      return messages.value
+    },
     prompt() {
       counters.promptCalls += 1
       return new Promise<void>((resolve) => {
@@ -42,12 +47,36 @@ function createFakeSession(sessionId = "restored-session-1"): FakeSessionControl
     session,
     followUpCalls,
     lastText,
+    messages,
     promptCalls: () => counters.promptCalls,
     resolvePrompt: () => settle?.(),
   }
 }
 
 describe("createRestoredChildHandle", () => {
+  test("#given a restored transcript ending on narrated tool use #when waitForIdle drains it #then the dangling narration is not accepted as completion", async () => {
+    const fake = createFakeSession()
+    fake.lastText.value = "Running the final command:"
+    fake.messages.value = [{
+      role: "assistant",
+      content: [
+        { type: "text", text: fake.lastText.value },
+        { type: "toolCall", id: "call-1", name: "bash", arguments: {} },
+      ],
+      stopReason: "toolUse",
+    }]
+
+    const handle = createRestoredChildHandle({ taskId: "task-1", session: fake.session })
+
+    expect(await handle.waitForIdle()).toEqual({
+      status: "error",
+      failure: {
+        kind: "child-turn-failed",
+        message: "restored session ended after a tool call without a terminal assistant response",
+      },
+    })
+  })
+
   test('#given completion "turn" and a restored session without assistant output #when waitForIdle is awaited #then it settles completed with empty text instead of child-turn-failed', async () => {
     const fake = createFakeSession()
     const handle = createRestoredChildHandle({ taskId: "task-1", session: fake.session, completion: "turn" })

--- a/packages/senpi-task/src/runners/in-process/child-handle.ts
+++ b/packages/senpi-task/src/runners/in-process/child-handle.ts
@@ -87,6 +87,7 @@ export type CreateRestoredChildHandleInput = {
 // from prompt() resolution alone (the silent-empty-completion bug).
 type TurnObservation = {
   text: string | undefined
+  terminalToolCall: boolean
   stopReason: string | undefined
   errorMessage: string | undefined
   provider: string | undefined
@@ -99,7 +100,8 @@ function observeTurnEvent(observation: TurnObservation, event: ChildSessionEvent
   const message = event.message
   if (!isRecord(message) || message.role !== "assistant") return
   const text = assistantText(message)
-  if (text !== undefined) observation.text = text
+  observation.terminalToolCall = assistantHasToolCall(message)
+  observation.text = observation.terminalToolCall ? undefined : text
   observation.stopReason = typeof message.stopReason === "string" ? message.stopReason : undefined
   observation.errorMessage = typeof message.errorMessage === "string" ? message.errorMessage : undefined
   observation.provider = typeof message.provider === "string" ? message.provider : undefined
@@ -117,6 +119,11 @@ function assistantText(message: Record<string, unknown>): string | undefined {
 
 function isTextPart(part: unknown): part is { readonly type: "text"; readonly text: string } {
   return isRecord(part) && part.type === "text" && typeof part.text === "string"
+}
+
+function assistantHasToolCall(message: Record<string, unknown>): boolean {
+  return Array.isArray(message.content)
+    && message.content.some((part: unknown) => isRecord(part) && part.type === "toolCall")
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -137,6 +144,16 @@ function turnOutcome(session: ChildSession, observation: TurnObservation, comple
       failure: {
         kind: "child-turn-failed",
         message: observation.errorMessage ?? `child turn ended with stopReason "${observation.stopReason}"`,
+      },
+    }
+  }
+  if (observation.terminalToolCall) {
+    return {
+      status: "error",
+      ...provenance,
+      failure: {
+        kind: "child-turn-failed",
+        message: "child turn ended after a tool call without a terminal assistant response",
       },
     }
   }
@@ -215,7 +232,13 @@ function createTrackedChildHandle(
   // Seeded for the restored case; createChildHandle's beginTurn replaces it immediately.
   let running: Promise<RunnerOutcome> = Promise.resolve(settledSessionOutcome(session, completion))
   const observation: TurnObservation = {
-    text: undefined, stopReason: undefined, errorMessage: undefined, baseline: undefined, provider: undefined, model: undefined,
+    text: undefined,
+    terminalToolCall: false,
+    stopReason: undefined,
+    errorMessage: undefined,
+    baseline: undefined,
+    provider: undefined,
+    model: undefined,
   }
   const unsubscribeObserver = session.subscribe((event) => observeTurnEvent(observation, event))
 
@@ -225,6 +248,7 @@ function createTrackedChildHandle(
     aborted = false
     turnActive = true
     observation.text = undefined
+    observation.terminalToolCall = false
     observation.stopReason = undefined
     observation.errorMessage = undefined
     observation.provider = undefined

--- a/packages/senpi-task/src/runners/in-process/child-handle.ts
+++ b/packages/senpi-task/src/runners/in-process/child-handle.ts
@@ -9,6 +9,7 @@ export type ChildSessionListener = (event: ChildSessionEvent) => void
 // live AgentSession; fakes implement only these members.
 export type ChildSession = {
   readonly sessionId: string
+  readonly messages?: readonly unknown[]
   prompt(text: string): Promise<void>
   steer(text: string): Promise<void>
   followUp(text: string): Promise<void>
@@ -101,7 +102,11 @@ function observeTurnEvent(observation: TurnObservation, event: ChildSessionEvent
   if (!isRecord(message) || message.role !== "assistant") return
   const text = assistantText(message)
   observation.terminalToolCall = assistantHasToolCall(message)
-  observation.text = observation.terminalToolCall ? undefined : text
+  if (observation.terminalToolCall) {
+    observation.text = undefined
+  } else if (text !== undefined) {
+    observation.text = text
+  }
   observation.stopReason = typeof message.stopReason === "string" ? message.stopReason : undefined
   observation.errorMessage = typeof message.errorMessage === "string" ? message.errorMessage : undefined
   observation.provider = typeof message.provider === "string" ? message.provider : undefined
@@ -148,6 +153,7 @@ function turnOutcome(session: ChildSession, observation: TurnObservation, comple
     }
   }
   if (observation.terminalToolCall) {
+    if (completion === "turn") return { status: "completed", finalResponse: "", ...provenance }
     return {
       status: "error",
       ...provenance,
@@ -207,6 +213,16 @@ async function runTurn(
 // transcript's last assistant text is the honest drain for a child whose completion never reached
 // its record (crash between turn end and transition). No text means nothing durable was produced.
 function settledSessionOutcome(session: ChildSession, completion: ChildCompletionPolicy): RunnerOutcome {
+  const restoredAssistant = lastAssistantMessage(session.messages)
+  if (completion !== "turn" && restoredAssistant !== undefined && assistantHasToolCall(restoredAssistant)) {
+    return {
+      status: "error",
+      failure: {
+        kind: "child-turn-failed",
+        message: "restored session ended after a tool call without a terminal assistant response",
+      },
+    }
+  }
   const final = session.getLastAssistantText()
   if (final !== undefined && final.length > 0) return { status: "completed", finalResponse: final }
   if (completion === "turn") return { status: "completed", finalResponse: "" }
@@ -214,6 +230,15 @@ function settledSessionOutcome(session: ChildSession, completion: ChildCompletio
     status: "error",
     failure: { kind: "child-turn-failed", message: "restored session has no assistant output" },
   }
+}
+
+function lastAssistantMessage(messages: readonly unknown[] | undefined): Record<string, unknown> | undefined {
+  if (messages === undefined) return undefined
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (isRecord(message) && message.role === "assistant") return message
+  }
+  return undefined
 }
 
 type TrackedChildHandle = {

--- a/packages/senpi-task/src/runners/rpc/handle.test.ts
+++ b/packages/senpi-task/src/runners/rpc/handle.test.ts
@@ -17,6 +17,7 @@ type RpcHandleWithTerminalFacts = RpcChildHandle & {
 function createHarness(): {
   readonly handle: RpcHandleWithTerminalFacts
   readonly emit: (event: AgentSessionEvent) => void
+  readonly close: () => void
 } {
   const child = Object.assign(new EventEmitter(), { pid: 4242 }) as unknown as ChildProcess
   const listeners = new Set<(event: AgentSessionEvent) => void>()
@@ -41,6 +42,7 @@ function createHarness(): {
     emit: (event) => {
       for (const listener of listeners) listener(event)
     },
+    close: () => child.emit("close", 0, null),
   }
 }
 
@@ -49,6 +51,36 @@ function event(value: unknown): AgentSessionEvent {
 }
 
 describe("createRpcChildHandle terminal turn observation", () => {
+  test("#given narration attached to a tool call #when the RPC child exits cleanly without agent_end #then the narration is not reused as successful completion", async () => {
+    // given
+    const harness = createHarness()
+    harness.emit(event({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Running the final command:" },
+          { type: "toolCall", id: "call-1", name: "bash", arguments: {} },
+        ],
+        stopReason: "toolUse",
+      },
+    }))
+
+    // when
+    harness.close()
+
+    // then
+    const waitForOutcome = harness.handle.waitForOutcome
+    if (waitForOutcome === undefined) throw new Error("RPC handle must expose waitForOutcome")
+    await expect(waitForOutcome()).resolves.toEqual({
+      status: "error",
+      failure: {
+        kind: "child-turn-failed",
+        message: "RPC child exited without assistant output",
+      },
+    })
+  })
+
   test("#given an assistant provider error followed by terminal agent_end #when idle settles #then text and failure fields are retained", async () => {
     // given
     const harness = createHarness()

--- a/packages/senpi-task/src/runners/rpc/handle.ts
+++ b/packages/senpi-task/src/runners/rpc/handle.ts
@@ -15,7 +15,13 @@ import { RpcCommandError } from "./errors"
 import { classifyChildExit } from "./exit-mapping"
 import { isHarmlessRpcShutdownError, type RpcProtocolClient } from "./protocol-client"
 import { terminateRpcChild } from "./terminate"
-import { agentEndOutcome, exitTurnOutcome, extractAssistantText, promptFailureOutcome } from "./turn-outcome"
+import {
+  agentEndOutcome,
+  assistantMessageHasToolCall,
+  exitTurnOutcome,
+  extractAssistantText,
+  promptFailureOutcome,
+} from "./turn-outcome"
 
 export type CreateRpcChildHandleOptions = {
   readonly client: RpcProtocolClient
@@ -93,7 +99,7 @@ export function createRpcChildHandle(options: CreateRpcChildHandleOptions): Trac
     outcome = built
     clearInterval(heartbeat)
     flush(idleWaiters)
-    if (turnOutcome === undefined) settleTurn(exitTurnOutcome(built, finalText))
+    if (turnOutcome === undefined) settleTurn(exitTurnOutcome(built, terminalAssistantMessage?.text))
     for (const waiter of exitWaiters.splice(0)) {
       waiter(built)
     }
@@ -172,7 +178,7 @@ export function createRpcChildHandle(options: CreateRpcChildHandleOptions): Trac
         ? Promise.resolve(turnOutcome)
         : outcome === undefined
           ? new Promise<RunnerOutcome>((resolve) => outcomeWaiters.push(resolve))
-          : Promise.resolve(exitTurnOutcome(outcome, finalText)),
+          : Promise.resolve(exitTurnOutcome(outcome, terminalAssistantMessage?.text)),
     lastAssistantText: () => finalText,
     terminalAssistantMessage: () => terminalAssistantMessage,
     wasAbortedByUser: () => abortedByUser,
@@ -212,7 +218,7 @@ function readSessionId(response: RpcResponse): string | undefined {
 function extractTerminalAssistantMessage(message: unknown): RpcTerminalAssistantMessage | undefined {
   if (typeof message !== "object" || message === null) return undefined
   const record = message as Record<string, unknown>
-  if (record.role !== "assistant") return undefined
+  if (record.role !== "assistant" || assistantMessageHasToolCall(record)) return undefined
   const text = extractAssistantText(record)
   const stopReason = typeof record.stopReason === "string" ? record.stopReason : undefined
   const errorMessage = typeof record.errorMessage === "string" ? record.errorMessage : undefined

--- a/packages/senpi-task/src/runners/rpc/turn-outcome-malformed.test.ts
+++ b/packages/senpi-task/src/runners/rpc/turn-outcome-malformed.test.ts
@@ -9,6 +9,34 @@ function malformedAgentEnd(overrides: Record<string, unknown>): AgentEndEvent {
 }
 
 describe("agentEndOutcome hostile wire payloads", () => {
+  describe("#given narration attached to the final assistant tool call", () => {
+    it("#when agent_end settles without a later assistant response #then the narration is not accepted as the final response", () => {
+      // given
+      const event = malformedAgentEnd({
+        messages: [{
+          role: "assistant",
+          stopReason: "toolUse",
+          content: [
+            { type: "text", text: "Now update the lifecycle class:" },
+            { type: "toolCall", id: "call-1", name: "edit", arguments: {} },
+          ],
+        }],
+      })
+
+      // when
+      const outcome = agentEndOutcome(event, undefined, "Now update the lifecycle class:")
+
+      // then
+      expect(outcome).toEqual({
+        status: "error",
+        failure: {
+          kind: "child-turn-failed",
+          message: "RPC child turn ended after a tool call without a terminal assistant response",
+        },
+      })
+    })
+  })
+
   describe("#given an agent_end whose messages field is absent", () => {
     it("#when the outcome is derived #then it degrades to a terminal error instead of throwing", () => {
       // given

--- a/packages/senpi-task/src/runners/rpc/turn-outcome.ts
+++ b/packages/senpi-task/src/runners/rpc/turn-outcome.ts
@@ -35,6 +35,15 @@ export function agentEndOutcome(
       },
     }
   }
+  if (assistantMessageHasToolCall(assistant)) {
+    return {
+      status: "error",
+      failure: {
+        kind: "child-turn-failed",
+        message: "RPC child turn ended after a tool call without a terminal assistant response",
+      },
+    }
+  }
   const messageText = assistant === undefined ? undefined : extractAssistantText(assistant)
   const final = messageText ?? (observedText !== baseline ? observedText : undefined)
   if (final !== undefined && final.length > 0) return { status: "completed", finalResponse: final }
@@ -79,6 +88,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isAssistantRecord(value: unknown): value is Record<string, unknown> {
   return isRecord(value) && value.role === "assistant"
+}
+
+export function assistantMessageHasToolCall(message: unknown): boolean {
+  return isAssistantRecord(message)
+    && Array.isArray(message.content)
+    && message.content.some((part: unknown) => isRecord(part) && part.type === "toolCall")
 }
 
 function readString(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- reject assistant narration as a terminal response when the same final message still contains a tool call
- apply the guard to live in-process turns, restored in-process transcripts, RPC `agent_end`, and the RPC clean-exit fallback
- preserve ordinary final assistant text, provider errors, cancellation, length-truncation text, revived-turn baselines, and intentional `completion: "turn"` policy completion

## Why
A child can emit narration such as "Running the final command:", issue a tool call, and then have that tool fail or time out without another assistant response. The runner previously captured that narration at `message_end` and classified the task as completed, hiding the failed final operation. The same stale success was possible when restoring a transcript that ended on an unfinished tool call.

## Verification
- RED: in-process and RPC regressions returned `completed` with pre-tool narration before the guard
- GREEN: 28 focused terminal-outcome tests, including terminating `completion: "turn"`, restored transcripts, RPC `agent_end`, and RPC clean exit
- GREEN: full `@oh-my-opencode/senpi-task` suite, 1,435 passed / 1 skipped / 0 failed on final head
- independent review caught the kibitzer terminating-tool contract; the second commit preserves its empty policy completion and closes the restored-session gap
- package typecheck was attempted but is currently blocked by four unchanged `process.on("unhandledRejection")` signal-typing errors caused by the installed Bun type surface; the repository-wide build fails on the same unrelated signal typing in other packages

## Scope
Seven senpi-task runner/test files only. The checkout's pre-existing evidence-file modification and bootstrap-generated Codex installer bundle were excluded from both commits.