### PR TITLE
test(doctor): keep installer-shaped agents.*.models valid (fixes #8104)

### DIFF
--- a/packages/omo-opencode/src/cli/doctor/checks/config.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/config.test.ts
@@ -265,5 +265,73 @@ describe("config check", () => {
         }
       }
     })
+
+    // regression: issue #8104 — installer-written mixed agents.*.models was
+    // reported as "Unknown config key" even though assets/omo.schema.json
+    // declares the key. Renaming to fallback_models then hit the deprecation
+    // checker, so no on-disk shape passed both checks.
+    it("does not flag installer-shaped agents.*.models as an invalid configuration", async () => {
+      const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+      const originalHome = process.env.HOME
+      const originalCwd = process.cwd()
+      const testRootDir = join(
+        tmpdir(),
+        `omo-doctor-installer-agent-models-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      )
+      const projectDir = join(testRootDir, "project")
+      const installerModels = [
+        "opencode-go/qwen3.7-plus",
+        { model: "opencode-go/minimax-m3" },
+        { model: "opencode-go/minimax-m2.7" },
+      ]
+
+      try {
+        //#given a unified user config with the installer's mixed models[] chain
+        mkdirSync(projectDir, { recursive: true })
+        mkdirSync(join(testRootDir, ".omo"), { recursive: true })
+        process.env.HOME = testRootDir
+        delete process.env.OPENCODE_CONFIG_DIR
+        writeFileSync(
+          join(testRootDir, ".omo", "omo.jsonc"),
+          JSON.stringify({
+            "[opencode]": {
+              agents: {
+                librarian: { models: installerModels },
+                explore: { models: installerModels },
+                atlas: { models: installerModels },
+                "sisyphus-junior": { models: installerModels },
+              },
+            },
+          }, null, 2) + "\n",
+          "utf-8",
+        )
+        process.chdir(projectDir)
+
+        //#when running the consolidated config check
+        const result = await config.checkConfig()
+        const unknownModels = result.issues.filter((issue) =>
+          issue.title === "Invalid configuration"
+          && issue.description.includes("Unknown config key: agents.")
+          && issue.description.includes(".models"),
+        )
+
+        //#then installer-shaped agents.*.models remains valid
+        expect(unknownModels).toEqual([])
+        expect(result.status).not.toBe("fail")
+      } finally {
+        process.chdir(originalCwd)
+        rmSync(testRootDir, { recursive: true, force: true })
+        if (originalConfigDir === undefined) {
+          delete process.env.OPENCODE_CONFIG_DIR
+        } else {
+          process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+        }
+        if (originalHome === undefined) {
+          delete process.env.HOME
+        } else {
+          process.env.HOME = originalHome
+        }
+      }
+    })
   })
 })

--- a/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
+++ b/packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts
@@ -378,4 +378,61 @@ describe("deprecated reasoning keys check", () => {
       }
     }
   })
+
+  it("#given installer-shaped agents.*.models #when the check runs #then models is not treated as a deprecated key", async () => {
+    const originalConfigDir = process.env.OPENCODE_CONFIG_DIR
+    const originalHome = process.env.HOME
+    const originalCwd = process.cwd()
+    const testRootDir = mkdtempSync(join(tmpdir(), "omo-doctor-installer-models-canonical-"))
+    const projectDir = join(testRootDir, "project")
+    const configPath = join(testRootDir, ".omo", "omo.jsonc")
+    const installerModels = [
+      "opencode-go/qwen3.7-plus",
+      { model: "opencode-go/minimax-m3" },
+      { model: "opencode-go/minimax-m2.7" },
+    ]
+
+    try {
+      mkdirSync(projectDir, { recursive: true })
+      mkdirSync(join(testRootDir, ".omo"), { recursive: true })
+      process.env.HOME = testRootDir
+      delete process.env.OPENCODE_CONFIG_DIR
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          agents: {
+            librarian: { models: installerModels },
+            explore: { models: installerModels },
+          },
+          "[opencode]": {
+            agents: {
+              atlas: { models: installerModels },
+              "sisyphus-junior": { models: installerModels },
+            },
+          },
+        }, null, 2) + "\n",
+        "utf-8",
+      )
+      process.chdir(projectDir)
+
+      const { checkDeprecatedReasoningKeys } = await import("./deprecated-reasoning-keys")
+      const result = await checkDeprecatedReasoningKeys()
+
+      expect(result.issues.filter((issue) => issue.description.includes(".models"))).toEqual([])
+      expect(result.status).toBe("pass")
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(testRootDir, { recursive: true, force: true })
+      if (originalConfigDir === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = originalConfigDir
+      }
+      if (originalHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = originalHome
+      }
+    }
+  })
 })

--- a/packages/omo-opencode/src/config/schema/agent-overrides.test.ts
+++ b/packages/omo-opencode/src/config/schema/agent-overrides.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import { OhMyOpenCodeConfigSchema } from "../schema"
+import { findUnknownKeyPaths } from "../../plugin-config/unknown-key-diagnostics"
 import { AgentOverridesSchema } from "./agent-overrides"
 
 describe("AgentOverridesSchema", () => {
@@ -56,5 +58,30 @@ describe("AgentOverridesSchema", () => {
     const result = AgentOverridesSchema.safeParse(input)
 
     expect(result.success).toBe(false)
+  })
+
+  test("accepts installer-shaped mixed models chains without unknown-key diagnostics", () => {
+    // given — OpenCode Go install writes a string primary plus object fallbacks
+    const installerModels = [
+      "opencode-go/qwen3.7-plus",
+      { model: "opencode-go/minimax-m3" },
+      { model: "opencode-go/minimax-m2.7" },
+    ]
+    const config = {
+      agents: {
+        librarian: { models: installerModels },
+        explore: { models: installerModels },
+        atlas: { models: installerModels },
+        "sisyphus-junior": { models: installerModels },
+      },
+    }
+
+    // when
+    const parsed = AgentOverridesSchema.safeParse(config.agents)
+    const unknown = findUnknownKeyPaths(OhMyOpenCodeConfigSchema, config)
+
+    // then
+    expect(parsed.success).toBe(true)
+    expect(unknown).toEqual([])
   })
 })

--- a/packages/omo-opencode/src/config/validate.test.ts
+++ b/packages/omo-opencode/src/config/validate.test.ts
@@ -274,4 +274,40 @@ describe("validatePluginConfig", () => {
       ])
     })
   })
+
+  // regression: issue #8104 — installer/migration writes a mixed models[] chain
+  // (string primary + object fallbacks). Doctor used to treat `agents.*.models`
+  // as an unknown key even though the published schema declares it.
+  it("#given installer-shaped mixed agents.*.models #when validating the user layer #then the chain is known and materializes", () => {
+    withOmoConfig("installer-agent-models", (fixture) => {
+      const installerModels = [
+        "opencode-go/qwen3.7-plus",
+        { model: "opencode-go/minimax-m3" },
+        { model: "opencode-go/minimax-m2.7" },
+      ]
+      writeUserConfig(fixture, {
+        "[opencode]": {
+          agents: {
+            librarian: { models: installerModels },
+            explore: { models: installerModels },
+            atlas: { models: installerModels },
+            "sisyphus-junior": { models: installerModels },
+          },
+        },
+      })
+
+      const result = validatePluginConfig(fixture.project)
+
+      expect(result.messages.filter((message) => message.includes("Unknown config key: agents."))).toEqual([])
+      expect(result.valid).toBe(true)
+      expect(result.config.agents?.librarian?.model).toBe("opencode-go/qwen3.7-plus")
+      expect(result.config.agents?.librarian?.fallback_models).toEqual([
+        { model: "opencode-go/minimax-m3" },
+        { model: "opencode-go/minimax-m2.7" },
+      ])
+      expect(result.config.agents?.explore?.model).toBe("opencode-go/qwen3.7-plus")
+      expect(result.config.agents?.atlas?.model).toBe("opencode-go/qwen3.7-plus")
+      expect(result.config.agents?.["sisyphus-junior"]?.model).toBe("opencode-go/qwen3.7-plus")
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Lock the installer/migration mixed `agents.*.models` chain (string primary + object fallbacks) so doctor cannot again report `Unknown config key: agents.librarian.models`.
- Covers schema unknown-key diagnostics, plugin config validation, the doctor config check, and the deprecated-key walker (canonical `models` is not a deprecated key).
- Runtime already accepts this shape on `dev` (`AgentOverrideConfigSchema.models`); this prevents the 4.19.4 loop from regressing: `models` unknown, `fallback_models` deprecated, no key passes both checks.

## Test plan
- [x] `bun test packages/omo-opencode/src/config/schema/agent-overrides.test.ts`
- [x] `bun test packages/omo-opencode/src/config/validate.test.ts`
- [x] `bun test packages/omo-opencode/src/cli/doctor/checks/config.test.ts`
- [x] `bun test packages/omo-opencode/src/cli/doctor/checks/deprecated-reasoning-keys.test.ts`
- [x] `bun test packages/omo-opencode/src/config/schema/fallback-models.test.ts`

Fixes #8104


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests so doctor no longer rejects the installer's mixed `agents.*.models` chain (string primary plus object fallbacks), fixing #8104. The previous workaround of renaming to `fallback_models` hit the deprecated-key check, so installer-written config couldn't pass doctor. Coverage now spans schema unknown-key diagnostics, plugin config validation, the doctor config check, and the deprecated-key walker.

<sup>Written for commit 5ff2cbf2ba45c8bc88bbb2df60c7d496ec141a2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

