### PR TITLE
feat(prompts): route Devin SWE-2 through Kimi K3 prompt

### DIFF
--- a/packages/model-core/src/model-family-detectors.test.ts
+++ b/packages/model-core/src/model-family-detectors.test.ts
@@ -16,6 +16,7 @@ import {
   isKimiK27Model,
   isKimiK3Model,
   isMiniMaxModel,
+  isSWE2Model,
 } from "./model-family-detectors"
 
 describe("model family detectors", () => {
@@ -61,6 +62,15 @@ describe("model family detectors", () => {
     expect(isKimiK3Model("kimi-for-coding/k2p7")).toBe(false)
     expect(isKimiK3Model("kimi-for-coding/k2p5")).toBe(false)
     expect(isKimiK3Model("anthropic/claude-opus-4-7")).toBe(false)
+  })
+
+  test("#given Devin SWE-2 model ids #then detects SWE-2 effort lanes only", () => {
+    expect(isSWE2Model("devin/swe-2-low")).toBe(true)
+    expect(isSWE2Model("devin/swe-2-high")).toBe(true)
+    expect(isSWE2Model("devin/swe-2-max")).toBe(true)
+    expect(isSWE2Model("swe-2")).toBe(true)
+    expect(isSWE2Model("devin/swe-1-7")).toBe(false)
+    expect(isSWE2Model("devin/swe-20")).toBe(false)
   })
 
   test("#given GLM model ids #then detects GLM family only", () => {

--- a/packages/model-core/src/model-family-detectors.ts
+++ b/packages/model-core/src/model-family-detectors.ts
@@ -83,6 +83,11 @@ export function isKimiK3Model(model: string): boolean {
   return false
 }
 
+export function isSWE2Model(model: string): boolean {
+  const modelName = extractModelName(model).toLowerCase()
+  return /^swe-2(?:[-.]|$)/.test(modelName)
+}
+
 export function isMiniMaxModel(model: string): boolean {
   const modelName = extractModelName(model).toLowerCase()
   return modelName.includes("minimax")

--- a/packages/prompts-core/src/atlas-prompts.ts
+++ b/packages/prompts-core/src/atlas-prompts.ts
@@ -29,6 +29,11 @@ export const atlasPromptVariants = {
     content: kimiK3Prompt,
     filePath: "packages/prompts-core/prompts/atlas/kimi-k3.md",
   },
+  "swe-2": {
+    kind: "bundled",
+    content: kimiK3Prompt,
+    filePath: "packages/prompts-core/prompts/atlas/kimi-k3.md",
+  },
   "kimi-k2-7": {
     kind: "bundled",
     content: kimiK27Prompt,

--- a/packages/prompts-core/src/types.ts
+++ b/packages/prompts-core/src/types.ts
@@ -4,6 +4,7 @@ export type ModelVariant =
   | "gemini"
   | "kimi"
   | "glm"
+  | "swe-2"
   | "planner"
   | "codex"
   | "opus-4-7"

--- a/packages/prompts-core/src/variant-resolver.test.ts
+++ b/packages/prompts-core/src/variant-resolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { atlasPromptVariants } from "./atlas-prompts"
 import type { PromptSource, VariantTable } from "./types"
 import { resolveVariant } from "./variant-resolver"
 
@@ -53,6 +54,22 @@ describe("resolveVariant", () => {
     expect(resolveVariant({ modelID: "kimi-for-coding/k3p1", variants: orderedVariants })).toBe("kimi-k3")
     expect(resolveVariant({ modelID: "kimi-k2.7", variants: orderedVariants })).toBe("kimi-k2-7")
     expect(resolveVariant({ modelID: "kimi-k2-6", variants: orderedVariants })).toBe("kimi")
+  })
+
+  test("#given a Devin SWE-2 model #then resolves the SWE-2 variant", () => {
+    const orderedVariants = {
+      "swe-2": promptSource("/prompts/swe-2"),
+      "kimi-k3": promptSource("/prompts/kimi-k3"),
+      kimi: promptSource("/prompts/kimi"),
+      default: promptSource("/prompts/default"),
+    } satisfies VariantTable
+
+    expect(resolveVariant({ modelID: "devin/swe-2-high", variants: orderedVariants })).toBe("swe-2")
+    expect(resolveVariant({ modelID: "devin/swe-1-7", variants: orderedVariants })).toBe("default")
+  })
+
+  test("#given Atlas SWE-2 #then uses the exact Kimi K3 system prompt", () => {
+    expect(atlasPromptVariants["swe-2"]).toEqual(atlasPromptVariants["kimi-k3"])
   })
 
   test("#given GLM model #then resolves glm variant", () => {

--- a/packages/prompts-core/src/variant-resolver.ts
+++ b/packages/prompts-core/src/variant-resolver.ts
@@ -7,6 +7,7 @@ import {
   isKimiK27Model,
   isKimiK3Model,
   isMiniMaxModel,
+  isSWE2Model,
 } from "@oh-my-opencode/model-core"
 import type { VariantTable } from "./types"
 
@@ -24,6 +25,7 @@ const MODEL_MATCHERS: Readonly<Record<string, ModelMatcher>> = {
   gpt: isGptModel,
   gemini: isGeminiModel,
   "kimi-k3": isKimiK3Model,
+  "swe-2": isSWE2Model,
   "kimi-k2-7": isKimiK27Model,
   kimi: isKimiK2Model,
   glm: isGlmModel,


### PR DESCRIPTION
## Summary
Adds first-class Devin SWE-2 model-family recognition to Omo and routes Atlas SWE-2 sessions through the exact existing Kimi K3 system prompt content. This keeps prompt content single-sourced while supporting the model IDs shipped by Devin CLI.

## Changes
- Add an exact-boundary `isSWE2Model` detector for `swe-2` and its effort lanes.
- Add an explicit `swe-2` Atlas prompt variant backed by the existing `kimi-k3.md` prompt object.
- Add regression tests for SWE-2 positive/negative detection, variant precedence, and prompt identity.

## QA & Evidence
- `bun test packages/model-core/src/model-family-detectors.test.ts packages/prompts-core/src/variant-resolver.test.ts` — 29 pass, 0 fail.
- `bunx tsgo --noEmit -p packages/model-core/tsconfig.json` — passed.
- `bunx tsgo --noEmit -p packages/prompts-core/tsconfig.json` — passed.
- Production runtime probe — `SWE2_RUNTIME_QA PASS`; SWE-2 resolved to the Kimi K3 prompt bytes.
- Evidence: `.omo/evidence/20260911-devin-swe2/README.md`

## Notes
The official Devin CLI `3000.10.21` binary contains `swe-2-low`, `swe-2-high`, `swe-2-max`, and `swe-2-high-lite`. The primary documented effort lanes are low/high/max; runtime model discovery remains outside this Omo prompt-core change.

## Related Issues
Fixes #8129


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Devin SWE-2 models (including effort lanes like `swe-2-low`, `swe-2-high`, `swe-2-max`) to the existing Kimi K3 system prompt, so they no longer fall back to the default prompt. Adds a new `swe-2` model family detector and prompt variant, with tests. Fixes #8129.

<sup>Written for commit c995fcd3cfc603c553704ad5a30cfe3dd3795f5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

