### PR TITLE
fix(release): verify the release notes before anything publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -997,8 +997,42 @@ jobs:
           JOB_SUMMARY_NEXT: Check package existence probes first, then npm publish logs and the LazyCodex smoke section.
         run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
 
+  verify-release-notes:
+    runs-on: ubuntu-latest
+    needs: [release-metadata, prepare-release-state]
+    if: >-
+      always() &&
+      needs.release-metadata.result == 'success' &&
+      needs.prepare-release-state.result == 'success'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare-release-state.outputs.release_sha }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.2"
+      # Fail before the platform builds rather than after them: the release body is extracted
+      # from this commit's CHANGELOG section, so a source prepared without one can never publish.
+      - name: Verify the release notes exist on the prepared source
+        env:
+          VERSION: ${{ needs.release-metadata.outputs.version }}
+        run: bun run script/print-release-notes.ts "$VERSION" > /dev/null
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        env:
+          JOB_SUMMARY_TITLE: Release notes preflight
+          JOB_SUMMARY_STATUS: ${{ job.status }}
+          JOB_SUMMARY_DETAILS: |
+            - Extracts this version's CHANGELOG section from the prepared release source.
+            - Fails closed when the section is absent, empty, or duplicated.
+            - Runs before the platform builds so a source without notes cannot burn a tag.
+          JOB_SUMMARY_NEXT: Author the notes under [Unreleased] and prepare a fresh release state.
+        run: GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" bash .github/scripts/write-job-summary.sh
+
   publish-platform:
-    needs: [gate-reuse, preflight-trust, release-metadata, prepare-release-state]
+    needs: [gate-reuse, preflight-trust, release-metadata, prepare-release-state, verify-release-notes]
     if: >-
       always() &&
       github.repository == 'code-yeongyu/oh-my-openagent' &&

--- a/script/ci-job-summary-workflow.test.ts
+++ b/script/ci-job-summary-workflow.test.ts
@@ -45,6 +45,7 @@ const workflowExpectations = [
       "prepare-release-state",
       "dispatch-provenance-safe-publish",
       "publish-main",
+      "verify-release-notes",
       "release",
       "post-publish-verify",
     ],


### PR DESCRIPTION
Fixes #8118

## Why

The 5.0.0-beta.54 run published `omo-ai` to npm in `publish-main`, then failed in `release` because the prepared source carried no changelog section. The result is a half-published version: an npm package and a tag with no GitHub release.

The notes check ran too late to prevent that. This adds a `verify-release-notes` job that extracts the section from the **prepared release source** and blocks `publish-platform`, which `publish-main` transitively waits on. A source without notes now fails in seconds, before anything is published and before twelve platform builds run.

## Note on the straddle that caused it

beta.54's release state was prepared before the stamping step existed, and the second-phase dispatch deliberately skips preparation, so there was nothing to stamp. Releases prepared from now on carry their own notes.

## Verification

- targeted workflow-shape, job-summary, platform-workflow and release-notes suites: 38 pass / 0 fail
- the new job is registered in the workflow job inventory and writes a job summary, per the repo conventions
- full `bun test script/`: 577 pass, 1 pre-existing failure unrelated to this change — the generated Codex installer bundle embeds `5.0.0-beta.53` while the root is `5.0.0-beta.54`. It reproduces on clean `dev`; this branch touches only `publish.yml` and the job-summary inventory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8118 by adding a `verify-release-notes` preflight job so a release source without changelog notes blocks publishing before anything ships. Previously the notes check ran after `publish-main`, which let the 5.0.0-beta.54 run publish an npm package and tag with no GitHub release.

**Details**
- The job fails closed when the version's CHANGELOG section is absent, empty, or duplicated on the prepared release source.
- `publish-platform` now depends on `verify-release-notes`, so it runs before the platform builds.
- The workflow job-summary inventory was updated to include the new job.
- Full `bun test script/` passes except one pre-existing, unrelated failure that also reproduces on clean `dev`.

<sup>Written for commit d07bd9c5a8d2d6e0b31767942b774855d0ef0a50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

