### PR TITLE
fix(omo-native): keep CLI --thinking from writing model preferences

### DIFF
--- a/packages/omo-native/bin/senpi-patch.mjs
+++ b/packages/omo-native/bin/senpi-patch.mjs
@@ -44,4 +44,22 @@ if (belowFloor) {
   )
 }
 
+// --thinking / model-derived thinking is a session override. The published Senpi
+// startup path re-applies the already-selected level through the persistent setter,
+// which writes modelThinkingLevels even when defaultThinkingLevel stays unchanged
+// (https://github.com/code-yeongyu/oh-my-openagent/issues/8116).
+const cliThinkingMainRelative = "dist/main.js"
+const cliThinkingPersistentApply =
+  "created.session.setThinkingLevel(created.session.thinkingLevel)"
+const cliThinkingSessionApply =
+  "created.session.setSessionThinkingLevel(created.session.thinkingLevel)"
+const cliThinkingMainPath = join(senpiRoot, cliThinkingMainRelative)
+if (!existsSync(cliThinkingMainPath)) throw new Error(`omo-ai: installed Senpi target is missing: ${cliThinkingMainRelative}`)
+const cliThinkingSource = readFileSync(cliThinkingMainPath, "utf8")
+if (cliThinkingSource.includes(cliThinkingPersistentApply)) {
+  writeFileSync(cliThinkingMainPath, cliThinkingSource.replaceAll(cliThinkingPersistentApply, cliThinkingSessionApply))
+} else if (!cliThinkingSource.includes(cliThinkingSessionApply)) {
+  throw new Error(`omo-ai: unsupported Senpi ${cliThinkingMainRelative}`)
+}
+
 prepareCompileSafeEngine(senpiRoot)

