### PR TITLE
ci(publish): propagate LazyCodex prereleases and add a LazyCodex-only release mode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: true
+      lazycodex_only:
+        description: "Publish only LazyCodex (lazycodex-ai npm + Codex marketplace + LazyCodex GitHub release) from the base head, without stamping or publishing omo packages. Requires an explicit version."
+        required: false
+        type: boolean
+        default: false
       prepared_release_sha:
         description: "Internal: exact prepared source SHA for the provenance-bearing publish run."
         required: false
@@ -154,7 +159,9 @@ jobs:
       contents: read
     steps:
       - name: Require LazyCodex sync token
-        if: needs.release-metadata.outputs.dist_tag == ''
+        # Every channel that publishes lazycodex-ai also syncs the Codex marketplace mirror, so the
+        # token is required whenever LazyCodex is published, not only on stable releases.
+        if: inputs.publish_lazycodex == true
         env:
           LAZYCODEX_SYNC_TOKEN: ${{ secrets.LAZYCODEX_SYNC_TOKEN }}
         run: |
@@ -168,6 +175,7 @@ jobs:
           REPO: code-yeongyu/oh-my-openagent
           WORKFLOW_FILE: publish.yml
           PUBLISH_LAZYCODEX: ${{ inputs.publish_lazycodex }}
