### PR TITLE
fix(omo-senpi): normalize changelog path to POSIX on Windows

### DIFF
--- a/packages/omo-senpi/src/install/local-launcher.ts
+++ b/packages/omo-senpi/src/install/local-launcher.ts
@@ -43,7 +43,7 @@ export function renderLocalLauncher(options: LocalLauncherOptions): string {
     userAgent: "omo",
     originator: "omo",
     changelog: {
-      path: join(options.pluginPath, "CHANGELOG.md"),
+      path: join(options.pluginPath, "CHANGELOG.md").replaceAll("\\", "/"),
     },
     // Same channel the published launcher declares, so a local install is never told to update
     // the engine it is pinned against.


### PR DESCRIPTION
## Problem

`renderLocalLauncher` uses `join()` to build the changelog path embedded in the brand JSON. On Windows CI runners, `join()` produces backslash separators (`\repo\packages\...`), which fails the brand identity assertion that expects POSIX paths (`/repo/packages/...`).

CI failure: https://github.com/code-yeongyu/oh-my-openagent/actions/runs/34636416817

## Fix

`.replaceAll('\\', '/')` normalizes the path to forward slashes, making the serialized brand JSON platform-agnostic.

## Test

`bun test packages/omo-senpi/src/install/local-launcher.test.ts` — 6/6 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes the changelog path in `renderLocalLauncher` to forward slashes so the serialized brand JSON is platform-agnostic and no longer breaks the brand identity assertion on Windows CI runners.

<sup>Written for commit ea2bf7007955bbd10b1cfba724391556b6f4deb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

