### PR TITLE
fix(omo-native): stop Senpi from emptying a sibling ~/.pi install

### DIFF
--- a/packages/omo-native/bin/lib/legacy-pi-dir-guard.js
+++ b/packages/omo-native/bin/lib/legacy-pi-dir-guard.js
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+export const LEGACY_PI_DIR_MIGRATION_RELATIVE = "dist/legacy-senpi-dir-migration.js"
+
+// Live upstream pi trees (`~/.pi/agent`, `cwd/.pi`) must stay put. Nested leftovers
+// under the branded `.omo` directory can still be absorbed.
+export const LIVE_PI_DIR_MOVES = `    const moves = [
+        [join(cwd, ".pi"), projectNewDir, "project config directory"],
+        [join(cwd, CONFIG_DIR_NAME, ".pi"), projectNewDir, "nested project config directory"],
+    ];
+    if (shouldMigrateHomeConfig) {
+        moves.unshift([join(homeDir, ".pi", "agent"), globalNewAgentDir, "global agent directory"], [join(homeDir, CONFIG_DIR_NAME, ".pi", "agent"), globalNewAgentDir, "nested global agent directory"], [join(homeDir, ".pi", "mom"), globalNewMomDir, "global mom directory"], [join(homeDir, CONFIG_DIR_NAME, ".pi", "mom"), globalNewMomDir, "nested global mom directory"]);
+    }
+`
+
+export const NESTED_PI_DIR_MOVES = `    const moves = [
+        [join(cwd, CONFIG_DIR_NAME, ".pi"), projectNewDir, "nested project config directory"],
+    ];
+    if (shouldMigrateHomeConfig) {
+        moves.unshift([join(homeDir, CONFIG_DIR_NAME, ".pi", "agent"), globalNewAgentDir, "nested global agent directory"], [join(homeDir, CONFIG_DIR_NAME, ".pi", "mom"), globalNewMomDir, "nested global mom directory"]);
+    }
+`
+
+/**
+ * Stops Senpi's branded-dir migration from emptying a sibling `@earendil-works/pi-coding-agent`
+ * install on every `omo` launch (https://github.com/code-yeongyu/oh-my-openagent/issues/8039).
+ */
+export function patchLegacyPiDirMigration(senpiRoot) {
+  const path = join(senpiRoot, LEGACY_PI_DIR_MIGRATION_RELATIVE)
+  if (!existsSync(path)) throw new Error(`omo-ai: installed Senpi target is missing: ${LEGACY_PI_DIR_MIGRATION_RELATIVE}`)
+  const source = readFileSync(path, "utf8")
+  if (source.includes(LIVE_PI_DIR_MOVES)) {
+    writeFileSync(path, source.replace(LIVE_PI_DIR_MOVES, NESTED_PI_DIR_MOVES))
+    return "rewritten"
+  }
+  if (source.includes(NESTED_PI_DIR_MOVES)) return "already-patched"
+  throw new Error(`omo-ai: unsupported Senpi ${LEGACY_PI_DIR_MIGRATION_RELATIVE}`)
+}

--- a/packages/omo-native/bin/senpi-patch.mjs
+++ b/packages/omo-native/bin/senpi-patch.mjs
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path"
 import { createRequire } from "node:module"
 import { fileURLToPath } from "node:url"
 import { prepareCompileSafeEngine } from "./lib/compile-safe-engine.js"
+import { patchLegacyPiDirMigration } from "./lib/legacy-pi-dir-guard.js"
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const require = createRequire(join(packageRoot, "package.json"))
@@ -44,4 +45,5 @@ if (belowFloor) {
   )
 }
 
+patchLegacyPiDirMigration(senpiRoot)
 prepareCompileSafeEngine(senpiRoot)

--- a/packages/omo-native/test/compile-safe-engine.test.ts
+++ b/packages/omo-native/test/compile-safe-engine.test.ts
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { prepareCompileSafeEngine } from "../bin/lib/compile-safe-engine.js"
+import { NESTED_PI_DIR_MOVES } from "../bin/lib/legacy-pi-dir-guard.js"
 
 const PACKAGE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
 const PATCH_SCRIPT = join(PACKAGE_ROOT, "bin", "senpi-patch.mjs")
