### PR TITLE
fix(omo-opencode): do not pass both category and subagent_type for @explore

### DIFF
--- a/packages/omo-opencode/src/plugin/tool-execute-before.test.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before.test.ts
@@ -321,6 +321,47 @@ describe("createToolExecuteBeforeHandler", () => {
       //#then
       expect(output.args.subagent_type).toBe("oracle")
     })
+
+    test("#given @explore mention with both category and subagent_type #when hook runs #then only subagent_type=explore is passed", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = {
+        args: {
+          category: "explore",
+          subagent_type: "explore",
+          prompt: "hello",
+          description: "Explore hello",
+        } as Record<string, unknown>,
+      }
+
+      //#when
+      await handler(input, output)
+
+      //#then — OpenCode task() is XOR; do not leave category on a named-agent mention
+      expect(output.args.category).toBeUndefined()
+      expect("category" in output.args).toBe(false)
+      expect(output.args.subagent_type).toBe("explore")
+    })
+
+    test("#given category=explore without subagent_type #when hook runs #then it maps to subagent_type only", async () => {
+      //#given
+      const ctx = createCtxWithSessionMessages()
+      const handler = createToolExecuteBeforeHandler({ ctx, hooks: emptyHooks })
+      const input = { tool: "task", sessionID: "ses_123", callID: "call_1" }
+      const output = {
+        args: { category: "explore", prompt: "hello" } as Record<string, unknown>,
+      }
+
+      //#when
+      await handler(input, output)
+
+      //#then
+      expect(output.args.category).toBeUndefined()
+      expect("category" in output.args).toBe(false)
+      expect(output.args.subagent_type).toBe("explore")
+    })
   })
 })
 

--- a/packages/omo-opencode/src/plugin/tool-execute-before.ts
+++ b/packages/omo-opencode/src/plugin/tool-execute-before.ts
@@ -3,6 +3,10 @@ import type { PluginContext } from "./types"
 import { isTrackedBtwSideSession } from "../features/btw-side"
 import { getMainSessionID } from "../features/claude-code-session-state"
 import { log, replaceToolArgs } from "../shared"
+import {
+  applyExclusiveTaskTarget,
+  normalizeExclusiveTaskTarget,
+} from "../tools/delegate-task/normalize-task-target"
 import { resolveSessionAgent } from "./session-agent-resolver"
 import { stopContinuation } from "./stop-continuation"
 
