### PR TITLE
fix(omo-opencode): resolve builtin agent fallback against connected providers

### DIFF
--- a/packages/omo-opencode/src/agents/builtin-agents/general-agents.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/general-agents.ts
@@ -93,7 +93,7 @@ export function collectPendingBuiltinAgents(input: {
         })
         resolution = { model: override.model, provenance: "override" as const }
       } else {
-        resolution = getFirstFallbackModel(requirement)
+        resolution = getFirstFallbackModel(requirement, availableModels)
       }
     }
     if (!resolution) {

--- a/packages/omo-opencode/src/agents/builtin-agents/hephaestus-agent.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/hephaestus-agent.ts
@@ -67,7 +67,7 @@ export function maybeCreateHephaestusConfig(input: {
   })
 
   if (isFirstRunNoCache && !hephaestusOverride?.model) {
-    hephaestusResolution = getFirstFallbackModel(hephaestusRequirement)
+    hephaestusResolution = getFirstFallbackModel(hephaestusRequirement, availableModels)
   }
 
   if (!hephaestusResolution) {

--- a/packages/omo-opencode/src/agents/builtin-agents/model-resolution.test.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/model-resolution.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="bun-types" />
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import * as connectedProvidersCache from "../../shared/connected-providers-cache"
+import { getFirstFallbackModel } from "./model-resolution"
+
+const SISYPHUS_PRIMARY = {
+  fallbackChain: [
+    {
+      providers: ["anthropic", "github-copilot", "opencode"],
+      model: "claude-opus-5",
+      variant: "max",
+    },
+  ],
+}
+
+afterEach(() => {
+  connectedProvidersCache._resetMemCacheForTesting()
+})
+
+describe("getFirstFallbackModel", () => {
+  describe("#given a fallback entry with multiple providers", () => {
+    test("#when availableModels only lists a later provider #then that provider is chosen", () => {
+      // given
+      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+      const availableModels = new Set(["github-copilot/claude-opus-5"])
+
+      try {
+        // when
+        const result = getFirstFallbackModel(SISYPHUS_PRIMARY, availableModels)
+
+        // then
+        expect(result).toEqual({
+          model: "github-copilot/claude-opus-5",
+          provenance: "provider-fallback",
+          variant: "max",
+        })
+      } finally {
+        cacheSpy.mockRestore()
+      }
+    })
+
+    test("#when availableModels is empty and a later provider is connected #then that provider is chosen", () => {
+      // given
+      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue([
+        "github-copilot",
+        "opencode",
+      ])
+
+      try {
+        // when
+        const result = getFirstFallbackModel(SISYPHUS_PRIMARY, new Set())
+
+        // then
+        expect(result).toEqual({
+          model: "github-copilot/claude-opus-5",
+          provenance: "provider-fallback",
+          variant: "max",
+        })
+      } finally {
+        cacheSpy.mockRestore()
+      }
+    })
+
+    test("#when no provider is connected or catalogued #then providers[0] is used", () => {
+      // given
+      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null)
+
+      try {
+        // when
+        const result = getFirstFallbackModel(SISYPHUS_PRIMARY, new Set())
+
+        // then
+        expect(result).toEqual({
+          model: "anthropic/claude-opus-5",
+          provenance: "provider-fallback",
+          variant: "max",
+        })
+      } finally {
+        cacheSpy.mockRestore()
+      }
+    })
+  })
+
+  describe("#given an empty requirement", () => {
+    test("#when fallbackChain is missing #then undefined is returned", () => {
+      expect(getFirstFallbackModel(undefined, new Set())).toBeUndefined()
+      expect(getFirstFallbackModel({ fallbackChain: [] }, new Set())).toBeUndefined()
+    })
+  })
+})

--- a/packages/omo-opencode/src/agents/builtin-agents/model-resolution.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/model-resolution.ts
@@ -1,4 +1,4 @@
-import { resolveModelPipeline } from "../../shared"
+import { isAnyProviderConnected, resolveModelPipeline } from "../../shared"
 import { transformModelForProvider } from "../../shared/provider-model-id-transform"
 
 export function applyModelResolution(input: {
@@ -16,12 +16,17 @@ export function applyModelResolution(input: {
   })
 }
 
-export function getFirstFallbackModel(requirement?: {
-  fallbackChain?: { providers: string[]; model: string; variant?: string }[]
-}) {
+export function getFirstFallbackModel(
+  requirement?: {
+    fallbackChain?: { providers: string[]; model: string; variant?: string }[]
+  },
+  availableModels: Set<string> = new Set(),
+) {
   const entry = requirement?.fallbackChain?.[0]
   if (!entry || entry.providers.length === 0) return undefined
-  const provider = entry.providers[0]
+  const provider =
+    entry.providers.find((candidate) => isAnyProviderConnected([candidate], availableModels))
+    ?? entry.providers[0]
   const transformedModel = transformModelForProvider(provider, entry.model)
   return {
     model: `${provider}/${transformedModel}`,

--- a/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.test.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.test.ts
@@ -1,9 +1,14 @@
 /// <reference types="bun-types" />
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import * as connectedProvidersCache from "../../shared/connected-providers-cache";
 import { maybeCreateSisyphusConfig } from "./sisyphus-agent";
 import type { AgentOverrides } from "../types";
 import type { CategoryConfig } from "../../config/schema";
+
+afterEach(() => {
+  connectedProvidersCache._resetMemCacheForTesting();
+});
 
 describe("maybeCreateSisyphusConfig", () => {
   describe("#given GPT model with user override allowing apply_patch", () => {
@@ -312,6 +317,89 @@ describe("maybeCreateSisyphusConfig", () => {
       expect(config).toBeDefined();
       expect(config?.model).toBe("openai/gpt-4o");
       expect(config?.permission).toHaveProperty("apply_patch", "allow");
+    });
+  });
+
+  describe("#given first-run registration without a user model override", () => {
+    test("#when applyModelResolution already found a connected system default #then that result is kept", () => {
+      // given — #8131: isFirstRunNoCache must not replace a successful resolution
+      // with unfiltered providers[0] (anthropic) on a Copilot-only machine.
+      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null);
+
+      try {
+        // when
+        const config = maybeCreateSisyphusConfig({
+          disabledAgents: [],
+          agentOverrides: {},
+          availableModels: new Set(),
+          systemDefaultModel: "github-copilot/claude-opus-5",
+          isFirstRunNoCache: true,
+          availableAgents: [],
+          availableSkills: [],
+          availableCategories: [],
+          mergedCategories: {},
+          useTaskSystem: false,
+        });
+
+        // then
+        expect(config).toBeDefined();
+        expect(config?.model).toBe("github-copilot/claude-opus-5");
+      } finally {
+        cacheSpy.mockRestore();
+      }
+    });
+
+    test("#when availableModels already contain a fallback provider #then that availability-filtered result is kept", () => {
+      // given
+      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null);
+
+      try {
+        // when
+        const config = maybeCreateSisyphusConfig({
+          disabledAgents: [],
+          agentOverrides: {},
+          availableModels: new Set(["github-copilot/claude-opus-5"]),
+          systemDefaultModel: "anthropic/claude-opus-5",
+          isFirstRunNoCache: true,
+          availableAgents: [],
+          availableSkills: [],
+          availableCategories: [],
+          mergedCategories: {},
+          useTaskSystem: false,
+        });
+
+        // then
+        expect(config).toBeDefined();
+        expect(config?.model).toBe("github-copilot/claude-opus-5");
+      } finally {
+        cacheSpy.mockRestore();
+      }
+    });
+
+    test("#when availability-aware resolution produces nothing #then first-entry providers[0] is used", () => {
+      // given
+      const cacheSpy = spyOn(connectedProvidersCache, "readConnectedProvidersCache").mockReturnValue(null);
+
+      try {
+        // when
+        const config = maybeCreateSisyphusConfig({
+          disabledAgents: [],
+          agentOverrides: {},
+          availableModels: new Set(),
+          isFirstRunNoCache: true,
+          availableAgents: [],
+          availableSkills: [],
+          availableCategories: [],
+          mergedCategories: {},
+          useTaskSystem: false,
+        });
+
+        // then
+        expect(config).toBeDefined();
+        expect(config?.model).toBe("anthropic/claude-opus-5");
+      } finally {
+        cacheSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts
+++ b/packages/omo-opencode/src/agents/builtin-agents/sisyphus-agent.ts
@@ -67,8 +67,8 @@ export function maybeCreateSisyphusConfig(input: {
     systemDefaultModel,
   })
 
-  if (isFirstRunNoCache && !sisyphusOverride?.model && !uiSelectedModel) {
-    sisyphusResolution = getFirstFallbackModel(sisyphusRequirement)
+  if (!sisyphusResolution && isFirstRunNoCache && !sisyphusOverride?.model && !uiSelectedModel) {
+    sisyphusResolution = getFirstFallbackModel(sisyphusRequirement, availableModels)
   }
 
   if (!sisyphusResolution) {


### PR DESCRIPTION
## Summary
- `getFirstFallbackModel()` always took `fallbackChain[0].providers[0]` (usually `anthropic`), so builtin agents registered as `anthropic/claude-opus-5` on Copilot-only machines.
- Sisyphus first-run then overwrote an already-resolved `github-copilot/...` model. `/start-work` used that configured model and died with `ProviderModelNotFoundError`.
- Fallback now picks the first provider that is connected or present in the catalogue (`isAnyProviderConnected`); Sisyphus only applies fallback when resolution is still empty. Delegate/`task(category=...)` is unchanged.
- Fixes #8131

## Test plan
- [x] `bun test` on `model-resolution.test.ts` + `sisyphus-agent.test.ts` → 16 pass / 0 fail (RED then GREEN)
- [x] Related builtin-agent / `call-omo-agent` regression: 128 pass
- [x] `bun run --cwd packages/omo-opencode typecheck`
- [ ] Copilot-only machine: `/start-work` should use `github-copilot/claude-opus-5` (or another connected id), not `anthropic/claude-opus-5`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes builtin agent fallback so it picks the first connected or catalogued provider instead of always defaulting to `anthropic`, and stops Sisyphus first-run from overwriting an already-resolved model. Fixes #8131.

**Changes**
- `getFirstFallbackModel` now filters fallback providers by connected providers or `availableModels`, falling back to `providers[0]` when nothing matches.
- Sisyphus only applies fallback when model resolution is still empty.
- Adds unit tests for provider filtering and Sisyphus first-run behavior.

<sup>Written for commit 99ad446fa4ccbf5062d39ee346e72c9b57346c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

