### PR TITLE
fix(model-core): recognize OpenCodex SWE-2 prompt aliases

### DIFF
--- a/packages/model-core/src/model-family-detectors.test.ts
+++ b/packages/model-core/src/model-family-detectors.test.ts
@@ -66,6 +66,14 @@ describe("model family detectors", () => {
 
   test("#given Devin SWE-2 model ids #then detects SWE-2 effort lanes only", () => {
     expect(isSWE2Model("devin/swe-2-low")).toBe(true)
+    expect(isSWE2Model("devin/swe-2-medium")).toBe(true)
+    expect(isSWE2Model("opencodex-chat/devin/swe-2-high")).toBe(true)
+    expect(isSWE2Model("ocx-devin-swe-2")).toBe(true)
+    expect(isSWE2Model("opencodex/ocx-devin-swe-2-high")).toBe(true)
+    expect(isSWE2Model("opencodex/OCX-DEVIN-SWE-2-MAX")).toBe(true)
+    expect(isSWE2Model("ocx-devin-swe-20")).toBe(false)
+    expect(isSWE2Model("ocx-devin-swe-1-7")).toBe(false)
+    expect(isSWE2Model("other-swe-2-high")).toBe(false)
     expect(isSWE2Model("devin/swe-2-high")).toBe(true)
     expect(isSWE2Model("devin/swe-2-max")).toBe(true)
     expect(isSWE2Model("swe-2")).toBe(true)

--- a/packages/model-core/src/model-family-detectors.ts
+++ b/packages/model-core/src/model-family-detectors.ts
@@ -85,7 +85,7 @@ export function isKimiK3Model(model: string): boolean {
 
 export function isSWE2Model(model: string): boolean {
   const modelName = extractModelName(model).toLowerCase()
-  return /^swe-2(?:[-.]|$)/.test(modelName)
+  return /^(?:ocx-devin-)?swe-2(?:[-.]|$)/.test(modelName)
 }
 
 export function isMiniMaxModel(model: string): boolean {

--- a/packages/prompts-core/src/variant-resolver.test.ts
+++ b/packages/prompts-core/src/variant-resolver.test.ts
@@ -65,6 +65,9 @@ describe("resolveVariant", () => {
     } satisfies VariantTable
 
     expect(resolveVariant({ modelID: "devin/swe-2-high", variants: orderedVariants })).toBe("swe-2")
+    expect(resolveVariant({ modelID: "opencodex/ocx-devin-swe-2", variants: orderedVariants })).toBe("swe-2")
+    expect(resolveVariant({ modelID: "ocx-devin-swe-2-medium", variants: orderedVariants })).toBe("swe-2")
+    expect(resolveVariant({ modelID: "ocx-devin-swe-20", variants: orderedVariants })).toBe("default")
     expect(resolveVariant({ modelID: "devin/swe-1-7", variants: orderedVariants })).toBe("default")
   })
 


### PR DESCRIPTION
## Summary

SWE-2 accessed through an OpenCodex alias such as `opencodex/ocx-devin-swe-2` falls back to the default prompt variant. Recognize the exact `ocx-devin-` prefix so it reaches the SWE-2 variant added in #8130, while similarly named non-SWE-2 models keep their previous routing.

## Changes

- Extend only the SWE-2 family predicate. Existing namespaced `devin/swe-2-*` ids continue to work.
- Cover alias detection and the actual `resolveVariant` consumer, including `swe-20` and unrelated-prefix exclusions. No prompt wording, client tool schemas, or global defaults change.

## QA & Evidence

- **What was tested:** `bun test packages/model-core/src/model-family-detectors.test.ts packages/prompts-core/src/variant-resolver.test.ts`.
  **Observed result:** 29 passed, 0 failed, 132 assertions.
  **Why sufficient:** The tests exercise both the detector and model-to-variant dispatch rather than asserting prompt text.
- **Regression check:** With the original detector restored, the new alias cases fail; restoring the fix makes both files pass.
- **Type check:** `cd packages/model-core && bun run typecheck` passed.
- `git diff --check` passed. AI-assisted implementation and verification.

## Risks & Residuals

- Recognition is restricted to the explicit OpenCodex Devin prefix and the existing SWE-2 family boundary. Other family matchers are untouched.
- The root dependency install's prepare build failed in the unchanged `packages/omo-opencode/src/features/background-agent/process-cleanup.test-helpers.ts` with TS2769/TS2322 (`BeforeExitListener`). The unrelated generated installer output was excluded. No claim that the root build or full suite passes; this PR is a draft.
- No app binaries were replaced and no user configurations or credentials are included.

## Automated Checks

```bash
bun test packages/model-core/src/model-family-detectors.test.ts packages/prompts-core/src/variant-resolver.test.ts
cd packages/model-core && bun run typecheck
git diff --check
```

## Related Issues

Follow-up to #8130.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SWE-2 model detection so OpenCodex aliases like `opencodex/ocx-devin-swe-2` now resolve to the SWE-2 prompt variant instead of falling back to the default. The predicate change only extends the SWE-2 family, so existing `devin/swe-2-*` ids and unrelated models keep their previous routing, and false positives like `ocx-devin-swe-20` still route to the default.

<sup>Written for commit 57299efd4badc9c739c4d6a0669b215b84aef2a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

