### PR TITLE
ci(publish): give the LazyCodex smoke the same 15-minute registry budget as omo-ai

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1592,9 +1592,15 @@ jobs:
             )
           }
 
+          # Same wall-clock budget as the omo-ai readiness loop above: npm exposes a freshly published
+          # version 4-5 minutes after `npm publish` returns, and a 12 x 10 s budget failed a successful
+          # lazycodex-ai publish in beta.31, beta.34, and 5.0.0-beta.57 (#8182).
+          SMOKE_READINESS_INTERVAL_SECONDS=15
+          SMOKE_READINESS_ATTEMPTS=60   # 60 x 15 s = 15 minutes
+
           smoke_lazycodex_package() {
             package_spec="$1"
-            for attempt in $(seq 1 12); do
+            for attempt in $(seq 1 "$SMOKE_READINESS_ATTEMPTS"); do
               SMOKE_DIR=$(mktemp -d)
               export HOME="$SMOKE_DIR/home"
               export CODEX_HOME="$SMOKE_DIR/codex"
@@ -1606,18 +1612,18 @@ jobs:
               expected_doctor_hint="Use \$omo:lcx-doctor"
 
               if ! registry_version=$(npm view "$package_spec" version --silent 2>"$SMOKE_DIR/registry-error"); then
-                echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/12)"
+                echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/${SMOKE_READINESS_ATTEMPTS}, ${SMOKE_READINESS_INTERVAL_SECONDS}s)"
                 cd "$GITHUB_WORKSPACE"
                 rm -rf "$SMOKE_DIR"
-                sleep 10
+                sleep "$SMOKE_READINESS_INTERVAL_SECONDS"
                 continue
               fi
 
               if [[ "$package_spec" != *"@latest" && "$registry_version" != "${package_spec##*@}" ]]; then
-                echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/12; visible=${registry_version})"
+                echo "Waiting for ${package_spec} registry propagation (attempt ${attempt}/${SMOKE_READINESS_ATTEMPTS}, ${SMOKE_READINESS_INTERVAL_SECONDS}s; visible=${registry_version})"
                 cd "$GITHUB_WORKSPACE"
                 rm -rf "$SMOKE_DIR"
-                sleep 10
+                sleep "$SMOKE_READINESS_INTERVAL_SECONDS"
                 continue
               fi
 
@@ -1689,7 +1695,7 @@ jobs:
               rm -rf "$SMOKE_DIR"
               return 0
             done
-            echo "::error::Published LazyCodex smoke failed for ${package_spec}"
+            echo "::error::${package_spec} never became visible on the registry within $((SMOKE_READINESS_ATTEMPTS * SMOKE_READINESS_INTERVAL_SECONDS)) s; the publish itself may have succeeded (check npm before rerunning), this is registry propagation, not a broken package"
             return 1
           }
 

--- a/.omo/evidence/20260912-lazycodex-smoke-budget/PLAN.md
+++ b/.omo/evidence/20260912-lazycodex-smoke-budget/PLAN.md
@@ -1,0 +1,16 @@
+# LazyCodex smoke readiness budget (issue #8182)
+
+Scope: `.github/workflows/publish.yml` `Smoke test published lazycodex-ai` + one executed-budget test.
+
+## Change
+- `smoke_lazycodex_package()`: `for attempt in $(seq 1 12)` / `sleep 10` -> `SMOKE_READINESS_ATTEMPTS=60`,
+  `SMOKE_READINESS_INTERVAL_SECONDS=15` (15 min, same shape as the omo-ai readiness loop in the same job).
+- Timeout message names registry propagation and says the publish may have succeeded.
+- New `script/publish-lazycodex-smoke-budget.test.ts`: executes the step's run block with bash-function stubs
+  (`npm` absent for N views, `npx` failing, `sleep` recording); asserts the loop reaches the package after 20 views
+  and that the exhausted budget sleeps >= 900 s and names propagation.
+
+## Verification
+- actionlint (`-shellcheck=''`) + `Bun.YAML.parse` locally.
+- Remote (mengmotaMac via bunshin): new test RED against `origin/dev`'s workflow, GREEN on the branch; all 20 suites
+  that read `publish.yml` GREEN; `typecheck:script` clean.