+          LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
         run: |
           OIDC_TOKEN=$(curl -sH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" \
@@ -179,14 +187,18 @@ jobs:
           fi
 
           PLATFORMS=(darwin-arm64 darwin-x64 darwin-x64-baseline linux-x64 linux-x64-baseline linux-arm64 linux-x64-musl linux-x64-musl-baseline linux-arm64-musl windows-x64 windows-x64-baseline windows-arm64)
-          ALL_PACKAGES=(oh-my-opencode oh-my-openagent omo-ai)
-          if [ "${PUBLISH_LAZYCODEX}" = "true" ]; then
-            ALL_PACKAGES+=(lazycodex-ai)
+          if [ "${LAZYCODEX_ONLY}" = "true" ]; then
+            ALL_PACKAGES=(lazycodex-ai)
+          else
+            ALL_PACKAGES=(oh-my-opencode oh-my-openagent omo-ai)
+            if [ "${PUBLISH_LAZYCODEX}" = "true" ]; then
+              ALL_PACKAGES+=(lazycodex-ai)
+            fi
+            for plat in "${PLATFORMS[@]}"; do
+              ALL_PACKAGES+=("oh-my-opencode-${plat}")
+              ALL_PACKAGES+=("oh-my-openagent-${plat}")
+            done
           fi
-          for plat in "${PLATFORMS[@]}"; do
-            ALL_PACKAGES+=("oh-my-opencode-${plat}")
-            ALL_PACKAGES+=("oh-my-openagent-${plat}")
-          done
 
           FAILED=()
           for pkg in "${ALL_PACKAGES[@]}"; do
@@ -239,10 +251,11 @@ jobs:
             echo "| Result | \`${{ job.status }}\` |"
             echo "| Workflow | \`${{ github.workflow }}\` |"
             echo "| LazyCodex publish | \`${{ inputs.publish_lazycodex }}\` |"
+            echo "| LazyCodex only | \`${{ inputs.lazycodex_only }}\` |"
             echo
             echo "### What this job checks"
             echo
-            echo "- Requires the LazyCodex sync token for stable releases."
+            echo "- Requires the LazyCodex sync token whenever LazyCodex is published."
             echo "- Verifies npm trusted-publisher mappings before release writes begin."
             echo
             echo "### If this fails"
@@ -273,7 +286,22 @@ jobs:
         env:
           RAW_VERSION: ${{ inputs.version }}
           BUMP: ${{ inputs.bump }}
+          PUBLISH_LAZYCODEX: ${{ inputs.publish_lazycodex }}
+          LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
         run: |
+          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+            # A LazyCodex-only release never bumps from the omo registry version and is
+            # meaningless without the lazycodex-ai publish it exists to ship.
+            if [ -z "$RAW_VERSION" ]; then
+              echo "::error::lazycodex_only requires an explicit version input."
+              exit 1
+            fi
+            if [ "$PUBLISH_LAZYCODEX" != "true" ]; then
+              echo "::error::lazycodex_only requires publish_lazycodex=true."
+              exit 1
+            fi
+          fi
+
           VERSION="$RAW_VERSION"
           if [ -z "$VERSION" ]; then
             PREV=$(curl -s https://registry.npmjs.org/oh-my-opencode/latest | jq -r '.version // "0.0.0"')
@@ -342,6 +370,7 @@ jobs:
             echo "| Result | \`${{ job.status }}\` |"
             echo "| Version | \`${{ steps.version.outputs.version || 'not calculated' }}\` |"
             echo "| Dist tag | \`${{ steps.version.outputs.dist_tag || 'latest' }}\` |"
+            echo "| LazyCodex only | \`${{ inputs.lazycodex_only }}\` |"
             echo "| Previous LazyCodex | \`${{ steps.version.outputs.previous_lazycodex_version || 'none' }}\` |"
             echo
             echo "### What this job checks"
@@ -398,6 +427,7 @@ jobs:
           OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
           RELEASE_REF: ${{ github.ref_name }}
           PREPARED_RELEASE_SHA: ${{ inputs.prepared_release_sha }}
+          LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
         run: |
           set -euo pipefail
 
@@ -418,6 +448,38 @@ jobs:
           git fetch origin "${BASE_REF}" --tags
 
           BASE_HEAD="$(git rev-parse "origin/${BASE_REF}")"
+
+          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+            # A LazyCodex-only release publishes the base head as-is: no omo manifest is stamped and no
+            # release commit lands on the base branch. The provenance-safe child is dispatched from the
+            # lazycodex-v<version> tag namespace so it never collides with an omo release tag, and a
+            # version number is refused when either namespace or npm already carries it, so one version
+            # can never map to two different lazycodex-ai payloads.
+            if git rev-parse -q --verify "refs/tags/lazycodex-v${VERSION}" >/dev/null; then
+              echo "::error::lazycodex-v${VERSION} already exists: a LazyCodex-only release already consumed this version. Bump to an unused version."
+              exit 1
+            fi
+            if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+              echo "::error::v${VERSION} already exists as an omo release tag; a LazyCodex-only release must not reuse an omo version number. Bump to an unused version."
+              exit 1
+            fi
+            NPM_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/lazycodex-ai/${VERSION}")
+            if [ "$NPM_STATUS" = "200" ]; then
+              echo "::error::lazycodex-ai@${VERSION} is already on npm; publishing a different tree under the same version is refused. Bump to an unused version."
+              exit 1
+            fi
+            echo "release_sha=${BASE_HEAD}" >> "$GITHUB_OUTPUT"
+            echo "needs_push=false" >> "$GITHUB_OUTPUT"
+            echo "LazyCodex-only release from origin/${BASE_REF} head ${BASE_HEAD}; no omo release state is stamped."
+            exit 0
+          fi
+
+          # A version consumed by a LazyCodex-only release already carries a lazycodex-ai payload built
+          # from a different tree; an omo release must never reuse that number.
+          if git rev-parse -q --verify "refs/tags/lazycodex-v${VERSION}" >/dev/null; then
+            echo "::error::lazycodex-v${VERSION} exists: this version was consumed by a LazyCodex-only release. Bump to an unused version so lazycodex-ai@${VERSION} keeps a single payload."
+            exit 1
+          fi
 
           # A release commit may only be REUSED when it is the current base head. A stamp that
           # sits behind the head belongs to an earlier, abandoned attempt: its tree predates every
@@ -639,6 +701,7 @@ jobs:
           BUMP: ${{ inputs.bump }}
           SKIP_PLATFORM: ${{ inputs.skip_platform }}
           PUBLISH_LAZYCODEX: ${{ inputs.publish_lazycodex }}
+          LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
@@ -648,23 +711,31 @@ jobs:
             exit 1
           fi
 
+          # LazyCodex-only releases tag the source under their own namespace so the omo release
+          # path can still refuse the number (and vice versa) instead of reusing a foreign tag.
+          RELEASE_TAG="v${VERSION}"
+          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+            RELEASE_TAG="lazycodex-v${VERSION}"
+          fi
+
           git fetch --force --tags
-          if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
-            TAG_SHA="$(git rev-list --max-count=1 "v${VERSION}")"
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
+            TAG_SHA="$(git rev-list --max-count=1 "${RELEASE_TAG}")"
             if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then
-              echo "::error::Existing tag v${VERSION} points to ${TAG_SHA}, not prepared release SHA ${RELEASE_SHA}."
+              echo "::error::Existing tag ${RELEASE_TAG} points to ${TAG_SHA}, not prepared release SHA ${RELEASE_SHA}."
               exit 1
             fi
           else
-            git tag "v${VERSION}" "$RELEASE_SHA"
-            git push origin "v${VERSION}"
+            git tag "${RELEASE_TAG}" "$RELEASE_SHA"
+            git push origin "${RELEASE_TAG}"
           fi
 
-          gh workflow run publish.yml --ref "v${VERSION}" \
+          gh workflow run publish.yml --ref "${RELEASE_TAG}" \
             -f "bump=${BUMP}" \
             -f "version=${VERSION}" \
             -f "skip_platform=${SKIP_PLATFORM}" \
             -f "publish_lazycodex=${PUBLISH_LAZYCODEX}" \
+            -f "lazycodex_only=${LAZYCODEX_ONLY}" \
             -f "prepared_release_sha=${RELEASE_SHA}"
 
       - name: Write job summary
@@ -694,7 +765,7 @@ jobs:
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success' &&
       needs.prepare-release-state.result == 'success' &&
-      (inputs.skip_platform == true || needs.publish-platform.result == 'success')
+      (inputs.skip_platform == true || inputs.lazycodex_only == true || needs.publish-platform.result == 'success')
     steps:
       - uses: actions/checkout@v7
         with:
@@ -720,6 +791,7 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Verify platform packages are published
+        if: inputs.lazycodex_only != true
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
         run: |
@@ -776,7 +848,13 @@ jobs:
         id: check
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
+          LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
         run: |
+          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "LazyCodex-only release: oh-my-opencode is not published"
+            exit 0
+          fi
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/oh-my-opencode/${VERSION}")
           if [ "$STATUS" = "200" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -789,7 +867,13 @@ jobs:
         id: check-openagent
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
+          LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
         run: |
+          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "LazyCodex-only release: oh-my-openagent is not published"
+            exit 0
+          fi
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/oh-my-openagent/${VERSION}")
           if [ "$STATUS" = "200" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -858,6 +942,11 @@ jobs:
           mv tmp.json packages/omo-codex/plugin/.codex-plugin/plugin.json
           jq --arg v "$VERSION" '.version = $v' packages/omo-codex/plugin/package.json > tmp.json
           mv tmp.json packages/omo-codex/plugin/package.json
+          # A LazyCodex-only release builds an unstamped tree: bring the component manifests and the
+          # LazyCodex(<version>) hook status messages to the release version too (no-op when the
+          # release commit already stamped them).
+          node packages/omo-codex/plugin/scripts/sync-version.mjs
+          node packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs
           npm --prefix packages/omo-codex/plugin ci
           bun run --cwd packages/omo-codex/plugin build
 
@@ -872,11 +961,11 @@ jobs:
         run: node script/verify-npm-payload.mjs
 
       - name: Build omo-ai payload
-        if: needs.release-metadata.outputs.already_published != 'true'
+        if: needs.release-metadata.outputs.already_published != 'true' && inputs.lazycodex_only != true
         run: bun run build:omo-native
 
       - name: Verify omo-ai payload
-        if: needs.release-metadata.outputs.already_published != 'true'
+        if: needs.release-metadata.outputs.already_published != 'true' && inputs.lazycodex_only != true
         run: node script/verify-omo-ai-payload.mjs
 
       - name: Strip token auth from .npmrc to force OIDC
@@ -962,7 +1051,7 @@ jobs:
           fi
 
       - name: Strip token auth before omo-ai publish
-        if: needs.release-metadata.outputs.already_published != 'true'
+        if: needs.release-metadata.outputs.already_published != 'true' && inputs.lazycodex_only != true
         run: |
           for f in .npmrc "$HOME/.npmrc"; do
             if [ -f "$f" ]; then
@@ -973,7 +1062,7 @@ jobs:
           done
 
       - name: Publish omo-ai (beta only)
-        if: needs.release-metadata.outputs.already_published != 'true'
+        if: needs.release-metadata.outputs.already_published != 'true' && inputs.lazycodex_only != true
         working-directory: packages/omo-native
         run: npm publish --ignore-scripts --access public --provenance --tag beta
 
@@ -1000,8 +1089,10 @@ jobs:
   verify-release-notes:
     runs-on: ubuntu-latest
     needs: [release-metadata, prepare-release-state]
+    # A LazyCodex-only release creates no omo GitHub release, so it has no CHANGELOG section to verify.
     if: >-
       always() &&
+      inputs.lazycodex_only != true &&
       needs.release-metadata.result == 'success' &&
       needs.prepare-release-state.result == 'success'
     steps:
@@ -1038,6 +1129,7 @@ jobs:
       github.repository == 'code-yeongyu/oh-my-openagent' &&
       inputs.prepared_release_sha != '' &&
       inputs.skip_platform != true &&
+      inputs.lazycodex_only != true &&
       needs.gate-reuse.result == 'success' &&
       needs.preflight-trust.result == 'success' &&
       needs.release-metadata.result == 'success' &&
@@ -1058,7 +1150,7 @@ jobs:
       needs.release-metadata.result == 'success' &&
       needs.prepare-release-state.result == 'success' &&
       needs.publish-main.result == 'success' &&
-      (inputs.skip_platform == true || needs.publish-platform.result == 'success')
+      (inputs.skip_platform == true || inputs.lazycodex_only == true || needs.publish-platform.result == 'success')
     steps:
       - uses: actions/checkout@v7
         with:
@@ -1078,6 +1170,7 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Generate changelog
+        if: inputs.lazycodex_only != true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.release-metadata.outputs.version }}
@@ -1091,8 +1184,11 @@ jobs:
           cat /tmp/changelog.md
 
 
+      # The marketplace mirror and the LazyCodex GitHub release follow every channel that publishes
+      # lazycodex-ai: the 5.0.0 line ships as 5.0.0-beta.N only, and a stable-only gate left Codex
+      # marketplace users on the last 4.x for months.
       - name: Checkout LazyCodex marketplace
-        if: needs.release-metadata.outputs.dist_tag == ''
+        if: inputs.publish_lazycodex == true
         uses: actions/checkout@v7
         with:
           repository: code-yeongyu/lazycodex
@@ -1101,7 +1197,7 @@ jobs:
           fetch-depth: 0
 
       - name: Sync LazyCodex Codex marketplace
-        if: needs.release-metadata.outputs.dist_tag == ''
+        if: inputs.publish_lazycodex == true
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
           LAZYCODEX_RELEASE_VERSION: ${{ needs.release-metadata.outputs.version }}
@@ -1110,6 +1206,8 @@ jobs:
           mv tmp.json packages/omo-codex/plugin/.codex-plugin/plugin.json
           jq --arg v "$VERSION" '.version = $v' packages/omo-codex/plugin/package.json > tmp.json
           mv tmp.json packages/omo-codex/plugin/package.json
+          node packages/omo-codex/plugin/scripts/sync-version.mjs
+          node packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs
           npm --prefix packages/omo-codex/plugin ci
           bun run build:git-bash-mcp
           bun run build:lsp-tools-mcp
@@ -1131,7 +1229,7 @@ jobs:
 
       - name: Resolve LazyCodex release payload
         id: lazycodex-release-state
-        if: needs.release-metadata.outputs.dist_tag == ''
+        if: inputs.publish_lazycodex == true
         env:
           PREVIOUS_LAZYCODEX_VERSION: ${{ needs.release-metadata.outputs.previous_lazycodex_version }}
         run: |
@@ -1166,9 +1264,12 @@ jobs:
           echo "previous_lazycodex_version=${PREVIOUS_LAZYCODEX_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Create LazyCodex GitHub release
-        if: needs.release-metadata.outputs.dist_tag == '' && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'
+        if: inputs.publish_lazycodex == true && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
+          DIST_TAG: ${{ needs.release-metadata.outputs.dist_tag }}
+          RELEASE_SHA: ${{ needs.prepare-release-state.outputs.release_sha }}
+          LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
           PREVIOUS_LAZYCODEX_VERSION: ${{ steps.lazycodex-release-state.outputs.previous_lazycodex_version }}
           GH_TOKEN: ${{ secrets.LAZYCODEX_SYNC_TOKEN }}
         run: |
@@ -1177,15 +1278,26 @@ jobs:
           # must fail the step instead of silently mis-assigning the badge.
           set -euo pipefail
 
+          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+            SOURCE_DESC="oh-my-openagent ${RELEASE_SHA} (LazyCodex-only release)"
+          else
+            SOURCE_DESC="oh-my-openagent v${VERSION} (${RELEASE_SHA})"
+          fi
           {
-            printf '%s\n' "Synced Codex Light marketplace payload from oh-my-openagent v${VERSION}."
+            printf '%s\n' "Synced Codex Light marketplace payload from ${SOURCE_DESC}."
             printf '%s\n' ""
             printf '%s\n' "Compared against: lazycodex-ai@${PREVIOUS_LAZYCODEX_VERSION}"
           } > /tmp/lazycodex-release-notes.md
 
-          LATEST_FLAG="$(gh release list --repo code-yeongyu/lazycodex --exclude-drafts --limit 1000 --json tagName --jq '.[].tagName' | bun script/release-latest-flag.ts "$VERSION")"
+          # A prerelease never takes the mirror's Latest badge: `codex plugin marketplace add`
+          # users browse that release, and it must stay on the stable line.
+          if [ -n "$DIST_TAG" ]; then
+            CHANNEL_FLAGS=(--prerelease --latest=false)
+          else
+            CHANNEL_FLAGS=("$(gh release list --repo code-yeongyu/lazycodex --exclude-drafts --limit 1000 --json tagName --jq '.[].tagName' | bun script/release-latest-flag.ts "$VERSION")")
+          fi
           gh release view "v${VERSION}" --repo code-yeongyu/lazycodex >/dev/null 2>&1 || \
-            gh release create "v${VERSION}" "$LATEST_FLAG" --repo code-yeongyu/lazycodex --target main --title "v${VERSION}" --notes-file /tmp/lazycodex-release-notes.md
+            gh release create "v${VERSION}" "${CHANNEL_FLAGS[@]}" --repo code-yeongyu/lazycodex --target main --title "v${VERSION}" --notes-file /tmp/lazycodex-release-notes.md
 
       - name: Create GitHub release
         # Always a full release, never `--prerelease`, on every channel: the npm
@@ -1199,6 +1311,7 @@ jobs:
         # release. That badge is load-bearing: `releases/latest/download/<asset>`
         # is the URL the compiled omo binary's self-update hint resolves against
         # (packages/omo-native/compile-entry.ts).
+        if: inputs.lazycodex_only != true
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1213,7 +1326,7 @@ jobs:
             gh release create "v${VERSION}" "$LATEST_FLAG" --title "v${VERSION}" --notes-file /tmp/changelog.md
 
       - name: Download release-binary artifacts
-        if: inputs.skip_platform != true
+        if: inputs.skip_platform != true && inputs.lazycodex_only != true
         uses: actions/download-artifact@v8
         with:
           pattern: release-binary-*
@@ -1224,7 +1337,7 @@ jobs:
         # Runs for both stable and dist-tagged releases: the compiled binaries
         # and SHA256SUMS are part of the release contract on every channel.
         # skip_platform reruns rely on the assets a prior run already uploaded.
-        if: inputs.skip_platform != true
+        if: inputs.skip_platform != true && inputs.lazycodex_only != true
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1245,6 +1358,7 @@ jobs:
         # upload is --clobber-idempotent and the per-target build is
         # unconditional, so this can only stay green when the release actually
         # carries its 13 assets (12 per-target omo binaries + SHA256SUMS).
+        if: inputs.lazycodex_only != true
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1263,6 +1377,7 @@ jobs:
           echo "Verified ${ASSET_COUNT}/13 release assets for v${VERSION}"
 
       - name: Delete draft release
+        if: inputs.lazycodex_only != true
         run: gh release delete next --yes 2>/dev/null || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1277,6 +1392,7 @@ jobs:
         # Fast-forward only: master always trails the new tag (releases move
         # forward on dev), so the direct refspec push is a clean FF and satisfies
         # the branch ruleset's non_fast_forward rule without needing a bypass.
+        if: inputs.lazycodex_only != true
         continue-on-error: true
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
@@ -1322,6 +1438,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Wait for omo-ai registry readiness
+        if: inputs.lazycodex_only != true
         env:
           OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
           ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}
@@ -1357,6 +1474,7 @@ jobs:
           done
 
       - name: Guard omo-ai dist-tags
+        if: inputs.lazycodex_only != true
         env:
           OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
           ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}
