### PR TITLE
fix(release): stop crediting release automation as a community contributor

### DIFF
--- a/script/generate-changelog.test.ts
+++ b/script/generate-changelog.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, test } from "bun:test"
-import { isExcludedReleaseNoteSubject, selectPreviousReleaseTag } from "./generate-changelog"
+import { isCommunityContributor, isExcludedReleaseNoteSubject, selectPreviousReleaseTag } from "./generate-changelog"
 
 describe("selectPreviousReleaseTag", () => {
   test("#given a beta target #when releases span channels #then the preceding beta is selected", () => {
@@ -46,5 +46,33 @@ describe("isExcludedReleaseNoteSubject", () => {
   ])("#given subject %p #when exclusion is checked #then excluded is %p", (subject, expected) => {
     // given / when / then
     expect(isExcludedReleaseNoteSubject(subject)).toBe(expected)
+  })
+})
+
+describe("isCommunityContributor", () => {
+  test("#given the release automation identity #when the footer is built #then it is not thanked as a community contributor", () => {
+    // given
+    const automation = "sisyphus-dev-ai"
+
+    // when
+    const credited = isCommunityContributor(automation)
+
+    // then
+    expect(credited).toBe(false)
+  })
+
+  test("#given maintainers and CI identities #when the footer is built #then none of them are credited", () => {
+    for (const login of ["code-yeongyu", "actions-user", "github-actions[bot]"]) {
+      expect(isCommunityContributor(login), `${login} must not be credited`).toBe(false)
+    }
+  })
+
+  test("#given any other bot account #when the footer is built #then it is not credited", () => {
+    expect(isCommunityContributor("dependabot[bot]")).toBe(false)
+    expect(isCommunityContributor("renovate[bot]")).toBe(false)
+  })
+
+  test("#given a genuine outside contributor #when the footer is built #then they are credited", () => {
+    expect(isCommunityContributor("minpeter")).toBe(true)
   })
 })

--- a/script/generate-changelog.ts
+++ b/script/generate-changelog.ts
@@ -3,7 +3,13 @@
 import { $ } from "bun"
 import { RELEASE_VERSION_PATTERN } from "./release-latest-flag"
 
-const TEAM = ["actions-user", "github-actions[bot]", "code-yeongyu"]
+const TEAM = ["actions-user", "github-actions[bot]", "code-yeongyu", "sisyphus-dev-ai"]
+
+// Release automation opens and merges the release-state pull request, so its commits land in every
+// release range. Crediting it as a community contributor misreports who wrote the release.
+export function isCommunityContributor(login: string): boolean {
+  return !TEAM.includes(login) && !login.endsWith("[bot]")
+}
 
 const EXCLUDED_PREFIX_PATTERN = /^(ignore:|test:|chore:|ci:|release:)/i
 const CONTAINED_SURFACE_PATTERN = /\bsenpi\b|\bpi-goal\b|\bpi-webfetch\b/i
@@ -73,7 +79,7 @@ async function getContributors(previousTag: string): Promise<string[]> {
       const title = message.split("\n")[0] ?? ""
       if (isExcludedReleaseNoteSubject(title)) continue
 
-      if (login && !TEAM.includes(login)) {
+      if (login && isCommunityContributor(login)) {
         if (!contributors.has(login)) contributors.set(login, [])
         contributors.get(login)?.push(title)
       }


### PR DESCRIPTION
## Why

The published v5.0.0-beta.55 release notes thank `@sisyphus-dev-ai` as a community contributor:

> **Thank you to 1 community contributor:**
> - @sisyphus-dev-ai

That account is the release automation. It opens and merges the release-state pull request, so its commit lands inside every release range and it will be credited on **every** release. This misreports who wrote the release on a public, permanent surface.

`TEAM` already excluded `actions-user`, `github-actions[bot]` and `code-yeongyu`, but not this identity.

## What changed

`isCommunityContributor` now excludes the automation identity and any `[bot]` account, so a future bot added to CI cannot silently appear in the credits.

## Verification

- RED: the automation-identity assertion fails before the fix.
- Mutation-checked, so the coverage is real rather than mirroring the implementation:
  - removing `sisyphus-dev-ai` from `TEAM` -> 1 failing test
  - removing the `[bot]` suffix guard -> 1 failing test
- GREEN: `bun test script/generate-changelog.test.ts` -> 20 pass / 0 fail
- A genuine outside contributor is still credited (asserted).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the release changelog from crediting the release automation account (`sisyphus-dev-ai`) as a community contributor. That account opens and merges the release pull request, so it appeared in every release's thank-you list.

The contributor filter now adds `sisyphus-dev-ai` to the team list and rejects any `[bot]`-suffixed login, so future CI bots can't silently show up in the credits.

<sup>Written for commit 67729eb6c02aad12093950eb6aedd2fad37932a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