@@ -132,9 +136,18 @@ export function createToolExecuteBeforeHandler(args: {
       const subagentType = typeof output.args.subagent_type === "string" ? output.args.subagent_type : undefined
       const taskId = typeof output.args.task_id === "string" ? output.args.task_id : undefined
 
-      if (category) {
-        replaceToolArgs(output, { subagent_type: "sisyphus-junior" })
-      } else if (!subagentType && taskId) {
+      if (category || subagentType) {
+        const normalized = normalizeExclusiveTaskTarget({
+          category,
+          subagent_type: subagentType,
+        })
+        // Category routing still uses sisyphus-junior internally; OpenCode's
+        // task() registry key is the config id, not the display name.
+        const hookTarget = normalized.category
+          ? { ...normalized, subagent_type: "sisyphus-junior" }
+          : normalized
+        output.args = applyExclusiveTaskTarget(output.args, hookTarget)
+      } else if (taskId) {
         const resolvedAgent = await resolveSessionAgent(ctx.client, taskId)
         replaceToolArgs(output, { subagent_type: resolvedAgent ?? "continue" })
       }

--- a/packages/omo-opencode/src/tools/delegate-task/normalize-task-target.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/normalize-task-target.test.ts
@@ -1,0 +1,57 @@
+declare const require: (name: string) => any
+const { describe, expect, test } = require("bun:test")
+import {
+  applyExclusiveTaskTarget,
+  normalizeExclusiveTaskTarget,
+} from "./normalize-task-target"
+
+describe("normalizeExclusiveTaskTarget (#7920)", () => {
+  test("#given @explore both category and subagent_type #when normalized #then only subagent_type remains", () => {
+    //#given
+    const input = { category: "explore", subagent_type: "explore" }
+
+    //#when
+    const result = normalizeExclusiveTaskTarget(input)
+
+    //#then
+    expect(result).toEqual({ subagent_type: "explore" })
+    expect(result.category).toBeUndefined()
+  })
+
+  test("#given category=explore only #when normalized #then it becomes subagent_type=explore", () => {
+    //#given / #when
+    const result = normalizeExclusiveTaskTarget({ category: "explore" })
+
+    //#then
+    expect(result).toEqual({ subagent_type: "explore" })
+  })
+
+  test("#given quoted explore category #when normalized #then quotes are stripped and category is dropped", () => {
+    //#given / #when
+    const result = normalizeExclusiveTaskTarget({ category: "'explore'" })
+
+    //#then
+    expect(result).toEqual({ subagent_type: "explore" })
+  })
+
+  test("#given a real category plus explore #when normalized #then category still wins", () => {
+    //#given / #when
+    const result = normalizeExclusiveTaskTarget({ category: "quick", subagent_type: "explore" })
+
+    //#then
+    expect(result).toEqual({ category: "quick", subagent_type: "Sisyphus-Junior" })
+  })
+
+  test("#given applyExclusiveTaskTarget #when category must be omitted #then the key is deleted not set undefined", () => {
+    //#given
+    const args = { category: "explore", subagent_type: "explore", prompt: "hello" }
+
+    //#when
+    const next = applyExclusiveTaskTarget(args, { subagent_type: "explore" })
+
+    //#then
+    expect("category" in next).toBe(false)
+    expect(next.subagent_type).toBe("explore")
+    expect(next.prompt).toBe("hello")
+  })
+})

--- a/packages/omo-opencode/src/tools/delegate-task/normalize-task-target.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/normalize-task-target.ts
@@ -1,0 +1,89 @@
+import { getAgentConfigKey } from "../../shared/agent-display-names"
+import { DEFAULT_CATEGORIES } from "./constants"
+import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
+import { sanitizeSubagentType } from "./subagent-discovery"
+
+/**
+ * Built-in agents that @-mentions and `subagent_type` invoke directly.
+ * These must never be paired with `category` when calling OpenCode task().
+ */
+const NAMED_SUBAGENT_KEYS = new Set([
+  "explore",
+  "librarian",
+  "oracle",
+  "metis",
+  "momus",
+  "multimodal-looker",
+  "hephaestus",
+  "plan",
+])
+
+export type ExclusiveTaskTarget = {
+  category?: string
+  subagent_type?: string
+}
+
+function nonemptyString(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed === "" ? undefined : trimmed
+}
+
+export function isNamedSubagentTarget(value: string | undefined): boolean {
+  const raw = nonemptyString(value)
+  if (!raw) return false
+  const key = getAgentConfigKey(sanitizeSubagentType(raw))
+  return NAMED_SUBAGENT_KEYS.has(key)
+}
+
+export function isKnownTaskCategory(value: string | undefined): boolean {
+  const raw = nonemptyString(value)
+  if (!raw) return false
+  return Object.prototype.hasOwnProperty.call(DEFAULT_CATEGORIES, raw)
+}
+
+/**
+ * OpenCode task() accepts category XOR subagent_type.
+ * @explore / other named-agent mentions must emit only subagent_type (#7920).
+ * Real categories still win over a conflicting subagent_type (issue #3624).
+ */
+export function normalizeExclusiveTaskTarget(input: ExclusiveTaskTarget): ExclusiveTaskTarget {
+  const category = nonemptyString(input.category)
+  const subagentType = nonemptyString(input.subagent_type)
+
+  if (isNamedSubagentTarget(subagentType) && !isKnownTaskCategory(category)) {
+    return { subagent_type: sanitizeSubagentType(subagentType!) }
+  }
+
+  if (isNamedSubagentTarget(category)) {
+    return { subagent_type: sanitizeSubagentType(category!) }
+  }
+
+  if (category) {
+    return { category, subagent_type: SISYPHUS_JUNIOR_AGENT }
+  }
+
+  if (subagentType) {
+    return { subagent_type: subagentType }
+  }
+
+  return {}
+}
+
+export function applyExclusiveTaskTarget(
+  args: Record<string, unknown>,
+  target: ExclusiveTaskTarget,
+): Record<string, unknown> {
+  const next = { ...args }
+  if (target.category === undefined) {
+    delete next.category
+  } else {
+    next.category = target.category
+  }
+  if (target.subagent_type === undefined) {
+    delete next.subagent_type
+  } else {
+    next.subagent_type = target.subagent_type
+  }
+  return next
+}

--- a/packages/omo-opencode/src/tools/delegate-task/tool-argument-preparation.test.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tool-argument-preparation.test.ts
@@ -1,0 +1,68 @@
+declare const require: (name: string) => any
+const { describe, expect, test } = require("bun:test")
+import { prepareDelegateTaskArgs } from "./tool-argument-preparation"
+
+function createCtx(): { metadata: (input: { title?: string }) => Promise<void> } {
+  return {
+    metadata: async () => {},
+  }
+}
+
+describe("prepareDelegateTaskArgs exclusive task target (#7920)", () => {
+  test("#given @explore mention with both category and subagent_type #when args are prepared #then only subagent_type=explore is passed", async () => {
+    //#given
+    const args = {
+      category: "explore",
+      subagent_type: "explore",
+      prompt: "hello",
+      description: "Explore hello",
+      run_in_background: false,
+      load_skills: [],
+    }
+
+    //#when
+    const prepared = await prepareDelegateTaskArgs(args, createCtx())
+
+    //#then — OpenCode task() rejects both; @explore must keep the named agent
+    expect(prepared.category).toBeUndefined()
+    expect(prepared.subagent_type).toBe("explore")
+    expect(prepared.requested_subagent_type).toBe("explore")
+  })
+
+  test("#given category=explore without subagent_type #when args are prepared #then category is rewritten to subagent_type only", async () => {
+    //#given
+    const args = {
+      category: "explore",
+      prompt: "hello",
+      run_in_background: false,
+      load_skills: [],
+    }
+
+    //#when
+    const prepared = await prepareDelegateTaskArgs(args, createCtx())
+
+    //#then
+    expect(prepared.category).toBeUndefined()
+    expect(prepared.subagent_type).toBe("explore")
+  })
+
+  test("#given a real category plus subagent_type=explore #when args are prepared #then category still wins", async () => {
+    //#given
+    const args = {
+      category: "quick",
+      subagent_type: "explore",
+      prompt: "Do something",
+      description: "Override test",
+      run_in_background: true,
+      load_skills: [],
+    }
+
+    //#when
+    const prepared = await prepareDelegateTaskArgs(args, createCtx())
+
+    //#then
+    expect(prepared.category).toBe("quick")
+    expect(prepared.subagent_type).toBe("Sisyphus-Junior")
+    expect(prepared.requested_subagent_type).toBe("explore")
+  })
+})

--- a/packages/omo-opencode/src/tools/delegate-task/tool-argument-preparation.ts
+++ b/packages/omo-opencode/src/tools/delegate-task/tool-argument-preparation.ts
@@ -1,22 +1,29 @@
 import type { DelegateTaskArgs, ToolContextWithMetadata } from "./types"
 import { SISYPHUS_JUNIOR_AGENT } from "./sisyphus-junior-agent"
+import { isKnownTaskCategory, normalizeExclusiveTaskTarget } from "./normalize-task-target"
 import { log } from "../../shared/logger"
 
 export async function prepareDelegateTaskArgs(args: Record<string, unknown>, ctx: ToolContextWithMetadata): Promise<DelegateTaskArgs> {
-  const category = typeof args.category === "string" ? args.category : undefined
+  const originalCategory = typeof args.category === "string" ? args.category : undefined
   const prompt = typeof args.prompt === "string" ? args.prompt : ""
   const originalSubagentType = typeof args.subagent_type === "string" ? args.subagent_type : undefined
-  let subagentType = originalSubagentType
+  const target = normalizeExclusiveTaskTarget({
+    category: originalCategory,
+    subagent_type: originalSubagentType,
+  })
+  const category = target.category
+  const subagentType = target.subagent_type
 
-  if (category && subagentType && subagentType !== SISYPHUS_JUNIOR_AGENT) {
+  if (
+    isKnownTaskCategory(originalCategory)
+    && originalSubagentType
+    && originalSubagentType !== SISYPHUS_JUNIOR_AGENT
+    && subagentType === SISYPHUS_JUNIOR_AGENT
+  ) {
     log("[task] category provided - overriding subagent_type to sisyphus-junior", {
-      category,
-      subagent_type: subagentType,
+      category: originalCategory,
+      subagent_type: originalSubagentType,
     })
-  }
-
-  if (category) {
-    subagentType = SISYPHUS_JUNIOR_AGENT
   }
 
   let description = typeof args.description === "string" ? args.description : undefined


### PR DESCRIPTION
## Summary
- `@explore` made OpenCode `task()` throw `Cannot call task() with both category and subagent_type`.
- `tool-argument-preparation` and `tool-execute-before` both wrote `subagent_type` whenever `category` was set, and did not delete `category`.
- Named agents (explore, librarian, …) now emit only `subagent_type`. Real task categories still win over a conflicting subagent (#3624).
- Fixes #7920

## Test plan
- [x] RED then GREEN: 4 new cases that previously kept `category: "explore"`
- [x] `normalize-task-target` / `tool-argument-preparation` / `tool-execute-before` tests: 29 pass
- [x] Existing category-wins cases in `tools.test.ts`: 2 pass
- [ ] Type `@explore hello` in a live session — must not throw the exclusive-arg error


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `@explore` mentions throwing `Cannot call task() with both category and subagent_type`.

- Adds a shared normalizer used by both `tool-argument-preparation` and `tool-execute-before` that emits only `subagent_type` for named agents and removes the `category` key.
- Real task categories still win over a conflicting `subagent_type` (#3624).

<sup>Written for commit 475204bb3d937508c62d60a6e5d018fe91a59cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

