### PR TITLE
fix(background-agent): fan out poll completion probes across sessions

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.fanout.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.fanout.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { BackgroundManager } from "./manager"
+import { MAX_POLL_PROBE_CONCURRENCY } from "./poll-session-probes"
+import type { BackgroundTask } from "./types"
+
+function createDeferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolve: (() => void) | undefined
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve: () => resolve?.() }
+}
+
+function createTask(sessionId: string): BackgroundTask {
+  return {
+    id: `bg_test_${sessionId}`,
+    sessionId,
+    parentSessionId: "parent-session",
+    parentMessageId: "parent-message",
+    description: "test task",
+    prompt: "test",
+    agent: "explore",
+    status: "running",
+    startedAt: new Date(),
+    progress: { toolCalls: 0, lastUpdate: new Date() },
+  }
+}
+
+describe("BackgroundManager poll probe fan-out", () => {
+  describe("#given five idle sessions", () => {
+    test("#when output and todo probes wait #then each fan-out reaches the bounded cap", async () => {
+      //#given
+      const sessionIDs = ["ses-1", "ses-2", "ses-3", "ses-4", "ses-5"]
+      const gate = createDeferred()
+      const outputStarted = createDeferred()
+      let outputCalls = 0
+      let outputInFlight = 0
+      let todoInFlight = 0
+      let maxOutputInFlight = 0
+      let maxTodoInFlight = 0
+      const directory = tmpdir()
+      const client = {
+        session: {
+          status: async () => ({ data: Object.fromEntries(sessionIDs.map((id) => [id, { type: "idle" }])) }),
+          get: async () => ({ data: { id: "ses-default" } }),
+          prompt: async () => ({}),
+          promptAsync: async () => ({}),
+          abort: async () => ({}),
+          messages: async () => {
+            outputCalls += 1
+            outputInFlight += 1
+            maxOutputInFlight = Math.max(maxOutputInFlight, outputInFlight)
+            if (outputCalls === sessionIDs.length) {
+              outputStarted.resolve()
+            }
+            await gate.promise
+            outputInFlight -= 1
+            return { data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "done" }] }] }
+          },
+          todo: async () => {
+            todoInFlight += 1
+            maxTodoInFlight = Math.max(maxTodoInFlight, todoInFlight)
+            await gate.promise
+            todoInFlight -= 1
+            return { data: [] }
+          },
+        },
+      }
+      const pluginContext: PluginInput = {
+        project: { id: "test-project", worktree: directory, time: { created: Date.now() } },
+        directory,
+        worktree: directory,
+        serverUrl: new URL("http://localhost:4096"),
+        $: unsafeTestValue<PluginInput["$"]>({}),
+        client: unsafeTestValue<PluginInput["client"]>(client),
+      }
+      const manager = new BackgroundManager({ pluginContext, enableParentSessionNotifications: false })
+      const tasks = sessionIDs.map(createTask)
+      for (const task of tasks) {
+        manager["tasks"].set(task.id, task)
+      }
+
+      try {
+        //#when
+        const poll = manager["pollRunningTasks"]()
+        await outputStarted.promise
+        gate.resolve()
+        await poll
+
+        //#then
+        expect(maxOutputInFlight).toBe(Math.min(sessionIDs.length, MAX_POLL_PROBE_CONCURRENCY))
+        expect(maxTodoInFlight).toBe(Math.min(sessionIDs.length, MAX_POLL_PROBE_CONCURRENCY))
+        for (const task of tasks) {
+          expect(task.status).toBe("completed")
+        }
+      } finally {
+        gate.resolve()
+        await manager.shutdown()
+      }
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.guards.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.guards.test.ts
@@ -177,29 +177,4 @@ describe("BackgroundManager poll probe guards", () => {
     })
   })
 
-  describe("#given an idle task before a terminal task", () => {
-    test("#when polling completes both #then teardown keeps task iteration order", async () => {
-      //#given
-      const abortedSessions: string[] = []
-      const manager = createManager({
-        status: async () => ({ data: { "ses-idle": { type: "idle" }, "ses-terminal": { type: "interrupted" } } }),
-        abort: async (input: { path: { id: string } }) => {
-          abortedSessions.push(input.path.id)
-          return {}
-        },
-      })
-      injectTask(manager, createTask("ses-idle"))
-      injectTask(manager, createTask("ses-terminal"))
-
-      try {
-        //#when
-        await manager["pollRunningTasks"]()
-
-        //#then
-        expect(abortedSessions).toEqual(["ses-idle", "ses-terminal"])
-      } finally {
-        await manager.shutdown()
-      }
-    })
-  })
 })

