### PR TITLE
fix(omo-opencode): drop core-listed skills from skill tool descriptions (fixes #8108)

### DIFF
--- a/packages/omo-opencode/src/tools/skill/description-formatter.core-overlap.test.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.core-overlap.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test"
+import {
+  formatCombinedDescription,
+  isDiscoverableByOpenCodeCore,
+} from "./description-formatter"
+import {
+  builtinSharedSkill,
+  localSkill,
+  makeCommand,
+  makeSkill,
+  opencodeNativeSkill,
+  sharedSkill,
+  userSkill,
+} from "./description-formatter.test-support"
+import type { SkillInfo } from "./types"
+
+function opencodeProjectSkill(name: string, description = "project opencode desc"): SkillInfo {
+  return makeSkill(name, description, {
+    scope: "opencode-project",
+    location: `/repo/.opencode/skills/${name}/SKILL.md`,
+  })
+}
+
+function opencodeGlobalSkill(name: string, description = "global opencode desc"): SkillInfo {
+  return makeSkill(name, description, {
+    scope: "opencode",
+    location: `/home/user/.config/opencode/skills/${name}/SKILL.md`,
+  })
+}
+
+function claudeUserSkill(name: string, description = "claude user desc"): SkillInfo {
+  return makeSkill(name, description, {
+    scope: "user",
+    location: `/home/user/.claude/skills/${name}/SKILL.md`,
+  })
+}
+
+function bundledDistSkill(name: string, description = "omo bundled desc"): SkillInfo {
+  return makeSkill(name, description, {
+    scope: "builtin",
+    location: `/opt/oh-my-openagent/dist/skills/${name}/SKILL.md`,
+  })
+}
+
+describe("isDiscoverableByOpenCodeCore", () => {
+  it("treats OpenCode-scanned user, project, and config-dir skills as core-listed", () => {
+    expect(isDiscoverableByOpenCodeCore(claudeUserSkill("playwright"))).toBe(true)
+    expect(isDiscoverableByOpenCodeCore(userSkill("frontend"))).toBe(true)
+    expect(isDiscoverableByOpenCodeCore(localSkill("review-work"))).toBe(true)
+    expect(isDiscoverableByOpenCodeCore(opencodeProjectSkill("debugging"))).toBe(true)
+    expect(isDiscoverableByOpenCodeCore(opencodeGlobalSkill("refactor"))).toBe(true)
+    expect(isDiscoverableByOpenCodeCore(opencodeNativeSkill("customize-opencode"))).toBe(true)
+    expect(isDiscoverableByOpenCodeCore(makeSkill("windows-claude", "desc", {
+      scope: "user",
+      location: "C:\\Users\\me\\.claude\\skills\\windows-claude\\SKILL.md",
+    }))).toBe(true)
+  })
+
+  it("keeps OMO-bundled builtin and shared skills that core discovery cannot see", () => {
+    expect(isDiscoverableByOpenCodeCore(makeSkill("git-master"))).toBe(false)
+    expect(isDiscoverableByOpenCodeCore(builtinSharedSkill("debugging"))).toBe(false)
+    expect(isDiscoverableByOpenCodeCore(sharedSkill("review-work"))).toBe(false)
+    expect(isDiscoverableByOpenCodeCore(bundledDistSkill("frontend"))).toBe(false)
+    expect(isDiscoverableByOpenCodeCore(makeSkill("security-review", "desc", {
+      location: "<builtin>/security-review/SKILL.md",
+    }))).toBe(false)
+  })
+})
+
+describe("formatCombinedDescription core overlap", () => {
+  it("omits core-listed skill descriptions from available_items while keeping OMO-bundled skills", () => {
+    const skills: SkillInfo[] = [
+      claudeUserSkill("playwright", "long playwright description payload"),
+      opencodeProjectSkill("local-debug", "long local debug description payload"),
+      bundledDistSkill("git-master", "bundled git-master description"),
+      makeSkill("review-work", "bundled review-work description"),
+    ]
+
+    const result = formatCombinedDescription(skills, [], { includeSkills: true })
+
+    expect(result).toContain("<available_items>")
+    expect(result).toContain("/git-master")
+    expect(result).toContain("bundled git-master description")
+    expect(result).toContain("/review-work")
+    expect(result).not.toContain("long playwright description payload")
+    expect(result).not.toContain("long local debug description payload")
+    expect(result).not.toContain("/playwright")
+    expect(result).not.toContain("/local-debug")
+  })
+
+  it("still lists slash commands when every skill is already covered by core", () => {
+    const skills: SkillInfo[] = [
+      claudeUserSkill("playwright"),
+      opencodeProjectSkill("local-debug"),
+    ]
+    const commands = [makeCommand("handoff", "handoff command")]
+
+    const result = formatCombinedDescription(skills, commands, { includeSkills: true })
+
+    expect(result).toContain("<available_items>")
+    expect(result).toContain("/handoff")
+    expect(result).not.toContain("/playwright")
+    expect(result).not.toContain("/local-debug")
+  })
+
+  it("suppresses builtin command aliases using the full skill list, not only the OMO-private remainder", () => {
+    const skills: SkillInfo[] = [
+      opencodeProjectSkill("refactor", "full refactor skill"),
+      makeSkill("ulw-execute", "full ulw-execute skill"),
+    ]
+    const commands = [
+      makeCommand("refactor", "short refactor command"),
+      makeCommand("ulw-execute", "short ulw-execute command"),
+      makeCommand("handoff", "handoff command"),
+    ]
+
+    const result = formatCombinedDescription(skills, commands, { includeSkills: true })
+
+    expect(result).toContain("/ulw-execute")
+    expect(result).toContain("/handoff")
+    expect(result).not.toContain("/refactor")
+    expect(result).not.toContain("short refactor command")
+    expect(result).not.toContain("short ulw-execute command")
+  })
+})

--- a/packages/omo-opencode/src/tools/skill/description-formatter.ts
+++ b/packages/omo-opencode/src/tools/skill/description-formatter.ts
@@ -46,6 +46,45 @@ function normalizeSkillName(name: string): string {
   return name.toLowerCase()
 }
 
+function normalizeSkillLocation(location: string): string {
+  return location.replace(/\\/g, "/").replace(/\/+$/, "")
+}
+
+function isOmoBundledSkillLocation(location: string | undefined): boolean {
+  if (!location) return false
+  const normalized = normalizeSkillLocation(location)
+  if (normalized === "<builtin>" || normalized.startsWith("<builtin>/")) return true
+  return (
+    /(?:^|\/)dist\/skills(?:\/|$)/.test(normalized)
+    || /(?:^|\/)(?:packages\/)?shared-skills(?:\/skills)?(?:\/|$)/.test(normalized)
+  )
+}
+
+function isOpenCodeCoreBuiltinLocation(location: string | undefined): boolean {
+  if (location === undefined) return false
+  const normalized = normalizeSkillLocation(location).trim()
+  return normalized === "" || normalized === "<built-in>"
+}
+
+const CORE_SCANNED_DIR_RE =
+  /(?:^|\/)(?:\.opencode\/skills?(?:\/|$)|(?:\.claude|\.agents)\/skills(?:\/|$)|(?:\.config\/opencode(?:\/profiles\/[^/]+)?\/skills?(?:\/|$)))/i
+
+function hasCoreScannedSkillLocation(location: string | undefined): boolean {
+  if (!location) return false
+  if (isOpenCodeCoreBuiltinLocation(location)) return true
+  const normalized = normalizeSkillLocation(location)
+  if (CORE_SCANNED_DIR_RE.test(normalized)) return true
+  return /ai\.opencode\.desktop(?:\.dev)?(?:\/.*)?\/skills?(?:\/|$)/i.test(normalized)
+}
+
+export function isDiscoverableByOpenCodeCore(skill: SkillInfo): boolean {
+  // OpenCode core already emits these in <available_skills>. OMO-bundled
+  // builtin/shared skills live under dist/skills and are invisible to that scan.
+  if (skill.scope === "builtin" || skill.scope === "shared") return false
+  if (isOmoBundledSkillLocation(skill.location)) return false
+  return hasCoreScannedSkillLocation(skill.location)
+}
+
 export function deduplicatePathAliasedSkills(skills: SkillInfo[]): SkillInfo[] {
   // After the shared/ prefix cutover, skills register under bare names only.
   // Exact-name deduplication is handled by the upstream merge; this pass is now
@@ -72,8 +111,9 @@ export function formatCombinedDescription(
   commands?: CommandInfo[],
   options: CombinedDescriptionOptions = {}
 ): string {
-  const availableSkills = options.includeSkills ? deduplicatePathAliasedSkills(skills ?? []) : []
-  const availableCommands = deduplicateCommandsForPathAliasedSkills(commands ?? [], availableSkills)
+  const allSkills = options.includeSkills ? deduplicatePathAliasedSkills(skills ?? []) : []
+  const availableSkills = allSkills.filter((skill) => !isDiscoverableByOpenCodeCore(skill))
+  const availableCommands = deduplicateCommandsForPathAliasedSkills(commands ?? [], allSkills)
 
   if (availableSkills.length === 0 && availableCommands.length === 0) {
     if ((skills?.length ?? 0) > 0) {

--- a/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/dynamic-discovery.test.ts
+++ b/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/dynamic-discovery.test.ts
@@ -114,7 +114,8 @@ describe("skill tool - dynamic description cache invalidation", () => {
 
       const refreshedResult = await refreshedTool.execute({ name: "second-skill" }, mockContext)
 
-      expect(refreshedTool.description).toContain("second-skill")
+      expect(refreshedResult).toContain("Second skill body")
+      expect(refreshedTool.description).not.toContain("second-skill")
     } finally {
       process.chdir(originalDirectory)
       clearSkillCache()

--- a/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/native-skills.test.ts
+++ b/packages/omo-opencode/src/tools/skill/zauc-mocks-skill-tools/native-skills.test.ts
@@ -31,7 +31,7 @@ describe("skill tool - nativeSkills integration", () => {
     expect(tool.description).toContain("native-visible-skill")
   })
 
-  it("keeps OpenCode-injected native skills in the description after the shared/ prefix cutover", () => {
+  it("omits OpenCode-injected native skills from available_items because core already lists them", () => {
     const tool = createSkillTool({
       skills: [],
       includeSkillsInDescription: true,
@@ -59,8 +59,10 @@ describe("skill tool - nativeSkills integration", () => {
 
     const description = tool.description
 
-    expect(description).toContain("<name>/customize-opencode</name>")
-    expect(description).toContain("Customize OpenCode")
+    expect(description).not.toContain("<name>/customize-opencode</name>")
+    expect(description).not.toContain("<name>/opencode/customize-opencode</name>")
+    expect(description).not.toContain("Customize OpenCode")
+    expect(description).not.toContain("Qualified OpenCode customize entry")
   })
 
   it("merges native skills exposed by PluginInput.skills.all()", async () => {


### PR DESCRIPTION
## Summary
- Keep `includeSkillsInDescription: true` so OMO-bundled `dist/skills` remain documented in the `skill` tool description. Flipping that default would delete the only listing OpenCode core can see for those skills.
- Filter `<available_items>` per skill instead: drop entries whose on-disk location is already scanned into core `<available_skills>` (`.opencode/skill(s)`, `.claude/skills`, `.agents/skills`, `~/.config/opencode/skill(s)`, OpenCode `<built-in>`).
- Slash-command alias suppression still uses the full skill list, so a core-listed skill does not reappear as a builtin command.

## Test plan
- [x] `bun test packages/omo-opencode/src/tools/skill/description-formatter.core-overlap.test.ts` (fail before / pass after)
- [x] `bun test packages/omo-opencode/src/tools/skill/`
- [x] `bun test packages/omo-opencode/src/plugin/tool-registry.test.ts packages/omo-opencode/src/plugin/skill-context-shared-skill.test.ts`

Fixes #8108


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8108 by removing skill definitions from the skill tool description that OpenCode core already lists in `<available_skills>`, so they no longer appear twice.

- Keeps `includeSkillsInDescription` enabled so OMO-bundled `dist/skills` remain documented.
- Filters `<available_items>` per skill by on-disk location, dropping core-scanned paths (`.opencode`, `.claude`, `.agents`, config dirs, built-ins) while keeping OMO-bundled skills.
- Slash-command alias suppression still uses the full skill list, so a core-listed skill does not reappear as a builtin command.

<sup>Written for commit e8a30befab140667470cdefdb619092982c02846. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

