### PR TITLE
feat(release): build the release body from the stamped changelog section

### DIFF
--- a/.agents/command/publish.md
+++ b/.agents/command/publish.md
@@ -203,22 +203,30 @@ NEW_VERSION=$(node -p "require('./package.json').version")
 gh release view "v${NEW_VERSION}" --json tagName,url --jq '{tag: .tagName, url: .url}'
 ```
 
-**After verifying, generate a local preview of the auto-generated content:**
+**Release notes are written BEFORE the release, not after.**
+
+The release body is extracted from the `CHANGELOG.md` section for this version. Author the user-facing
+notes under `## [Unreleased]` and land them before dispatching `/publish`; release-state preparation
+stamps that heading into `## [<version>] - <UTC date>` and commits it with the release state, so the
+published commit already carries its own notes.
+
+Preview exactly what the release body will be:
 
 ```bash
-bun run script/generate-changelog.ts
+bun run script/generate-changelog.ts > /tmp/contributors.md
+bun run script/print-release-notes.ts "${NEW_VERSION}" /tmp/contributors.md
 ```
 
 <agent-instruction>
 After running the preview, present the output to the user and say:
 
-> **The following content is ALREADY included in the release automatically:**
-> - Commit changelog (grouped by feat/fix/refactor)
-> - Contributor thank-you messages (for non-team contributors)
+> **This is the exact body the release will publish:** the notes you authored under `[Unreleased]`,
+> then contributor thank-yous for non-team contributors, then the install footer.
 >
-> You do NOT need to write any of this. It's handled.
+> Both steps are fail-closed: an absent, empty, or duplicated section aborts the release instead of
+> publishing blank notes, and re-stamping a version that already has a section is refused.
 >
-> **For all release types**, an enhanced summary is **required** — I'll draft one in the next step.
+> If the `[Unreleased]` section is empty, STOP and write the notes first — the release cannot proceed.
 
 **APPROVAL GATE (single, binary):** The user's initial publish request with a named bump type IS the only approval this workflow requires. Do NOT wait for a separate acknowledgement here. Present the preview, then IMMEDIATELY proceed to Step 6. The only exception: if the user explicitly said "let me review the changelog before you continue" (or equivalent), stop and wait. Otherwise continue without ending the turn.
 </agent-instruction>

--- a/.agents/skills/publish/SKILL.md
+++ b/.agents/skills/publish/SKILL.md
@@ -202,22 +202,30 @@ NEW_VERSION=$(node -p "require('./package.json').version")
 gh release view "v${NEW_VERSION}" --json tagName,url --jq '{tag: .tagName, url: .url}'
 ```
 
-**After verifying, generate a local preview of the auto-generated content:**
+**Release notes are written BEFORE the release, not after.**
+
+The release body is extracted from the `CHANGELOG.md` section for this version. Author the user-facing
+notes under `## [Unreleased]` and land them before dispatching `/publish`; release-state preparation
+stamps that heading into `## [<version>] - <UTC date>` and commits it with the release state, so the
+published commit already carries its own notes.
+
+Preview exactly what the release body will be:
 
 ```bash
-bun run script/generate-changelog.ts
+bun run script/generate-changelog.ts > /tmp/contributors.md
+bun run script/print-release-notes.ts "${NEW_VERSION}" /tmp/contributors.md
 ```
 
 <agent-instruction>
 After running the preview, present the output to the user and say:
 
-> **The following content is ALREADY included in the release automatically:**
-> - Commit changelog (grouped by feat/fix/refactor)
-> - Contributor thank-you messages (for non-team contributors)
+> **This is the exact body the release will publish:** the notes you authored under `[Unreleased]`,
+> then contributor thank-yous for non-team contributors, then the install footer.
 >
-> You do NOT need to write any of this. It's handled.
+> Both steps are fail-closed: an absent, empty, or duplicated section aborts the release instead of
+> publishing blank notes, and re-stamping a version that already has a section is refused.
 >