--- a/.omo/evidence/20260912-lazycodex-smoke-budget/remote-executed-budget.md
+++ b/.omo/evidence/20260912-lazycodex-smoke-budget/remote-executed-budget.md
@@ -1,0 +1,51 @@
+# Remote executed-budget evidence (issue #8182, PR #8183)
+
+Machine: a second macOS box in the fleet via the bunshin mesh (bun 1.4.2). Local host ran no `bun test`.
+Workspace: `/tmp/lcx-smoke-20260912/omo` = shallow clone of `fix/lazycodex-smoke-readiness-budget` @ 1819ea3.
+
+## What was tested
+- GREEN: the 20 suites that read `publish.yml` (incl. the new `publish-lazycodex-smoke-budget.test.ts`, which
+  executes the smoke step's run block with `npm`/`npx`/`sleep` stubbed as bash functions).
+- RED: the new suite + `publish-lazycodex-workflow.test.ts` against `origin/dev`'s `publish.yml` (1712 lines).
+- `bun run typecheck:script`.
+
+## What was observed
+```
+host=mengmotaMac bun=1.4.2
+HEAD=1819ea3
+INSTALL_EXIT=0
+=== GREEN (branch) ===
+GREEN_EXIT=0
+ 99 pass
+ 0 fail
+Ran 99 tests across 20 files. [9.45s]
+(pass) publish.yml post-publish-verify LazyCodex smoke readiness > #given the registry needs ~5 minutes to expose the version #when the smoke polls #then it reaches the package instead of giving up [319.19ms]
+(pass) publish.yml post-publish-verify LazyCodex smoke readiness > #given the registry never exposes the version #when the budget is exhausted #then it fails and names propagation, not the package [985.44ms]
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when publish-main is inspected #then it no longer carries the post-publish verification steps [1.04ms]
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when the workflow is parsed #then post-publish-verify owns every one of those steps [0.07ms]
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when post-publish-verify is wired #then it runs after the release job [0.05ms]
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when the release job is wired #then it never waits on post-publish-verify [0.05ms]
+=== RED (origin/dev publish.yml + branch tests) ===
+    1712 /tmp/dev-publish.yml
+RED_EXIT=1
+ 5 pass
+ 3 fail
+Ran 8 tests across 2 files. [1109.00ms]
+(fail) LazyCodex publish workflow > smoke tests the published LazyCodex alias after npm publish [0.60ms]
+(fail) publish.yml post-publish-verify LazyCodex smoke readiness > #given the registry needs ~5 minutes to expose the version #when the smoke polls #then it reaches the package instead of giving up [232.24ms]
+(fail) publish.yml post-publish-verify LazyCodex smoke readiness > #given the registry never exposes the version #when the budget is exhausted #then it fails and names propagation, not the package [184.36ms]
+=== typecheck:script ===
+TC_EXIT=0
+$ tsgo --noEmit -p script/tsconfig.json
+REMOTE_DONE
+
+EXIT_CODE=0
+```
+
+## Why it is enough
+The budget is a machine-consumed value the loop executes; the test runs the real loop and measures npm views and
+slept seconds, so the old 12 x 10 s loop fails both cases and the 60 x 15 s loop passes both. The live path is the
+next LazyCodex release's smoke step.
+
+## What was omitted
+Remote hostnames and the install log. No secrets were involved.

--- a/script/publish-lazycodex-smoke-budget.test.ts
+++ b/script/publish-lazycodex-smoke-budget.test.ts
@@ -1,0 +1,73 @@
+/// <reference types="bun-types" />
+
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+/**
+ * Executes the "Smoke test published lazycodex-ai" step of publish.yml with `npm`, `npx`, and
+ * `sleep` stubbed as bash functions, so the propagation budget is asserted rather than assumed.
+ *
+ * Regression pinned (2026-09-12, 5.0.0-beta.57, #8182): `npm publish` succeeded at 06:08:39Z, the
+ * registry exposed the version at 06:12:54Z, and the smoke gave up at 06:12:23Z after 12 x 10 s -
+ * a false failure of a successful publish, the same shape the omo-ai readiness loop was cured of
+ * in `publish-readiness-budget.test.ts`.
+ */
+
+const workflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
+const workflowText = readFileSync(workflowPath, "utf8").replace(/\r\n/g, "\n")
+const workflow = Bun.YAML.parse(workflowText) as { jobs: Record<string, { steps: Array<{ name?: string; run?: string }> }> }
+
+function smokeRunBlock(): string {
+  const step = workflow.jobs["post-publish-verify"].steps.find((s) => s.name === "Smoke test published lazycodex-ai")
+  if (!step?.run) throw new Error("post-publish-verify has no 'Smoke test published lazycodex-ai' run block")
+  return step.run
+}
+
+interface Outcome { readonly status: number; readonly output: string; readonly npmViews: number; readonly sleptSeconds: number }
+
+function runSmoke(readyAfterViews: number): Outcome {
+  const root = mkdtempSync(join(tmpdir(), "publish-lazycodex-smoke-"))
+  try {
+    const counter = join(root, "npm-views")
+    const sleeps = join(root, "sleeps")
+    writeFileSync(counter, "0")
+    writeFileSync(sleeps, "")
+    const preamble = [
+      "npm() {",
+      '  local n; n=$(cat "$COUNTER"); n=$((n+1)); printf "%s" "$n" > "$COUNTER"',
+      '  if [ "$n" -gt "$READY_AFTER" ]; then printf "%s\\n" "$OMO_VERSION"; return 0; fi',
+      "  return 1",
+      "}",
+      "npx() { return 1; }",
+      'sleep() { printf "%s\\n" "$1" >> "$SLEEPS"; }',
+      "export -f npm npx sleep",
+      "",
+    ].join("\n")
+    const script = join(root, "smoke.sh")
+    writeFileSync(script, preamble + smokeRunBlock())
+    const result = spawnSync("bash", [script], {
+      encoding: "utf8",
+      env: { ...process.env, COUNTER: counter, SLEEPS: sleeps, READY_AFTER: String(readyAfterViews), OMO_VERSION: "5.0.0-beta.57", DIST_TAG: "beta", GITHUB_WORKSPACE: root },
+    })
+    const sleptSeconds = readFileSync(sleeps, "utf8").split("\n").filter(Boolean).reduce((sum, line) => sum + Number(line), 0)
+    return { status: result.status ?? -1, output: result.stdout + result.stderr, npmViews: Number(readFileSync(counter, "utf8").trim()), sleptSeconds }
+  } finally { rmSync(root, { recursive: true, force: true }) }
+}
+
+describe("publish.yml post-publish-verify LazyCodex smoke readiness", () => {
+  test("#given the registry needs ~5 minutes to expose the version #when the smoke polls #then it reaches the package instead of giving up", () => {
+    const outcome = runSmoke(20)
+    expect(outcome.npmViews).toBe(21)
+    expect(outcome.output).toContain("became visible")
+  })
+
+  test("#given the registry never exposes the version #when the budget is exhausted #then it fails and names propagation, not the package", () => {
+    const outcome = runSmoke(Number.MAX_SAFE_INTEGER)
+    expect(outcome.status).not.toBe(0)
+    expect(outcome.output).toContain("registry propagation")
+    expect(outcome.sleptSeconds).toBeGreaterThanOrEqual(15 * 60)
+  })
+})

--- a/script/publish-lazycodex-workflow.test.ts
+++ b/script/publish-lazycodex-workflow.test.ts
@@ -315,7 +315,8 @@ describe("LazyCodex publish workflow", () => {
     const smokesReleaseVersion = smokeStep.includes('smoke_lazycodex_package "lazycodex-ai@${OMO_VERSION}"')
     const smokesStableLatestOnly = smokeStep.includes('if [ -z "$DIST_TAG" ]; then') &&
       smokeStep.includes('smoke_lazycodex_package "lazycodex-ai@latest"')
-    const retriesRegistryPropagation = smokeStep.includes("for attempt in $(seq 1 12)") &&
+    const retriesRegistryPropagation = smokeStep.includes('for attempt in $(seq 1 "$SMOKE_READINESS_ATTEMPTS")') &&
+      smokeStep.includes('sleep "$SMOKE_READINESS_INTERVAL_SECONDS"') &&
       smokeStep.includes("registry propagation")
     const distinguishesVisibleInstallFailure =
       smokeStep.includes('npm view "$package_spec" version --silent') &&


### PR DESCRIPTION
## What

`publish.yml` `post-publish-verify` / `Smoke test published lazycodex-ai`: the registry-propagation wait goes from 12 x 10 s (2 min) to the omo-ai readiness budget (`SMOKE_READINESS_ATTEMPTS=60`, `SMOKE_READINESS_INTERVAL_SECONDS=15`, 15 min). The exhausted-budget message now says the package never became visible within the budget and that the publish may still have succeeded, instead of `Published LazyCodex smoke failed`.

## Why

npm exposes a freshly published version 4-5 minutes after `npm publish` returns. The LazyCodex-only release `5.0.0-beta.57` (#8175) published at 06:08:39Z, the registry document stamped the version at 06:12:54Z, and the smoke gave up at 06:12:23Z; `gh run rerun --failed` passed unchanged. beta.31 and beta.34 hit the same shape; the omo-ai loop in the same job was fixed after beta.42 (`publish-readiness-budget.test.ts`) but the LazyCodex loop kept the old budget.

## Tests

- New `script/publish-lazycodex-smoke-budget.test.ts` executes the step's run block with `npm`/`npx`/`sleep` stubbed as bash functions (same harness shape as `publish-readiness-budget.test.ts`): with the registry visible only after 20 views the loop must reach the package (21 views, `became visible` branch); with the registry never visible the loop must sleep >= 900 s in total and name registry propagation.
- `script/publish-lazycodex-workflow.test.ts` pins the loop to the budget variables instead of `seq 1 12`.
- Remote RED/GREEN + `typecheck:script` evidence is recorded under `.omo/evidence/20260912-lazycodex-smoke-budget/`.

## Residual risk

None beyond a longer red-path wait: a genuinely unpublished package now fails after 15 minutes instead of 2, with a message that points at the registry.

Fixes #8182

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LazyCodex post-publish smoke test falsely failing successful releases when npm takes its usual 4–5 minutes to expose a freshly published version.

- Extends the registry-propagation wait from 12 × 10 s to 60 × 15 s, matching the omo-ai readiness budget in the same job.
- Changes the exhausted-budget error to say the package never became visible and that the publish may still have succeeded, instead of blaming the package.
- Adds `script/publish-lazycodex-smoke-budget.test.ts`, which runs the step with stubbed `npm`/`npx`/`sleep` and pins the budget.
- Updates `script/publish-lazycodex-workflow.test.ts` to match the new loop variables.

<sup>Written for commit 3fff6bd142b9524f3fb162d94d4e5f0f2b7bb622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

