### PR TITLE
fix(omo-opencode): keep agent-usage reminder off tool result payloads

### DIFF
--- a/packages/omo-opencode/src/hooks/agent-usage-reminder/hook.ts
+++ b/packages/omo-opencode/src/hooks/agent-usage-reminder/hook.ts
@@ -1,4 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin";
+import type { Message, Part } from "@opencode-ai/sdk";
 import {
   loadAgentUsageState,
   saveAgentUsageState,
@@ -7,6 +8,7 @@ import {
 import { TARGET_TOOLS, AGENT_TOOLS, REMINDER_MESSAGE } from "./constants";
 import type { AgentUsageState } from "./types";
 import { getSessionAgent } from "../../features/claude-code-session-state";
+import { isRealUserTextPart, log } from "../../shared";
 import { getAgentConfigKey } from "../../shared/agent-display-names";
 import { resolveSessionEventID } from "../../shared/event-session-id";
 
@@ -29,6 +31,16 @@ interface EventInput {
   };
 }
 
+type MessageWithParts = { info: Message; parts: Part[] };
+
+interface ReminderInjectionTarget {
+  message: MessageWithParts;
+  messageID: string;
+  sessionID: string;
+  state: AgentUsageState;
+  textPartIndex: number;
+}
+
 /**
  * Only orchestrator agents should receive usage reminders.
  * Subagents (explore, librarian, oracle, etc.) are the targets of delegation,
@@ -48,6 +60,33 @@ function isOrchestratorAgent(agentName: string): boolean {
   return ORCHESTRATOR_AGENTS.has(getAgentConfigKey(agentName));
 }
 
+function findLatestReminderTarget(
+  messages: MessageWithParts[],
+  getState: (sessionID: string) => AgentUsageState,
+): ReminderInjectionTarget | undefined {
+  for (let messageIndex = messages.length - 1; messageIndex >= 0; messageIndex -= 1) {
+    const message = messages[messageIndex];
+    if (message?.info.role !== "user") continue;
+    const sessionID = message.info.sessionID;
+    const messageID = message.info.id;
+    if (typeof sessionID !== "string" || typeof messageID !== "string") continue;
+
+    const state = getState(sessionID);
+    if (!state.reminderPending || state.agentUsed || state.reminderCount >= MAX_REMINDERS) {
+      continue;
+    }
+
+    for (let partIndex = message.parts.length - 1; partIndex >= 0; partIndex -= 1) {
+      const part = message.parts[partIndex];
+      if (part && isRealUserTextPart(part)) {
+        return { message, messageID, sessionID, state, textPartIndex: partIndex };
+      }
+    }
+  }
+
+  return undefined;
+}
+
 export function createAgentUsageReminderHook(_ctx: PluginInput) {
   const sessionStates = new Map<string, AgentUsageState>();
 
@@ -58,6 +97,7 @@ export function createAgentUsageReminderHook(_ctx: PluginInput) {
         sessionID,
         agentUsed: false,
         reminderCount: 0,
+        reminderPending: false,
         updatedAt: Date.now(),
       };
       sessionStates.set(sessionID, state);
@@ -65,11 +105,16 @@ export function createAgentUsageReminderHook(_ctx: PluginInput) {
     return sessionStates.get(sessionID)!;
   }
 
+  function persist(state: AgentUsageState): void {
+    state.updatedAt = Date.now();
+    saveAgentUsageState(state);
+  }
+
   function markAgentUsed(sessionID: string): void {
     const state = getOrCreateState(sessionID);
     state.agentUsed = true;
-    state.updatedAt = Date.now();
-    saveAgentUsageState(state);
+    state.reminderPending = false;
+    persist(state);
   }
 
   function resetState(sessionID: string): void {
@@ -79,7 +124,7 @@ export function createAgentUsageReminderHook(_ctx: PluginInput) {
 
   const toolExecuteAfter = async (
     input: ToolExecuteInput,
-    output: ToolExecuteOutput,
+    _output: ToolExecuteOutput,
   ) => {
     const { tool, sessionID } = input;
 
@@ -101,14 +146,40 @@ export function createAgentUsageReminderHook(_ctx: PluginInput) {
 
     const state = getOrCreateState(sessionID);
 
-    if (state.agentUsed || state.reminderCount >= MAX_REMINDERS) {
+    if (state.agentUsed || state.reminderCount >= MAX_REMINDERS || state.reminderPending) {
       return;
     }
 
-    output.output += REMINDER_MESSAGE;
-    state.reminderCount++;
-    state.updatedAt = Date.now();
-    saveAgentUsageState(state);
+    state.reminderPending = true;
+    persist(state);
+    log("[agent-usage-reminder] Reminder queued", {
+      sessionID,
+      reminderCount: state.reminderCount,
+    });
+  };
+
+  const messagesTransform = async (
+    _input: Record<string, never>,
+    output: { messages: MessageWithParts[] },
+  ): Promise<void> => {
+    const target = findLatestReminderTarget(output.messages, getOrCreateState);
+    if (!target) return;
+
+    target.message.parts.splice(target.textPartIndex, 0, {
+      id: `prt_agent_usage_reminder_${target.messageID}`,
+      sessionID: target.sessionID,
+      messageID: target.messageID,
+      type: "text",
+      text: REMINDER_MESSAGE,
+      synthetic: true,
+    });
+    target.state.reminderPending = false;
+    target.state.reminderCount++;
+    persist(target.state);
+    log("[agent-usage-reminder] Reminder injected", {
+      sessionID: target.sessionID,
+      reminderCount: target.state.reminderCount,
+    });
   };
 
   const eventHandler = async ({ event }: EventInput) => {
@@ -124,6 +195,7 @@ export function createAgentUsageReminderHook(_ctx: PluginInput) {
 
   return {
     "tool.execute.after": toolExecuteAfter,
+    "experimental.chat.messages.transform": messagesTransform,
     event: eventHandler,
   };
 }

--- a/packages/omo-opencode/src/hooks/agent-usage-reminder/index.test.ts
+++ b/packages/omo-opencode/src/hooks/agent-usage-reminder/index.test.ts
@@ -1,6 +1,8 @@
 import type { PluginInput } from "@opencode-ai/plugin";
+import type { Message, Part } from "@opencode-ai/sdk";
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { createAgentUsageReminderHook } from "./index";
+import { REMINDER_MESSAGE } from "./constants";
 import { clearSessionAgent, updateSessionAgent, _resetForTesting } from "../../features/claude-code-session-state";
 import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value";
 import * as storage from "./storage";
@@ -27,84 +29,226 @@ describe("agent-usage-reminder hook", () => {
     return createAgentUsageReminderHook(unsafeTestValue<PluginInput>({}));
   }
 
+  type MessageWithParts = {
+    info: Message;
+    parts: Part[];
+  };
+
+  function createOutput(text = "result") {
+    return { title: "", output: text, metadata: {} };
+  }
+
+  function createUserTurn(
+    sessionID: string,
+    text: string,
+    options: { id?: string; synthetic?: boolean } = {},
+  ): MessageWithParts {
+    const messageID = options.id ?? `msg_${sessionID}`;
+    return {
+      info: {
+        id: messageID,
+        sessionID,
+        role: "user",
+        time: { created: 1 },
+        agent: "sisyphus",
+        model: { providerID: "test", modelID: "test" },
+      },
+      parts: [{
+        id: `prt_${messageID}`,
+        sessionID,
+        messageID,
+        type: "text",
+        text,
+        ...(options.synthetic === true ? { synthetic: true } : {}),
+      }],
+    };
+  }
+
+  function findReminderParts(messages: MessageWithParts[]): Part[] {
+    return messages.flatMap((message) => message.parts).filter(
+      (part) => part.type === "text"
+        && part.synthetic === true
+        && part.id === `prt_agent_usage_reminder_${part.messageID}`,
+    );
+  }
+
+  async function transformMessages(
+    hook: ReturnType<typeof createHook>,
+    messages: MessageWithParts[],
+  ): Promise<void> {
+    await hook["experimental.chat.messages.transform"]({}, { messages });
+  }
+
+  async function useTool(
+    hook: ReturnType<typeof createHook>,
+    sessionID: string,
+    tool: string,
+    callID: string,
+    output = createOutput(),
+  ) {
+    await hook["tool.execute.after"]({ tool, sessionID, callID }, output);
+    return output;
+  }
+
+  test("does not append the reminder onto tool result payloads", async () => {
+    const hook = createHook();
+    const sessionID = "agent-usage-payload-session";
+    updateSessionAgent(sessionID, "Sisyphus");
+    const original = "stdout\r\nwith trailing bytes\u0000\n";
+    const output = createOutput(original);
+
+    await useTool(hook, sessionID, "grep", "1", output);
+    const messages = [createUserTurn(sessionID, "continue")];
+    await transformMessages(hook, messages);
+
+    expect(output.output).toBe(original);
+    expect(output.output).not.toContain("[Agent Usage Reminder]");
+    expect(findReminderParts(messages)).toHaveLength(1);
+    expect(messages[0]?.parts[0]).toMatchObject({ synthetic: true, type: "text" });
+    expect(messages[0]?.parts[1]).toMatchObject({ text: "continue", type: "text" });
+    const reminder = findReminderParts(messages)[0];
+    expect(reminder?.type).toBe("text");
+    if (reminder?.type !== "text") throw new Error("expected reminder text part");
+    expect(reminder.text).toBe(REMINDER_MESSAGE);
+
+    clearSessionAgent(sessionID);
+  });
+
   test("caps reminders and does not re-arm after session.compacted", async () => {
-    // given - an orchestrator session has already hit the reminder cap
     const hook = createHook();
     const sessionID = "agent-usage-compact-session";
     updateSessionAgent(sessionID, "Sisyphus");
 
-    const output1 = { title: "", output: "result-1", metadata: {} };
-    const output2 = { title: "", output: "result-2", metadata: {} };
-    const output3 = { title: "", output: "result-3", metadata: {} };
-    const output4 = { title: "", output: "result-4", metadata: {} };
+    const outputs = [
+      createOutput("result-1"),
+      createOutput("result-2"),
+      createOutput("result-3"),
+      createOutput("result-4"),
+    ];
+    const injected: MessageWithParts[] = [];
 
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "1" }, output1);
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "2" }, output2);
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "3" }, output3);
+    for (const [index, output] of outputs.slice(0, 3).entries()) {
+      await useTool(hook, sessionID, "grep", String(index + 1), output);
+      const messages = [createUserTurn(sessionID, `continue-${index + 1}`, { id: `msg_${index + 1}` })];
+      await transformMessages(hook, messages);
+      injected.push(...messages);
+    }
 
-    // then - the first three reminders are shown
-    expect(output1.output).toContain("[Agent Usage Reminder]");
-    expect(output2.output).toContain("[Agent Usage Reminder]");
-    expect(output3.output).toContain("[Agent Usage Reminder]");
+    expect(outputs[0]?.output).toBe("result-1");
+    expect(outputs[1]?.output).toBe("result-2");
+    expect(outputs[2]?.output).toBe("result-3");
+    expect(findReminderParts(injected)).toHaveLength(3);
 
-    // when - compaction happens and another target tool runs
     await hook.event({ event: { type: "session.compacted", properties: { sessionID } } });
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "4" }, output4);
+    await useTool(hook, sessionID, "grep", "4", outputs[3]);
+    const afterCompact = [createUserTurn(sessionID, "continue-4", { id: "msg_4" })];
+    await transformMessages(hook, afterCompact);
 
-    // then - compaction does not reset the reminder cap
-    expect(output4.output).not.toContain("[Agent Usage Reminder]");
+    expect(outputs[3]?.output).toBe("result-4");
+    expect(findReminderParts(afterCompact)).toHaveLength(0);
 
     clearSessionAgent(sessionID);
   });
 
   test("resets reminder state on session.deleted", async () => {
-    // given - an orchestrator session has reminder state
     const hook = createHook();
     const sessionID = "agent-usage-delete-session";
     updateSessionAgent(sessionID, "Sisyphus");
 
-    const output1 = { title: "", output: "result-1", metadata: {} };
-    const output2 = { title: "", output: "result-2", metadata: {} };
-    const output3 = { title: "", output: "result-3", metadata: {} };
-    const output4 = { title: "", output: "result-4", metadata: {} };
-    const output5 = { title: "", output: "result-5", metadata: {} };
+    const outputs = [
+      createOutput("result-1"),
+      createOutput("result-2"),
+      createOutput("result-3"),
+      createOutput("result-4"),
+      createOutput("result-5"),
+    ];
 
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "1" }, output1);
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "2" }, output2);
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "3" }, output3);
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "4" }, output4);
+    for (const [index, output] of outputs.slice(0, 4).entries()) {
+      await useTool(hook, sessionID, "grep", String(index + 1), output);
+      const messages = [createUserTurn(sessionID, `continue-${index + 1}`, { id: `msg_${index + 1}` })];
+      await transformMessages(hook, messages);
+      if (index < 3) {
+        expect(findReminderParts(messages)).toHaveLength(1);
+      } else {
+        expect(findReminderParts(messages)).toHaveLength(0);
+      }
+    }
 
-    expect(output1.output).toContain("[Agent Usage Reminder]");
-    expect(output2.output).toContain("[Agent Usage Reminder]");
-    expect(output3.output).toContain("[Agent Usage Reminder]");
-    expect(output4.output).not.toContain("[Agent Usage Reminder]");
+    expect(outputs[0]?.output).toBe("result-1");
+    expect(outputs[3]?.output).toBe("result-4");
 
-    // when - the session is deleted and another target tool runs
     await hook.event({ event: { type: "session.deleted", properties: { info: { id: sessionID } } } });
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "5" }, output5);
+    await useTool(hook, sessionID, "grep", "5", outputs[4]);
+    const afterDelete = [createUserTurn(sessionID, "continue-5", { id: "msg_5" })];
+    await transformMessages(hook, afterDelete);
 
-    // then - deletion still resets the state
-    expect(output5.output).toContain("[Agent Usage Reminder]");
+    expect(outputs[4]?.output).toBe("result-5");
+    expect(findReminderParts(afterDelete)).toHaveLength(1);
 
     clearSessionAgent(sessionID);
   });
 
   test("does not re-arm after session.compacted when task delegation already happened", async () => {
-    // given - an orchestrator session already delegated through task
     const hook = createHook();
     const sessionID = "agent-usage-delegated-session";
     updateSessionAgent(sessionID, "Sisyphus");
 
-    const output = { title: "", output: "result", metadata: {} };
+    const output = createOutput();
+    await useTool(hook, sessionID, "task", "1", output);
 
-    await hook["tool.execute.after"]({ tool: "task", sessionID, callID: "1" }, output);
-
-    // when - compaction happens and another target tool runs
     await hook.event({ event: { type: "session.compacted", properties: { sessionID } } });
-    await hook["tool.execute.after"]({ tool: "grep", sessionID, callID: "2" }, output);
+    await useTool(hook, sessionID, "grep", "2", output);
+    const messages = [createUserTurn(sessionID, "continue")];
+    await transformMessages(hook, messages);
 
-    // then - compaction does not clear delegated state
-    expect(output.output).not.toContain("[Agent Usage Reminder]");
+    expect(output.output).toBe("result");
+    expect(findReminderParts(messages)).toHaveLength(0);
+
+    clearSessionAgent(sessionID);
+  });
+
+  test("coalesces multiple target tools into one injected reminder", async () => {
+    const hook = createHook();
+    const sessionID = "agent-usage-coalesce-session";
+    updateSessionAgent(sessionID, "Sisyphus");
+
+    const first = createOutput("grep-hits");
+    const second = createOutput("glob-hits");
+    const third = createOutput("fetch-body");
+    await useTool(hook, sessionID, "grep", "1", first);
+    await useTool(hook, sessionID, "glob", "2", second);
+    await useTool(hook, sessionID, "webfetch", "3", third);
+
+    const firstTurn = [createUserTurn(sessionID, "first turn", { id: "msg_first" })];
+    await transformMessages(hook, firstTurn);
+    await useTool(hook, sessionID, "grep", "4", createOutput("later"));
+    const secondTurn = [createUserTurn(sessionID, "second turn", { id: "msg_second" })];
+    await transformMessages(hook, secondTurn);
+
+    expect(first.output).toBe("grep-hits");
+    expect(second.output).toBe("glob-hits");
+    expect(third.output).toBe("fetch-body");
+    expect(findReminderParts(firstTurn)).toHaveLength(1);
+    expect(findReminderParts(secondTurn)).toHaveLength(1);
+
+    clearSessionAgent(sessionID);
+  });
+
+  test("retains a queued reminder until a real user text part exists", async () => {
+    const hook = createHook();
+    const sessionID = "agent-usage-pending-session";
+    updateSessionAgent(sessionID, "Sisyphus");
+    await useTool(hook, sessionID, "grep", "1");
+
+    const noText = createUserTurn(sessionID, "unused");
+    noText.parts = [];
+    await transformMessages(hook, []);
+    await transformMessages(hook, [noText]);
+    await transformMessages(hook, [createUserTurn(sessionID, "internal", { synthetic: true })]);
+    const realMessages = [createUserTurn(sessionID, "real user text", { id: "msg_real" })];
+    await transformMessages(hook, realMessages);
+
+    expect(findReminderParts(realMessages)).toHaveLength(1);
 
     clearSessionAgent(sessionID);
   });

--- a/packages/omo-opencode/src/hooks/agent-usage-reminder/types.ts
+++ b/packages/omo-opencode/src/hooks/agent-usage-reminder/types.ts
@@ -2,5 +2,6 @@ export interface AgentUsageState {
   sessionID: string;
   agentUsed: boolean;
   reminderCount: number;
+  reminderPending?: boolean;
   updatedAt: number;
 }

--- a/packages/omo-opencode/src/plugin/messages-transform.ts
+++ b/packages/omo-opencode/src/plugin/messages-transform.ts
@@ -37,6 +37,7 @@ type MessagesTransformHooks = {
   toolPairValidator?: CreatedHooks["toolPairValidator"]
   monitorStatusInjector?: CreatedHooks["monitorStatusInjector"]
   categorySkillReminder?: CreatedHooks["categorySkillReminder"]
+  agentUsageReminder?: CreatedHooks["agentUsageReminder"]
 }
 type MessagesTransformHookKey = keyof MessagesTransformHooks
 type MessagesTransformHookEntry = {
@@ -62,6 +63,7 @@ const MESSAGES_TRANSFORM_HOOKS = [
   { key: "toolPairValidator", name: "toolPairValidator" },
   { key: "monitorStatusInjector", name: "monitorStatusInjector" },
   { key: "categorySkillReminder", name: "categorySkillReminder" },
+  { key: "agentUsageReminder", name: "agentUsageReminder" },
 ] satisfies readonly MessagesTransformHookEntry[]
 
 function getSessionID(message: MessageWithParts): string | undefined {


### PR DESCRIPTION
## Summary
- `agent-usage-reminder` appended `REMINDER_MESSAGE` onto `output.output` in `tool.execute.after`, contaminating grep/glob/webfetch payloads.
- The hook now only queues a pending reminder. Injection happens via `experimental.chat.messages.transform` as a synthetic user text part (same channel as category-skill-reminder).
- `MAX_REMINDERS=3`, compaction non-reset, delete reset, and delegation short-circuit are unchanged.
- Fixes #7830

## Test plan
- [x] `bun test` agent-usage-reminder hook + storage → 7 pass
- [x] `bun test` messages-transform → 22 pass
- [ ] After a direct grep/glob, the tool result string must not contain `[Agent Usage Reminder]`
- [ ] Orchestrator should still see the reminder as a synthetic user part on the next turn


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the agent-usage reminder polluting tool result payloads by injecting it as a synthetic user message instead of appending it to tool output. Tool results from grep/glob/webfetch now stay clean, and the reminder appears on the next turn through the same messages-transform channel as the category-skill reminder.

- Queues a pending reminder in `tool.execute.after`; injection happens later via `experimental.chat.messages.transform`.
- Adds `reminderPending` state so multiple tool calls coalesce into a single reminder per turn.
- Registers the hook in the messages-transform plugin; reminder cap, compaction, deletion, and delegation behavior are unchanged.
- Fixes #7830.

<sup>Written for commit 0d0d04fa1d514b99b28b4d38d9332851da1ed0fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