@@ -1378,6 +1496,7 @@ jobs:
           fi
 
       - name: Verify omo-ai live install
+        if: inputs.lazycodex_only != true
         env:
           OMO_AI_VERSION: ${{ needs.release-metadata.outputs.omo_ai_version }}
           ALREADY_PUBLISHED: ${{ needs.release-metadata.outputs.already_published }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -449,7 +449,7 @@ jobs:
 
           BASE_HEAD="$(git rev-parse "origin/${BASE_REF}")"
 
-          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+          if [ "${LAZYCODEX_ONLY:-}" = "true" ]; then
             # A LazyCodex-only release publishes the base head as-is: no omo manifest is stamped and no
             # release commit lands on the base branch. The provenance-safe child is dispatched from the
             # lazycodex-v<version> tag namespace so it never collides with an omo release tag, and a
@@ -714,7 +714,7 @@ jobs:
           # LazyCodex-only releases tag the source under their own namespace so the omo release
           # path can still refuse the number (and vice versa) instead of reusing a foreign tag.
           RELEASE_TAG="v${VERSION}"
-          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+          if [ "${LAZYCODEX_ONLY:-}" = "true" ]; then
             RELEASE_TAG="lazycodex-v${VERSION}"
           fi
 
@@ -1267,7 +1267,6 @@ jobs:
         if: inputs.publish_lazycodex == true && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'
         env:
           VERSION: ${{ needs.release-metadata.outputs.version }}
-          DIST_TAG: ${{ needs.release-metadata.outputs.dist_tag }}
           RELEASE_SHA: ${{ needs.prepare-release-state.outputs.release_sha }}
           LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
           PREVIOUS_LAZYCODEX_VERSION: ${{ steps.lazycodex-release-state.outputs.previous_lazycodex_version }}
@@ -1278,7 +1277,7 @@ jobs:
           # must fail the step instead of silently mis-assigning the badge.
           set -euo pipefail
 
-          if [ "$LAZYCODEX_ONLY" = "true" ]; then
+          if [ "${LAZYCODEX_ONLY:-}" = "true" ]; then
             SOURCE_DESC="oh-my-openagent ${RELEASE_SHA} (LazyCodex-only release)"
           else
             SOURCE_DESC="oh-my-openagent v${VERSION} (${RELEASE_SHA})"
@@ -1289,15 +1288,11 @@ jobs:
             printf '%s\n' "Compared against: lazycodex-ai@${PREVIOUS_LAZYCODEX_VERSION}"
           } > /tmp/lazycodex-release-notes.md
 