-> **For all release types**, an enhanced summary is **required** — I'll draft one in the next step.
+> If the `[Unreleased]` section is empty, STOP and write the notes first — the release cannot proceed.
 
 **APPROVAL GATE (single, binary):** The user's initial publish request with a named bump type IS the only approval this workflow requires. Do NOT wait for a separate acknowledgement here. Present the preview, then IMMEDIATELY proceed to Step 6. The only exception: if the user explicitly said "let me review the changelog before you continue" (or equivalent), stop and wait. Otherwise continue without ending the turn.
 </agent-instruction>

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -472,6 +472,9 @@ jobs:
           jq --arg v "$VERSION" '.version = $v' packages/omo-senpi/package.json > tmp.json && mv tmp.json packages/omo-senpi/package.json
           node packages/omo-senpi/plugin/scripts/sync-version.mjs
           node packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs
+          # Stamp the authored ## [Unreleased] notes into this release's section so the released
+          # commit carries the notes the GitHub release body is later extracted from.
+          bun run script/stamp-release-changelog.ts "$VERSION"
           npm --prefix packages/omo-codex/plugin install --package-lock-only --ignore-scripts --no-audit --fund=false
           bun install --lockfile-only
 
@@ -481,7 +484,7 @@ jobs:
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add package.json packages/omo-native/package.json packages/oh-my-opencode-*/package.json packages/omo-senpi/package.json packages/omo-senpi/plugin/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/package-lock.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
+          git add CHANGELOG.md package.json packages/omo-native/package.json packages/oh-my-opencode-*/package.json packages/omo-senpi/package.json packages/omo-senpi/plugin/package.json packages/omo-codex/package.json packages/omo-codex/plugin/package.json packages/omo-codex/plugin/package-lock.json packages/omo-codex/plugin/.codex-plugin/plugin.json packages/omo-codex/plugin/components/*/package.json packages/omo-codex/plugin/hooks/*.json packages/omo-codex/plugin/components/*/hooks/hooks.json bun.lock
           git add -f packages/omo-senpi/plugin/extensions
           git diff --cached --quiet || git commit -m "release: v${VERSION}"
 
@@ -1041,11 +1044,17 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Generate changelog
-        run: |
-          bun run script/generate-changelog.ts > /tmp/changelog.md
-          cat /tmp/changelog.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.release-metadata.outputs.version }}
+        run: |
+          # The release body comes from the CHANGELOG section stamped into the released commit,
+          # so the notes are reviewed in the release PR rather than written after publication.
+          # Fail-closed: a missing or empty section aborts before the release is created.
+          set -euo pipefail
+          bun run script/generate-changelog.ts > /tmp/contributors.md || true
+          bun run script/print-release-notes.ts "$VERSION" /tmp/contributors.md > /tmp/changelog.md
+          cat /tmp/changelog.md
 
 
       - name: Checkout LazyCodex marketplace

--- a/.opencode/command/publish.md
+++ b/.opencode/command/publish.md
@@ -203,22 +203,30 @@ NEW_VERSION=$(node -p "require('./package.json').version")
 gh release view "v${NEW_VERSION}" --json tagName,url --jq '{tag: .tagName, url: .url}'
 ```
 
-**After verifying, generate a local preview of the auto-generated content:**
+**Release notes are written BEFORE the release, not after.**
+
+The release body is extracted from the `CHANGELOG.md` section for this version. Author the user-facing
+notes under `## [Unreleased]` and land them before dispatching `/publish`; release-state preparation
+stamps that heading into `## [<version>] - <UTC date>` and commits it with the release state, so the
+published commit already carries its own notes.
+
+Preview exactly what the release body will be:
 
 ```bash
-bun run script/generate-changelog.ts
+bun run script/generate-changelog.ts > /tmp/contributors.md
+bun run script/print-release-notes.ts "${NEW_VERSION}" /tmp/contributors.md
 ```
 
 <agent-instruction>
 After running the preview, present the output to the user and say:
 
-> **The following content is ALREADY included in the release automatically:**
-> - Commit changelog (grouped by feat/fix/refactor)
-> - Contributor thank-you messages (for non-team contributors)
+> **This is the exact body the release will publish:** the notes you authored under `[Unreleased]`,
+> then contributor thank-yous for non-team contributors, then the install footer.
 >
-> You do NOT need to write any of this. It's handled.
+> Both steps are fail-closed: an absent, empty, or duplicated section aborts the release instead of
+> publishing blank notes, and re-stamping a version that already has a section is refused.
 >
