### PR TITLE
fix(config-migration): keep a category models chain when merging fallback_models

### DIFF
--- a/.omo/evidence/20260912-fix-8191/after-fix.txt
+++ b/.omo/evidence/20260912-fix-8191/after-fix.txt
@@ -1,0 +1,46 @@
+# bun run driver.ts on this branch (fix applied)
+
+--- ~/.omo/omo.jsonc before ---
+{
+  "categories": {
+    "quick": {
+      "models": [
+        "primary/model",
+        "second/model"
+      ],
+      "fallback_models": [
+        "legacy/fallback"
+      ]
+    }
+  }
+}
+--- oh-my-openagent config migrate ---
+status: migrated
+target: /private/var/folders/7_/jgfykr3d5b12qrh10lvz_l000000gn/T/omo-e2e-GG9L2T/.omo/omo.jsonc
+transform: {
+  "categories": {
+    "quick": {
+      "models": [
+        "primary/model",
+        "second/model",
+        "legacy/fallback"
+      ]
+    }
+  }
+}
+--- exit code 0 ---
+--- ~/.omo/omo.jsonc after ---
+{
+  "categories": {
+    "quick": {
+      "models": [
+        "primary/model",
+        "second/model",
+        "legacy/fallback"
+      ]
+    }
+  },
+  "_migrations": [
+    "2026-08-reasoning-unification"
+  ]
+}

--- a/.omo/evidence/20260912-fix-8191/before-fix.txt
+++ b/.omo/evidence/20260912-fix-8191/before-fix.txt
@@ -1,0 +1,42 @@
+# bun run driver.ts on origin/dev (unpatched)
+
+--- ~/.omo/omo.jsonc before ---
+{
+  "categories": {
+    "quick": {
+      "models": [
+        "primary/model",
+        "second/model"
+      ],
+      "fallback_models": [
+        "legacy/fallback"
+      ]
+    }
+  }
+}
+--- oh-my-openagent config migrate ---
+status: migrated
+target: /private/var/folders/7_/jgfykr3d5b12qrh10lvz_l000000gn/T/omo-e2e-LVO6Dx/.omo/omo.jsonc
+transform: {
+  "categories": {
+    "quick": {
+      "models": [
+        "legacy/fallback"
+      ]
+    }
+  }
+}
+--- exit code 0 ---
+--- ~/.omo/omo.jsonc after ---
+{
+  "categories": {
+    "quick": {
+      "models": [
+        "legacy/fallback"
+      ]
+    }
+  },
+  "_migrations": [
+    "2026-08-reasoning-unification"
+  ]
+}

--- a/.omo/evidence/20260912-fix-8191/driver.ts
+++ b/.omo/evidence/20260912-fix-8191/driver.ts
@@ -1,0 +1,22 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { runConfigMigrate } from "./packages/omo-opencode/src/cli/config-migrate"
+
+const home = mkdtempSync(join(tmpdir(), "omo-e2e-"))
+mkdirSync(join(home, ".omo"), { recursive: true })
+const target = join(home, ".omo", "omo.jsonc")
+writeFileSync(target, `${JSON.stringify({
+  categories: {
+    quick: { models: ["primary/model", "second/model"], fallback_models: ["legacy/fallback"] },
+  },
+}, null, 2)}\n`)
+
+console.log("--- ~/.omo/omo.jsonc before ---")
+console.log(readFileSync(target, "utf-8").trim())
+console.log("--- oh-my-openagent config migrate ---")
+const code = runConfigMigrate({ cwd: home, environment: { HOME: home }, output: (line) => console.log(line) })
+console.log(`--- exit code ${code} ---`)
+console.log("--- ~/.omo/omo.jsonc after ---")
+console.log(readFileSync(target, "utf-8").trim())

--- a/.omo/evidence/20260912-fix-8191/mutation-green.txt
+++ b/.omo/evidence/20260912-fix-8191/mutation-green.txt
@@ -1,0 +1,8 @@
+# same test file with the fix applied
+
+bun test v1.4.2 (744846f84)
+
+ 6 pass
+ 0 fail
+ 14 expect() calls
+Ran 6 tests across 1 file. [521.00ms]