-          # A prerelease never takes the mirror's Latest badge: `codex plugin marketplace add`
-          # users browse that release, and it must stay on the stable line.
-          if [ -n "$DIST_TAG" ]; then
-            CHANNEL_FLAGS=(--prerelease --latest=false)
-          else
-            CHANNEL_FLAGS=("$(gh release list --repo code-yeongyu/lazycodex --exclude-drafts --limit 1000 --json tagName --jq '.[].tagName' | bun script/release-latest-flag.ts "$VERSION")")
-          fi
+          # Same badge rule as the omo release above (#7743): never `--prerelease`, Latest decided by
+          # the highest published semver, so a later stable outranks every beta on the mirror too.
+          LATEST_FLAG="$(gh release list --repo code-yeongyu/lazycodex --exclude-drafts --limit 1000 --json tagName --jq '.[].tagName' | bun script/release-latest-flag.ts "$VERSION")"
           gh release view "v${VERSION}" --repo code-yeongyu/lazycodex >/dev/null 2>&1 || \
-            gh release create "v${VERSION}" "${CHANNEL_FLAGS[@]}" --repo code-yeongyu/lazycodex --target main --title "v${VERSION}" --notes-file /tmp/lazycodex-release-notes.md
+            gh release create "v${VERSION}" "$LATEST_FLAG" --repo code-yeongyu/lazycodex --target main --title "v${VERSION}" --notes-file /tmp/lazycodex-release-notes.md
 
       - name: Create GitHub release
         # Always a full release, never `--prerelease`, on every channel: the npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -460,7 +460,7 @@ jobs:
               exit 1
             fi
             if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
-              echo "::error::v${VERSION} already exists as an omo release tag; a LazyCodex-only release must not reuse an omo version number. Bump to an unused version."
+              echo "::error::v${VERSION} already exists as an omo release tag; a LazyCodex-only release must not reuse a number the omo line already released. Bump to an unused version."
               exit 1
             fi
             NPM_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/lazycodex-ai/${VERSION}")

--- a/.omo/evidence/20260912-lazycodex-beta-release-channel/PLAN.md
+++ b/.omo/evidence/20260912-lazycodex-beta-release-channel/PLAN.md
@@ -1,0 +1,34 @@
+# LazyCodex beta release channel + LazyCodex-only mode (issue #8175)
+
+Scope: `.github/workflows/publish.yml` and its shape tests only. No plugin or installer code changes.
+
+## Changes
+
+1. Beta channel propagates LazyCodex
+   - `Require LazyCodex sync token`, `Checkout LazyCodex marketplace`, `Sync LazyCodex Codex marketplace`,
+     `Resolve LazyCodex release payload`: `if: inputs.publish_lazycodex == true` (was `dist_tag == ''`).
+   - `Create LazyCodex GitHub release`: same gate + `lazycodex_changed`; prerelease -> `--prerelease --latest=false`,
+     stable -> `release-latest-flag.ts` as before. Notes carry the source SHA.
+2. `lazycodex_only` input
+   - `release-metadata`: requires explicit `version` and `publish_lazycodex=true`.
+   - `preflight-trust`: trusted-publisher probe covers `lazycodex-ai` only.
+   - `prepare-release-state`: no stamp commit; `release_sha = origin/<base> head`; refuses `lazycodex-v<version>`,
+     `v<version>`, and an existing `lazycodex-ai@<version>`. Normal path refuses `lazycodex-v<version>`.
+   - `dispatch-provenance-safe-publish`: tags `lazycodex-v<version>` and forwards `lazycodex_only` to the child.
+   - `publish-main`: wrapper probes force `skip=true`; omo-ai steps and platform wait skip; plugin build also runs
+     `sync-version.mjs` + `sync-hook-status-messages.mjs` so an unstamped tree ships coherent manifests.
+   - `verify-release-notes`, `publish-platform`: skipped. `release`: omo changelog/release/assets/master mirror skipped;
+     marketplace sync + LazyCodex release run. `post-publish-verify`: omo-ai probes skipped; LazyCodex smoke runs.
+3. Tests
+   - Inverted: `publish-lazycodex-workflow.test.ts` (stable-only gate -> every publishing channel).
+   - Tag-namespace literal updates: `publish-workflow.test.ts`, `publish-release-platform-workflow.test.ts`,
+     `publish-resume-idempotency.test.ts`.
+   - New: `publish-lazycodex-channel-workflow.test.ts` (YAML-parsed `if` contracts + shell-branch tokens).
+
+## Verification
+
+- actionlint clean locally; `Bun.YAML.parse` succeeds.
+- Remote (mengmotaMac via bunshin): every `*.test.ts` that reads `publish.yml` GREEN on the branch; the new and
+  inverted assertions RED against `origin/dev`'s `publish.yml`. `bun run typecheck:script` clean.
+- Ship: after merge, dispatch `publish.yml` on `dev` with `lazycodex_only=true version=5.0.0-beta.57`; verify the
+  mirror commit, the LazyCodex GitHub prerelease, `lazycodex-ai` dist-tags (`latest` unchanged), and the smoke step.

--- a/.omo/evidence/20260912-lazycodex-beta-release-channel/PLAN.md
+++ b/.omo/evidence/20260912-lazycodex-beta-release-channel/PLAN.md
@@ -7,8 +7,9 @@ Scope: `.github/workflows/publish.yml` and its shape tests only. No plugin or in
 1. Beta channel propagates LazyCodex
    - `Require LazyCodex sync token`, `Checkout LazyCodex marketplace`, `Sync LazyCodex Codex marketplace`,
      `Resolve LazyCodex release payload`: `if: inputs.publish_lazycodex == true` (was `dist_tag == ''`).
-   - `Create LazyCodex GitHub release`: same gate + `lazycodex_changed`; prerelease -> `--prerelease --latest=false`,
-     stable -> `release-latest-flag.ts` as before. Notes carry the source SHA.
+   - `Create LazyCodex GitHub release`: same gate + `lazycodex_changed`; the badge rule stays the repo-wide one from
+     #7743 (`release-latest-flag.ts`, never `--prerelease`) so a later stable outranks every beta. Notes carry the
+     source SHA.
 2. `lazycodex_only` input
    - `release-metadata`: requires explicit `version` and `publish_lazycodex=true`.
    - `preflight-trust`: trusted-publisher probe covers `lazycodex-ai` only.