-> **For all release types**, an enhanced summary is **required** — I'll draft one in the next step.
+> If the `[Unreleased]` section is empty, STOP and write the notes first — the release cannot proceed.
 
 **APPROVAL GATE (single, binary):** The user's initial publish request with a named bump type IS the only approval this workflow requires. Do NOT wait for a separate acknowledgement here. Present the preview, then IMMEDIATELY proceed to Step 6. The only exception: if the user explicitly said "let me review the changelog before you continue" (or equivalent), stop and wait. Otherwise continue without ending the turn.
 </agent-instruction>

--- a/script/changelog-release-notes.test.ts
+++ b/script/changelog-release-notes.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import {
+  assertUtcDate,
+  composeReleaseBody,
+  extractReleaseNotes,
+  stampUnreleased,
+} from "./changelog-release-notes"
+
+const CHANGELOG = [
+  "# Changelog",
+  "",
+  "## [Unreleased]",
+  "",
+  "### Added",
+  "",
+  "- a new thing",
+  "",
+  "## [5.0.0-beta.53] - 2026-09-10",
+  "",
+  "- an older thing",
+  "",
+].join("\n")
+
+describe("stampUnreleased", () => {
+  test("#given authored notes #when stamped #then a released section appears and Unreleased reopens empty", () => {
+    const stamped = stampUnreleased(CHANGELOG, "5.0.0-beta.54", "2026-09-11")
+    expect(stamped).toContain("## [5.0.0-beta.54] - 2026-09-11")
+    expect(stamped.indexOf("## [Unreleased]")).toBeLessThan(stamped.indexOf("## [5.0.0-beta.54]"))
+    expect(extractReleaseNotes(stamped, "5.0.0-beta.54")).toBe("### Added\n\n- a new thing")
+  })
+
+  test("#given an empty Unreleased section #when stamped #then it refuses", () => {
+    const empty = "# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n\n- old\n"
+    expect(() => stampUnreleased(empty, "2.0.0", "2026-09-11")).toThrow(/empty/)
+  })
+
+  test("#given the version already released #when stamped again #then it refuses", () => {
+    expect(() => stampUnreleased(CHANGELOG, "5.0.0-beta.53", "2026-09-11")).toThrow(/already contains/)
+  })
+
+  test("#given no Unreleased heading #when stamped #then it refuses", () => {
+    expect(() => stampUnreleased("# Changelog\n", "1.0.0", "2026-09-11")).toThrow(/no ## \[Unreleased\]/)
+  })
+
+  test("#given an impossible date #when stamped #then it refuses", () => {
+    expect(() => stampUnreleased(CHANGELOG, "9.9.9", "2026-02-30")).toThrow(/not a real calendar date/)
+    expect(() => assertUtcDate("2026-9-1")).toThrow(/YYYY-MM-DD/)
+  })
+})
+
+describe("extractReleaseNotes", () => {
+  test("#given a released section #when extracted #then only its body is returned", () => {
+    expect(extractReleaseNotes(CHANGELOG, "5.0.0-beta.53")).toBe("- an older thing")
+  })
+
+  test("#given a missing version #when extracted #then it fails closed", () => {
+    expect(() => extractReleaseNotes(CHANGELOG, "9.9.9")).toThrow(/no section/)
+  })
+
+  test("#given a duplicated section #when extracted #then it fails closed", () => {
+    const dup = CHANGELOG + "\n## [5.0.0-beta.53] - 2026-09-10\n\n- dupe\n"
+    expect(() => extractReleaseNotes(dup, "5.0.0-beta.53")).toThrow(/2 sections/)
+  })
+
+  test("#given an empty released section #when extracted #then it fails closed", () => {
+    const blank = "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n## [0.9.0] - 2025-12-01\n\n- old\n"
+    expect(() => extractReleaseNotes(blank, "1.0.0")).toThrow(/empty/)
+  })
+})
+
+describe("composeReleaseBody", () => {
+  test("#given notes, contributors and a footer #when composed #then order is notes, contributors, footer", () => {
+    const body = composeReleaseBody("### Added\n\n- thing", "**Thanks:**\n- @someone", "\`\`\`bash\nnpm i -g omo-ai@beta\n\`\`\`")
+    expect(body.indexOf("- thing")).toBeLessThan(body.indexOf("@someone"))
+    expect(body.indexOf("@someone")).toBeLessThan(body.indexOf("npm i -g"))
+    expect(body.endsWith("\n")).toBe(true)
+  })
+
+  test("#given no contributors #when composed #then no blank block is inserted", () => {
+    expect(composeReleaseBody("notes", "", "footer")).toBe("notes\n\nfooter\n")
+  })
+})

--- a/script/changelog-release-notes.ts
+++ b/script/changelog-release-notes.ts
@@ -1,0 +1,77 @@
+/**
+ * Release-note source of truth.
+ *
+ * The changelog is authored under `## [Unreleased]`. Release-state preparation stamps that
+ * heading into `## [<version>] - <UTC date>` and opens a fresh empty Unreleased block, so the
+ * released commit already carries the notes. The release job then extracts that exact section
+ * for the GitHub release body.
+ *
+ * Every operation is fail-closed: a missing, empty, or duplicated section throws rather than
+ * publishing a release with silently empty notes.
+ */
+
+const UNRELEASED_HEADING = "## [Unreleased]"
+
+/** `## [1.2.3] - 2026-09-11`, capturing the version token. */
+function releaseHeadingPattern(version: string): RegExp {
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  return new RegExp(`^## \\[${escaped}\\][^\\n]*$`, "m")
+}
+
+export function assertUtcDate(date: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) throw new Error(`release date must be YYYY-MM-DD, got: ${date}`)
+  const [year, month, day] = date.split("-").map(Number) as [number, number, number]
+  const utc = new Date(Date.UTC(year, month - 1, day))
+  if (utc.getUTCFullYear() !== year || utc.getUTCMonth() !== month - 1 || utc.getUTCDate() !== day) {
+    throw new Error(`release date is not a real calendar date: ${date}`)
+  }
+  return date
+}
+
+/**
+ * Stamp `## [Unreleased]` into a released section and reopen an empty Unreleased block.
+ * Idempotent by refusal: stamping a version that already exists throws.
+ */
+export function stampUnreleased(changelog: string, version: string, date: string): string {
+  assertUtcDate(date)
+  if (!version.trim()) throw new Error("version is required")
+  if (releaseHeadingPattern(version).test(changelog)) {
+    throw new Error(`changelog already contains a section for ${version}`)
+  }
+  const index = changelog.indexOf(UNRELEASED_HEADING)
+  if (index < 0) throw new Error("changelog has no ## [Unreleased] heading to stamp")
+  const body = sectionBodyAt(changelog, index + UNRELEASED_HEADING.length)
+  if (!body.trim()) throw new Error("refusing to stamp an empty ## [Unreleased] section")
+  return `${changelog.slice(0, index)}${UNRELEASED_HEADING}\n\n## [${version}] - ${date}${changelog.slice(index + UNRELEASED_HEADING.length)}`
+}
+
+/** Body text from `start` up to the next `## ` heading (or end of file). */
+function sectionBodyAt(changelog: string, start: number): string {
+  const rest = changelog.slice(start)
+  const next = rest.search(/^## /m)
+  return next < 0 ? rest : rest.slice(0, next)
+}
+
+/**
+ * Extract the released section for a version. Fail-closed: throws when the section is absent,
+ * empty, or duplicated, so a release can never publish blank notes.
+ */
+export function extractReleaseNotes(changelog: string, version: string): string {
+  const pattern = releaseHeadingPattern(version)
+  const matches = changelog.match(new RegExp(pattern.source, "gm")) ?? []
+  if (matches.length === 0) throw new Error(`changelog has no section for ${version}`)
+  if (matches.length > 1) throw new Error(`changelog has ${matches.length} sections for ${version}`)
+  const found = pattern.exec(changelog)
+  if (!found) throw new Error(`changelog has no section for ${version}`)
+  const body = sectionBodyAt(changelog, found.index + found[0].length).trim()
+  if (!body) throw new Error(`release section for ${version} is empty`)
+  return body
+}
+
+/** Release body = authored notes, then the contributor block, then the install footer. */
+export function composeReleaseBody(notes: string, contributors: string, installFooter: string): string {
+  const parts = [notes.trim()]
+  if (contributors.trim()) parts.push(contributors.trim())
+  if (installFooter.trim()) parts.push(installFooter.trim())
+  return `${parts.join("\n\n")}\n`
+}

--- a/script/omo-ai-publish-shape.test.ts
+++ b/script/omo-ai-publish-shape.test.ts
@@ -158,7 +158,7 @@ describe("omo-ai publish workflow shape", () => {
     expect(update.env?.OMO_AI_VERSION).toBe("${{ needs.release-metadata.outputs.omo_ai_version }}")
     expect(prepare.run).toContain(stampLine)
     expect(update.run).toContain(stampLine)
-    expect(prepare.run).toContain("git add package.json packages/omo-native/package.json ")
+    expect(prepare.run).toContain("git add CHANGELOG.md package.json packages/omo-native/package.json ")
   })
 
   test("builds and verifies the payload before stripping token auth", () => {

--- a/script/print-release-notes.ts
+++ b/script/print-release-notes.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env bun
+/** Release step: print the GitHub release body for <version>, fail-closed. */
+import { composeReleaseBody, extractReleaseNotes } from "./changelog-release-notes"
+
+const INSTALL_FOOTER = ["\`\`\`bash", "npm i -g omo-ai@beta", "\`\`\`"].join("\n")
+
+async function main(): Promise<void> {
+  const version = process.argv[2]
+  if (!version) {
+    console.error("usage: bun script/print-release-notes.ts <version> [contributors-file]")
+    process.exit(2)
+  }
+  const path = new URL("../CHANGELOG.md", import.meta.url)
+  const notes = extractReleaseNotes(await Bun.file(path).text(), version)
+  const contributorsFile = process.argv[3]
+  const contributors = contributorsFile ? await Bun.file(contributorsFile).text() : ""
+  process.stdout.write(composeReleaseBody(notes, contributors, INSTALL_FOOTER))
+}
+
+if (import.meta.main) await main()

--- a/script/stamp-release-changelog.ts
+++ b/script/stamp-release-changelog.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env bun
+/** Release-state step: stamp ## [Unreleased] into the released section for <version>. */
+import { stampUnreleased } from "./changelog-release-notes"
+
+async function main(): Promise<void> {
+  const version = process.argv[2]
+  const date = process.argv[3] ?? new Date().toISOString().slice(0, 10)
+  if (!version) {
+    console.error("usage: bun script/stamp-release-changelog.ts <version> [YYYY-MM-DD]")
+    process.exit(2)
+  }
+  const path = new URL("../CHANGELOG.md", import.meta.url)
+  const stamped = stampUnreleased(await Bun.file(path).text(), version, date)
+  await Bun.write(path, stamped)
+  console.error(`stamped ## [${version}] - ${date}`)
+}
+
+if (import.meta.main) await main()


### PR DESCRIPTION
Fixes #8118

## Summary
Release notes are now authored before the release and extracted from the changelog, instead of being a commit list that gets hand-edited after publication.

- Release-state preparation stamps `## [Unreleased]` into `## [<version>] - <UTC date>` and commits it, so the released commit already carries its own notes.
- The release job builds the GitHub body from that exact section, then appends contributor thank-yous and the install footer.
- `publish.md` (both byte-identical copies) now tells the operator to write the notes before dispatching.

## Fail-closed
Verified by exit code, not pipeline status:

- unknown version -> exit 1, zero stdout
- already-released version -> exit 1, changelog untouched
- empty `[Unreleased]`, duplicated section, impossible calendar date -> all refused

A release can no longer publish blank or duplicated notes.

## Verification
- 27 pass / 0 fail, `typecheck:script` exit 0
- real round-trip against the repository's actual changelog in a scratch copy, restored afterwards

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release notes are now authored in the changelog before the release and stamped into the released commit, instead of being a commit list hand-edited after publication. The GitHub release body is extracted from the stamped changelog section, then appends contributor thank-yous and the install footer.

**Fail-closed**
- An unknown or already-released version aborts with exit 1 and leaves the changelog untouched.
- A missing, empty, or duplicated section aborts instead of publishing blank notes.
- All three publish runbook copies direct operators to write notes before dispatching.
- All 27 tests pass and the real changelog round-trips successfully.

<sup>Written for commit 0fa641a598c677f67ad66ae3636d1a249633b120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

