### PR TITLE
fix(background-agent): prevent cancellation lifecycle races

### DIFF
--- a/packages/omo-opencode/src/features/background-agent/cancel-task-cleanup.test.ts
+++ b/packages/omo-opencode/src/features/background-agent/cancel-task-cleanup.test.ts
@@ -135,6 +135,7 @@ describe("BackgroundManager.cancelTask cleanup", () => {
     // then
     expect(cancelled).toBe(false)
     expect(task.status).toBe("running")
+    expect(task.cancellationRequested).toBeUndefined()
     expect(getTaskMap(manager).get(task.id)).toBe(task)
     expect(getPendingByParent(manager).get(task.parentSessionId)).toEqual(new Set([task.id]))
   })
@@ -219,5 +220,213 @@ describe("BackgroundManager.cancelTask cleanup", () => {
     expect(cancelled).toBe(true)
     expect(concurrencyManager.getCount(concurrencyKey)).toBe(1)
     expect(manager.getTask(pendingTask.id)?.status).toBe("running")
+  })
+
+  test("#given cancellation is waiting for session abort #when session.idle arrives #then idle does not complete or re-abort the task", async () => {
+    let resolveAbort: (() => void) | undefined
+    let abortStarted: (() => void) | undefined
+    const abortPending = new Promise<void>((resolve) => { resolveAbort = resolve })
+    const abortStartedPromise = new Promise<void>((resolve) => { abortStarted = resolve })
+    let abortCalls = 0
+    const manager = createBackgroundManager(undefined, async () => {
+      abortCalls += 1
+      abortStarted?.()
+      await abortPending
+      return { data: true }
+    })
+    const task = createMockTask({
+      id: "task-cancel-idle-race",
+      parentSessionId: "parent-session-cancel-idle-race",
+      sessionId: "session-cancel-idle-race",
+    })
+
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+    Reflect.set(manager, "validateSessionHasOutput", async () => true)
+    Reflect.set(manager, "checkSessionTodos", async () => false)
+    let fallbackCalls = 0
+    Reflect.set(manager, "tryFallbackRetry", async () => {
+      fallbackCalls += 1
+      return true
+    })
+
+    const cancellation = manager.cancelTask(task.id, {
+      skipNotification: true,
+      source: "test",
+    })
+    await abortStartedPromise
+    manager.handleEvent({
+      type: "session.idle",
+      properties: { sessionID: task.sessionId },
+    })
+    manager.handleEvent({
+      type: "message.updated",
+      properties: {
+        info: {
+          sessionID: task.sessionId,
+          role: "assistant",
+          error: { name: "MessageAbortedError", message: "Aborted" },
+        },
+      },
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(task.status).toBe("running")
+    expect(task.cancellationRequested).toBe(true)
+    expect(abortCalls).toBe(1)
+    expect(fallbackCalls).toBe(0)
+
+    resolveAbort?.()
+    expect(await cancellation).toBe(true)
+    expect(task.status).toBe("cancelled")
+    expect(abortCalls).toBe(1)
+  })
+
+  test("#given cancellation is already in flight #when cancelTask is called again #then only the first request aborts and finalizes", async () => {
+    let resolveAbort: (() => void) | undefined
+    let abortStarted: (() => void) | undefined
+    const abortPending = new Promise<void>((resolve) => { resolveAbort = resolve })
+    const abortStartedPromise = new Promise<void>((resolve) => { abortStarted = resolve })
+    let abortCalls = 0
+    const manager = createBackgroundManager(undefined, async () => {
+      abortCalls += 1
+      abortStarted?.()
+      await abortPending
+      return { data: true }
+    })
+    const task = createMockTask({
+      id: "task-concurrent-cancel",
+      parentSessionId: "parent-session-concurrent-cancel",
+      sessionId: "session-concurrent-cancel",
+    })
+
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+
+    const firstCancellation = manager.cancelTask(task.id, { skipNotification: true, source: "first" })
+    await abortStartedPromise
+    const secondCancellation = manager.cancelTask(task.id, { skipNotification: true, source: "second" })
+
+    expect(await secondCancellation).toBe(false)
+    expect(abortCalls).toBe(1)
+
+    resolveAbort?.()
+    expect(await firstCancellation).toBe(true)
+    expect(task.status).toBe("cancelled")
+  })
+
+  test("#given cancellation abort fails while idle is suppressed #when abort failure completes #then the idle event is replayed", async () => {
+    let rejectAbort: (() => void) | undefined
+    let abortStarted: (() => void) | undefined
+    const abortPending = new Promise<void>((_, reject) => { rejectAbort = () => reject(new Error("abort failed")) })
+    const abortStartedPromise = new Promise<void>((resolve) => { abortStarted = resolve })
+    let abortCalls = 0
+    const manager = createBackgroundManager(undefined, async () => {
+      abortCalls += 1
+      if (abortCalls === 1) {
+        abortStarted?.()
+        await abortPending
+      }
+      return { data: true }
+    })
+    const task = createMockTask({
+      id: "task-replay-idle-after-abort-failure",
+      parentSessionId: "parent-session-replay-idle",
+      sessionId: "session-replay-idle",
+      startedAt: new Date(Date.now() - 10_000),
+    })
+
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+    Reflect.set(manager, "validateSessionHasOutput", async () => true)
+    Reflect.set(manager, "checkSessionTodos", async () => false)
+
+    const cancellation = manager.cancelTask(task.id, { skipNotification: true, source: "test" })
+    await abortStartedPromise
+    manager.handleEvent({ type: "session.idle", properties: { sessionID: task.sessionId } })
+    rejectAbort?.()
+
+    expect(await cancellation).toBe(false)
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(task.status).toBe("completed")
+    expect(abortCalls).toBe(2)
+  })
+
+  test("#given cancellation abort fails while assistant error is suppressed #when abort failure completes #then the assistant error is replayed", async () => {
+    let rejectAbort: (() => void) | undefined
+    let abortStarted: (() => void) | undefined
+    const abortPending = new Promise<void>((_, reject) => { rejectAbort = () => reject(new Error("abort failed")) })
+    const abortStartedPromise = new Promise<void>((resolve) => { abortStarted = resolve })
+    let fallbackCalls = 0
+    const manager = createBackgroundManager(undefined, async () => {
+      abortStarted?.()
+      await abortPending
+      return { data: true }
+    })
+    const task = createMockTask({
+      id: "task-replay-assistant-error-after-abort-failure",
+      parentSessionId: "parent-session-replay-assistant-error",
+      sessionId: "session-replay-assistant-error",
+    })
+
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+    Reflect.set(manager, "tryFallbackRetry", async () => {
+      fallbackCalls += 1
+      return true
+    })
+
+    const cancellation = manager.cancelTask(task.id, { skipNotification: true, source: "test" })
+    await abortStartedPromise
+    manager.handleEvent({
+      type: "message.updated",
+      properties: {
+        info: { sessionID: task.sessionId, role: "assistant", error: { name: "Retryable", message: "temporary" } },
+      },
+    })
+    rejectAbort?.()
+
+    expect(await cancellation).toBe(false)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(fallbackCalls).toBe(1)
+  })
+
+  test("#given cancellation abort fails while session error is suppressed #when abort failure completes #then the session error is replayed", async () => {
+    let rejectAbort: (() => void) | undefined
+    let abortStarted: (() => void) | undefined
+    const abortPending = new Promise<void>((_, reject) => { rejectAbort = () => reject(new Error("abort failed")) })
+    const abortStartedPromise = new Promise<void>((resolve) => { abortStarted = resolve })
+    const manager = createBackgroundManager(undefined, async () => {
+      abortStarted?.()
+      await abortPending
+      return { data: true }
+    })
+    const task = createMockTask({
+      id: "task-replay-session-error-after-abort-failure",
+      parentSessionId: "parent-session-replay-session-error",
+      sessionId: "session-replay-session-error",
+    })
+
+    getTaskMap(manager).set(task.id, task)
+    getPendingByParent(manager).set(task.parentSessionId, new Set([task.id]))
+    Reflect.set(manager, "verifySessionExists", async () => false)
+
+    const cancellation = manager.cancelTask(task.id, { skipNotification: true, source: "test" })
+    await abortStartedPromise
+    manager.handleEvent({
+      type: "session.error",
+      properties: { sessionID: task.sessionId, error: { name: "MessageAbortedError", message: "Aborted" } },
+    })
+    rejectAbort?.()
+
+    expect(await cancellation).toBe(false)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(task.status).toBe("error")
+    expect(task.error).toBe("Aborted")
   })
 })