--- a/.omo/evidence/20260912-lazycodex-beta-release-channel/remote-shape-tests.md
+++ b/.omo/evidence/20260912-lazycodex-beta-release-channel/remote-shape-tests.md
@@ -1,0 +1,80 @@
+# Remote shape-test evidence (issue #8175, PR #8177)
+
+Machine: a second macOS box in the fleet via the bunshin mesh (bun 1.4.0). Local host ran no `bun test`.
+Workspace: `/tmp/lcx-shape-20260912b/omo` = shallow clone of `fix/lazycodex-beta-release-channel` @ f132166.
+
+## What was tested
+- GREEN: every `*.test.ts` that reads `publish.yml` (19 files) against the branch workflow.
+- RED: the new `publish-lazycodex-channel-workflow.test.ts` plus the four updated suites against `origin/dev`'s
+  `publish.yml` (1598 lines, swapped in via `git show origin/dev:...`, restored afterwards).
+- `bun run typecheck:script` (tsgo) on the branch.
+- actionlint locally (`-shellcheck=''`, the CI setting): clean.
+
+## What was observed
+```
+HEAD=f132166
+--- green ---
+ 97 pass
+ 0 fail
+Ran 97 tests across 19 files. [4.02s]
+--- red ---
+ 28 pass
+ 12 fail
+Ran 40 tests across 5 files. [355.00ms]
+(fail) LazyCodex publish channels > every channel that publishes lazycodex-ai also syncs the marketplace and cuts the LazyCodex release [0.15ms]
+(fail) LazyCodex publish channels > lazycodex_only is a dispatch input that reaches the provenance-safe child under its own tag namespace [0.09ms]
+(fail) LazyCodex publish channels > lazycodex_only publishes the base head without stamping and refuses a version either release path already used [0.09ms]
+(fail) LazyCodex publish channels > lazycodex_only skips every omo publish, release, and verification surface [0.14ms]
+(fail) LazyCodex publish channels > publish-time plugin builds stamp the manifests an unstamped tree would otherwise leave behind [0.09ms]
+(fail) LazyCodex publish workflow > publishes a LazyCodex GitHub release only when the marketplace payload changed [0.32ms]
+(fail) publish resume idempotency > keeps every resumability guard in the real publish workflow [0.28ms]
+(fail) publish resume idempotency > reports the exact guard removed by an in-memory mutation [0.19ms]
+(fail) publish resume idempotency > reports the stale-stamp refusal when the head-equality guard is neutralised [0.20ms]
+(fail) release and platform publish workflows > publishes platform packages before installable wrappers [0.16ms]
+(fail) release and platform publish workflows > validates an existing release tag before redispatching its prepared source [0.12ms]
+(fail) test workflows > dispatches a source-pinned publish run before provenance-bearing release operations [0.29ms]
+--- tc ---
+$ tsgo --noEmit -p script/tsconfig.json
+--- dev publish.yml used for RED ---
+    1598 /tmp/dev-publish.yml
+publish.yml restored clean
+
+EXIT=0
+```
+
+## First attempt (commit dedc679, superseded)
+5 GREEN failures drove two fixes: the LazyCodex mirror release keeps the #7743 badge rule (no `--prerelease`,
+`release-latest-flag.ts`), and every `set -u` script reads `${LAZYCODEX_ONLY:-}` because the stale-stamp harness
+executes the prepare step with an explicit env. The first RED attempt was invalid (a `--single-branch` clone has no
+`origin/dev`; the swapped file was empty) and was rerun with `git fetch origin dev:refs/remotes/origin/dev`.
+```
+host=mengmotaMac bun=1.4.0 load={ 5.60 5.83 5.42 }
+HEAD=dedc679
+INSTALL_EXIT=0
+
+595 packages installed [2.29s]
+=== GREEN (branch publish.yml) ===
+GREEN_EXIT=1
+ 92 pass
+ 5 fail
+Ran 97 tests across 19 files. [5.89s]
+(fail) omo-ai publish workflow shape > decides the Latest badge from the highest published semver, never from a pre-release flag [0.80ms]
+(fail) omo-ai publish workflow shape > publishes omo-ai through beta-only OIDC after every wrapper publish [5.77ms]
+(fail) omo-ai publish workflow shape > always runs readiness, dist-tag guard, and live verification [0.36ms]
+(fail) test workflows > attaches and verifies release-binary assets on every GitHub release [0.27ms]
+(fail) publish.yml prepare-release-state reuse decision > #given the 'release: vX' commit IS the base head #when prepare runs for vX #then it reuses that SHA without pushing [325.01ms]
+(fail) omo-ai publish workflow shape > decides the Latest badge from the highest published semver, never from a pre-release flag [0.80ms]
+(fail) omo-ai publish workflow shape > publishes omo-ai through beta-only OIDC after every wrapper publish [5.77ms]
+(fail) omo-ai publish workflow shape > always runs readiness, dist-tag guard, and live verification [0.36ms]
+(fail) test workflows > attaches and verifies release-binary assets on every GitHub release [0.27ms]
+(fail) publish.yml prepare-release-state reuse decision > #given the 'release: vX' commit IS the base head #when prepare runs for vX #then it reuses that SHA without pushing [325.01ms]
+```
+
+## Why it is enough
+The workflow is declarative; its contract is the set of `if:` gates, input plumbing, and shell branches the tests
+parse from the real file. RED proves the new assertions distinguish the old contract; GREEN proves the whole shape
+suite (including the stale-stamp harness that executes the prepare script) accepts the new one. The live contract is
+exercised by the first `lazycodex_only` dispatch after merge; its evidence is posted on #8175.
+
+## What was omitted
+Remote hostnames and the raw install log. No secrets were involved.

