### PR TITLE
fix(omo-senpi): measure Kibitzer retention fixtures against the injected clock

### DIFF
--- a/packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts
+++ b/packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts
@@ -314,13 +314,15 @@ describe("kibitzer sidecar retention", () => {
     const f = await fixture()
     const recall = f.context.identityPaths.recall
     const locks = f.context.identityPaths.locks
-    const eightDaysAgo = Date.now() - 8 * DAY_MS
+    // Age is measured against the fixture's pinned clock, the same clock the sweep reads; deriving it
+    // from wall-clock time instead makes the test pass or fail depending on the day it runs.
+    const eightDaysAgo = f.clock.now - 8 * DAY_MS
     expect(KIBITZER_SIDECAR_RETENTION_MS).toBe(7 * DAY_MS)
 
     const stale = await sidecarDirWithTranscript(f.context, "stale-session", eightDaysAgo)
     const active = await sidecarDirWithTranscript(f.context, "active-session", eightDaysAgo)
     const otherProcess = await sidecarDirWithTranscript(f.context, "other-process-session", eightDaysAgo)
-    const fresh = await sidecarDirWithTranscript(f.context, "fresh-session", Date.now())
+    const fresh = await sidecarDirWithTranscript(f.context, "fresh-session", f.clock.now)
     const tombstone = join(recall, "sidecars", ".prune-leftover")
     await mkdir(tombstone, { recursive: true })
     await writeFile(join(tombstone, "child.jsonl"), "{}\n")


### PR DESCRIPTION
## Summary

The Kibitzer retention test pinned a fake clock for the sweep but backdated its fixtures from the real `Date.now()`. Once wall-clock time drifted more than a day past the pinned clock, the "eight days old" directory measured only **6.84 days** against that clock — under the seven-day retention — so the sweep correctly kept it and the assertion failed.

It fails deterministically on `dev` for everyone, on both macOS and the Ubuntu runner, and it is a required check, so it blocks unrelated PRs.

Fixes #8196

## Change

Both fixture timestamps now come from the same injected clock the sweep reads.

## Verification

`bun test packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts` → 7 pass / 0 fail (it was 6 pass / 1 fail on `dev` with the same command).

The file no longer reads the real clock anywhere: `grep -c 'Date.now()' observe.test.ts` → 0, so the outcome cannot depend on the date the suite runs.

Production code is untouched. I checked the sweep itself is correct with a standalone probe against the real modules: `pruneKibitzerSidecars` removes an unowned aged directory, and `own()` followed by `onSessionShutdown()` removes the aged directory once ownership is released.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Kibitzer retention test so it no longer fails when wall-clock time drifts more than a day past the injected clock the sweep reads. Fixes #8196.

- Fixture timestamps now come from `f.clock.now` instead of `Date.now()`.
- The test outcome no longer depends on the date the suite runs.
- Production code is unchanged.

<sup>Written for commit 36a66d42d84b5cf436a02dc92244302f8a8ba8e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