--- a/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.guards.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.guards.test.ts
@@ -1,0 +1,205 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
+
+const ASSISTANT_OUTPUT = {
+  data: [{
+    info: { role: "assistant", finish: "end_turn", id: "msg-2" },
+    parts: [{ type: "text", text: "done" }],
+  }],
+}
+
+function createManager(sessionOverrides: Record<string, unknown> = {}): BackgroundManager {
+  const directory = tmpdir()
+  const client = {
+    session: {
+      status: async () => ({ data: {} }),
+      get: async () => ({ data: { id: "ses-default" } }),
+      prompt: async () => ({}),
+      promptAsync: async () => ({}),
+      abort: async () => ({}),
+      todo: async () => ({ data: [] }),
+      messages: async () => ASSISTANT_OUTPUT,
+      ...sessionOverrides,
+    },
+  }
+  const pluginContext: PluginInput = {
+    project: { id: "test-project", worktree: directory, time: { created: Date.now() } },
+    directory,
+    worktree: directory,
+    serverUrl: new URL("http://localhost:4096"),
+    $: unsafeTestValue<PluginInput["$"]>({}),
+    client: unsafeTestValue<PluginInput["client"]>(client),
+  }
+  return new BackgroundManager({ pluginContext, enableParentSessionNotifications: false })
+}
+
+function createTask(sessionId: string, status: BackgroundTask["status"] = "running"): BackgroundTask {
+  return {
+    id: `bg_test_${sessionId}`,
+    sessionId,
+    parentSessionId: "parent-session",
+    parentMessageId: "parent-message",
+    description: "test task",
+    prompt: "test",
+    agent: "explore",
+    status,
+    startedAt: new Date(),
+    progress: { toolCalls: 0, lastUpdate: new Date() },
+  }
+}
+
+function injectTask(manager: BackgroundManager, task: BackgroundTask): void {
+  manager["tasks"].set(task.id, task)
+}
+
+function createDeferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolve: (() => void) | undefined
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve: () => resolve?.() }
+}
+
+describe("BackgroundManager poll probe guards", () => {
+  describe("#given a task re-bound to a new session while an old output probe is pending", () => {
+    test("#when polling resumes #then the old probe cannot complete the new session", async () => {
+      //#given
+      const outputGate = createDeferred()
+      const outputStarted = createDeferred()
+      const manager = createManager({
+        status: async () => ({ data: { "ses-old": { type: "idle" } } }),
+        messages: async () => {
+          outputStarted.resolve()
+          await outputGate.promise
+          return ASSISTANT_OUTPUT
+        },
+      })
+      const task = createTask("ses-old")
+      injectTask(manager, task)
+
+      try {
+        //#when
+        const poll = manager["pollRunningTasks"]()
+        await outputStarted.promise
+        const restartedAt = new Date()
+        task.sessionId = "ses-new"
+        task.currentAttemptID = "att-new"
+        task.attempts = [{
+          attemptId: "att-new",
+          attemptNumber: 2,
+          sessionId: "ses-new",
+          status: "running",
+          startedAt: restartedAt,
+        }]
+        task.startedAt = restartedAt
+        outputGate.resolve()
+        await poll
+
+        //#then
+        expect(task.status).toBe("running")
+      } finally {
+        outputGate.resolve()
+        await manager.shutdown()
+      }
+    })
+  })
+
+  describe("#given an empty todo probe followed by a todo.updated event", () => {
+    test("#when an earlier task completes #then the newer incomplete todo observation blocks completion", async () => {
+      //#given
+      let abortCount = 0
+      const manager = createManager({
+        status: async () => ({ data: { "ses-first": { type: "idle" }, "ses-second": { type: "idle" } } }),
+        abort: async () => {
+          abortCount += 1
+          if (abortCount === 1) {
+            manager.handleEvent({
+              type: "todo.updated",
+              properties: { sessionID: "ses-second", todos: [{ status: "in_progress" }] },
+            })
+          }
+          return {}
+        },
+      })
+      const first = createTask("ses-first")
+      const second = createTask("ses-second")
+      injectTask(manager, first)
+      injectTask(manager, second)
+
+      try {
+        //#when
+        await manager["pollRunningTasks"]()
+
+        //#then
+        expect(second.status).toBe("running")
+      } finally {
+        await manager.shutdown()
+      }
+    })
+  })
+
+  describe("#given shutdown clears tasks while a probe is pending", () => {
+    test("#when the probe settles #then no detached task is completed", async () => {
+      //#given
+      const outputGate = createDeferred()
+      const outputStarted = createDeferred()
+      const manager = createManager({
+        status: async () => ({ data: { "ses-held": { type: "idle" } } }),
+        messages: async () => {
+          outputStarted.resolve()
+          await outputGate.promise
+          return ASSISTANT_OUTPUT
+        },
+      })
+      const task = createTask("ses-held")
+      injectTask(manager, task)
+
+      try {
+        //#when
+        const poll = manager["pollRunningTasks"]()
+        await outputStarted.promise
+        await manager.shutdown()
+        outputGate.resolve()
+        await poll
+
+        //#then
+        expect(task.status).toBe("running")
+      } finally {
+        outputGate.resolve()
+        await manager.shutdown()
+      }
+    })
+  })
+
+  describe("#given an idle task before a terminal task", () => {
+    test("#when polling completes both #then teardown keeps task iteration order", async () => {
+      //#given
+      const abortedSessions: string[] = []
+      const manager = createManager({
+        status: async () => ({ data: { "ses-idle": { type: "idle" }, "ses-terminal": { type: "interrupted" } } }),
+        abort: async (input: { path: { id: string } }) => {
+          abortedSessions.push(input.path.id)
+          return {}
+        },
+      })
+      injectTask(manager, createTask("ses-idle"))
+      injectTask(manager, createTask("ses-terminal"))
+
+      try {
+        //#when
+        await manager["pollRunningTasks"]()
+
+        //#then
+        expect(abortedSessions).toEqual(["ses-idle", "ses-terminal"])
+      } finally {
+        await manager.shutdown()
+      }
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.order.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.order.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
+
+function createTask(sessionId: string): BackgroundTask {
+  return {
+    id: `bg_test_${sessionId}`,
+    sessionId,
+    parentSessionId: "parent-session",
+    parentMessageId: "parent-message",
+    description: "test task",
+    prompt: "test",
+    agent: "explore",
+    status: "running",
+    startedAt: new Date(),
+    progress: { toolCalls: 0, lastUpdate: new Date() },
+  }
+}
+
+describe("BackgroundManager poll terminal ordering", () => {
+  describe("#given an idle task before a terminal task", () => {
+    test("#when polling completes both #then teardown keeps task iteration order", async () => {
+      //#given
+      const abortedSessions: string[] = []
+      const directory = tmpdir()
+      const client = {
+        session: {
+          status: async () => ({ data: { "ses-idle": { type: "idle" }, "ses-terminal": { type: "interrupted" } } }),
+          get: async () => ({ data: { id: "ses-default" } }),
+          prompt: async () => ({}),
+          promptAsync: async () => ({}),
+          abort: async (input: { path: { id: string } }) => {
+            abortedSessions.push(input.path.id)
+            return {}
+          },
+          todo: async () => ({ data: [] }),
+          messages: async () => ({ data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "done" }] }] }),
+        },
+      }
+      const pluginContext: PluginInput = {
+        project: { id: "test-project", worktree: directory, time: { created: Date.now() } },
+        directory,
+        worktree: directory,
+        serverUrl: new URL("http://localhost:4096"),
+        $: unsafeTestValue<PluginInput["$"]>({}),
+        client: unsafeTestValue<PluginInput["client"]>(client),
+      }
+      const manager = new BackgroundManager({ pluginContext, enableParentSessionNotifications: false })
+      for (const task of [createTask("ses-idle"), createTask("ses-terminal")]) {
+        manager["tasks"].set(task.id, task)
+      }
+
+      try {
+        //#when
+        await manager["pollRunningTasks"]()
+
+        //#then
+        expect(abortedSessions).toEqual(["ses-idle", "ses-terminal"])
+      } finally {
+        await manager.shutdown()
+      }
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.test.ts
@@ -63,70 +63,7 @@ function injectTask(manager: BackgroundManager, task: BackgroundTask): void {
   manager["tasks"].set(task.id, task)
 }
 
-function createOverlapRecorder(): { track: () => Promise<void>, calls: number, maxInFlight: number } {
-  const recorder = {
-    calls: 0,
-    maxInFlight: 0,
-    inFlight: 0,
-    async track(): Promise<void> {
-      recorder.calls += 1
-      recorder.inFlight += 1
-      recorder.maxInFlight = Math.max(recorder.maxInFlight, recorder.inFlight)
-      await new Promise((resolve) => setTimeout(resolve, 5))
-      recorder.inFlight -= 1
-    },
-  }
-  return recorder
-}
-
-const ASSISTANT_OUTPUT = {
-  data: [{
-    info: { role: "assistant", finish: "end_turn", id: "msg-2" },
-    parts: [{ type: "text", text: "done" }],
-  }, {
-    info: { role: "user", id: "msg-1" },
-    parts: [{ type: "text", text: "go" }],
-  }],
-}
-
 describe("BackgroundManager poll probe fan-out", () => {
-  describe("#given five running tasks whose sessions all report idle in one tick", () => {
-    test("#when pollRunningTasks runs #then every output probe overlaps and every task completes", async () => {
-      //#given
-      const sessionIDs = ["ses-1", "ses-2", "ses-3", "ses-4", "ses-5"]
-      const outputRecorder = createOverlapRecorder()
-      const todoRecorder = createOverlapRecorder()
-      const manager = createManager({
-        status: async () => ({
-          data: Object.fromEntries(sessionIDs.map((id) => [id, { type: "idle" }])),
-        }),
-        messages: async () => {
-          await outputRecorder.track()
-          return ASSISTANT_OUTPUT
-        },
-        todo: async () => {
-          await todoRecorder.track()
-          return { data: [] }
-        },
-      })
-      const tasks = sessionIDs.map((id) => createRunningTask(id))
-      for (const task of tasks) injectTask(manager, task)
-
-      //#when
-      await manager["pollRunningTasks"]()
-      manager.shutdown()
-
-      //#then
-      expect(outputRecorder.calls).toBe(sessionIDs.length)
-      expect(outputRecorder.maxInFlight).toBe(sessionIDs.length)
-      expect(todoRecorder.calls).toBe(sessionIDs.length)
-      expect(todoRecorder.maxInFlight).toBe(sessionIDs.length)
-      for (const task of tasks) {
-        expect(task.status).toBe("completed")
-      }
-    })
-  })
-
   describe("#given a task whose session vanished from status after the missed-poll threshold", () => {
     test("#when pollRunningTasks runs #then the crashed-session path still marks the task as error", async () => {
       //#given
@@ -143,48 +80,16 @@ describe("BackgroundManager poll probe fan-out", () => {
       })
       injectTask(manager, task)
 
-      //#when
-      await manager["pollRunningTasks"]()
-      manager.shutdown()
+      try {
+        //#when
+        await manager["pollRunningTasks"]()
 
-      //#then
-      expect(task.status).toBe("error")
-      expect(task.error).toContain("no longer exists")
-    })
-  })
-
-  describe("#given one idle task with open todos, one idle task without, and one busy task", () => {
-    test("#when pollRunningTasks runs #then only the idle task without open todos completes", async () => {
-      //#given
-      const manager = createManager({
-        status: async () => ({
-          data: {
-            "ses-done": { type: "idle" },
-            "ses-todos": { type: "idle" },
-            "ses-busy": { type: "busy" },
-          },
-        }),
-        messages: async () => ASSISTANT_OUTPUT,
-        todo: async (args: { path?: { id?: string } }) => {
-          if (args?.path?.id === "ses-todos") {
-            return { data: [{ id: "t1", content: "still working", status: "in_progress", priority: "high" }] }
-          }
-          return { data: [] }
-        },
-      })
-      const done = createRunningTask("ses-done")
-      const withTodos = createRunningTask("ses-todos")
-      const busy = createRunningTask("ses-busy")
-      for (const task of [done, withTodos, busy]) injectTask(manager, task)
-
-      //#when
-      await manager["pollRunningTasks"]()
-      manager.shutdown()
-
-      //#then
-      expect(done.status).toBe("completed")
-      expect(withTodos.status).toBe("running")
-      expect(busy.status).toBe("running")
+        //#then
+        expect(task.status).toBe("error")
+        expect(task.error).toContain("no longer exists")
+      } finally {
+        await manager.shutdown()
+      }
     })
   })
 
@@ -200,12 +105,15 @@ describe("BackgroundManager poll probe fan-out", () => {
       const broken = createRunningTask("ses-broken")
       injectTask(manager, broken)
 
-      //#when
-      await manager["pollRunningTasks"]()
-      manager.shutdown()
+      try {
+        //#when
+        await manager["pollRunningTasks"]()
 
-      //#then
-      expect(broken.status).toBe("completed")
+        //#then
+        expect(broken.status).toBe("completed")
+      } finally {
+        await manager.shutdown()
+      }
     })
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.test.ts
@@ -1,0 +1,211 @@
+/// <reference types="bun-types" />
+
+import { describe, test, expect } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { BackgroundManager } from "./manager"
+import { MIN_SESSION_GONE_POLLS } from "./session-existence"
+import type { BackgroundTask } from "./types"
+
+function createPluginContext(client: object): PluginInput {
+  const directory = tmpdir()
+  return {
+    project: {
+      id: "test-project",
+      worktree: directory,
+      time: { created: Date.now() },
+    },
+    directory,
+    worktree: directory,
+    serverUrl: new URL("http://localhost:4096"),
+    $: {} as PluginInput["$"],
+    client: client as PluginInput["client"],
+  }
+}
+
+function createManager(sessionOverrides: Record<string, unknown>): BackgroundManager {
+  const client = {
+    session: {
+      status: async () => ({ data: {} }),
+      get: async () => ({ data: { id: "ses-default" } }),
+      prompt: async () => ({}),
+      promptAsync: async () => ({}),
+      abort: async () => ({}),
+      todo: async () => ({ data: [] }),
+      messages: async () => ({ data: [] }),
+      ...sessionOverrides,
+    },
+  }
+  return new BackgroundManager({
+    pluginContext: createPluginContext(client),
+    config: undefined,
+    enableParentSessionNotifications: false,
+  })
+}
+
+function createRunningTask(sessionId: string, overrides: Partial<BackgroundTask> = {}): BackgroundTask {
+  return {
+    id: `bg_test_${sessionId}`,
+    sessionId,
+    parentSessionId: "parent-session",
+    parentMessageId: "parent-msg",
+    description: "test task",
+    prompt: "test",
+    agent: "explore",
+    status: "running",
+    startedAt: new Date(),
+    progress: { toolCalls: 0, lastUpdate: new Date() },
+    ...overrides,
+  }
+}
+
+function injectTask(manager: BackgroundManager, task: BackgroundTask): void {
+  manager["tasks"].set(task.id, task)
+}
+
+function createOverlapRecorder(): { track: () => Promise<void>, calls: number, maxInFlight: number } {
+  const recorder = {
+    calls: 0,
+    maxInFlight: 0,
+    inFlight: 0,
+    async track(): Promise<void> {
+      recorder.calls += 1
+      recorder.inFlight += 1
+      recorder.maxInFlight = Math.max(recorder.maxInFlight, recorder.inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      recorder.inFlight -= 1
+    },
+  }
+  return recorder
+}
+
+const ASSISTANT_OUTPUT = {
+  data: [{
+    info: { role: "assistant", finish: "end_turn", id: "msg-2" },
+    parts: [{ type: "text", text: "done" }],
+  }, {
+    info: { role: "user", id: "msg-1" },
+    parts: [{ type: "text", text: "go" }],
+  }],
+}
+
+describe("BackgroundManager poll probe fan-out", () => {
+  describe("#given five running tasks whose sessions all report idle in one tick", () => {
+    test("#when pollRunningTasks runs #then every output probe overlaps and every task completes", async () => {
+      //#given
+      const sessionIDs = ["ses-1", "ses-2", "ses-3", "ses-4", "ses-5"]
+      const outputRecorder = createOverlapRecorder()
+      const todoRecorder = createOverlapRecorder()
+      const manager = createManager({
+        status: async () => ({
+          data: Object.fromEntries(sessionIDs.map((id) => [id, { type: "idle" }])),
+        }),
+        messages: async () => {
+          await outputRecorder.track()
+          return ASSISTANT_OUTPUT
+        },
+        todo: async () => {
+          await todoRecorder.track()
+          return { data: [] }
+        },
+      })
+      const tasks = sessionIDs.map((id) => createRunningTask(id))
+      for (const task of tasks) injectTask(manager, task)
+
+      //#when
+      await manager["pollRunningTasks"]()
+      manager.shutdown()
+
+      //#then
+      expect(outputRecorder.calls).toBe(sessionIDs.length)
+      expect(outputRecorder.maxInFlight).toBe(sessionIDs.length)
+      expect(todoRecorder.calls).toBe(sessionIDs.length)
+      expect(todoRecorder.maxInFlight).toBe(sessionIDs.length)
+      for (const task of tasks) {
+        expect(task.status).toBe("completed")
+      }
+    })
+  })
+
+  describe("#given a task whose session vanished from status after the missed-poll threshold", () => {
+    test("#when pollRunningTasks runs #then the crashed-session path still marks the task as error", async () => {
+      //#given
+      const manager = createManager({
+        status: async () => ({ data: {} }),
+        messages: async () => ({ data: [] }),
+        get: async () => ({
+          error: { message: "Session not found", status: 404 },
+          data: undefined,
+        }),
+      })
+      const task = createRunningTask("ses-gone", {
+        consecutiveMissedPolls: MIN_SESSION_GONE_POLLS,
+      })
+      injectTask(manager, task)
+
+      //#when
+      await manager["pollRunningTasks"]()
+      manager.shutdown()
+
+      //#then
+      expect(task.status).toBe("error")
+      expect(task.error).toContain("no longer exists")
+    })
+  })
+
+  describe("#given one idle task with open todos, one idle task without, and one busy task", () => {
+    test("#when pollRunningTasks runs #then only the idle task without open todos completes", async () => {
+      //#given
+      const manager = createManager({
+        status: async () => ({
+          data: {
+            "ses-done": { type: "idle" },
+            "ses-todos": { type: "idle" },
+            "ses-busy": { type: "busy" },
+          },
+        }),
+        messages: async () => ASSISTANT_OUTPUT,
+        todo: async (args: { path?: { id?: string } }) => {
+          if (args?.path?.id === "ses-todos") {
+            return { data: [{ id: "t1", content: "still working", status: "in_progress", priority: "high" }] }
+          }
+          return { data: [] }
+        },
+      })
+      const done = createRunningTask("ses-done")
+      const withTodos = createRunningTask("ses-todos")
+      const busy = createRunningTask("ses-busy")
+      for (const task of [done, withTodos, busy]) injectTask(manager, task)
+
+      //#when
+      await manager["pollRunningTasks"]()
+      manager.shutdown()
+
+      //#then
+      expect(done.status).toBe("completed")
+      expect(withTodos.status).toBe("running")
+      expect(busy.status).toBe("running")
+    })
+  })
+
+  describe("#given an idle task whose messages endpoint rejects", () => {
+    test("#when pollRunningTasks runs #then the upstream fail-open contract still completes it", async () => {
+      //#given
+      const manager = createManager({
+        status: async () => ({ data: { "ses-broken": { type: "idle" } } }),
+        messages: async () => {
+          throw new Error("messages endpoint exploded")
+        },
+      })
+      const broken = createRunningTask("ses-broken")
+      injectTask(manager, broken)
+
+      //#when
+      await manager["pollRunningTasks"]()
+      manager.shutdown()
+
+      //#then
+      expect(broken.status).toBe("completed")
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.todos.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.polling.parallel-probes.todos.test.ts
@@ -1,0 +1,76 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "node:os"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { unsafeTestValue } from "../../../../../test-support/unsafe-test-value"
+import { BackgroundManager } from "./manager"
+import type { BackgroundTask } from "./types"
+
+function createManager(): BackgroundManager {
+  const directory = tmpdir()
+  const client = {
+    session: {
+      status: async () => ({ data: { "ses-done": { type: "idle" }, "ses-todos": { type: "idle" }, "ses-busy": { type: "busy" } } }),
+      get: async () => ({ data: { id: "ses-default" } }),
+      prompt: async () => ({}),
+      promptAsync: async () => ({}),
+      abort: async () => ({}),
+      todo: async (args: { path?: { id?: string } }) => args.path?.id === "ses-todos"
+        ? { data: [{ id: "t1", content: "still working", status: "in_progress", priority: "high" }] }
+        : { data: [] },
+      messages: async () => ({ data: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "done" }] }] }),
+    },
+  }
+  const pluginContext: PluginInput = {
+    project: { id: "test-project", worktree: directory, time: { created: Date.now() } },
+    directory,
+    worktree: directory,
+    serverUrl: new URL("http://localhost:4096"),
+    $: unsafeTestValue<PluginInput["$"]>({}),
+    client: unsafeTestValue<PluginInput["client"]>(client),
+  }
+  return new BackgroundManager({ pluginContext, enableParentSessionNotifications: false })
+}
+
+function createTask(sessionId: string): BackgroundTask {
+  return {
+    id: `bg_test_${sessionId}`,
+    sessionId,
+    parentSessionId: "parent-session",
+    parentMessageId: "parent-message",
+    description: "test task",
+    prompt: "test",
+    agent: "explore",
+    status: "running",
+    startedAt: new Date(),
+    progress: { toolCalls: 0, lastUpdate: new Date() },
+  }
+}
+
+describe("BackgroundManager polling todo gates", () => {
+  describe("#given idle tasks with and without open todos and one active task", () => {
+    test("#when polling runs #then only the idle task without open todos completes", async () => {
+      //#given
+      const manager = createManager()
+      const done = createTask("ses-done")
+      const withTodos = createTask("ses-todos")
+      const busy = createTask("ses-busy")
+      for (const task of [done, withTodos, busy]) {
+        manager["tasks"].set(task.id, task)
+      }
+
+      try {
+        //#when
+        await manager["pollRunningTasks"]()
+
+        //#then
+        expect(done.status).toBe("completed")
+        expect(withTodos.status).toBe("running")
+        expect(busy.status).toBe("running")
+      } finally {
+        await manager.shutdown()
+      }
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -81,7 +81,7 @@ import {
 } from "./loop-detector"
 import { ParentWakeNotifier, type ParentWakePromptContext } from "./parent-wake-notifier"
 import type { PendingParentWake } from "./parent-wake-dedupe"
-import { type PollProbeResults, resolvePollSessionProbes } from "./poll-session-probes"
+import { startPollSessionProbes, type PollSessionProbeBatch } from "./poll-session-probes"
 import { registerManagerForCleanup, unregisterManagerForCleanup } from "./process-cleanup"
 import { removeTaskToastTracking } from "./remove-task-toast-tracking"
 import {
@@ -181,15 +181,24 @@ interface Todo {
   id: string
 }
 
-/**
- * A running task whose session looks idle or gone, pending confirmation probes.
- */
-interface PollCompletionCandidate {
+interface PollCandidateTaskIdentity {
   task: BackgroundTask
   sessionID: string
+  currentAttemptID: string | undefined
+  startedAt: Date | undefined
   completionSource: string
+}
+
+interface PollTerminalCandidate extends PollCandidateTaskIdentity {
+  kind: "terminal"
+}
+
+interface PollProbeCandidate extends PollCandidateTaskIdentity {
+  kind: "probe"
   sessionGoneThresholdReached: boolean
 }
+
+type PollCompletionCandidate = PollTerminalCandidate | PollProbeCandidate
 
 function formatAttemptModelSummary(attempt: Pick<BackgroundTaskAttempt, "providerId" | "modelId"> | undefined): string | undefined {
   if (!attempt?.providerId || !attempt.modelId) {
@@ -3059,18 +3068,22 @@ The task was re-queued on a fallback model after a retryable failure.
       await this.checkAndInterruptStaleTasks(allStatuses)
 
       const candidates = await this.collectPollCompletionCandidates(allStatuses)
-      const probes = await resolvePollSessionProbes(
-        candidates.map((candidate) => ({
+      if (this.shutdownTriggered) return
+
+      const probes = startPollSessionProbes(
+        candidates.filter((candidate): candidate is PollProbeCandidate => candidate.kind === "probe").map((candidate) => ({
           sessionID: candidate.sessionID,
           requiresExistenceCheck: candidate.sessionGoneThresholdReached,
         })),
         {
-          validateSessionHasOutput: (sessionID) => this.validateSessionHasOutput(sessionID),
-          verifySessionExists: (sessionID) => this.verifySessionExists(sessionID),
-          checkSessionTodos: (sessionID) => this.checkSessionTodos(sessionID),
-        },
-        (sessionID, probe, error) => {
-          log("[background-agent] Poll probe failed:", { sessionID, probe, error })
+          resolvers: {
+            validateSessionHasOutput: (sessionID) => this.validateSessionHasOutput(sessionID),
+            verifySessionExists: (sessionID) => this.verifySessionExists(sessionID),
+            checkSessionTodos: (sessionID) => this.checkSessionTodos(sessionID),
+          },
+          onProbeError: (sessionID, probe, error) => {
+            log("[background-agent] Poll probe failed:", { sessionID, probe, error })
+          },
         },
       )
       await this.resolvePollCompletionCandidates(candidates, probes)
@@ -3086,10 +3099,9 @@ The task was re-queued on a fallback model after a retryable failure.
   /**
    * Classify every running task against the batched session status map.
    *
-   * Terminal and retry transitions are applied here because they mutate task
-   * state and must keep their original sequential ordering. Tasks that look
-   * idle or gone are returned as candidates instead, so their confirmation
-   * probes can run as one batch rather than one blocking round trip per task.
+   * Retry transitions are applied here because they mutate task state. Terminal
+   * and probe-backed actions are returned in task order, so teardown remains
+   * ordered while session reads begin without waiting for earlier teardown.
    */
   private async collectPollCompletionCandidates(
     allStatuses: SessionStatusMap | undefined,
@@ -3128,7 +3140,14 @@ The task was re-queued on a fallback model after a retryable failure.
         }
 
         if (sessionStatus && isTerminalSessionStatus(sessionStatus.type)) {
-          await this.tryCompleteTask(task, `polling (terminal session status: ${sessionStatus.type})`)
+          candidates.push({
+            kind: "terminal",
+            task,
+            sessionID,
+            currentAttemptID: task.currentAttemptID,
+            startedAt: task.startedAt,
+            completionSource: `polling (terminal session status: ${sessionStatus.type})`,
+          })
           continue
         }
 
@@ -3152,7 +3171,15 @@ The task was re-queued on a fallback model after a retryable failure.
           ? "polling (idle status)"
           : "polling (session gone from status)"
 
-        candidates.push({ task, sessionID, completionSource, sessionGoneThresholdReached })
+        candidates.push({
+          kind: "probe",
+          task,
+          sessionID,
+          currentAttemptID: task.currentAttemptID,
+          startedAt: task.startedAt,
+          completionSource,
+          sessionGoneThresholdReached,
+        })
       } catch (error) {
         log("[background-agent] Poll error for task:", { taskId: task.id, error })
       }
@@ -3162,22 +3189,53 @@ The task was re-queued on a fallback model after a retryable failure.
   }
 
   /**
-   * Apply the batched probe results in the original task order.
-   *
-   * A probe that is missing from the result maps failed for that session, so
-   * the task is left running and reconsidered on the next tick. That keeps one
-   * unhealthy session from deciding the outcome of its neighbours.
+   * Apply completion actions in original task order. Each probe is awaited only
+   * when its ordered candidate is reached, so a slow suffix cannot block a ready
+   * prefix from releasing its concurrency slot.
    */
+  private isCurrentPollCompletionCandidate(candidate: PollCompletionCandidate): boolean {
+    const { task } = candidate
+    const isCurrent = !this.shutdownTriggered
+      && this.tasks.get(task.id) === task
+      && task.status === "running"
+      && task.sessionId === candidate.sessionID
+      && task.currentAttemptID === candidate.currentAttemptID
+      && task.startedAt === candidate.startedAt
+    if (!isCurrent) {
+      log("[background-agent] Skipping stale poll completion candidate:", {
+        taskId: task.id,
+        sessionID: candidate.sessionID,
+        shutdownTriggered: this.shutdownTriggered,
+      })
+    }
+    return isCurrent
+  }
+
   private async resolvePollCompletionCandidates(
     candidates: Array<PollCompletionCandidate>,
-    probes: PollProbeResults,
+    probes: PollSessionProbeBatch,
   ): Promise<void> {
     for (const candidate of candidates) {
+      if (this.shutdownTriggered) return
       const { task, sessionID } = candidate
-      if (task.status !== "running") continue
 
       try {
-        const hasValidOutput = probes.hasOutput.get(sessionID)
+        if (candidate.kind === "terminal") {
+          if (!this.isCurrentPollCompletionCandidate(candidate)) continue
+          await this.tryCompleteTask(task, candidate.completionSource)
+          continue
+        }
+
+        const result = probes.resultsBySession.get(sessionID)
+        if (!result) {
+          log("[background-agent] Output probe unresolved this poll, waiting:", task.id)
+          continue
+        }
+
+        const probeResult = await result
+        if (!this.isCurrentPollCompletionCandidate(candidate)) continue
+
+        const hasValidOutput = probeResult.hasOutput
         if (hasValidOutput === undefined) {
           log("[background-agent] Output probe unresolved this poll, waiting:", task.id)
           continue
@@ -3185,7 +3243,7 @@ The task was re-queued on a fallback model after a retryable failure.
 
         if (!hasValidOutput) {
           if (candidate.sessionGoneThresholdReached) {
-            const sessionExists = probes.sessionExists.get(sessionID)
+            const sessionExists = probeResult.sessionExists
             if (sessionExists === false) {
               log("[background-agent] Session no longer exists (crashed), marking task as error:", task.id)
               await this.failCrashedTask(task, "Subagent session no longer exists (process likely crashed). The session disappeared without producing any output.")
@@ -3200,13 +3258,13 @@ The task was re-queued on a fallback model after a retryable failure.
           continue
         }
 
-        const hasIncompleteTodos = probes.hasIncompleteTodos.get(sessionID)
+        const hasIncompleteTodos = probeResult.hasIncompleteTodos
         if (hasIncompleteTodos === undefined) {
           log("[background-agent] Todo probe unresolved this poll, waiting:", task.id)
           continue
         }
 
-        if (hasIncompleteTodos) {
+        if (hasIncompleteTodos || this.observedIncompleteTodosBySession.get(sessionID) === true) {
           log("[background-agent] Task has incomplete todos via polling, waiting:", task.id)
           continue
         }

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -81,6 +81,7 @@ import {
 } from "./loop-detector"
 import { ParentWakeNotifier, type ParentWakePromptContext } from "./parent-wake-notifier"
 import type { PendingParentWake } from "./parent-wake-dedupe"
+import { type PollProbeResults, resolvePollSessionProbes } from "./poll-session-probes"
 import { registerManagerForCleanup, unregisterManagerForCleanup } from "./process-cleanup"
 import { removeTaskToastTracking } from "./remove-task-toast-tracking"
 import {
@@ -178,6 +179,16 @@ interface Todo {
   status: string
   priority: string
   id: string
+}
+
+/**
+ * A running task whose session looks idle or gone, pending confirmation probes.
+ */
+interface PollCompletionCandidate {
+  task: BackgroundTask
+  sessionID: string
+  completionSource: string
+  sessionGoneThresholdReached: boolean
 }
 
 function formatAttemptModelSummary(attempt: Pick<BackgroundTaskAttempt, "providerId" | "modelId"> | undefined): string | undefined {
@@ -3047,97 +3058,163 @@ The task was re-queued on a fallback model after a retryable failure.
 
       await this.checkAndInterruptStaleTasks(allStatuses)
 
-      for (const task of this.tasks.values()) {
-        if (task.status !== "running") continue
-
-        const sessionID = task.sessionId
-        if (!sessionID) continue
-
-        try {
-          const sessionStatus = allStatuses?.[sessionID]
-          // Handle retry before checking running state
-          if (sessionStatus?.type === "retry") {
-            const retryMessage = typeof (sessionStatus as { message?: string }).message === "string"
-              ? (sessionStatus as { message?: string }).message
-              : undefined
-            const errorInfo = { name: "SessionRetry", message: retryMessage }
-            if (await this.tryFallbackRetry(task, errorInfo, "polling:session.status")) {
-              continue
-            }
-          }
-
-          // Only skip completion when session status is actively running.
-          // Unknown or terminal statuses (like "interrupted") fall through to completion.
-          if (sessionStatus && isActiveSessionStatus(sessionStatus.type)) {
-            log("[background-agent] Session still running, relying on event-based progress:", {
-              taskId: task.id,
-              sessionID,
-              sessionStatus: sessionStatus.type,
-              toolCalls: task.progress?.toolCalls ?? 0,
-            })
-            continue
-          }
-
-          if (sessionStatus && isTerminalSessionStatus(sessionStatus.type)) {
-            await this.tryCompleteTask(task, `polling (terminal session status: ${sessionStatus.type})`)
-            continue
-          }
-
-          if (sessionStatus && sessionStatus.type !== "idle") {
-            log("[background-agent] Unknown session status, treating as potentially idle:", {
-              taskId: task.id,
-              sessionID,
-              sessionStatus: sessionStatus.type,
-            })
-          }
-
-          if (allStatuses === undefined) {
-            continue
-          }
-
-          // Session is idle or no longer in status response (completed/disappeared)
-          const sessionGoneFromStatus = allStatuses !== undefined && !sessionStatus
-          const sessionGoneThresholdReached = sessionGoneFromStatus
-            && (task.consecutiveMissedPolls ?? 0) >= MIN_SESSION_GONE_POLLS
-          const completionSource = sessionStatus?.type === "idle"
-            ? "polling (idle status)"
-            : "polling (session gone from status)"
-          const hasValidOutput = await this.validateSessionHasOutput(sessionID)
-          if (!hasValidOutput) {
-            if (sessionGoneThresholdReached) {
-              const sessionExists = await this.verifySessionExists(sessionID)
-              if (!sessionExists) {
-                log("[background-agent] Session no longer exists (crashed), marking task as error:", task.id)
-                await this.failCrashedTask(task, "Subagent session no longer exists (process likely crashed). The session disappeared without producing any output.")
-                continue
-              }
-
-              task.consecutiveMissedPolls = 0
-            }
-            log("[background-agent] Polling idle/gone but no valid output yet, waiting:", task.id)
-            continue
-          }
-
-          // Re-check status after async operation
-          if (task.status !== "running") continue
-
-          const hasIncompleteTodos = await this.checkSessionTodos(sessionID)
-          if (hasIncompleteTodos) {
-            log("[background-agent] Task has incomplete todos via polling, waiting:", task.id)
-            continue
-          }
-
-          await this.tryCompleteTask(task, completionSource)
-        } catch (error) {
-          log("[background-agent] Poll error for task:", { taskId: task.id, error })
-        }
-      }
+      const candidates = await this.collectPollCompletionCandidates(allStatuses)
+      const probes = await resolvePollSessionProbes(
+        candidates.map((candidate) => ({
+          sessionID: candidate.sessionID,
+          requiresExistenceCheck: candidate.sessionGoneThresholdReached,
+        })),
+        {
+          validateSessionHasOutput: (sessionID) => this.validateSessionHasOutput(sessionID),
+          verifySessionExists: (sessionID) => this.verifySessionExists(sessionID),
+          checkSessionTodos: (sessionID) => this.checkSessionTodos(sessionID),
+        },
+        (sessionID, probe, error) => {
+          log("[background-agent] Poll probe failed:", { sessionID, probe, error })
+        },
+      )
+      await this.resolvePollCompletionCandidates(candidates, probes)
 
       if (!this.hasRunningTasks()) {
         this.stopPolling()
       }
     } finally {
       this.pollingInFlight = false
+    }
+  }
+
+  /**
+   * Classify every running task against the batched session status map.
+   *
+   * Terminal and retry transitions are applied here because they mutate task
+   * state and must keep their original sequential ordering. Tasks that look
+   * idle or gone are returned as candidates instead, so their confirmation
+   * probes can run as one batch rather than one blocking round trip per task.
+   */
+  private async collectPollCompletionCandidates(
+    allStatuses: SessionStatusMap | undefined,
+  ): Promise<Array<PollCompletionCandidate>> {
+    const candidates: Array<PollCompletionCandidate> = []
+
+    for (const task of this.tasks.values()) {
+      if (task.status !== "running") continue
+
+      const sessionID = task.sessionId
+      if (!sessionID) continue
+
+      try {
+        const sessionStatus = allStatuses?.[sessionID]
+        // Handle retry before checking running state
+        if (sessionStatus?.type === "retry") {
+          const retryMessage = typeof (sessionStatus as { message?: string }).message === "string"
+            ? (sessionStatus as { message?: string }).message
+            : undefined
+          const errorInfo = { name: "SessionRetry", message: retryMessage }
+          if (await this.tryFallbackRetry(task, errorInfo, "polling:session.status")) {
+            continue
+          }
+        }
+
+        // Only skip completion when session status is actively running.
+        // Unknown or terminal statuses (like "interrupted") fall through to completion.
+        if (sessionStatus && isActiveSessionStatus(sessionStatus.type)) {
+          log("[background-agent] Session still running, relying on event-based progress:", {
+            taskId: task.id,
+            sessionID,
+            sessionStatus: sessionStatus.type,
+            toolCalls: task.progress?.toolCalls ?? 0,
+          })
+          continue
+        }
+
+        if (sessionStatus && isTerminalSessionStatus(sessionStatus.type)) {
+          await this.tryCompleteTask(task, `polling (terminal session status: ${sessionStatus.type})`)
+          continue
+        }
+
+        if (sessionStatus && sessionStatus.type !== "idle") {
+          log("[background-agent] Unknown session status, treating as potentially idle:", {
+            taskId: task.id,
+            sessionID,
+            sessionStatus: sessionStatus.type,
+          })
+        }
+
+        if (allStatuses === undefined) {
+          continue
+        }
+
+        // Session is idle or no longer in status response (completed/disappeared)
+        const sessionGoneFromStatus = allStatuses !== undefined && !sessionStatus
+        const sessionGoneThresholdReached = sessionGoneFromStatus
+          && (task.consecutiveMissedPolls ?? 0) >= MIN_SESSION_GONE_POLLS
+        const completionSource = sessionStatus?.type === "idle"
+          ? "polling (idle status)"
+          : "polling (session gone from status)"
+
+        candidates.push({ task, sessionID, completionSource, sessionGoneThresholdReached })
+      } catch (error) {
+        log("[background-agent] Poll error for task:", { taskId: task.id, error })
+      }
+    }
+
+    return candidates
+  }
+
+  /**
+   * Apply the batched probe results in the original task order.
+   *
+   * A probe that is missing from the result maps failed for that session, so
+   * the task is left running and reconsidered on the next tick. That keeps one
+   * unhealthy session from deciding the outcome of its neighbours.
+   */
+  private async resolvePollCompletionCandidates(
+    candidates: Array<PollCompletionCandidate>,
+    probes: PollProbeResults,
+  ): Promise<void> {
+    for (const candidate of candidates) {
+      const { task, sessionID } = candidate
+      if (task.status !== "running") continue
+
+      try {
+        const hasValidOutput = probes.hasOutput.get(sessionID)
+        if (hasValidOutput === undefined) {
+          log("[background-agent] Output probe unresolved this poll, waiting:", task.id)
+          continue
+        }
+
+        if (!hasValidOutput) {
+          if (candidate.sessionGoneThresholdReached) {
+            const sessionExists = probes.sessionExists.get(sessionID)
+            if (sessionExists === false) {
+              log("[background-agent] Session no longer exists (crashed), marking task as error:", task.id)
+              await this.failCrashedTask(task, "Subagent session no longer exists (process likely crashed). The session disappeared without producing any output.")
+              continue
+            }
+
+            if (sessionExists === true) {
+              task.consecutiveMissedPolls = 0
+            }
+          }
+          log("[background-agent] Polling idle/gone but no valid output yet, waiting:", task.id)
+          continue
+        }
+
+        const hasIncompleteTodos = probes.hasIncompleteTodos.get(sessionID)
+        if (hasIncompleteTodos === undefined) {
+          log("[background-agent] Todo probe unresolved this poll, waiting:", task.id)
+          continue
+        }
+
+        if (hasIncompleteTodos) {
+          log("[background-agent] Task has incomplete todos via polling, waiting:", task.id)
+          continue
+        }
+
+        await this.tryCompleteTask(task, candidate.completionSource)
+      } catch (error) {
+        log("[background-agent] Poll error for task:", { taskId: task.id, error })
+      }
     }
   }
 

--- a/packages/omo-opencode/src/features/background-agent/poll-session-probes.concurrent.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/poll-session-probes.concurrent.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test"
+import { MAX_POLL_PROBE_CONCURRENCY, startPollSessionProbes } from "./poll-session-probes"
+import type { PollSessionProbeBatch, PollSessionProbeResult } from "./poll-session-probes"
+
+function createDeferred(): { readonly promise: Promise<void>; readonly resolve: () => void } {
+  let resolve: (() => void) | undefined
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve: () => resolve?.() }
+}
+
+function getProbeResult(batch: PollSessionProbeBatch, sessionID: string): Promise<PollSessionProbeResult> {
+  const result = batch.resultsBySession.get(sessionID)
+  if (!result) {
+    throw new Error(`missing probe result for ${sessionID}`)
+  }
+  return result
+}
+
+describe("startPollSessionProbes concurrency", () => {
+  describe("#given more sessions than the configured probe cap", () => {
+    test("#when output probes wait #then no more than the cap is in flight", async () => {
+      //#given
+      const gate = createDeferred()
+      const sessionIDs = Array.from({ length: MAX_POLL_PROBE_CONCURRENCY + 2 }, (_, index) => `ses-${index}`)
+      let inFlight = 0
+      let maxInFlight = 0
+      const batch = startPollSessionProbes(
+        sessionIDs.map((sessionID) => ({ sessionID, requiresExistenceCheck: false })),
+        {
+          resolvers: {
+            validateSessionHasOutput: async () => {
+              inFlight += 1
+              maxInFlight = Math.max(maxInFlight, inFlight)
+              await gate.promise
+              inFlight -= 1
+              return false
+            },
+            verifySessionExists: async () => true,
+            checkSessionTodos: async () => false,
+          },
+        },
+      )
+
+      try {
+        //#when
+        const observedInFlight = maxInFlight
+        gate.resolve()
+        await Promise.all(sessionIDs.map((sessionID) => getProbeResult(batch, sessionID)))
+
+        //#then
+        expect(observedInFlight).toBe(MAX_POLL_PROBE_CONCURRENCY)
+      } finally {
+        gate.resolve()
+      }
+    })
+  })
+
+  describe("#given a fast session and a different stalled output probe", () => {
+    test("#when the fast output resolves #then its todo probe starts without waiting for the stall", async () => {
+      //#given
+      const slowGate = createDeferred()
+      const todoStarted = createDeferred()
+      const batch = startPollSessionProbes([
+        { sessionID: "ses-fast", requiresExistenceCheck: false },
+        { sessionID: "ses-slow", requiresExistenceCheck: false },
+      ], {
+        resolvers: {
+          validateSessionHasOutput: async (sessionID) => {
+            if (sessionID === "ses-slow") {
+              await slowGate.promise
+              return false
+            }
+            return true
+          },
+          verifySessionExists: async () => true,
+          checkSessionTodos: async () => {
+            todoStarted.resolve()
+            return false
+          },
+        },
+      })
+
+      try {
+        //#when
+        await todoStarted.promise
+        const fast = await getProbeResult(batch, "ses-fast")
+
+        //#then
+        expect(fast.hasIncompleteTodos).toBe(false)
+      } finally {
+        slowGate.resolve()
+        await getProbeResult(batch, "ses-slow")
+      }
+    })
+  })
+
+  describe("#given an output probe that exceeds its deadline", () => {
+    test("#when resolving #then only that session's result remains unset", async () => {
+      //#given
+      const reported: string[] = []
+      const batch = startPollSessionProbes([{ sessionID: "ses-hung", requiresExistenceCheck: false }], {
+        resolvers: {
+          validateSessionHasOutput: () => new Promise<boolean>(() => {}),
+          verifySessionExists: async () => true,
+          checkSessionTodos: async () => false,
+        },
+        onProbeError: (_sessionID, probe) => reported.push(probe),
+        timeoutMs: 0,
+      })
+
+      //#when
+      const result = await getProbeResult(batch, "ses-hung")
+
+      //#then
+      expect(result.hasOutput).toBeUndefined()
+      expect(reported).toEqual(["output"])
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/poll-session-probes.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/poll-session-probes.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "bun:test"
+import { resolvePollSessionProbes } from "./poll-session-probes"
+import type { PollProbeResolvers, PollProbeTarget } from "./poll-session-probes"
+
+interface ProbeRecorder {
+  readonly calls: string[]
+  readonly maxInFlight: number
+  resolving: (value: boolean) => (sessionID: string) => Promise<boolean>
+  rejecting: (failingSessionID: string, value: boolean) => (sessionID: string) => Promise<boolean>
+}
+
+function createProbeRecorder(label: string): ProbeRecorder {
+  const calls: string[] = []
+  let inFlight = 0
+  let maxInFlight = 0
+
+  async function enter(sessionID: string): Promise<void> {
+    calls.push(`${label}:${sessionID}`)
+    inFlight += 1
+    maxInFlight = Math.max(maxInFlight, inFlight)
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    inFlight -= 1
+  }
+
+  return {
+    calls,
+    get maxInFlight() {
+      return maxInFlight
+    },
+    resolving: (value) => async (sessionID) => {
+      await enter(sessionID)
+      return value
+    },
+    rejecting: (failingSessionID, value) => async (sessionID) => {
+      await enter(sessionID)
+      if (sessionID === failingSessionID) throw new Error(`probe failed for ${sessionID}`)
+      return value
+    },
+  }
+}
+
+function createResolvers(overrides: Partial<PollProbeResolvers> = {}): PollProbeResolvers {
+  return {
+    validateSessionHasOutput: async () => true,
+    verifySessionExists: async () => true,
+    checkSessionTodos: async () => false,
+    ...overrides,
+  }
+}
+
+function targetsFor(sessionIDs: string[], requiresExistenceCheck = false): PollProbeTarget[] {
+  return sessionIDs.map((sessionID) => ({ sessionID, requiresExistenceCheck }))
+}
+
+describe("resolvePollSessionProbes", () => {
+  describe("#given many sessions to probe", () => {
+    test("#when resolving #then every output probe is in flight at the same time", async () => {
+      //#given
+      const output = createProbeRecorder("output")
+      const sessionIDs = ["ses-1", "ses-2", "ses-3", "ses-4", "ses-5"]
+
+      //#when
+      const results = await resolvePollSessionProbes(
+        targetsFor(sessionIDs),
+        createResolvers({ validateSessionHasOutput: output.resolving(true) }),
+      )
+
+      //#then
+      expect(output.maxInFlight).toBe(sessionIDs.length)
+      expect(results.hasOutput.size).toBe(sessionIDs.length)
+    })
+
+    test("#when every session has output #then the todo probes also overlap", async () => {
+      //#given
+      const todos = createProbeRecorder("todo")
+      const sessionIDs = ["ses-1", "ses-2", "ses-3", "ses-4"]
+
+      //#when
+      await resolvePollSessionProbes(
+        targetsFor(sessionIDs),
+        createResolvers({ checkSessionTodos: todos.resolving(false) }),
+      )
+
+      //#then
+      expect(todos.maxInFlight).toBe(sessionIDs.length)
+    })
+  })
+
+  describe("#given a session that produced output", () => {
+    test("#when resolving #then only the todo probe follows", async () => {
+      //#given
+      const todos = createProbeRecorder("todo")
+      const existence = createProbeRecorder("existence")
+
+      //#when
+      const results = await resolvePollSessionProbes(
+        targetsFor(["ses-1"], true),
+        createResolvers({
+          validateSessionHasOutput: async () => true,
+          checkSessionTodos: todos.resolving(true),
+          verifySessionExists: existence.resolving(true),
+        }),
+      )
+
+      //#then
+      expect(todos.calls).toEqual(["todo:ses-1"])
+      expect(existence.calls).toEqual([])
+      expect(results.hasIncompleteTodos.get("ses-1")).toBe(true)
+      expect(results.sessionExists.has("ses-1")).toBe(false)
+    })
+  })
+
+  describe("#given a session without output that reached the missed poll threshold", () => {
+    test("#when resolving #then only the existence probe follows", async () => {
+      //#given
+      const todos = createProbeRecorder("todo")
+      const existence = createProbeRecorder("existence")
+
+      //#when
+      const results = await resolvePollSessionProbes(
+        targetsFor(["ses-1"], true),
+        createResolvers({
+          validateSessionHasOutput: async () => false,
+          checkSessionTodos: todos.resolving(false),
+          verifySessionExists: existence.resolving(false),
+        }),
+      )
+
+      //#then
+      expect(existence.calls).toEqual(["existence:ses-1"])
+      expect(todos.calls).toEqual([])
+      expect(results.sessionExists.get("ses-1")).toBe(false)
+      expect(results.hasIncompleteTodos.has("ses-1")).toBe(false)
+    })
+  })
+
+  describe("#given a session without output that does not need an existence check", () => {
+    test("#when resolving #then no follow up probe runs", async () => {
+      //#given
+      const todos = createProbeRecorder("todo")
+      const existence = createProbeRecorder("existence")
+
+      //#when
+      const results = await resolvePollSessionProbes(
+        targetsFor(["ses-1"], false),
+        createResolvers({
+          validateSessionHasOutput: async () => false,
+          checkSessionTodos: todos.resolving(false),
+          verifySessionExists: existence.resolving(true),
+        }),
+      )
+
+      //#then
+      expect(todos.calls).toEqual([])
+      expect(existence.calls).toEqual([])
+      expect(results.hasOutput.get("ses-1")).toBe(false)
+    })
+  })
+
+  describe("#given the same session appears twice with different existence flags", () => {
+    test("#when resolving #then each probe runs once and the existence check is kept", async () => {
+      //#given
+      const output = createProbeRecorder("output")
+      const existence = createProbeRecorder("existence")
+      const targets: PollProbeTarget[] = [
+        { sessionID: "ses-1", requiresExistenceCheck: false },
+        { sessionID: "ses-1", requiresExistenceCheck: true },
+      ]
+
+      //#when
+      await resolvePollSessionProbes(
+        targets,
+        createResolvers({
+          validateSessionHasOutput: output.resolving(false),
+          verifySessionExists: existence.resolving(true),
+        }),
+      )
+
+      //#then
+      expect(output.calls).toEqual(["output:ses-1"])
+      expect(existence.calls).toEqual(["existence:ses-1"])
+    })
+  })
+
+  describe("#given one output probe rejects", () => {
+    test("#when resolving #then the entry stays unset and the other sessions still resolve", async () => {
+      //#given
+      const output = createProbeRecorder("output")
+      const reported: string[] = []
+
+      //#when
+      const results = await resolvePollSessionProbes(
+        targetsFor(["ses-1", "ses-2"]),
+        createResolvers({ validateSessionHasOutput: output.rejecting("ses-1", true) }),
+        (sessionID) => {
+          reported.push(sessionID)
+        },
+      )
+
+      //#then
+      expect(results.hasOutput.has("ses-1")).toBe(false)
+      expect(results.hasOutput.get("ses-2")).toBe(true)
+      expect(reported).toEqual(["ses-1"])
+    })
+  })
+
+  describe("#given no targets", () => {
+    test("#when resolving #then no probe runs", async () => {
+      //#given
+      const output = createProbeRecorder("output")
+
+      //#when
+      const results = await resolvePollSessionProbes(
+        [],
+        createResolvers({ validateSessionHasOutput: output.resolving(true) }),
+      )
+
+      //#then
+      expect(output.calls).toEqual([])
+      expect(results.hasOutput.size).toBe(0)
+    })
+  })
+})

--- a/packages/omo-opencode/src/features/background-agent/poll-session-probes.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/poll-session-probes.test.ts
@@ -1,43 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { resolvePollSessionProbes } from "./poll-session-probes"
-import type { PollProbeResolvers, PollProbeTarget } from "./poll-session-probes"
-
-interface ProbeRecorder {
-  readonly calls: string[]
-  readonly maxInFlight: number
-  resolving: (value: boolean) => (sessionID: string) => Promise<boolean>
-  rejecting: (failingSessionID: string, value: boolean) => (sessionID: string) => Promise<boolean>
-}
-
-function createProbeRecorder(label: string): ProbeRecorder {
-  const calls: string[] = []
-  let inFlight = 0
-  let maxInFlight = 0
-
-  async function enter(sessionID: string): Promise<void> {
-    calls.push(`${label}:${sessionID}`)
-    inFlight += 1
-    maxInFlight = Math.max(maxInFlight, inFlight)
-    await new Promise((resolve) => setTimeout(resolve, 5))
-    inFlight -= 1
-  }
-
-  return {
-    calls,
-    get maxInFlight() {
-      return maxInFlight
-    },
-    resolving: (value) => async (sessionID) => {
-      await enter(sessionID)
-      return value
-    },
-    rejecting: (failingSessionID, value) => async (sessionID) => {
-      await enter(sessionID)
-      if (sessionID === failingSessionID) throw new Error(`probe failed for ${sessionID}`)
-      return value
-    },
-  }
-}
+import { startPollSessionProbes } from "./poll-session-probes"
+import type { PollProbeResolvers, PollProbeTarget, PollSessionProbeBatch, PollSessionProbeResult } from "./poll-session-probes"
 
 function createResolvers(overrides: Partial<PollProbeResolvers> = {}): PollProbeResolvers {
   return {
@@ -48,176 +11,170 @@ function createResolvers(overrides: Partial<PollProbeResolvers> = {}): PollProbe
   }
 }
 
-function targetsFor(sessionIDs: string[], requiresExistenceCheck = false): PollProbeTarget[] {
-  return sessionIDs.map((sessionID) => ({ sessionID, requiresExistenceCheck }))
+function getProbeResult(batch: PollSessionProbeBatch, sessionID: string): Promise<PollSessionProbeResult> {
+  const result = batch.resultsBySession.get(sessionID)
+  if (!result) {
+    throw new Error(`missing probe result for ${sessionID}`)
+  }
+  return result
 }
 
-describe("resolvePollSessionProbes", () => {
-  describe("#given many sessions to probe", () => {
-    test("#when resolving #then every output probe is in flight at the same time", async () => {
-      //#given
-      const output = createProbeRecorder("output")
-      const sessionIDs = ["ses-1", "ses-2", "ses-3", "ses-4", "ses-5"]
-
-      //#when
-      const results = await resolvePollSessionProbes(
-        targetsFor(sessionIDs),
-        createResolvers({ validateSessionHasOutput: output.resolving(true) }),
-      )
-
-      //#then
-      expect(output.maxInFlight).toBe(sessionIDs.length)
-      expect(results.hasOutput.size).toBe(sessionIDs.length)
-    })
-
-    test("#when every session has output #then the todo probes also overlap", async () => {
-      //#given
-      const todos = createProbeRecorder("todo")
-      const sessionIDs = ["ses-1", "ses-2", "ses-3", "ses-4"]
-
-      //#when
-      await resolvePollSessionProbes(
-        targetsFor(sessionIDs),
-        createResolvers({ checkSessionTodos: todos.resolving(false) }),
-      )
-
-      //#then
-      expect(todos.maxInFlight).toBe(sessionIDs.length)
-    })
-  })
-
+describe("startPollSessionProbes", () => {
   describe("#given a session that produced output", () => {
     test("#when resolving #then only the todo probe follows", async () => {
       //#given
-      const todos = createProbeRecorder("todo")
-      const existence = createProbeRecorder("existence")
+      const calls: string[] = []
+      const batch = startPollSessionProbes([{ sessionID: "ses-1", requiresExistenceCheck: true }], {
+        resolvers: createResolvers({
+          checkSessionTodos: async () => {
+            calls.push("todos")
+            return true
+          },
+          verifySessionExists: async () => {
+            calls.push("existence")
+            return true
+          },
+        }),
+      })
 
       //#when
-      const results = await resolvePollSessionProbes(
-        targetsFor(["ses-1"], true),
-        createResolvers({
-          validateSessionHasOutput: async () => true,
-          checkSessionTodos: todos.resolving(true),
-          verifySessionExists: existence.resolving(true),
-        }),
-      )
+      const result = await getProbeResult(batch, "ses-1")
 
       //#then
-      expect(todos.calls).toEqual(["todo:ses-1"])
-      expect(existence.calls).toEqual([])
-      expect(results.hasIncompleteTodos.get("ses-1")).toBe(true)
-      expect(results.sessionExists.has("ses-1")).toBe(false)
+      expect(calls).toEqual(["todos"])
+      expect(result.hasIncompleteTodos).toBe(true)
+      expect(result.sessionExists).toBeUndefined()
     })
   })
 
-  describe("#given a session without output that reached the missed poll threshold", () => {
+  describe("#given a session without output at the missed-poll threshold", () => {
     test("#when resolving #then only the existence probe follows", async () => {
       //#given
-      const todos = createProbeRecorder("todo")
-      const existence = createProbeRecorder("existence")
+      const calls: string[] = []
+      const batch = startPollSessionProbes([{ sessionID: "ses-1", requiresExistenceCheck: true }], {
+        resolvers: createResolvers({
+          validateSessionHasOutput: async () => false,
+          checkSessionTodos: async () => {
+            calls.push("todos")
+            return false
+          },
+          verifySessionExists: async () => {
+            calls.push("existence")
+            return false
+          },
+        }),
+      })
 
       //#when
-      const results = await resolvePollSessionProbes(
-        targetsFor(["ses-1"], true),
-        createResolvers({
-          validateSessionHasOutput: async () => false,
-          checkSessionTodos: todos.resolving(false),
-          verifySessionExists: existence.resolving(false),
-        }),
-      )
+      const result = await getProbeResult(batch, "ses-1")
 
       //#then
-      expect(existence.calls).toEqual(["existence:ses-1"])
-      expect(todos.calls).toEqual([])
-      expect(results.sessionExists.get("ses-1")).toBe(false)
-      expect(results.hasIncompleteTodos.has("ses-1")).toBe(false)
+      expect(calls).toEqual(["existence"])
+      expect(result.sessionExists).toBe(false)
+      expect(result.hasIncompleteTodos).toBeUndefined()
     })
   })
 
-  describe("#given a session without output that does not need an existence check", () => {
-    test("#when resolving #then no follow up probe runs", async () => {
+  describe("#given a session without output that does not need existence verification", () => {
+    test("#when resolving #then no follow-up probe runs", async () => {
       //#given
-      const todos = createProbeRecorder("todo")
-      const existence = createProbeRecorder("existence")
+      const calls: string[] = []
+      const batch = startPollSessionProbes([{ sessionID: "ses-1", requiresExistenceCheck: false }], {
+        resolvers: createResolvers({
+          validateSessionHasOutput: async () => false,
+          checkSessionTodos: async () => {
+            calls.push("todos")
+            return false
+          },
+          verifySessionExists: async () => {
+            calls.push("existence")
+            return true
+          },
+        }),
+      })
 
       //#when
-      const results = await resolvePollSessionProbes(
-        targetsFor(["ses-1"], false),
-        createResolvers({
-          validateSessionHasOutput: async () => false,
-          checkSessionTodos: todos.resolving(false),
-          verifySessionExists: existence.resolving(true),
-        }),
-      )
+      const result = await getProbeResult(batch, "ses-1")
 
       //#then
-      expect(todos.calls).toEqual([])
-      expect(existence.calls).toEqual([])
-      expect(results.hasOutput.get("ses-1")).toBe(false)
+      expect(calls).toEqual([])
+      expect(result.hasOutput).toBe(false)
     })
   })
 
-  describe("#given the same session appears twice with different existence flags", () => {
-    test("#when resolving #then each probe runs once and the existence check is kept", async () => {
+  describe("#given duplicate sessions with different existence requirements", () => {
+    test("#when resolving #then one output probe retains the existence requirement", async () => {
       //#given
-      const output = createProbeRecorder("output")
-      const existence = createProbeRecorder("existence")
+      let outputCalls = 0
+      let existenceCalls = 0
       const targets: PollProbeTarget[] = [
         { sessionID: "ses-1", requiresExistenceCheck: false },
         { sessionID: "ses-1", requiresExistenceCheck: true },
       ]
+      const batch = startPollSessionProbes(targets, {
+        resolvers: createResolvers({
+          validateSessionHasOutput: async () => {
+            outputCalls += 1
+            return false
+          },
+          verifySessionExists: async () => {
+            existenceCalls += 1
+            return true
+          },
+        }),
+      })
 
       //#when
-      await resolvePollSessionProbes(
-        targets,
-        createResolvers({
-          validateSessionHasOutput: output.resolving(false),
-          verifySessionExists: existence.resolving(true),
-        }),
-      )
+      await getProbeResult(batch, "ses-1")
 
       //#then
-      expect(output.calls).toEqual(["output:ses-1"])
-      expect(existence.calls).toEqual(["existence:ses-1"])
+      expect(outputCalls).toBe(1)
+      expect(existenceCalls).toBe(1)
     })
   })
 
-  describe("#given one output probe rejects", () => {
-    test("#when resolving #then the entry stays unset and the other sessions still resolve", async () => {
+  describe("#given a rejecting output probe", () => {
+    test("#when resolving #then its result is unset and other sessions keep resolving", async () => {
       //#given
-      const output = createProbeRecorder("output")
       const reported: string[] = []
+      const batch = startPollSessionProbes([
+        { sessionID: "ses-failing", requiresExistenceCheck: false },
+        { sessionID: "ses-ready", requiresExistenceCheck: false },
+      ], {
+        resolvers: createResolvers({
+          validateSessionHasOutput: async (sessionID) => {
+            if (sessionID === "ses-failing") {
+              throw new Error("probe failure")
+            }
+            return true
+          },
+        }),
+        onProbeError: (sessionID, probe) => reported.push(`${probe}:${sessionID}`),
+      })
 
       //#when
-      const results = await resolvePollSessionProbes(
-        targetsFor(["ses-1", "ses-2"]),
-        createResolvers({ validateSessionHasOutput: output.rejecting("ses-1", true) }),
-        (sessionID) => {
-          reported.push(sessionID)
-        },
-      )
+      const [failing, ready] = await Promise.all([
+        getProbeResult(batch, "ses-failing"),
+        getProbeResult(batch, "ses-ready"),
+      ])
 
       //#then
-      expect(results.hasOutput.has("ses-1")).toBe(false)
-      expect(results.hasOutput.get("ses-2")).toBe(true)
-      expect(reported).toEqual(["ses-1"])
+      expect(failing.hasOutput).toBeUndefined()
+      expect(ready.hasOutput).toBe(true)
+      expect(reported).toEqual(["output:ses-failing"])
     })
   })
 
   describe("#given no targets", () => {
-    test("#when resolving #then no probe runs", async () => {
+    test("#when starting probes #then the result map is empty", () => {
       //#given
-      const output = createProbeRecorder("output")
+      const batch = startPollSessionProbes([], { resolvers: createResolvers() })
 
       //#when
-      const results = await resolvePollSessionProbes(
-        [],
-        createResolvers({ validateSessionHasOutput: output.resolving(true) }),
-      )
+      const resultCount = batch.resultsBySession.size
 
       //#then
-      expect(output.calls).toEqual([])
-      expect(results.hasOutput.size).toBe(0)
+      expect(resultCount).toBe(0)
     })
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/poll-session-probes.ts
+++ b/packages/omo-opencode/src/features/background-agent/poll-session-probes.ts
@@ -1,0 +1,84 @@
+export interface PollProbeTarget {
+  sessionID: string
+  requiresExistenceCheck: boolean
+}
+
+export interface PollProbeResolvers {
+  validateSessionHasOutput: (sessionID: string) => Promise<boolean>
+  verifySessionExists: (sessionID: string) => Promise<boolean>
+  checkSessionTodos: (sessionID: string) => Promise<boolean>
+}
+
+export interface PollProbeResults {
+  hasOutput: ReadonlyMap<string, boolean>
+  sessionExists: ReadonlyMap<string, boolean>
+  hasIncompleteTodos: ReadonlyMap<string, boolean>
+}
+
+function dedupeTargets(targets: readonly PollProbeTarget[]): Map<string, boolean> {
+  const existenceRequired = new Map<string, boolean>()
+  for (const target of targets) {
+    const previous = existenceRequired.get(target.sessionID)
+    existenceRequired.set(target.sessionID, (previous ?? false) || target.requiresExistenceCheck)
+  }
+  return existenceRequired
+}
+
+export type PollProbeName = "output" | "todos" | "existence"
+
+/**
+ * Resolves the read-only session probes a polling tick needs, in two parallel waves
+ * instead of one round trip per task.
+ *
+ * A probe that rejects leaves its entry unset. Callers treat an unset entry as
+ * "unresolved this tick" and skip the task, which is what the previous per-task
+ * try/catch did.
+ */
+export async function resolvePollSessionProbes(
+  targets: readonly PollProbeTarget[],
+  resolvers: PollProbeResolvers,
+  onProbeError?: (sessionID: string, probe: PollProbeName, error: unknown) => void,
+): Promise<PollProbeResults> {
+  const hasOutput = new Map<string, boolean>()
+  const sessionExists = new Map<string, boolean>()
+  const hasIncompleteTodos = new Map<string, boolean>()
+
+  if (targets.length === 0) {
+    return { hasOutput, sessionExists, hasIncompleteTodos }
+  }
+
+  const existenceRequired = dedupeTargets(targets)
+  const sessionIDs = [...existenceRequired.keys()]
+
+  await Promise.all(sessionIDs.map(async (sessionID) => {
+    try {
+      hasOutput.set(sessionID, await resolvers.validateSessionHasOutput(sessionID))
+    } catch (error) {
+      onProbeError?.(sessionID, "output", error)
+    }
+  }))
+
+  await Promise.all(sessionIDs.map(async (sessionID) => {
+    const outputResult = hasOutput.get(sessionID)
+    if (outputResult === undefined) return
+
+    if (outputResult) {
+      try {
+        hasIncompleteTodos.set(sessionID, await resolvers.checkSessionTodos(sessionID))
+      } catch (error) {
+        onProbeError?.(sessionID, "todos", error)
+      }
+      return
+    }
+
+    if (existenceRequired.get(sessionID) !== true) return
+
+    try {
+      sessionExists.set(sessionID, await resolvers.verifySessionExists(sessionID))
+    } catch (error) {
+      onProbeError?.(sessionID, "existence", error)
+    }
+  }))
+
+  return { hasOutput, sessionExists, hasIncompleteTodos }
+}

--- a/packages/omo-opencode/src/features/background-agent/poll-session-probes.ts
+++ b/packages/omo-opencode/src/features/background-agent/poll-session-probes.ts
@@ -9,10 +9,25 @@ export interface PollProbeResolvers {
   checkSessionTodos: (sessionID: string) => Promise<boolean>
 }
 
-export interface PollProbeResults {
-  hasOutput: ReadonlyMap<string, boolean>
-  sessionExists: ReadonlyMap<string, boolean>
-  hasIncompleteTodos: ReadonlyMap<string, boolean>
+export const MAX_POLL_PROBE_CONCURRENCY = 8
+export const POLL_PROBE_TIMEOUT_MS = 2_500
+
+export interface PollSessionProbeResult {
+  readonly hasOutput?: boolean
+  readonly sessionExists?: boolean
+  readonly hasIncompleteTodos?: boolean
+}
+
+export interface PollSessionProbeBatch {
+  readonly resultsBySession: ReadonlyMap<string, Promise<PollSessionProbeResult>>
+}
+
+export interface PollSessionProbeOptions {
+  readonly resolvers: PollProbeResolvers
+  readonly onProbeError?: (sessionID: string, probe: PollProbeName, error: unknown) => void
+  /** Optional overrides retain production's bounded defaults. */
+  readonly concurrency?: number
+  readonly timeoutMs?: number
 }
 
 function dedupeTargets(targets: readonly PollProbeTarget[]): Map<string, boolean> {
@@ -26,59 +41,123 @@ function dedupeTargets(targets: readonly PollProbeTarget[]): Map<string, boolean
 
 export type PollProbeName = "output" | "todos" | "existence"
 
-/**
- * Resolves the read-only session probes a polling tick needs, in two parallel waves
- * instead of one round trip per task.
- *
- * A probe that rejects leaves its entry unset. Callers treat an unset entry as
- * "unresolved this tick" and skip the task, which is what the previous per-task
- * try/catch did.
- */
-export async function resolvePollSessionProbes(
-  targets: readonly PollProbeTarget[],
-  resolvers: PollProbeResolvers,
-  onProbeError?: (sessionID: string, probe: PollProbeName, error: unknown) => void,
-): Promise<PollProbeResults> {
-  const hasOutput = new Map<string, boolean>()
-  const sessionExists = new Map<string, boolean>()
-  const hasIncompleteTodos = new Map<string, boolean>()
+class PollProbeTimeoutError extends Error {
+  readonly name = "PollProbeTimeoutError"
 
-  if (targets.length === 0) {
-    return { hasOutput, sessionExists, hasIncompleteTodos }
+  constructor(timeoutMs: number) {
+    super(`poll probe timed out after ${timeoutMs}ms`)
+  }
+}
+
+function withProbeTimeout<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new PollProbeTimeoutError(timeoutMs)), timeoutMs)
+    void operation().then(
+      (value) => {
+        clearTimeout(timeout)
+        resolve(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timeout)
+        reject(error)
+      },
+    )
+  })
+}
+
+interface ProbeSessionContext {
+  readonly options: PollSessionProbeOptions
+  readonly timeoutMs: number
+}
+
+async function probeSession(
+  sessionID: string,
+  requiresExistenceCheck: boolean,
+  context: ProbeSessionContext,
+): Promise<PollSessionProbeResult> {
+  const { resolvers, onProbeError } = context.options
+  let hasOutput: boolean
+  try {
+    hasOutput = await withProbeTimeout(
+      () => resolvers.validateSessionHasOutput(sessionID),
+      context.timeoutMs,
+    )
+  } catch (error) {
+    onProbeError?.(sessionID, "output", error)
+    return {}
   }
 
+  if (hasOutput) {
+    try {
+      return {
+        hasOutput,
+        hasIncompleteTodos: await withProbeTimeout(
+          () => resolvers.checkSessionTodos(sessionID),
+          context.timeoutMs,
+        ),
+      }
+    } catch (error) {
+      onProbeError?.(sessionID, "todos", error)
+      return { hasOutput }
+    }
+  }
+
+  if (!requiresExistenceCheck) {
+    return { hasOutput }
+  }
+
+  try {
+    return {
+      hasOutput,
+      sessionExists: await withProbeTimeout(
+        () => resolvers.verifySessionExists(sessionID),
+        context.timeoutMs,
+      ),
+    }
+  } catch (error) {
+    onProbeError?.(sessionID, "existence", error)
+    return { hasOutput }
+  }
+}
+
+/**
+ * Starts bounded read-only output and follow-up probes. A worker owns one session's
+ * output-then-follow-up chain, so a slow session never creates a global wave barrier.
+ * Eight concurrent sessions keep polling responsive without multiplying full-history
+ * reads into an unbounded request burst.
+ */
+export function startPollSessionProbes(
+  targets: readonly PollProbeTarget[],
+  options: PollSessionProbeOptions,
+): PollSessionProbeBatch {
   const existenceRequired = dedupeTargets(targets)
   const sessionIDs = [...existenceRequired.keys()]
+  const resultsBySession = new Map<string, Promise<PollSessionProbeResult>>()
+  const resultResolvers = new Map<string, (result: PollSessionProbeResult) => void>()
+  const context: ProbeSessionContext = {
+    options,
+    timeoutMs: options.timeoutMs ?? POLL_PROBE_TIMEOUT_MS,
+  }
 
-  await Promise.all(sessionIDs.map(async (sessionID) => {
-    try {
-      hasOutput.set(sessionID, await resolvers.validateSessionHasOutput(sessionID))
-    } catch (error) {
-      onProbeError?.(sessionID, "output", error)
+  for (const sessionID of sessionIDs) {
+    resultsBySession.set(sessionID, new Promise((resolve) => {
+      resultResolvers.set(sessionID, resolve)
+    }))
+  }
+
+  let nextSessionIndex = 0
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const sessionID = sessionIDs[nextSessionIndex]
+      nextSessionIndex += 1
+      if (!sessionID) return
+      const result = await probeSession(sessionID, existenceRequired.get(sessionID) === true, context)
+      resultResolvers.get(sessionID)?.(result)
     }
-  }))
+  }
+  const concurrency = Math.max(options.concurrency ?? MAX_POLL_PROBE_CONCURRENCY, 1)
+  const workerCount = Math.min(concurrency, sessionIDs.length)
+  void Promise.all(Array.from({ length: workerCount }, worker))
 
-  await Promise.all(sessionIDs.map(async (sessionID) => {
-    const outputResult = hasOutput.get(sessionID)
-    if (outputResult === undefined) return
-
-    if (outputResult) {
-      try {
-        hasIncompleteTodos.set(sessionID, await resolvers.checkSessionTodos(sessionID))
-      } catch (error) {
-        onProbeError?.(sessionID, "todos", error)
-      }
-      return
-    }
-
-    if (existenceRequired.get(sessionID) !== true) return
-
-    try {
-      sessionExists.set(sessionID, await resolvers.verifySessionExists(sessionID))
-    } catch (error) {
-      onProbeError?.(sessionID, "existence", error)
-    }
-  }))
-
-  return { hasOutput, sessionExists, hasIncompleteTodos }
+  return { resultsBySession }
 }


### PR DESCRIPTION
## Problem

With many background tasks alive, poll ticks stop keeping up and completion detection lags badly. The more idle sessions there are, the worse it gets, which looks from the outside like a global rate limit or a stalled event loop.

## Root cause

`pollRunningTasks()` walked running tasks in a sequential `for` loop and awaited the completion probes inline, one task at a time. Each idle session could cost two serial round-trips (`validateSessionHasOutput`, then `checkSessionTodos` or `verifySessionExists`), so probe depth was O(idle tasks) per tick. With 40 idle tasks that is up to 80 serial round-trips inside a single 3 s tick, while `pollingInFlight` holds off the next one.

This is provider agnostic. It is not a rate limit and not a model problem, it is serial fan-out in the poll path.

## Fix

Split the poll tick into three phases:

1. `collectPollCompletionCandidates` walks tasks synchronously and classifies each one as terminal or probe. No awaits, so no session can block classification of another.
2. `startPollSessionProbes` (new `poll-session-probes.ts`) runs the probes as a bounded worker pool across sessions. Each session keeps its own sequential chain, so probe ordering per session is unchanged, but distinct sessions now overlap.
3. `resolvePollCompletionCandidates` consumes the per-session results and applies completion.

Probe concurrency is capped at `MAX_POLL_PROBE_CONCURRENCY = 8` and every individual probe is bounded by `POLL_PROBE_TIMEOUT_MS = 2_500`. A probe that fails or times out degrades to a partial result, which surfaces as "unresolved" and defers to the next tick. A failed probe can never falsely complete or fail a task.

Behavior that is deliberately preserved: per-session probe ordering, the `pollingInFlight` re-entry guard, terminal candidates short-circuiting without any probe, and the existing crash-detection rule that requires `hasOutput === false` and the session-gone threshold and `sessionExists === false` together.

## Tests

`manager.polling.parallel-probes.test.ts` pins the actual regression by recording `maxInFlight` across a tick. Against `dev` it fails with `Expected: 5, Received: 1`, which is the serial behavior. Supporting suites cover the worker pool directly (`poll-session-probes.test.ts`, `poll-session-probes.concurrent.test.ts`) and the manager guards, fan-out and todo paths (`manager.polling.parallel-probes.guards.test.ts`, `.fanout.test.ts`, `.todos.test.ts`, `.order.test.ts`). All deferred gates in these tests are deterministic, with no `setTimeout` sleeps.

## Verification

- `bunx tsgo --noEmit -p tsconfig.json` clean
- `bun test src/features/background-agent/` 784 pass, 0 fail, 71 files

## Review

The first draft of this change was put through two independent adversarial reviews before this revision. They raised a stale-attempt race on the completion path, todo-cache staleness, unbounded probe fan-out, missing per-probe timeouts, shutdown not being honored mid-resolution, and oversized test files. Every one of those is addressed here: the completion path re-checks `isCurrentPollCompletionCandidate` after each await, shutdown is checked before probes start and again inside the resolution loop, fan-out is capped, every probe carries a timeout, and the integration suite is split so each file stays under the 200 LOC guideline.
