### PR TITLE
fix(omo-native): fail doctor when the x-search skill is missing (fixes #7774)

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,11 @@
+## 2026-09-11 — omo doctor requires the published x-search skill (#7774)
+
+`omo doctor` (npm launcher and compiled binary) now fails when
+`plugin/skills-conditional/x-search/SKILL.md` is missing from the installed payload. The
+credential-gated skill already ships in omo-ai, but doctor previously only checked the
+manifest, extension, and two runtimes, so a stripped install still passed while sessions
+with an xAI credential opened with a Skill conflict.
+
 ## 2026-09-09 - Suspend native DAG runs on committed session switches (#8020)
 
 OMO no longer cancels DAG nodes from the vetoable `session_before_switch` hook. Committed shutdown first retires scheduler admission and settlement, awaits in-flight admission and journal delivery, then persists the pause before task-child suspension. Returning in the same process can reclaim an explicitly released own lease; active self claims and live foreign holders remain protected. Completed output is reused, running children reconcile through their durable task owners, and pending dependents are admitted once. Deliberate workflow cancellation remains destructive. `/session` information and `/resume` selector cancellation are unchanged. External terminal-hosted controllers are outside this native DAG lifecycle fix.

--- a/packages/omo-native/bin/lib/doctor.js
+++ b/packages/omo-native/bin/lib/doctor.js
@@ -69,6 +69,7 @@ function readDistTags(options) {
 // payload, not every skill. x-search is the exception because it is credential-gated
 // (not under plugin/skills) and a missing copy used to pass doctor while senpi
 // reported a Skill conflict on every xAI session (#7774).
+/** @type {ReadonlyArray<readonly [string, string]>} */
 export const DOCTOR_PLUGIN_ARTIFACTS = [
   ["plugin manifest", "plugin/package.json"],
   ["extension", "plugin/extensions/omo.js"],

--- a/packages/omo-native/bin/lib/doctor.js
+++ b/packages/omo-native/bin/lib/doctor.js
@@ -65,11 +65,16 @@ function readDistTags(options) {
   }
 }
 
-const artifacts = [
+// Shared with compiled-binary doctor. Keep this list short: identity of a valid
+// payload, not every skill. x-search is the exception because it is credential-gated
+// (not under plugin/skills) and a missing copy used to pass doctor while senpi
+// reported a Skill conflict on every xAI session (#7774).
+export const DOCTOR_PLUGIN_ARTIFACTS = [
   ["plugin manifest", "plugin/package.json"],
   ["extension", "plugin/extensions/omo.js"],
   ["lsp-daemon runtime", "plugin/runtime/lsp-daemon/dist/cli.js"],
   ["agent-toolkit runtime", "plugin/runtime/agent-toolkit/cli.js"],
+  ["x-search skill", "plugin/skills-conditional/x-search/SKILL.md"],
 ]
 
 function pass(lines, message) {
@@ -374,7 +379,7 @@ export function runDoctor(inventory, args = [], options = {}) {
 
   let failed = false
   const lines = []
-  for (const [label, artifact] of artifacts) {
+  for (const [label, artifact] of DOCTOR_PLUGIN_ARTIFACTS) {
     const path = join(packageRoot, artifact)
     if (existsSync(path)) pass(lines, `${label}: ${artifact}`)
     else {

--- a/packages/omo-native/compile-entry.ts
+++ b/packages/omo-native/compile-entry.ts
@@ -19,7 +19,7 @@ import { buildLabel, parseBuildInfo, versionLines } from "./build-info"
 import { migrateLegacyBunGlobalManifest } from "./bin/lib/legacy-bun-global-migration.js"
 import { adoptLegacyFlatState, canonicalAgentDir } from "./bin/lib/agent-dir.js"
 import { nearestNodeBin, readJson } from "./bin/lib/package-paths.js"
-import { runDoctor } from "./bin/lib/doctor.js"
+import { DOCTOR_PLUGIN_ARTIFACTS, runDoctor } from "./bin/lib/doctor.js"
 import { detectHarnesses, needsSetupSuggestion } from "./bin/lib/setup-detect.js"
 import { printSetupReport } from "./bin/lib/setup-report.js"
 import { delimiter } from "node:path"
@@ -44,12 +44,6 @@ registerBunOAuthFlows()
 const earlyCommands = new Set(["install", "remove", "list", "config", "auth", "app-server"])
 const selfUpdateTargets = new Set(["self", "senpi", "omo"])
 const engineUpdateTargets = new Set(["--extensions", "--models"])
-const doctorArtifacts = [
-  ["plugin manifest", "plugin/package.json"],
-  ["extension", "plugin/extensions/omo.js"],
-  ["lsp-daemon runtime", "plugin/runtime/lsp-daemon/dist/cli.js"],
-  ["agent-toolkit runtime", "plugin/runtime/agent-toolkit/cli.js"],
-] as const
 
 export function buildSenpiArgs(args: string[], execDir: string): string[] {
   const command = args[0]
@@ -134,7 +128,7 @@ export function remapSenpiEnvironment(source: NodeJS.ProcessEnv = process.env, e
 function runCompiledDoctor(inventory: Awaited<ReturnType<typeof detectHarnesses>>, execDir: string, enginePin: string): void {
   let failed = false
   const lines: string[] = []
-  for (const [label, artifact] of doctorArtifacts) {
+  for (const [label, artifact] of DOCTOR_PLUGIN_ARTIFACTS) {
     if (existsSync(join(execDir, artifact))) lines.push(`PASS ${label}: ${artifact}`)
     else {
       lines.push(`FAIL ${label}: missing ${artifact}`)

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -14,6 +14,7 @@ import {
   updateHint,
   versionLine,
 } from "../compile-entry"
+import { DOCTOR_PLUGIN_ARTIFACTS } from "../bin/lib/doctor.js"
 import { loadOpenAICodexOAuth } from "../../../node_modules/@code-yeongyu/senpi/node_modules/@earendil-works/pi-ai/dist/auth/oauth/load.js"
 import { openaiCodexOAuth } from "../../../node_modules/@code-yeongyu/senpi/node_modules/@earendil-works/pi-ai/dist/auth/oauth/openai-codex.js"
 import { openaiCodexProvider } from "../../../node_modules/@code-yeongyu/senpi/node_modules/@earendil-works/pi-ai/dist/providers/openai-codex.js"
@@ -304,7 +305,7 @@ describe("embedded runtime provisioning", () => {
   test("compiled doctor resolves package artifacts from the provided execDir", async () => {
     const root = temp()
     writeFileSync(join(root, "package.json"), JSON.stringify({ version: "9.2.1" }))
-    for (const artifact of ["plugin/package.json", "plugin/extensions/omo.js", "plugin/runtime/lsp-daemon/dist/cli.js", "plugin/runtime/agent-toolkit/cli.js"]) {
+    for (const [, artifact] of DOCTOR_PLUGIN_ARTIFACTS) {
       const path = join(root, artifact)
       mkdirSync(join(path, ".."), { recursive: true })
       writeFileSync(path, "fixture\n")
@@ -312,16 +313,20 @@ describe("embedded runtime provisioning", () => {
     const output: string[] = []
     const originalLog = console.log
     const originalExitCode = process.exitCode
+    let doctorExitCode: string | number | undefined
     console.log = (value?: unknown) => { output.push(String(value)) }
     process.exitCode = undefined
     try {
       await runCompiledLauncher(["doctor"], root, "2026.8.28", root)
+      doctorExitCode = process.exitCode
     } finally {
       console.log = originalLog
       process.exitCode = originalExitCode
     }
     expect(output.join("\n")).toContain("PASS plugin manifest: plugin/package.json")
+    expect(output.join("\n")).toContain("PASS x-search skill: plugin/skills-conditional/x-search/SKILL.md")
     expect(output.join("\n")).toContain("INFO omo 9.2.1 (engine: senpi 2026.8.28)")
+    expect(doctorExitCode).toBe(0)
   })
 
   test("version uses the manifest engine pin without a provisioned senpi package", async () => {

--- a/packages/omo-native/test/compile-entry.test.ts
+++ b/packages/omo-native/test/compile-entry.test.ts
@@ -318,7 +318,7 @@ describe("embedded runtime provisioning", () => {
     process.exitCode = undefined
     try {
       await runCompiledLauncher(["doctor"], root, "2026.8.28", root)
-      doctorExitCode = process.exitCode
+      doctorExitCode = process.exitCode as string | number | undefined
     } finally {
       console.log = originalLog
       process.exitCode = originalExitCode

--- a/packages/omo-native/test/doctor-edition.test.ts
+++ b/packages/omo-native/test/doctor-edition.test.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
 import {
+  DOCTOR_PLUGIN_ARTIFACTS,
   fetchNpmDistTagsSync,
   latestFromDistTags,
   runDoctor,
@@ -13,12 +14,7 @@ import { packageManifest, updateTarget } from "../bin/lib/package-paths.js"
 
 const SOURCE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
 const roots: string[] = []
-const artifacts = [
-  ["plugin manifest", "plugin/package.json"],
-  ["extension", "plugin/extensions/omo.js"],
-  ["lsp-daemon runtime", "plugin/runtime/lsp-daemon/dist/cli.js"],
-  ["agent-toolkit runtime", "plugin/runtime/agent-toolkit/cli.js"],
-] as const
+const artifacts = DOCTOR_PLUGIN_ARTIFACTS as ReadonlyArray<readonly [string, string]>
 
 type Fixture = { root: string; packageRoot: string; launcher: string; agentDir: string }
 type InstallLayout = "bun" | "npm"

--- a/packages/omo-native/test/doctor-transient-memory.test.ts
+++ b/packages/omo-native/test/doctor-transient-memory.test.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
-import { countTransientMemoryIdentities, formatTransientMemoryLines } from "../bin/lib/doctor.js"
+import { countTransientMemoryIdentities, DOCTOR_PLUGIN_ARTIFACTS, formatTransientMemoryLines } from "../bin/lib/doctor.js"
 
 const SOURCE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
 const roots: string[] = []
@@ -75,12 +75,7 @@ describe("omo doctor transient memory identities", () => {
     writeFile(join(senpiRoot, "dist", "index.js"), "export const fixture = true\n")
     writeFile(join(senpiRoot, "dist", "cli.js"), "process.exit(0)\n")
     writeFile(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
-    for (const artifact of [
-      "plugin/package.json",
-      "plugin/extensions/omo.js",
-      "plugin/runtime/lsp-daemon/dist/cli.js",
-      "plugin/runtime/agent-toolkit/cli.js",
-    ]) writeFile(join(packageRoot, artifact))
+    for (const [, artifact] of DOCTOR_PLUGIN_ARTIFACTS) writeFile(join(packageRoot, artifact))
 
     const memoryHome = join(root, "memory")
     writeFile(join(memoryHome, "agents", "durable-1", "repo", "system", "persona.md"))

--- a/packages/omo-native/test/doctor.test.ts
+++ b/packages/omo-native/test/doctor.test.ts
@@ -4,15 +4,11 @@ import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
+import { DOCTOR_PLUGIN_ARTIFACTS } from "../bin/lib/doctor.js"
 
 const SOURCE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
 const roots: string[] = []
-const artifacts = [
-  ["plugin manifest", "plugin/package.json"],
-  ["extension", "plugin/extensions/omo.js"],
-  ["lsp-daemon runtime", "plugin/runtime/lsp-daemon/dist/cli.js"],
-  ["agent-toolkit runtime", "plugin/runtime/agent-toolkit/cli.js"],
-] as const
+const artifacts = DOCTOR_PLUGIN_ARTIFACTS as ReadonlyArray<readonly [string, string]>
 
 type Fixture = { root: string; packageRoot: string; launcher: string; agentDir: string }
 
@@ -61,6 +57,12 @@ afterEach(() => {
 })
 
 describe("omo doctor", () => {
+  describe("#given the plugin diagnostic checklist", () => {
+    test("#when inspected #then it requires the published x-search skill", () => {
+      expect(artifacts.map(([, path]) => path)).toContain("plugin/skills-conditional/x-search/SKILL.md")
+    })
+  })
+
   describe("#given a complete packaged installation", () => {
     describe("#when diagnostics run", () => {
       test("#then every required check passes", () => {

--- a/packages/omo-native/test/setup-detect-cache.test.ts
+++ b/packages/omo-native/test/setup-detect-cache.test.ts
@@ -11,6 +11,7 @@ import {
   readSetupSuggestionCache,
   setupDetectInputStats,
 } from "../bin/lib/setup-detect-cache.js"
+import { DOCTOR_PLUGIN_ARTIFACTS } from "../bin/lib/doctor.js"
 
 // The launcher answers the interactive banner's sibling-credential hint from a small cache instead
 // of blocking on live detection. These tests pin that contract through the real surfaces: the
@@ -64,10 +65,7 @@ writeFileSync(process.env.CAPTURE_FILE, "spawned")
 process.exit(0)
 `)
   write(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
-  for (const artifact of [
-    "plugin/package.json", "plugin/extensions/omo.js", "plugin/runtime/lsp-daemon/dist/cli.js",
-    "plugin/runtime/agent-toolkit/cli.js",
-  ]) write(join(packageRoot, artifact), "fixture\n")
+  for (const [, artifact] of DOCTOR_PLUGIN_ARTIFACTS) write(join(packageRoot, artifact), "fixture\n")
   const env = { HOME: home, SENPI_CODING_AGENT_DIR: agentDir, XDG_DATA_HOME: xdg }
   return {
     root,

--- a/packages/omo-native/test/setup-detect.test.ts
+++ b/packages/omo-native/test/setup-detect.test.ts
@@ -7,6 +7,7 @@ import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { detectHarnesses, needsSetupSuggestion } from "../bin/lib/setup-detect.js"
 import { formatSetupReport } from "../bin/lib/setup-report.js"
+import { DOCTOR_PLUGIN_ARTIFACTS } from "../bin/lib/doctor.js"
 
 function sqlLiteral(value: string | null): string {
   return value === null ? "NULL" : `'${value.replace(/'/g, "''")}'`
@@ -143,10 +144,7 @@ function createLauncherFixture(fixture: Fixture): string {
   write(join(senpiRoot, "dist", "index.js"), "export const fixture = true\n")
   write(join(senpiRoot, "dist", "cli.js"), "process.exit(0)\n")
   write(join(senpiRoot, "dist", "core", "brand.js"), "export {}\n")
-  for (const artifact of [
-    "plugin/package.json", "plugin/extensions/omo.js", "plugin/runtime/lsp-daemon/dist/cli.js",
-    "plugin/runtime/agent-toolkit/cli.js",
-  ]) write(join(packageRoot, artifact), "fixture\n")
+  for (const [, artifact] of DOCTOR_PLUGIN_ARTIFACTS) write(join(packageRoot, artifact), "fixture\n")
   return join(packageRoot, "bin", "omo.js")
 }
 

--- a/script/agent-command-string-audit.allowlist.json
+++ b/script/agent-command-string-audit.allowlist.json
@@ -23,7 +23,7 @@
     ".github/workflows/publish.yml: /bin/omo",
     "AGENTS.md: omo doctor",
     "CLAUDE.md: omo doctor",
-    "changes.md: omo doctor x2",
+    "changes.md: omo doctor x4",
     "packages/omo-codex/README.md: omo get-local-version",
     "packages/omo-native/AGENTS.md: /bin/omo x2",
     "packages/omo-native/AGENTS.md: omo doctor x2",


### PR DESCRIPTION
## Summary
- `omo-ai@5.0.0-0.beta.53` already ships `plugin/skills-conditional/x-search/SKILL.md` (the original missing-payload bug from beta.40). Doctor still only checked the manifest, extension, and two runtimes, so a stripped install passed while xAI sessions opened with a Skill conflict.
- `omo doctor` (npm launcher and compiled binary) now requires that published path. Both checklists share `DOCTOR_PLUGIN_ARTIFACTS` so they cannot drift.
- Fixtures that run doctor now write the same artifact list.

## Test plan
- [x] `bun test packages/omo-native/test/doctor.test.ts` (includes missing x-search skill failure)
- [x] `bun test packages/omo-native/test/doctor-edition.test.ts`
- [x] `bun test packages/omo-native/test/doctor-transient-memory.test.ts`
- [x] `bun test packages/omo-native/test/compile-entry.test.ts` (compiled doctor PASS x-search skill)
- [x] `bun test packages/omo-native/test/setup-detect.test.ts`
- [x] `bun test packages/omo-native/test/setup-detect-cache.test.ts`
- [x] Confirmed `omo-ai@5.0.0-0.beta.53` tarball contains `package/plugin/skills-conditional/x-search/SKILL.md`
- Senpi/bundle regen: not required (no omo-senpi source change)

Fixes #7774


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `omo doctor` so it fails when the published x-search skill is missing from the installed payload. The skill already ships in `omo-ai`, but doctor only checked the manifest, extension, and two runtimes, so a stripped install passed while xAI sessions opened with a Skill conflict.

- Adds `plugin/skills-conditional/x-search/SKILL.md` to the required artifacts in both the npm launcher and compiled binary.
- Both checklists now share `DOCTOR_PLUGIN_ARTIFACTS`, so they cannot drift.
- Test fixtures that run doctor write the same artifact list.

<sup>Written for commit 937eedf199a92c4416f328b033c47828815280d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