@@ -143,6 +144,10 @@ describe("compile-safe engine preparation", () => {
         write(
           join(root, "node_modules", "@earendil-works", "pi-ai", "dist", "api", "anthropic-messages.js"),
           'const claudeCodeVersion = "2.1.251";\n',
+        )
+        write(
+          join(root, "dist", "legacy-senpi-dir-migration.js"),
+          `export function migrateLegacySenpiDirs() {}\n${NESTED_PI_DIR_MOVES}`,
         )
         const result = spawnSync("node", [PATCH_SCRIPT], {
           encoding: "utf8",

--- a/packages/omo-native/test/legacy-pi-dir-guard.test.ts
+++ b/packages/omo-native/test/legacy-pi-dir-guard.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import {
+  LEGACY_PI_DIR_MIGRATION_RELATIVE,
+  LIVE_PI_DIR_MOVES,
+  NESTED_PI_DIR_MOVES,
+  patchLegacyPiDirMigration,
+} from "../bin/lib/legacy-pi-dir-guard.js"
+
+const PACKAGE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
+const INSTALLED_MIGRATION = join(PACKAGE_ROOT, "node_modules", "@code-yeongyu", "senpi", LEGACY_PI_DIR_MIGRATION_RELATIVE)
+
+const roots: string[] = []
+
+function writeMigration(body: string): string {
+  const root = mkdtempSync(join(tmpdir(), "omo-legacy-pi-dir-"))
+  roots.push(root)
+  const path = join(root, LEGACY_PI_DIR_MIGRATION_RELATIVE)
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, body)
+  return root
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("legacy pi-dir migration guard", () => {
+  describe("#given Senpi still moves ~/.pi/agent and cwd/.pi into the branded dirs", () => {
+    describe("#when postinstall patches the engine", () => {
+      test("#then only nested leftover .omo/.pi paths remain eligible to migrate", () => {
+        const root = writeMigration(`export function migrateLegacySenpiDirs() {}\n${LIVE_PI_DIR_MOVES}`)
+        expect(patchLegacyPiDirMigration(root)).toBe("rewritten")
+        const source = readFileSync(join(root, LEGACY_PI_DIR_MIGRATION_RELATIVE), "utf8")
+        expect(source).toContain(NESTED_PI_DIR_MOVES)
+        expect(source).not.toContain('[join(cwd, ".pi"), projectNewDir, "project config directory"]')
+        expect(source).not.toContain('[join(homeDir, ".pi", "agent")')
+      })
+    })
+  })
+
+  describe("#given the live .pi moves were already removed", () => {
+    describe("#when the patch runs again", () => {
+      test("#then the file stays byte-identical", () => {
+        const root = writeMigration(`export function migrateLegacySenpiDirs() {}\n${NESTED_PI_DIR_MOVES}`)
+        const before = readFileSync(join(root, LEGACY_PI_DIR_MIGRATION_RELATIVE), "utf8")
+        expect(patchLegacyPiDirMigration(root)).toBe("already-patched")
+        expect(readFileSync(join(root, LEGACY_PI_DIR_MIGRATION_RELATIVE), "utf8")).toBe(before)
+      })
+    })
+  })
+
+  describe("#given the migration module matches neither known shape", () => {
+    describe("#when the patch runs", () => {
+      test("#then it fails loud instead of leaving a stealing migrate in place", () => {
+        const root = writeMigration("export function migrateLegacySenpiDirs() {}\n")
+        expect(() => patchLegacyPiDirMigration(root)).toThrow(
+          `omo-ai: unsupported Senpi ${LEGACY_PI_DIR_MIGRATION_RELATIVE}`,
+        )
+      })
+    })
+  })
+
+  describe("#given the currently pinned Senpi package", () => {
+    describe("#when its published migration is inspected", () => {
+      test("#then it still contains the live .pi moves this guard rewrites", () => {
+        expect(readFileSync(INSTALLED_MIGRATION, "utf8")).toContain(LIVE_PI_DIR_MOVES)
+      })
+    })
+  })
+})

--- a/packages/omo-native/test/senpi-patch.test.ts
+++ b/packages/omo-native/test/senpi-patch.test.ts
@@ -5,6 +5,8 @@ import { dirname, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
+import { LEGACY_PI_DIR_MIGRATION_RELATIVE, NESTED_PI_DIR_MOVES } from "../bin/lib/legacy-pi-dir-guard.js"
+
 const PACKAGE_ROOT = resolve(fileURLToPath(new URL("..", import.meta.url)))
 const PATCH_SCRIPT = join(PACKAGE_ROOT, "bin", "senpi-patch.mjs")
 const BUNDLED_ANTHROPIC_MESSAGES = "node_modules/@earendil-works/pi-ai/dist/api/anthropic-messages.js"
@@ -41,6 +43,9 @@ function createFixture(claudeCodeVersion: string): Fixture {
   const anthropicMessages = join(root, BUNDLED_ANTHROPIC_MESSAGES)
   mkdirSync(dirname(anthropicMessages), { recursive: true })
   writeFileSync(anthropicMessages, anthropicMessagesSource(claudeCodeVersion))
+  const migration = join(root, LEGACY_PI_DIR_MIGRATION_RELATIVE)
+  mkdirSync(dirname(migration), { recursive: true })
+  writeFileSync(migration, `export function migrateLegacySenpiDirs() {}\n${NESTED_PI_DIR_MOVES}`)
   return { root, anthropicMessages }
 }
 


### PR DESCRIPTION
## Summary
- Launching `omo` on a machine that also has upstream pi (`@earendil-works/pi-coding-agent`) ran Senpi's branded-dir migration, which **renames** `~/.pi/agent` into `~/.omo/agent` and `cwd/.pi` into `cwd/.omo`.
- When both trees already exist, leftover unique files are still stolen on every launch, so putting the pi install back does not stick.
- Postinstall now drops those live `.pi` roots from the move list and only absorbs nested leftovers under the branded `.omo` directory.
- Fixes #8039

## Test plan
- [x] `legacy-pi-dir-guard.test.ts`: rewrite / already-patched / fail-loud / pin against the published Senpi snippet
- [x] Existing `senpi-patch` floor tests and `compile-safe-engine` postinstall fixture: 15 pass
- [ ] After `omo` postinstall, launching with both `~/.pi/agent` and `~/.omo/agent` present must leave `~/.pi/agent` intact

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Senpi's branded-dir migration from emptying a sibling `@earendil-works/pi-coding-agent` install on every `omo` launch. Previously, live `~/.pi/agent` and `cwd/.pi` trees were renamed into `.omo` dirs and leftover unique files were stolen on each launch; now those live `.pi` roots are left in place and only nested leftovers under the branded `.omo` directory are absorbed.

**Bug Fixes**
- Postinstall patches the migration to drop live `.pi` roots and fails loud if the installed Senpi module doesn't match a known shape.
- Re-running the patch leaves an already-patched migration byte-identical.
- Adds tests covering rewrite, idempotency, fail-loud, and pins against the published Senpi snippet.

<sup>Written for commit e5fc093ff0f1a18f5b55b55ba79289fc9888e0d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