--- a/packages/omo-opencode/src/features/background-agent/manager.ts
+++ b/packages/omo-opencode/src/features/background-agent/manager.ts
@@ -271,6 +271,7 @@ export class BackgroundManager {
   private completedTaskArchive: Map<string, BackgroundTask> = new Map()
   private completedTaskSummaries: Map<string, BackgroundTaskNotificationTask[]> = new Map()
   private idleDeferralTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+  private cancellationEvents: Map<string, Event[]> = new Map()
   private notificationQueueByParent: Map<string, Promise<void>> = new Map()
   private readonly parentWakeNotifier: ParentWakeNotifier
   private parentWakeTextDeltaBuffers: Map<string, string> = new Map()
@@ -1574,6 +1575,24 @@ The fallback retry session is now created and can be inspected directly.
     this.observedIncompleteTodosBySession.delete(sessionID)
   }
 
+  private deferCancellationEvent(task: BackgroundTask, event: Event): void {
+    const events = this.cancellationEvents.get(task.id) ?? []
+    if (!events.some((pendingEvent) => pendingEvent.type === event.type)) {
+      events.push(event)
+      this.cancellationEvents.set(task.id, events)
+    }
+  }
+
+  private replayCancellationEvents(taskID: string): void {
+    const events = this.cancellationEvents.get(taskID)
+    this.cancellationEvents.delete(taskID)
+    for (const event of events ?? []) this.handleEvent(event)
+  }
+
+  private discardCancellationEvents(taskID: string): void {
+    this.cancellationEvents.delete(taskID)
+  }
+
 
   private shouldHoldDispatchedParentWakeForTextDelta(
     eventType: string,
@@ -1672,6 +1691,10 @@ The fallback retry session is now created and can be inspected directly.
 
       const { task } = resolved
       if (task.status !== "running") return
+      if (task.cancellationRequested) {
+        this.deferCancellationEvent(task, event)
+        return
+      }
 
       const assistantError = info.error
       if (!assistantError) return
@@ -1820,6 +1843,11 @@ The fallback retry session is now created and can be inspected directly.
     if (event.type === "session.idle") {
       if (!props || typeof props !== "object") return
       const sessionID = resolveSessionEventID(props)
+      const resolved = sessionID ? this.resolveTaskAttemptBySession(sessionID) : undefined
+      if (resolved?.isCurrent && resolved.task.cancellationRequested) {
+        this.deferCancellationEvent(resolved.task, event)
+        return
+      }
       if (sessionID) {
         void this.enqueueNotificationForParent(sessionID, () => this.flushPendingParentWake(sessionID)).catch((error) => {
           log("[background-agent] Failed to flush pending parent wake:", { sessionID, error })
@@ -1857,6 +1885,14 @@ The fallback retry session is now created and can be inspected directly.
 
       const { task } = resolved
       if (task.status !== "running") return
+      if (task.cancellationRequested) {
+        this.deferCancellationEvent(task, event)
+        log("[background-agent] Ignoring session.error during task cancellation:", {
+          taskId: task.id,
+          sessionID,
+        })
+        return
+      }
 
       const errorObj = props?.error as { name?: string; message?: string } | undefined
       const errorName = errorObj?.name
@@ -2404,6 +2440,7 @@ The task was re-queued on a fallback model after a retryable failure.
     if (!task || (task.status !== "running" && task.status !== "pending")) {
       return false
     }
+    if (task.cancellationRequested) return false
 
     const source = options?.source ?? "cancel"
     const abortSession = options?.abortSession !== false
@@ -2429,9 +2466,21 @@ The task was re-queued on a fallback model after a retryable failure.
 
     const wasRunning = task.status === "running"
     if (wasRunning && abortSession && task.sessionId) {
+      task.cancellationRequested = true
+      log("[background-agent] Task cancellation requested:", {
+        taskId: task.id,
+        sessionID: task.sessionId,
+        source,
+      })
       const aborted = await this.abortSessionWithLogging(task.sessionId, `task cancellation (${source})`)
-      if (!aborted) return false
+      if (!aborted) {
+        task.cancellationRequested = undefined
+        this.replayCancellationEvents(task.id)
+        return false
+      }
 
+      task.cancellationRequested = undefined
+      this.discardCancellationEvents(task.id)
       clearDelegatedChildSessionBootstrap(task.sessionId)
       SessionCategoryRegistry.remove(task.sessionId)
     }
@@ -2550,7 +2599,7 @@ The task was re-queued on a fallback model after a retryable failure.
    */
   private async tryCompleteTask(task: BackgroundTask, source: string): Promise<boolean> {
     // Guard: Check if task is still running (could have been completed by another path)
-    if (task.status !== "running") {
+    if (task.status !== "running" || task.cancellationRequested) {
       log("[background-agent] Task already completed, skipping:", { taskId: task.id, status: task.status, source })
       return false
     }
@@ -2603,6 +2652,11 @@ The task was re-queued on a fallback model after a retryable failure.
         clearDelegatedChildSessionBootstrap(task.sessionId)
         SessionCategoryRegistry.remove(task.sessionId)
 
+        log("[background-agent] Task completion cleanup abort requested:", {
+          taskId: task.id,
+          sessionID: task.sessionId,
+          source,
+        })
         // Awaited to prevent dangling promise during subagent teardown (Bun/WebKit SIGABRT)
         await this.abortSessionWithLogging(task.sessionId, `task completion (${source})`)
 
@@ -3215,6 +3269,7 @@ The task was re-queued on a fallback model after a retryable failure.
     this.idleDeferralTimers.clear()
 
     this.parentWakeNotifier.shutdown()
+    this.cancellationEvents.clear()
 
     for (const sessionID of trackedSessionIDs) {
       subagentSessions.delete(sessionID)

--- a/packages/omo-opencode/src/features/background-agent/types.ts
+++ b/packages/omo-opencode/src/features/background-agent/types.ts
@@ -95,6 +95,8 @@ export interface BackgroundTask {
   /** ID of the currently active attempt */
   currentAttemptID?: string
 
+  cancellationRequested?: boolean
+
   /** Last message count for stability detection */
   lastMsgCount?: number
   /** Number of consecutive polls with stable message count */

--- a/packages/omo-opencode/src/hooks/runtime-fallback/constants.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/constants.ts
@@ -40,4 +40,4 @@ export const HOOK_NAME = "runtime-fallback"
  * practice) yet much shorter than the 30-minute outer poll timeout that
  * would otherwise be the only safety net.
  */
-export const DEFAULT_FIRST_PROMPT_WATCHDOG_MS = 90_000
+export const DEFAULT_FIRST_PROMPT_WATCHDOG_MS = 180_000

--- a/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
+++ b/packages/omo-opencode/src/hooks/runtime-fallback/first-prompt-watchdog.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import type { HookDeps, RuntimeFallbackPluginInput } from "./types"
 import type { AutoRetryHelpers } from "./auto-retry"
 import { subagentSessions } from "../../features/claude-code-session-state"
+import { DEFAULT_FIRST_PROMPT_WATCHDOG_MS } from "./constants"
 import { createFirstPromptWatchdog, observeEventForWatchdog, type FirstPromptWatchdog } from "./first-prompt-watchdog"
 
 const WATCHDOG_MS = 100
@@ -154,6 +155,10 @@ const PLUGIN_CONFIG_WITH_FALLBACK = {
 
 describe("first-prompt-watchdog", () => {
   let fakeTimers: FakeTimers | undefined
+
+  it("uses a three-minute default so slow first tokens can arrive before fallback", () => {
+    expect(DEFAULT_FIRST_PROMPT_WATCHDOG_MS).toBe(180_000)
+  })
 
   function getFakeTimers(): FakeTimers {
     if (!fakeTimers) {


### PR DESCRIPTION
## Summary

- Prevent explicit background-task cancellation from racing with idle, assistant-error, and session-error handling.
- Record cancellation intent before awaiting `session.abort()` and reject concurrent duplicate cancellation requests.
- Replay deferred lifecycle events when abort fails; discard them when cancellation succeeds; clear deferred state during shutdown.
- Extend the runtime-fallback first-prompt watchdog from 90 seconds to 3 minutes.

## Relationship to #7490

This is the companion PR to [#7490](https://github.com/code-yeongyu/oh-my-openagent/pull/7490), which remains open and unmerged. #7490 bounds todo continuation after retryable provider errors. Its implementation is not present in current `dev`; both fixes need to be checked after every OMO update until their upstream changes land.

This PR intentionally contains only the five source/test files for the cancellation and watchdog fixes. The #7490 provider-error continuation changes, global workstation configuration, canon files, generated bundles, and protected `opencode-claude` iterator changes are excluded.

## Root Cause

`BackgroundManager.cancelTask()` previously awaited the session abort before marking the task as cancelling. Event handlers could therefore observe a running task during the abort window and perform duplicate completion, abort, or fallback work. A single global `MessageAbortedError` suppression would be unsafe because normal completion also performs an expected cleanup abort.

## Verification

- Background-agent suite: `772 pass, 0 fail`.
- Runtime-fallback suite: `287 pass, 0 fail`.
- Cancellation-specific tests plus runtime-fallback: `296 pass, 0 fail`.
- `bun run typecheck`: passed.
- `bun run build`: passed.
- Local bundle normal-completion and explicit-cancellation canaries exited 0.
- `git diff --check`: passed; PR range contains exactly five intended files.

A single-process invocation loading the entire background-agent directory before runtime-fallback exposes 43 existing cross-suite test-isolation failures; the two suites pass independently and the changed cancellation tests pass with runtime-fallback. This is recorded for CI review rather than hidden or masked.

## Release Note

`v5.0.0-beta.55` already exists and is immutable. After this PR and #7490 are merged, the next prerelease should be `v5.0.0-beta.56` or the next available version through the repository `publish.yml` workflow. Do not republish or move beta.55.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents background-task cancellation from racing with idle, assistant-error, and session-error handling, and extends the runtime-fallback first-prompt watchdog from 90 seconds to 3 minutes. `cancelTask()` previously awaited the session abort before marking the task as cancelling, so lifecycle events could trigger duplicate completion, abort, or fallback work.

**Cancellation lifecycle**
- Cancellation intent is set before awaiting `session.abort()`; idle, assistant-error, and session-error handlers defer or ignore events while it's set.
- Deferred events replay if the abort fails and are discarded when it succeeds.
- A second cancel call while one is in flight returns `false` and does not abort again.

**Rollout**
- Companion PR #7490 (provider-error continuation) is not in `dev`; both fixes need re-checking after each OMO update until upstream lands.
- beta.55 is immutable; the next prerelease should be beta.56 via `publish.yml`.

<sup>Written for commit d63e1baef94f27a4f445937a9304f9b4deeb9dc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