--- a/script/omo-ai-publish-shape.test.ts
+++ b/script/omo-ai-publish-shape.test.ts
@@ -185,8 +185,8 @@ describe("omo-ai publish workflow shape", () => {
     expect(publishIndex).toBeGreaterThan(originalStripIndex)
     expect(publishIndex).toBeGreaterThan(lastWrapperPublishIndex)
     expect(dedicatedStripIndex).toBe(publishIndex - 1)
-    expect(dedicatedStrip.if).toBe("needs.release-metadata.outputs.already_published != 'true'")
-    expect(publish.if).toBe("needs.release-metadata.outputs.already_published != 'true'")
+    expect(dedicatedStrip.if).toBe("needs.release-metadata.outputs.already_published != 'true' && inputs.lazycodex_only != true")
+    expect(publish.if).toBe("needs.release-metadata.outputs.already_published != 'true' && inputs.lazycodex_only != true")
     expect(publish["working-directory"]).toBe("packages/omo-native")
     expect(publish.run).toContain("npm publish --ignore-scripts --access public --provenance --tag beta")
     expect(publish.run, "omo-ai publish must hardcode --tag beta rather than DIST_TAG").not.toContain("$DIST_TAG")
@@ -196,10 +196,11 @@ describe("omo-ai publish workflow shape", () => {
   test("always runs readiness, dist-tag guard, and live verification", () => {
     // These probes moved out of publish-main into post-publish-verify: they assert registry state that is
     // already public once publish-main succeeds, so gating the release job on them could only strand a
-    // published release. They stay unconditional inside their new job.
+    // published release. Inside their new job the only gate is the LazyCodex-only mode, which
+    // publishes no omo-ai at all.
     for (const name of ["Wait for omo-ai registry readiness", "Guard omo-ai dist-tags", "Verify omo-ai live install"]) {
       const step = namedStep("post-publish-verify", name)
-      expect(step).not.toHaveProperty("if")
+      expect(step.if).toBe("inputs.lazycodex_only != true")
       expect(step.env?.OMO_AI_VERSION).toBe("${{ needs.release-metadata.outputs.omo_ai_version }}")
       expect(step.env?.ALREADY_PUBLISHED).toBe("${{ needs.release-metadata.outputs.already_published }}")
     }

--- a/script/publish-lazycodex-channel-workflow.test.ts
+++ b/script/publish-lazycodex-channel-workflow.test.ts
@@ -56,7 +56,7 @@ const PUBLISH_LAZYCODEX = "inputs.publish_lazycodex == true"
 const NOT_LAZYCODEX_ONLY = "inputs.lazycodex_only != true"
 
 describe("LazyCodex publish channels", () => {
-  test("prereleases sync the marketplace and cut a LazyCodex prerelease that never takes the Latest badge", () => {
+  test("every channel that publishes lazycodex-ai also syncs the marketplace and cuts the LazyCodex release", () => {
     // #given
     const releaseStep = step("release", "Create LazyCodex GitHub release")
     const releaseRun = run("release", "Create LazyCodex GitHub release")
@@ -68,17 +68,14 @@ describe("LazyCodex publish channels", () => {
       step("release", "Sync LazyCodex Codex marketplace").if,
       step("release", "Resolve LazyCodex release payload").if,
     ]
-    const prereleaseBranch = shellBranch(releaseRun, 'if [ -n "$DIST_TAG" ]; then')
+    const onlyBranch = shellBranch(releaseRun, 'if [ "${LAZYCODEX_ONLY:-}" = "true" ]; then')
 
     // #then
     for (const gate of marketplaceGates) expect(gate).toBe(PUBLISH_LAZYCODEX)
     expect(releaseStep.if).toBe(`${PUBLISH_LAZYCODEX} && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'`)
-    expect(releaseStep.env?.DIST_TAG).toBe("${{ needs.release-metadata.outputs.dist_tag }}")
-    expect(prereleaseBranch).toContain("CHANNEL_FLAGS=(--prerelease --latest=false)")
-    expect(prereleaseBranch).toContain("bun script/release-latest-flag.ts")
-    expect(prereleaseBranch.indexOf("--prerelease")).toBeLessThan(prereleaseBranch.indexOf("else"))
-    expect(releaseRun).toContain('gh release create "v${VERSION}" "${CHANNEL_FLAGS[@]}"')
-    expect(releaseRun).not.toContain('"$LATEST_FLAG"')
+    expect(releaseStep.env?.RELEASE_SHA).toBe("${{ needs.prepare-release-state.outputs.release_sha }}")
+    expect(onlyBranch).toContain("${RELEASE_SHA}")
+    expect(releaseRun).not.toContain("dist_tag")
   })
 
   test("lazycodex_only is a dispatch input that reaches the provenance-safe child under its own tag namespace", () => {
@@ -88,7 +85,7 @@ describe("LazyCodex publish channels", () => {
     const metadataRun = run("release-metadata", "Calculate version")
 
     // #when
-    const onlyBranch = shellBranch(dispatchRun, 'if [ "$LAZYCODEX_ONLY" = "true" ]; then')
+    const onlyBranch = shellBranch(dispatchRun, 'if [ "${LAZYCODEX_ONLY:-}" = "true" ]; then')
     const metadataGuard = shellBranch(metadataRun, 'if [ "$LAZYCODEX_ONLY" = "true" ]; then')
 
     // #then
@@ -108,7 +105,7 @@ describe("LazyCodex publish channels", () => {
     const prepareRun = run("prepare-release-state", "Prepare release state (generation)")
 
     // #when
-    const onlyBranch = shellBranch(prepareRun, 'if [ "$LAZYCODEX_ONLY" = "true" ]; then')
+    const onlyBranch = shellBranch(prepareRun, 'if [ "${LAZYCODEX_ONLY:-}" = "true" ]; then')
     const afterOnlyBranch = prepareRun.slice(prepareRun.indexOf(onlyBranch) + onlyBranch.length)
     const omoRefusal = afterOnlyBranch.indexOf('refs/tags/lazycodex-v${VERSION}')
 

--- a/script/publish-lazycodex-channel-workflow.test.ts
+++ b/script/publish-lazycodex-channel-workflow.test.ts
@@ -1,0 +1,181 @@
+/// <reference types="bun-types" />
+
+// LazyCodex channel contract for publish.yml (issue #8175): prereleases propagate LazyCodex exactly
+// like stable releases, and `lazycodex_only` publishes LazyCodex without touching any omo surface.
+
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+interface WorkflowStep {
+  readonly name?: string
+  readonly if?: string
+  readonly run?: string
+  readonly env?: Record<string, string>
+}
+
+interface WorkflowJob {
+  readonly if?: string
+  readonly steps?: readonly WorkflowStep[]
+}
+
+interface Workflow {
+  readonly on: { readonly workflow_dispatch: { readonly inputs: Record<string, { readonly type: string; readonly default?: unknown }> } }
+  readonly jobs: Record<string, WorkflowJob>
+}
+
+const workflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
+const workflowText = readFileSync(workflowPath, "utf8").replace(/\r\n/g, "\n")
+const workflow = Bun.YAML.parse(workflowText) as Workflow
+
+function job(name: string): WorkflowJob {
+  const found = workflow.jobs[name]
+  if (found === undefined) throw new Error(`publish.yml has no job ${name}`)
+  return found
+}
+
+function step(jobName: string, stepName: string): WorkflowStep {
+  const found = job(jobName).steps?.find((candidate) => candidate.name === stepName)
+  if (found === undefined) throw new Error(`publish.yml job ${jobName} has no step ${stepName}`)
+  return found
+}
+
+function run(jobName: string, stepName: string): string {
+  const body = step(jobName, stepName).run
+  if (body === undefined) throw new Error(`publish.yml step ${jobName}/${stepName} has no run block`)
+  return body
+}
+
+function shellBranch(body: string, opener: string): string {
+  const start = body.indexOf(opener)
+  if (start < 0) throw new Error(`shell body has no branch opening with ${opener}`)
+  const end = body.indexOf("\nfi\n", start)
+  return body.slice(start, end < 0 ? undefined : end)
+}
+
+const PUBLISH_LAZYCODEX = "inputs.publish_lazycodex == true"
+const NOT_LAZYCODEX_ONLY = "inputs.lazycodex_only != true"
+
+describe("LazyCodex publish channels", () => {
+  test("prereleases sync the marketplace and cut a LazyCodex prerelease that never takes the Latest badge", () => {
+    // #given
+    const releaseStep = step("release", "Create LazyCodex GitHub release")
+    const releaseRun = run("release", "Create LazyCodex GitHub release")
+
+    // #when
+    const marketplaceGates = [
+      step("preflight-trust", "Require LazyCodex sync token").if,
+      step("release", "Checkout LazyCodex marketplace").if,
+      step("release", "Sync LazyCodex Codex marketplace").if,
+      step("release", "Resolve LazyCodex release payload").if,
+    ]
+    const prereleaseBranch = shellBranch(releaseRun, 'if [ -n "$DIST_TAG" ]; then')
+
+    // #then
+    for (const gate of marketplaceGates) expect(gate).toBe(PUBLISH_LAZYCODEX)
+    expect(releaseStep.if).toBe(`${PUBLISH_LAZYCODEX} && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'`)
+    expect(releaseStep.env?.DIST_TAG).toBe("${{ needs.release-metadata.outputs.dist_tag }}")
+    expect(prereleaseBranch).toContain("CHANNEL_FLAGS=(--prerelease --latest=false)")
+    expect(prereleaseBranch).toContain("bun script/release-latest-flag.ts")
+    expect(prereleaseBranch.indexOf("--prerelease")).toBeLessThan(prereleaseBranch.indexOf("else"))
+    expect(releaseRun).toContain('gh release create "v${VERSION}" "${CHANNEL_FLAGS[@]}"')
+    expect(releaseRun).not.toContain('"$LATEST_FLAG"')
+  })
+
+  test("lazycodex_only is a dispatch input that reaches the provenance-safe child under its own tag namespace", () => {
+    // #given
+    const input = workflow.on.workflow_dispatch.inputs.lazycodex_only
+    const dispatchRun = run("dispatch-provenance-safe-publish", "Tag prepared source and dispatch provenance-safe publish")
+    const metadataRun = run("release-metadata", "Calculate version")
+
+    // #when
+    const onlyBranch = shellBranch(dispatchRun, 'if [ "$LAZYCODEX_ONLY" = "true" ]; then')
+    const metadataGuard = shellBranch(metadataRun, 'if [ "$LAZYCODEX_ONLY" = "true" ]; then')
+
+    // #then
+    expect(input?.type).toBe("boolean")
+    expect(input?.default).toBe(false)
+    expect(dispatchRun).toContain('RELEASE_TAG="v${VERSION}"')
+    expect(onlyBranch).toContain('RELEASE_TAG="lazycodex-v${VERSION}"')
+    expect(dispatchRun).toContain('git tag "${RELEASE_TAG}" "$RELEASE_SHA"')
+    expect(dispatchRun).toContain('gh workflow run publish.yml --ref "${RELEASE_TAG}"')
+    expect(dispatchRun).toContain('-f "lazycodex_only=${LAZYCODEX_ONLY}"')
+    expect(metadataGuard).toContain('if [ -z "$RAW_VERSION" ]; then')
+    expect(metadataGuard).toContain('if [ "$PUBLISH_LAZYCODEX" != "true" ]; then')
+  })
+
+  test("lazycodex_only publishes the base head without stamping and refuses a version either release path already used", () => {
+    // #given
+    const prepareRun = run("prepare-release-state", "Prepare release state (generation)")
+
+    // #when
+    const onlyBranch = shellBranch(prepareRun, 'if [ "$LAZYCODEX_ONLY" = "true" ]; then')
+    const afterOnlyBranch = prepareRun.slice(prepareRun.indexOf(onlyBranch) + onlyBranch.length)
+    const omoRefusal = afterOnlyBranch.indexOf('refs/tags/lazycodex-v${VERSION}')
+
+    // #then
+    expect(onlyBranch).toContain('git rev-parse -q --verify "refs/tags/lazycodex-v${VERSION}"')
+    expect(onlyBranch).toContain('git rev-parse -q --verify "refs/tags/v${VERSION}"')
+    expect(onlyBranch).toContain('https://registry.npmjs.org/lazycodex-ai/${VERSION}')
+    expect(onlyBranch).toContain('echo "release_sha=${BASE_HEAD}" >> "$GITHUB_OUTPUT"')
+    expect(onlyBranch).toContain('echo "needs_push=false" >> "$GITHUB_OUTPUT"')
+    expect(onlyBranch).not.toContain("git commit")
+    expect(omoRefusal).toBeGreaterThanOrEqual(0)
+    expect(omoRefusal).toBeLessThan(afterOnlyBranch.indexOf("reuse_or_refuse() {"))
+  })
+
+  test("lazycodex_only skips every omo publish, release, and verification surface", () => {
+    // #given
+    const omoSkippedSteps: ReadonlyArray<readonly [string, string]> = [
+      ["publish-main", "Verify platform packages are published"],
+      ["publish-main", "Build omo-ai payload"],
+      ["publish-main", "Verify omo-ai payload"],
+      ["publish-main", "Strip token auth before omo-ai publish"],
+      ["publish-main", "Publish omo-ai (beta only)"],
+      ["release", "Generate changelog"],
+      ["release", "Create GitHub release"],
+      ["release", "Download release-binary artifacts"],
+      ["release", "Upload release assets"],
+      ["release", "Verify uploaded assets"],
+      ["release", "Delete draft release"],
+      ["release", "Mirror release to master"],
+      ["post-publish-verify", "Wait for omo-ai registry readiness"],
+      ["post-publish-verify", "Guard omo-ai dist-tags"],
+      ["post-publish-verify", "Verify omo-ai live install"],
+    ]
+    const wrapperProbes = [
+      run("publish-main", "Check if already published"),
+      run("publish-main", "Check if oh-my-openagent already published"),
+    ]
+
+    // #then
+    for (const [jobName, stepName] of omoSkippedSteps) {
+      expect(step(jobName, stepName).if, `${jobName}/${stepName} must skip under lazycodex_only`).toContain(NOT_LAZYCODEX_ONLY)
+    }
+    expect(job("verify-release-notes").if).toContain(NOT_LAZYCODEX_ONLY)
+    expect(job("publish-platform").if).toContain(NOT_LAZYCODEX_ONLY)
+    for (const jobName of ["publish-main", "release"]) {
+      expect(job(jobName).if).toContain("inputs.skip_platform == true || inputs.lazycodex_only == true || needs.publish-platform.result == 'success'")
+    }
+    for (const probe of wrapperProbes) {
+      const onlyBranch = shellBranch(probe, 'if [ "$LAZYCODEX_ONLY" = "true" ]; then')
+      expect(onlyBranch).toContain('echo "skip=true" >> "$GITHUB_OUTPUT"')
+      expect(probe.indexOf(onlyBranch)).toBeLessThan(probe.indexOf("STATUS=$(curl"))
+    }
+    expect(step("publish-main", "Publish lazycodex-ai").if).not.toContain("lazycodex_only")
+    expect(step("post-publish-verify", "Smoke test published lazycodex-ai").if).not.toContain("lazycodex_only")
+  })
+
+  test("publish-time plugin builds stamp the manifests an unstamped tree would otherwise leave behind", () => {
+    // #given
+    const buildRuns = [run("publish-main", "Build Codex plugin components"), run("release", "Sync LazyCodex Codex marketplace")]
+
+    // #then
+    for (const body of buildRuns) {
+      const versionSync = body.indexOf("node packages/omo-codex/plugin/scripts/sync-version.mjs")
+      const hookSync = body.indexOf("node packages/omo-codex/plugin/scripts/sync-hook-status-messages.mjs")
+      expect(versionSync).toBeGreaterThanOrEqual(0)
+      expect(hookSync).toBeGreaterThan(versionSync)
+      expect(body.indexOf("npm --prefix packages/omo-codex/plugin ci")).toBeGreaterThan(hookSync)
+    }
+  })
+})

--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -112,9 +112,11 @@ describe("LazyCodex publish workflow", () => {
       publishLazycodexStep.includes("if: inputs.publish_lazycodex == true && steps.check-lazycodex.outputs.skip != 'true'") &&
       publishLazycodexStep.includes("npm publish --ignore-scripts --access public --provenance --tag latest --loglevel verbose") &&
       !publishLazycodexStep.includes("continue-on-error: true")
-    const syncsLazycodexMarketplaceOnStableReleases = workflow.includes("name: Sync LazyCodex Codex marketplace") &&
-      syncMarketplaceStep.includes("if: needs.release-metadata.outputs.dist_tag == ''") &&
-      lazycodexReleaseStateStep.includes("if: needs.release-metadata.outputs.dist_tag == ''")
+    const syncsLazycodexMarketplaceOnEveryPublishingChannel = workflow.includes("name: Sync LazyCodex Codex marketplace") &&
+      syncMarketplaceStep.includes("if: inputs.publish_lazycodex == true") &&
+      lazycodexReleaseStateStep.includes("if: inputs.publish_lazycodex == true") &&
+      !syncMarketplaceStep.includes("dist_tag == ''") &&
+      !lazycodexReleaseStateStep.includes("dist_tag == ''")
     const tokenRequirementBeforePublish = workflow.indexOf("name: Require LazyCodex sync token") <
       workflow.indexOf("publish-main:")
     const requiresLazycodexSyncToken = workflow.includes("LAZYCODEX_SYNC_TOKEN: ${{ secrets.LAZYCODEX_SYNC_TOKEN }}") &&
@@ -138,7 +140,7 @@ describe("LazyCodex publish workflow", () => {
       lazycodexReleaseStateStep.includes("previous_lazycodex_version=${PREVIOUS_LAZYCODEX_VERSION}")
     const createsLazycodexReleaseOnlyWhenChanged =
       lazycodexReleaseStep.includes(
-        "if: needs.release-metadata.outputs.dist_tag == '' && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'",
+        "if: inputs.publish_lazycodex == true && steps.lazycodex-release-state.outputs.lazycodex_changed == 'true'",
       ) &&
       lazycodexReleaseStep.includes("GH_TOKEN: ${{ secrets.LAZYCODEX_SYNC_TOKEN }}") &&
       lazycodexReleaseStep.includes('gh release create "v${VERSION}"') &&
@@ -162,8 +164,8 @@ describe("LazyCodex publish workflow", () => {
     expect(alwaysChecksLazycodexNpm, "release must always check lazycodex using the release version").toBe(true)
     expect(publishesLazycodexNpm, "lazycodex npm publish must be part of the normal release, tag stable releases as latest, and fail loudly").toBe(true)
     expect(
-      syncsLazycodexMarketplaceOnStableReleases,
-      "LazyCodex marketplace sync must run on every stable release (empty dist_tag)",
+      syncsLazycodexMarketplaceOnEveryPublishingChannel,
+      "LazyCodex marketplace sync must run on every channel that publishes lazycodex-ai, prereleases included",
     ).toBe(true)
     expect(requiresLazycodexSyncToken, "release must require a cross-repo token for LazyCodex push").toBe(true)
     expect(capturesPreviousLazycodexBeforePublishing, "release metadata must capture the previous lazycodex-ai version before publishing the new one").toBe(true)

--- a/script/publish-release-platform-workflow.test.ts
+++ b/script/publish-release-platform-workflow.test.ts
@@ -33,7 +33,7 @@ describe("release and platform publish workflows", () => {
     const mainWaitsForPlatform = workflow.includes(
       "needs: [gate-reuse, preflight-trust, release-metadata, prepare-release-state, publish-platform]",
     ) &&
-      workflow.includes("inputs.skip_platform == true || needs.publish-platform.result == 'success'")
+      workflow.includes("inputs.skip_platform == true || inputs.lazycodex_only == true || needs.publish-platform.result == 'success'")
     const releaseUsesMetadata = workflow.includes("VERSION: ${{ needs.release-metadata.outputs.version }}")
     const wrappersVerifyPlatformPackages = workflow.includes("name: Verify platform packages are published") &&
       workflow.includes("Missing platform package(s); refusing to publish wrappers.")
@@ -149,11 +149,12 @@ describe("release and platform publish workflows", () => {
 
     // #when
     const checksExistingTagTarget =
-      dispatchJob.includes('if git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then') &&
-      dispatchJob.includes('TAG_SHA="$(git rev-list --max-count=1 "v${VERSION}")"') &&
+      dispatchJob.includes('RELEASE_TAG="v${VERSION}"') &&
+      dispatchJob.includes('if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then') &&
+      dispatchJob.includes('TAG_SHA="$(git rev-list --max-count=1 "${RELEASE_TAG}")"') &&
       dispatchJob.includes('"$TAG_SHA" != "$RELEASE_SHA"')
-    const createsMissingTagAtPreparedSource = dispatchJob.includes('git tag "v${VERSION}" "$RELEASE_SHA"')
-    const redispatchesTag = dispatchJob.includes('gh workflow run publish.yml --ref "v${VERSION}"')
+    const createsMissingTagAtPreparedSource = dispatchJob.includes('git tag "${RELEASE_TAG}" "$RELEASE_SHA"')
+    const redispatchesTag = dispatchJob.includes('gh workflow run publish.yml --ref "${RELEASE_TAG}"')
     const marketplacePushSkipsWhenClean = workflow.includes("LazyCodex marketplace already up to date")
 
     // #then

--- a/script/publish-resume-idempotency.test.ts
+++ b/script/publish-resume-idempotency.test.ts
@@ -46,7 +46,7 @@ export function assertResumeGuards(workflowText: string): string[] {
   const dispatchPublish = section(workflowText, "  dispatch-provenance-safe-publish:", "  publish-main:")
   const dispatchExistingTag = section(
     dispatchPublish,
-    '          if git rev-parse -q --verify "refs/tags/v${VERSION}"',
+    '          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}"',
     "          else\n            git tag",
   )
   const publishMain = section(workflowText, "  publish-main:", "  publish-platform:")
@@ -82,7 +82,7 @@ export function assertResumeGuards(workflowText: string): string[] {
 
   if (!hasAll(dispatchExistingTag, [
     'if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then',
-    'echo "::error::Existing tag v${VERSION} points to ${TAG_SHA}, not prepared release SHA ${RELEASE_SHA}."',
+    'echo "::error::Existing tag ${RELEASE_TAG} points to ${TAG_SHA}, not prepared release SHA ${RELEASE_SHA}."',
     "exit 1",
   ])) findings.push(resumeGuardFindings.dispatchTagShaMismatchRefusal)
 
@@ -116,7 +116,8 @@ export function assertResumeGuards(workflowText: string): string[] {
     "prepared_release_sha:",
     "inputs.prepared_release_sha == ''",
     "inputs.prepared_release_sha != ''",
-    'gh workflow run publish.yml --ref "v${VERSION}"',
+    'RELEASE_TAG="v${VERSION}"',
+    'gh workflow run publish.yml --ref "${RELEASE_TAG}"',
     '-f "prepared_release_sha=${RELEASE_SHA}"',
     'if [ "$PREPARED_RELEASE_SHA" != "$GITHUB_SHA" ]; then',
   ])) findings.push(resumeGuardFindings.preparedShaDispatchRouting)

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -180,7 +180,9 @@ describe("test workflows", () => {
     const verifyChecksEveryHash = verifyStep.includes("shasum -a 256 -c SHA256SUMS")
     const verifyFailsBelowThirteenAssets = verifyStep.includes('"$ASSET_COUNT" -ne 13')
     const stepsAreChannelNeutral = ![downloadStep, uploadStep, verifyStep].some((step) => step.includes("dist_tag"))
-    const verifyRunsUnconditionally = !verifyStep.includes("if:") && !verifyStep.includes("skip_platform")
+    const verifyRunsUnconditionally = !verifyStep.includes("skip_platform") &&
+      (verifyStep.match(/\n\s+if: /g) ?? []).length <= 1 &&
+      (!verifyStep.includes("if:") || verifyStep.includes("if: inputs.lazycodex_only != true"))
 
     // #then
     expect(stepsFollowReleaseCreation, "release-binary steps must live inside the release job after Create GitHub release").toBe(true)

--- a/script/publish-workflow.test.ts
+++ b/script/publish-workflow.test.ts
@@ -109,8 +109,9 @@ describe("test workflows", () => {
     const validatesDispatchSource = prepareJob.includes("PREPARED_RELEASE_SHA: ${{ inputs.prepared_release_sha }}") &&
       prepareJob.includes('"$PREPARED_RELEASE_SHA" != "$GITHUB_SHA"')
     const dispatchesPinnedTagRun =
-      dispatchJob.includes('git tag "v${VERSION}" "$RELEASE_SHA"') &&
-      dispatchJob.includes('gh workflow run publish.yml --ref "v${VERSION}"') &&
+      dispatchJob.includes('RELEASE_TAG="v${VERSION}"') &&
+      dispatchJob.includes('git tag "${RELEASE_TAG}" "$RELEASE_SHA"') &&
+      dispatchJob.includes('gh workflow run publish.yml --ref "${RELEASE_TAG}"') &&
       dispatchJob.includes('prepared_release_sha=${RELEASE_SHA}')
     const provenanceOperationsRequirePinnedRun =
       publishMainJob.includes("inputs.prepared_release_sha != ''") &&


### PR DESCRIPTION
## What

`publish.yml` only.

1. **Prereleases propagate LazyCodex.** `Require LazyCodex sync token`, `Checkout LazyCodex marketplace`, `Sync LazyCodex Codex marketplace`, `Resolve LazyCodex release payload`, and `Create LazyCodex GitHub release` were gated on `dist_tag == ''`. They now gate on `inputs.publish_lazycodex == true`. The mirror release keeps the repo-wide badge rule from #7743 (`release-latest-flag.ts`, never `--prerelease`), so a later stable outranks every beta by semver. The release notes now name the source commit.
2. **`lazycodex_only` dispatch input.** Publishes `lazycodex-ai`, syncs the marketplace, and cuts the LazyCodex GitHub (pre)release from the current base head, without stamping a release commit and without publishing `oh-my-opencode` / `oh-my-openagent` / `omo-ai` / platform packages / an omo GitHub release. The provenance-safe child is dispatched from a `lazycodex-v<version>` tag. `release-metadata` requires an explicit `version`; `prepare-release-state` refuses a version whose `lazycodex-v<version>` or `v<version>` tag exists or whose `lazycodex-ai@<version>` is already on npm, and the normal omo path refuses a `lazycodex-v<version>`-consumed number, so one version never maps to two payloads.
3. **Publish-time stamping for unstamped trees.** `Build Codex plugin components` and the marketplace sync also run `sync-version.mjs` + `sync-hook-status-messages.mjs` (no-ops when the release commit already stamped them).

## Why

Every 5.0.0-beta.N since 2026-08-01 published `lazycodex-ai` to npm `beta` but never reached `code-yeongyu/lazycodex`; the mirror and `lazycodex-ai@latest` are frozen at 4.19.4, so Codex marketplace users never received #7990 / #7976 / #8000. The stable-only gate (f1ac07d58, #5111) assumed a stable cadence the 5.0.0 line does not have. There was also no way to ship LazyCodex without cutting a full omo release.

## Tests

- Inverted `script/publish-lazycodex-workflow.test.ts` (stable-only gate -> every publishing channel).
- Tag-namespace literals in `publish-workflow.test.ts`, `publish-release-platform-workflow.test.ts`, `publish-resume-idempotency.test.ts`.
- New `script/publish-lazycodex-channel-workflow.test.ts`: YAML-parsed `if` contracts for the beta gates, the `lazycodex_only` input/forwarding/tag namespace, the version-refusal branches, every omo surface skipped under `lazycodex_only`, and the publish-time stamping order.
- Remote run (bun 1.4.0): GREEN `97 pass / 0 fail` over the 19 suites that read `publish.yml`; RED `28 pass / 12 fail` for the new + updated suites against `origin/dev`'s workflow; `typecheck:script` clean. Recorded under `.omo/evidence/20260912-lazycodex-beta-release-channel/`.

## Residual risk

- The workflow itself is exercised only by a real dispatch. The first `lazycodex_only` run (planned: `5.0.0-beta.57`) is the live QA; its evidence will be posted on #8175.
- After a LazyCodex-only release of `X`, the next omo release must use a number other than `X` (the workflow refuses the reuse with an explicit message).

Fixes #8175