--- a/packages/omo-native/test/compile-safe-engine.test.ts
+++ b/packages/omo-native/test/compile-safe-engine.test.ts
@@ -144,6 +144,10 @@ describe("compile-safe engine preparation", () => {
           join(root, "node_modules", "@earendil-works", "pi-ai", "dist", "api", "anthropic-messages.js"),
           'const claudeCodeVersion = "2.1.251";\n',
         )
+        write(
+          join(root, "dist", "main.js"),
+          "created.session.setSessionThinkingLevel(created.session.thinkingLevel);\n",
+        )
         const result = spawnSync("node", [PATCH_SCRIPT], {
           encoding: "utf8",
           env: { ...process.env, OMO_SENPI_PATCH_ROOT: root },

--- a/packages/omo-native/test/senpi-patch.test.ts
+++ b/packages/omo-native/test/senpi-patch.test.ts
@@ -8,11 +8,16 @@ import { fileURLToPath } from "node:url"
 const PACKAGE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
 const PATCH_SCRIPT = join(PACKAGE_ROOT, "bin", "senpi-patch.mjs")
 const BUNDLED_ANTHROPIC_MESSAGES = "node_modules/@earendil-works/pi-ai/dist/api/anthropic-messages.js"
+const BUNDLED_MAIN = "dist/main.js"
 const FLOOR = "2.1.251"
+const CLI_THINKING_PERSISTENT =
+  "created.session.setThinkingLevel(created.session.thinkingLevel)"
+const CLI_THINKING_SESSION =
+  "created.session.setSessionThinkingLevel(created.session.thinkingLevel)"
 
 const roots: string[] = []
 
-type Fixture = { root: string; anthropicMessages: string }
+type Fixture = { root: string; anthropicMessages: string; main: string }
 
 function anthropicMessagesSource(claudeCodeVersion: string): string {
   return [
@@ -30,7 +35,17 @@ function anthropicMessagesSource(claudeCodeVersion: string): string {
   ].join("\n")
 }
 
-function createFixture(claudeCodeVersion: string): Fixture {
+function cliThinkingMainSource(apply: string): string {
+  return [
+    "const cliThinkingOverride = runtimeParsed.thinking !== undefined || cliThinkingFromModel;",
+    "if (created.session.model && cliThinkingOverride) {",
+    `    ${apply};`,
+    "}",
+    "",
+  ].join("\n")
+}
+
+function createFixture(claudeCodeVersion: string, apply = CLI_THINKING_SESSION): Fixture {
   const root = mkdtempSync(join(tmpdir(), "omo-senpi-patch-"))
   roots.push(root)
   writeFileSync(join(root, "package.json"), JSON.stringify({
@@ -41,7 +56,10 @@ function createFixture(claudeCodeVersion: string): Fixture {
   const anthropicMessages = join(root, BUNDLED_ANTHROPIC_MESSAGES)
   mkdirSync(dirname(anthropicMessages), { recursive: true })
   writeFileSync(anthropicMessages, anthropicMessagesSource(claudeCodeVersion))
-  return { root, anthropicMessages }
+  const main = join(root, BUNDLED_MAIN)
+  mkdirSync(dirname(main), { recursive: true })
+  writeFileSync(main, cliThinkingMainSource(apply))
+  return { root, anthropicMessages, main }
 }
 
 function runPatch(root: string) {
@@ -113,6 +131,58 @@ describe("senpi-patch claudeCodeVersion floor", () => {
         const result = runPatch(fixture.root)
         expect(result.status).not.toBe(0)
         expect(result.stderr).toContain(`omo-ai: unsupported Senpi ${BUNDLED_ANTHROPIC_MESSAGES}`)
+      })
+    })
+  })
+})
+
+describe("senpi-patch CLI thinking session-only apply", () => {
+  describe("#given startup re-applies the CLI thinking level through the persistent setter", () => {
+    describe("#when the patch script runs as postinstall does", () => {
+      test("#then the apply is rewritten to the session-only setter", () => {
+        const fixture = createFixture(FLOOR, CLI_THINKING_PERSISTENT)
+        const result = runPatch(fixture.root)
+        expect(result.status).toBe(0)
+        expect(readFileSync(fixture.main, "utf8")).toBe(cliThinkingMainSource(CLI_THINKING_SESSION))
+        expect(readFileSync(fixture.anthropicMessages, "utf8")).toBe(anthropicMessagesSource(FLOOR))
+      })
+    })
+  })
+
+  describe("#given startup already uses the session-only setter", () => {
+    describe("#when the patch script runs", () => {
+      test("#then dist/main.js stays byte-identical", () => {
+        const fixture = createFixture(FLOOR, CLI_THINKING_SESSION)
+        const before = readFileSync(fixture.main, "utf8")
+        const result = runPatch(fixture.root)
+        expect(result.status).toBe(0)
+        expect(readFileSync(fixture.main, "utf8")).toBe(before)
+      })
+    })
+  })
+
+  describe("#given the thinking apply was already rewritten", () => {
+    describe("#when the patch script runs again", () => {
+      test("#then the rewritten file is left unchanged and the exit stays clean", () => {
+        const fixture = createFixture(FLOOR, CLI_THINKING_PERSISTENT)
+        runPatch(fixture.root)
+        const afterFirst = readFileSync(fixture.main, "utf8")
+        expect(afterFirst).toBe(cliThinkingMainSource(CLI_THINKING_SESSION))
+        const second = runPatch(fixture.root)
+        expect(second.status).toBe(0)
+        expect(readFileSync(fixture.main, "utf8")).toBe(afterFirst)
+      })
+    })
+  })
+
+  describe("#given dist/main.js has neither thinking apply form", () => {
+    describe("#when the patch script runs", () => {
+      test("#then it fails with the unsupported-Senpi error naming dist/main.js", () => {
+        const fixture = createFixture(FLOOR)
+        writeFileSync(fixture.main, "export {}\n")
+        const result = runPatch(fixture.root)
+        expect(result.status).not.toBe(0)
+        expect(result.stderr).toContain(`omo-ai: unsupported Senpi ${BUNDLED_MAIN}`)
       })
     })
   })


### PR DESCRIPTION
## Summary
- Native/Senpi startup re-applied the already-selected `--thinking` level through `setThinkingLevel`, which writes `modelThinkingLevels` / `modelLastOnThinkingLevels`.
- A later launch without the flag then preferred the overwritten per-model `low` even when `defaultThinkingLevel` was still `high`.
- Postinstall now rewrites that one apply to `setSessionThinkingLevel`, matching the session-only setter the issue verified locally. Persistent RPC/interactive preference changes are unchanged.
- Fixes #8116

## Test plan
- [x] `bun test` `senpi-patch.test.ts` + `compile-safe-engine.test.ts` + `package-shape.test.ts` + `anthropic-tool-search-compat.test.ts`: 28 pass
- [x] RED fixture with the persistent setter is rewritten; already-patched and missing-snippet cases stay idempotent / fail loud
- [ ] After `omo` postinstall, `senpi --thinking low` must leave `settings.json` model maps unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Senpi postinstall patch so `--thinking` no longer overwrites saved per-model preferences. Previously, startup re-applied the CLI thinking level through the persistent setter, writing `modelThinkingLevels` even when `defaultThinkingLevel` stayed unchanged; now it uses the session-only setter, so a later launch without the flag keeps the saved per-model preference.

**Bug Fixes**
- Postinstall rewrites `setThinkingLevel` to `setSessionThinkingLevel` in `dist/main.js`.
- The patch is idempotent for already-patched files and fails loudly if the expected snippet is missing.

<sup>Written for commit 414fbb460d8c3a538fdace5d2fa4492ded8a27ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