--- a/.omo/evidence/20260912-fix-8191/mutation-red.txt
+++ b/.omo/evidence/20260912-fix-8191/mutation-red.txt
@@ -1,0 +1,57 @@
+# new regression tests against the unpatched line (expected to fail)
+
+bun test v1.4.2 (744846f84)
+
+packages/omo-opencode/src/config-migration/reasoning-unification.test.ts:
+51 | 
+52 |     // when
+53 |     const result = transformReasoningUnification(input)
+54 | 
+55 |     // then
+56 |     expect(result.document.categories?.quick).toEqual({
+                                                   ^
+error: expect(received).toEqual(expected)
+
+@@ -2,7 +2,2 @@
+    "models": [
+-     "primary/model",
+-     {
+-       "model": "second/model",
+-       "reasoning": "high",
+-     },
+      "legacy/fallback",
+
+- Expected  - 5
++ Received  + 0
+
+      at <anonymous> (/Users/lukasbuck/Local/oss-issues/oh-my-openagent/packages/omo-opencode/src/config-migration/reasoning-unification.test.ts:56:47)
+(fail) 2026-08 reasoning unification migration > #given a category with a canonical chain and legacy fallbacks #when transformed #then the chain keeps its primary and the fallbacks are appended [0.32ms]
+64 | 
+65 |     // when
+66 |     const result = transformReasoningUnification(input)
+67 | 
+68 |     // then
+69 |     expect(result.document.categories?.deep).toEqual({ models: [{ model: "a/b", reasoning: "high" }] })
+                                                  ^
+error: expect(received).toEqual(expected)
+
+  {
+-   "models": [
+-     {
+-       "model": "a/b",
+-       "reasoning": "high",
+-     },
+-   ],
++   "models": [],
+  }
+
+- Expected  - 6
++ Received  + 1
+
+      at <anonymous> (/Users/lukasbuck/Local/oss-issues/oh-my-openagent/packages/omo-opencode/src/config-migration/reasoning-unification.test.ts:69:46)
+(fail) 2026-08 reasoning unification migration > #given a category chain with an empty fallback list #when transformed #then the chain survives instead of becoming empty [0.16ms]
+
+ 4 pass
+ 2 fail
+ 14 expect() calls
+Ran 6 tests across 1 file. [616.00ms]

--- a/.omo/evidence/20260912-fix-8191/qa-summary.md
+++ b/.omo/evidence/20260912-fix-8191/qa-summary.md
@@ -1,0 +1,36 @@
+# QA Evidence - fix(config-migration): keep a category models chain when merging fallback_models (#8191)
+
+## What was tested
+- RED -> GREEN on the pure transform `transformReasoningUnification`, which is what the `2026-08-reasoning-unification` plan commits.
+- A driver that runs the real CLI entry point `runConfigMigrate` against a throwaway `HOME`, so the plan, the journal, the commit and the target rewrite all execute as they do for a user typing `oh-my-openagent config migrate`.
+- Typecheck (`tsgo`) and the suites around config migration, the omo-config-core migration engine, config loading and the config schemas.
+
+## What was observed
+### Live surface - real `config migrate` (`driver.ts`, `before-fix.txt`, `after-fix.txt`)
+Input category, written to `$HOME/.omo/omo.jsonc` with no `_migrations` marker:
+
+```jsonc
+{ "categories": { "quick": { "models": ["primary/model", "second/model"], "fallback_models": ["legacy/fallback"] } } }
+```
+
+- Before fix (`origin/dev`): `status: migrated`, and the file on disk becomes `models: ["legacy/fallback"]`. The declared chain is gone and the former fallback is now the primary model.
+- After fix: `models: ["primary/model", "second/model", "legacy/fallback"]`. The chain keeps its order and the legacy fallback is appended.
+
+Both runs exit 0 and add the `2026-08-reasoning-unification` marker, so the difference is only in the migrated document.
+
+### RED - unmodified dev (`mutation-red.txt`)
+With only the one changed line reverted to `origin/dev`, the two new tests fail (`4 pass / 2 fail`):
+- chain plus legacy fallbacks collapses to the fallbacks alone
+- chain plus an empty `fallback_models` collapses to `models: []`, leaving the category with no model
+
+### GREEN - with fix (`mutation-green.txt`)
+`6 pass / 0 fail`, including the committed 2026-08 fixture test, which is unchanged because that fixture has no category carrying both keys.
+
+### Related suites (`related-suites.txt`)
+`bun test` over `packages/omo-opencode/src/config-migration`, `packages/omo-config-core/src/migration`, `packages/omo-opencode/src/startup-migration.test.ts`, `packages/omo-opencode/src/config`, `packages/omo-config-core/src/schema` and the `config-migrate` CLI test: `317 pass / 0 fail`.
+
+### Typecheck (`typecheck.txt`)
+`tsgo --noEmit -p packages/omo-opencode/tsconfig.json` exit 0, no output.
+
+## Not covered
+No live OpenCode session was driven, so this is not an `opencode-qa` run. The change is confined to the document transform that `config migrate` and the plugin startup migration share, and the driver above exercises that path through the real CLI function rather than through the harness.

--- a/.omo/evidence/20260912-fix-8191/related-suites.txt
+++ b/.omo/evidence/20260912-fix-8191/related-suites.txt
@@ -1,0 +1,8 @@
+# related suites
+
+bun test v1.4.2 (744846f84)
+
+ 317 pass
+ 0 fail
+ 762 expect() calls
+Ran 317 tests across 45 files. [759.00ms]

--- a/.omo/evidence/20260912-fix-8191/typecheck.txt
+++ b/.omo/evidence/20260912-fix-8191/typecheck.txt
@@ -1,0 +1,3 @@
+# tsgo --noEmit -p packages/omo-opencode/tsconfig.json
+
+(no output, exit 0)

--- a/packages/omo-opencode/src/config-migration/reasoning-unification.test.ts
+++ b/packages/omo-opencode/src/config-migration/reasoning-unification.test.ts
@@ -38,6 +38,37 @@ describe("2026-08 reasoning unification migration", () => {
     expect(journal).not.toContain('kept reasoningEffort="xhigh"')
   })
 
+  test("#given a category with a canonical chain and legacy fallbacks #when transformed #then the chain keeps its primary and the fallbacks are appended", () => {
+    // given
+    const input = {
+      categories: {
+        quick: {
+          models: ["primary/model", { model: "second/model", variant: "high" }],
+          fallback_models: ["legacy/fallback"],
+        },
+      },
+    }
+
+    // when
+    const result = transformReasoningUnification(input)
+
+    // then
+    expect(result.document.categories?.quick).toEqual({
+      models: ["primary/model", { model: "second/model", reasoning: "high" }, "legacy/fallback"],
+    })
+  })
+
+  test("#given a category chain with an empty fallback list #when transformed #then the chain survives instead of becoming empty", () => {
+    // given
+    const input = { categories: { deep: { models: [{ model: "a/b", reasoning: "high" }], fallback_models: [] } } }
+
+    // when
+    const result = transformReasoningUnification(input)
+
+    // then
+    expect(result.document.categories?.deep).toEqual({ models: [{ model: "a/b", reasoning: "high" }] })
+  })
+
   test("#given an existing user omo config #when planned and executed #then dry-run, backup, journaled execution, and marker use the existing engine", () => {
     // given
     const root = mkdtempSync(join(tmpdir(), "omo-reasoning-migration-"))

--- a/packages/omo-opencode/src/config-migration/reasoning-unification.ts
+++ b/packages/omo-opencode/src/config-migration/reasoning-unification.ts
@@ -88,7 +88,9 @@ function normalizeDefinition(
   if (!shouldCombine) return normalized
 
   const primary = primaryModelRef(value, opencode)
-  const existing = kind === "agent" ? normalizedList(value["models"]) : []
+  // Categories accept the canonical `models` chain too, so a chain already written by hand must
+  // survive the merge; dropping it would silently replace the primary model with a fallback.
+  const existing = normalizedList(value["models"])
   const fallbacks = normalizedList(fallbackModels)
   normalized["models"] = [...(primary === undefined ? [] : [primary]), ...existing, ...fallbacks]
   delete normalized["model"]


### PR DESCRIPTION
## Summary

- `config migrate` destroyed a category's model chain when the category carried both the canonical `models` array and a leftover `fallback_models` key: `models: [A, B]` plus `fallback_models: [C]` was rewritten to `models: [C]`, so the former fallback became the primary model. With an empty `fallback_models` the category was left with `models: []` and no model at all.
- Agents were already merged correctly. Categories now follow the same rule, so the migration is `[primary?, ...declared chain, ...legacy fallbacks]` for both kinds.
- Fixes #8191. Context for anyone converting agents or categories by hand: #8186.

## Changes

- `packages/omo-opencode/src/config-migration/reasoning-unification.ts`: `normalizeDefinition()` reads the existing `models` chain for categories too. The `kind === "agent"` guard predates `CategoryConfigSchema` accepting `models`, and with categories now declaring an ordered chain the guard silently dropped it. One line plus a comment saying why it matters.
- `packages/omo-opencode/src/config-migration/reasoning-unification.test.ts`: two regression tests, one for a chain plus legacy fallbacks and one for a chain plus an empty fallback list.
- `.omo/evidence/20260912-fix-8191/`: driver, before and after logs, red/green mutation output, related suites, typecheck.

## QA & Evidence

- **What was tested:** the real CLI entry point `runConfigMigrate` against a throwaway `HOME` holding a category with both keys and no `_migrations` marker, so the plan, journal, commit and target rewrite all ran.
  **Observed result:** on `origin/dev` the file on disk became `models: ["legacy/fallback"]`; on this branch it became `models: ["primary/model", "second/model", "legacy/fallback"]`. Both runs exit 0 and add the `2026-08-reasoning-unification` marker, so only the migrated document differs.
  **Artifact:** `.omo/evidence/20260912-fix-8191/driver.ts`, `before-fix.txt`, `after-fix.txt`
  **Why sufficient:** it is the same function `oh-my-openagent config migrate` calls, and it proves the loss and the fix on the file the user actually keeps.

- **What was tested:** the two new tests with the changed line reverted to `origin/dev`, then restored.
  **Observed result:** `4 pass / 2 fail` reverted, `6 pass / 0 fail` restored. The committed 2026-08 fixture test passes in both, because that fixture has no category carrying both keys, which is how this slipped through.
  **Artifact:** `.omo/evidence/20260912-fix-8191/mutation-red.txt`, `mutation-green.txt`
  **Why sufficient:** the tests fail for the intended reason and are not tautological.

- **What was tested:** `bun test` over `packages/omo-opencode/src/config-migration`, `packages/omo-config-core/src/migration`, `startup-migration.test.ts`, `packages/omo-opencode/src/config`, `packages/omo-config-core/src/schema`, and the `config-migrate` CLI test.
  **Observed result:** `317 pass / 0 fail`.
  **Artifact:** `.omo/evidence/20260912-fix-8191/related-suites.txt`
  **Why sufficient:** covers both callers of the transform and the engine that commits it.

- **What was tested:** `tsgo --noEmit -p packages/omo-opencode/tsconfig.json`.
  **Observed result:** exit 0, no output.
  **Artifact:** `.omo/evidence/20260912-fix-8191/typecheck.txt`

## Risks & Residuals

- **No live harness QA.** I cannot drive a real OpenCode session in this environment, so this is not an `opencode-qa` run. Accepted, with the CLI-level driver above as the substitute: the change is confined to the pure document transform shared by `config migrate` and the plugin startup migration.
- **Behaviour change is narrow.** A category with only `model` plus `fallback_models` migrates byte for byte as before, which the unchanged 2026-08 fixture pins. Only categories that already use `models` see a different result, and for them the old result was the data loss.
- **Duplicate heads are possible** when a category sets `model` and repeats the same entry as the head of `models`. That matches the existing agent behaviour and is left as is rather than adding dedupe in a fix PR.
- **Root `bun test` and `test:codex`** were not part of this evidence; the targeted suites and the typecheck above are. CI runs the full matrix.

## Automated Checks

```bash
bun test packages/omo-opencode/src/config-migration packages/omo-config-core/src/migration \
  packages/omo-opencode/src/startup-migration.test.ts packages/omo-opencode/src/config \
  packages/omo-config-core/src/schema packages/omo-opencode/src/cli/config-migrate.test.ts
# 317 pass, 0 fail

./node_modules/.bin/tsgo --noEmit -p packages/omo-opencode/tsconfig.json
# exit 0
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `config migrate` dropping a category's declared `models` chain whenever a leftover `fallback_models` key is present. Previously `models: [A, B]` plus `fallback_models: [C]` was rewritten to `models: [C]`, promoting a fallback to primary, and an empty `fallback_models` left the category with no model at all; categories now merge the same way agents do, preserving `[primary?, ...declared chain, ...legacy fallbacks]`. Fixes #8191.

**Bug Fixes**
- `normalizeDefinition()` now reads the existing `models` chain for categories, matching the agent path.
- Adds two regression tests: a chain with legacy fallbacks and a chain with an empty fallback list.
- Categories that don't declare `models` already migrate byte-for-byte as before, so only the data-loss case changes.
- A category setting both `model` and the same entry at the head of `models` can produce duplicate heads; that matches existing agent behavior and is left as-is.

<sup>Written for commit 162eedd7c25edfa19391e001da1473437c65de9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

