### PR TITLE
feat(tui-sidebar): show active LSP clients from the lsp-daemon status mirror

### DIFF
--- a/packages/lsp-daemon/src/daemon-server.ts
+++ b/packages/lsp-daemon/src/daemon-server.ts
@@ -15,6 +15,7 @@ import {
 import type { DaemonPaths } from "./paths.js";
 import { handleDaemonMessage } from "./request-routing.js";
 import { createLineDecoder, encodeJsonLine } from "./socket-jsonrpc.js";
+import { startStatusMirror } from "./status-mirror.js";
 import { reapStaleDaemonVersions } from "./version-reap.js";
 
 export { DaemonAlreadyRunningError, DaemonStartupDeferredError } from "./ownership.js";
@@ -81,6 +82,7 @@ export async function startDaemonServer(
 		throw error;
 	}
 	lease.lock.release();
+	const stopStatusMirror = startStatusMirror(paths);
 
 	// Best-effort cross-version reap: the daemon now owns its version, so older
 	// sibling versions may be reaped. Never block or crash startup on failure.
@@ -91,6 +93,7 @@ export async function startDaemonServer(
 		if (closed) return;
 		closed = true;
 		clearInterval(idleTimer);
+		stopStatusMirror();
 		for (const socket of connections) socket.destroy();
 		connections.clear();
 		await closeServer(server);
@@ -106,6 +109,7 @@ export async function startDaemonServer(
 		}
 		if (Date.now() - lastActiveAt < idleShutdownMs) return;
 		if (options.onIdleShutdown) {
+			stopStatusMirror();
 			options.onIdleShutdown();
 			return;
 		}

--- a/packages/lsp-daemon/src/status-mirror.ts
+++ b/packages/lsp-daemon/src/status-mirror.ts
@@ -1,0 +1,62 @@
+import { renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLspManager } from "@oh-my-opencode/lsp-core/lsp/manager";
+import { setPrivateFileMode } from "./ipc-protocol.js";
+import type { DaemonPaths } from "./paths.js";
+
+const STATUS_MIRROR_INTERVAL_MS = 2_000;
+const STATUS_MIRROR_FILE_NAME = "status.json";
+const STATUS_MIRROR_VERSION = 1;
+
+export function startStatusMirror(paths: DaemonPaths, intervalMs = STATUS_MIRROR_INTERVAL_MS): () => void {
+	const statusPath = join(paths.dir, STATUS_MIRROR_FILE_NAME);
+	const tempPath = `${statusPath}.tmp`;
+
+	const writeStatus = (): void => {
+		try {
+			const status = {
+				version: STATUS_MIRROR_VERSION,
+				updatedAt: Date.now(),
+				pid: process.pid,
+				clients: getLspManager()
+					.getSnapshot()
+					.map((snapshot) => ({
+						serverId: snapshot.serverId,
+						root: snapshot.root,
+						alive: snapshot.alive,
+						isInitializing: snapshot.isInitializing,
+						refCount: snapshot.refCount,
+					})),
+			};
+			writeFileSync(tempPath, `${JSON.stringify(status)}\n`, { mode: 0o600 });
+			setPrivateFileMode(tempPath);
+			renameSync(tempPath, statusPath);
+		} catch (error) {
+			logMirrorError(error);
+		}
+	};
+
+	writeStatus();
+	const timer = setInterval(writeStatus, intervalMs);
+	timer.unref();
+
+	return () => {
+		clearInterval(timer);
+		unlinkQuietly(statusPath);
+		unlinkQuietly(tempPath);
+	};
+}
+
+function unlinkQuietly(path: string): void {
+	try {
+		unlinkSync(path);
+	} catch (error) {
+		if (!(error instanceof Error)) throw error;
+	}
+}
+
+function logMirrorError(error: unknown): void {
+	const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+	process.stderr.write(`[lsp-daemon] status mirror: ${message}\n`);
+}

--- a/packages/lsp-daemon/test/status-mirror.test.ts
+++ b/packages/lsp-daemon/test/status-mirror.test.ts
@@ -1,0 +1,145 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getLspManager } from "@oh-my-opencode/lsp-core/lsp/manager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type DaemonServerHandle, startDaemonServer } from "../src/daemon-server.js";
+import { startStatusMirror } from "../src/status-mirror.js";
+import { daemonTestPaths } from "./daemon-path-fixture.js";
+
+vi.mock("@oh-my-opencode/lsp-core/lsp/manager", () => ({
+	getLspManager: vi.fn(),
+	disposeDefaultLspManager: vi.fn(async () => {}),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	return {
+		...actual,
+		renameSync: vi.fn(actual.renameSync),
+		writeFileSync: vi.fn(actual.writeFileSync),
+	};
+});
+
+const managerMock = vi.mocked(getLspManager);
+const renameMock = vi.mocked(renameSync);
+const writeMock = vi.mocked(writeFileSync);
+const tempDirectories: string[] = [];
+const servers: DaemonServerHandle[] = [];
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	renameMock.mockClear();
+	writeMock.mockClear();
+});
+
+afterEach(async () => {
+	vi.useRealTimers();
+	managerMock.mockReset();
+	for (const server of servers.splice(0)) await server.close();
+	for (const directory of tempDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function tempPaths() {
+	const directory = mkdtempSync(join(tmpdir(), "lsp-daemon-status-mirror-"));
+	tempDirectories.push(directory);
+	const paths = daemonTestPaths(directory);
+	mkdirSync(paths.dir, { recursive: true });
+	return paths;
+}
+
+describe("startStatusMirror", () => {
+	it("writes the versioned status shape with only public client fields", () => {
+		const paths = tempPaths();
+		const updatedAt = 1_789_226_530_000;
+		vi.setSystemTime(updatedAt);
+		managerMock.mockReturnValue({
+			getSnapshot: () => [
+				{
+					serverId: "typescript",
+					root: "/abs/path",
+					alive: true,
+					isInitializing: false,
+					refCount: 1,
+					command: ["tsserver"],
+					pendingWaiters: 2,
+					lastUsedAt: 3,
+				},
+			],
+		} as unknown as ReturnType<typeof getLspManager>);
+
+		const stop = startStatusMirror(paths);
+		const status = JSON.parse(readFileSync(join(paths.dir, "status.json"), "utf8")) as Record<string, unknown>;
+
+		expect(status).toEqual({
+			version: 1,
+			updatedAt,
+			pid: process.pid,
+			clients: [{ serverId: "typescript", root: "/abs/path", alive: true, isInitializing: false, refCount: 1 }],
+		});
+		stop();
+	});
+
+	it("writes through a temporary file before renaming to the status path", () => {
+		const paths = tempPaths();
+		managerMock.mockReturnValue({ getSnapshot: () => [] } as unknown as ReturnType<typeof getLspManager>);
+
+		const stop = startStatusMirror(paths);
+
+		expect(renameMock).toHaveBeenCalledWith(join(paths.dir, "status.json.tmp"), join(paths.dir, "status.json"));
+		expect(renameMock).toHaveBeenCalledTimes(1);
+		expect(writeMock).toHaveBeenCalledWith(
+			join(paths.dir, "status.json.tmp"),
+			expect.any(String),
+			expect.objectContaining({ mode: 0o600 }),
+		);
+		expect(writeMock.mock.calls.every(([path]) => path !== join(paths.dir, "status.json"))).toBe(true);
+		stop();
+	});
+
+	it("clears its interval and removes both status artifacts on stop", async () => {
+		const paths = tempPaths();
+		managerMock.mockReturnValue({ getSnapshot: () => [] } as unknown as ReturnType<typeof getLspManager>);
+		const stop = startStatusMirror(paths, 100);
+		writeFileSync(join(paths.dir, "status.json.tmp"), "leftover", { mode: 0o600 });
+
+		stop();
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(existsSync(join(paths.dir, "status.json"))).toBe(false);
+		expect(existsSync(join(paths.dir, "status.json.tmp"))).toBe(false);
+	});
+
+	it("logs a write error and retries on the next tick", async () => {
+		const paths = tempPaths();
+		managerMock.mockReturnValue({ getSnapshot: () => [] } as unknown as ReturnType<typeof getLspManager>);
+		const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+		renameMock.mockImplementationOnce(() => {
+			throw new Error("temporary rename failure");
+		});
+
+		const stop = startStatusMirror(paths, 100);
+		expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("temporary rename failure"));
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(existsSync(join(paths.dir, "status.json"))).toBe(true);
+		stop();
+		stderrSpy.mockRestore();
+		renameMock.mockReset();
+	});
+
+	it("creates the mirror after daemon startup and removes it on close", async () => {
+		const paths = tempPaths();
+		managerMock.mockReturnValue({ getSnapshot: () => [] } as unknown as ReturnType<typeof getLspManager>);
+
+		const server = await startDaemonServer(paths, { onIdleShutdown: () => {} });
+		servers.push(server);
+
+		expect(existsSync(join(paths.dir, "status.json"))).toBe(true);
+		await server.close();
+
+		expect(existsSync(join(paths.dir, "status.json"))).toBe(false);
+		expect(existsSync(join(paths.dir, "status.json.tmp"))).toBe(false);
+		servers.splice(servers.indexOf(server), 1);
+	});
+});

--- a/packages/omo-opencode/src/features/tui-sidebar/AGENTS.md
+++ b/packages/omo-opencode/src/features/tui-sidebar/AGENTS.md
@@ -4,13 +4,13 @@
 
 ## OVERVIEW
 
-24 .ts files (12 impl + 12 co-located tests). Two halves connected only by a JSON mirror file on disk: the plugin process writes runtime snapshots (`TuiStateMirror`), the TUI process polls the mirror, derives section states, and renders sidebar nodes. Gated on `tui.sidebar.enabled` (on unless explicitly `false`).
+26 .ts files (13 impl + 13 co-located tests). Two halves connected only by a JSON mirror file on disk: the plugin process writes runtime snapshots (`TuiStateMirror`), the TUI process polls the mirror, derives section states, and renders sidebar nodes. Gated on `tui.sidebar.enabled` (on unless explicitly `false`).
 
 ## DATA FLOW
 
 ```
 plugin side:  events/heartbeat → TuiStateMirror.flush() → buildTuiRuntimeSnapshot() → writeMirror() (atomic JSON)
-TUI side:     1s poll → readMirror() → derivers → computeView() → viewKey diff → buildViewNodes() → sidebar_content
+TUI side:     1s poll → readMirror() + lsp-status-reader.ts → derivers → computeView() → viewKey diff → buildViewNodes() → sidebar_content (including LSP)
 ```
 
 ## STRUCTURE
@@ -19,18 +19,19 @@ TUI side:     1s poll → readMirror() → derivers → computeView() → viewKe
 |------|---------|
 | `mirror-manager.ts` | `TuiStateMirror` — debounced (250ms) flush, 2s heartbeat, single in-flight write, start/stop lifecycle |
 | `snapshot-builder.ts` | `buildTuiRuntimeSnapshot` — active agents from session statuses, job board from `BackgroundManager.getTasksSnapshot()`, loop state; redacts `activeGoal` text before write |
-| `snapshot-schema.ts` | Zod schema `TuiRuntimeSnapshotSchema` (version literal 1) + `parseSnapshot` |
+| `snapshot-schema.ts` | Zod schema `TuiRuntimeSnapshotSchema` (version literal 2, including LSP clients) + `parseSnapshot` |
 | `mirror-io.ts` | `writeMirror` (atomic, mode 0600) / `readMirror` — rejects unparseable, wrong-project, or stale (>6s) snapshots |
 | `mirror-path.ts` | XDG data dir + sha1(projectDir) prefix filename; `canonicalProjectDir` via realpath |
 | `loop-reader.ts` | Reads `.omo/ulw-loop/*/goals.json` (v1 schema) + legacy `.omo/loop/goals.json`, freshest live loop wins; stale after 120s |
+| `lsp-status-reader.ts` | Reads fresh LSP daemon `v*/status.json` snapshots, selecting the newest `updatedAt` and degrading invalid input to no clients |
 | `derivers.ts` | Snapshot → section states; jobs sorted by status priority (running first), caps MAX_AGENTS/MAX_JOBS = 12 |
 | `compute-view.ts` | `computeView` picks active/broken/idle; `viewKey` gives stable string for re-render diffing |
-| `render-view.ts` | `buildViewNodes` (themed box/text tree) + `describeView` (plain lines); 24-char label truncation |
+| `render-view.ts` | `buildViewNodes` (themed box/text tree) + `describeView` (plain lines), including the active/idle LSP section; 24-char label truncation |
 | `state-types.ts` | Discriminated-union section states (`kind` tags) + `assertNever` |
 | `roster-resolver.ts` | Idle-view model roster from config via doctor's model resolution |
 | `element-helpers.ts` | `ViewNode` type + `box`/`text` constructors (renderer-agnostic) |
 | `config-validator.ts` | Re-export of `validatePluginConfig` |
-| `constants.ts` | All timing/size knobs: STALE_MS 6s, HEARTBEAT_MS 2s, POLL_INTERVAL_MS 1s, WRITE_DEBOUNCE_MS 250ms, LOOP_FRESH_MS 120s |
+| `constants.ts` | All timing/size knobs: STALE_MS 6s, HEARTBEAT_MS 2s, POLL_INTERVAL_MS 1s, WRITE_DEBOUNCE_MS 250ms, LOOP_FRESH_MS 120s, LSP freshness 15s, LSP cap 12 |
 
 ## KEY EXPORTS
 

--- a/packages/omo-opencode/src/features/tui-sidebar/compute-view.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/compute-view.test.ts
@@ -10,6 +10,8 @@ import type {
   SidebarView,
 } from "./state-types"
 
+const noLsp = { kind: "none" } as const
+
 const validConfig: ConfigState = { kind: "valid" }
 const invalidConfig: ConfigState = {
   kind: "invalid",
@@ -50,13 +52,14 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: idleJobs,
       loop: idleLoop,
+      lsp: noLsp,
     }
 
     // when
     const view = computeView(sections)
 
     // then
-    expect(view).toEqual({ kind: "idle", roster })
+    expect(view).toEqual({ kind: "idle", roster, lsp: noLsp })
     expect("configBanner" in view).toBe(false)
   })
 
@@ -68,6 +71,7 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: idleJobs,
       loop: idleLoop,
+      lsp: noLsp,
     }
 
     // when
@@ -85,6 +89,7 @@ describe("tui sidebar computeView", () => {
       agents: activeAgents,
       jobs: idleJobs,
       loop: idleLoop,
+      lsp: noLsp,
     }
 
     // when
@@ -97,6 +102,7 @@ describe("tui sidebar computeView", () => {
       agents: activeAgents,
       jobs: idleJobs,
       configBanner: { kind: "none" },
+      lsp: noLsp,
     })
   })
 
@@ -108,6 +114,7 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: activeJobs,
       loop: idleLoop,
+      lsp: noLsp,
     }
 
     // when
@@ -120,6 +127,7 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: activeJobs,
       configBanner: { kind: "invalid" },
+      lsp: noLsp,
     })
   })
 
@@ -131,6 +139,7 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: idleJobs,
       loop: liveLoop,
+      lsp: noLsp,
     }
 
     // when
@@ -143,7 +152,26 @@ describe("tui sidebar computeView", () => {
       agents: idleAgents,
       jobs: idleJobs,
       configBanner: { kind: "none" },
+      lsp: noLsp,
     })
+  })
+
+  it("#given only LSP clients #when computing view #then it remains idle with the LSP section", () => {
+    const lsp = {
+      kind: "list" as const,
+      clients: [{ serverId: "typescript", root: "/workspace", state: "alive" as const, refCount: 1 }],
+    }
+
+    const view = computeView({
+      config: validConfig,
+      roster,
+      agents: idleAgents,
+      jobs: idleJobs,
+      loop: idleLoop,
+      lsp,
+    })
+
+    expect(view).toEqual({ kind: "idle", roster, lsp })
   })
 
   it("#given equivalent views built with different literal key order #when computing keys #then viewKey is stable", () => {
@@ -154,6 +182,7 @@ describe("tui sidebar computeView", () => {
       agents: activeAgents,
       jobs: activeJobs,
       configBanner: { kind: "invalid" },
+      lsp: noLsp,
     }
     const second: SidebarView = {
       configBanner: { kind: "invalid" },
@@ -173,6 +202,7 @@ describe("tui sidebar computeView", () => {
         kind: "live",
       },
       kind: "active",
+      lsp: noLsp,
     }
 
     // when
@@ -185,10 +215,11 @@ describe("tui sidebar computeView", () => {
 
   it("#given a changed view value #when computing keys #then viewKey changes", () => {
     // given
-    const original: SidebarView = { kind: "idle", roster }
+    const original: SidebarView = { kind: "idle", roster, lsp: noLsp }
     const changed: SidebarView = {
       kind: "idle",
       roster: { kind: "rows", rows: [{ label: "atlas", model: "openai/gpt-5.5" }] },
+      lsp: noLsp,
     }
 
     // when
@@ -197,5 +228,19 @@ describe("tui sidebar computeView", () => {
 
     // then
     expect(changedKey).not.toBe(originalKey)
+  })
+
+  it("#given changed LSP data #when computing keys #then viewKey changes", () => {
+    const first: SidebarView = {
+      kind: "idle",
+      roster,
+      lsp: { kind: "list", clients: [{ serverId: "typescript", root: "/workspace", state: "alive", refCount: 1 }] },
+    }
+    const second: SidebarView = {
+      ...first,
+      lsp: { kind: "list", clients: [{ serverId: "typescript", root: "/workspace", state: "alive", refCount: 2 }] },
+    }
+
+    expect(viewKey(second)).not.toBe(viewKey(first))
   })
 })

--- a/packages/omo-opencode/src/features/tui-sidebar/compute-view.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/compute-view.ts
@@ -5,6 +5,7 @@ import type {
   JobBoardState,
   LoopLive,
   LoopState,
+  LspState,
   RosterState,
   SidebarView,
 } from "./state-types"
@@ -15,6 +16,7 @@ export type ComputeViewSections = {
   readonly agents: AgentsState
   readonly jobs: JobBoardState
   readonly loop: LoopState
+  readonly lsp: LspState
 }
 
 export function computeView(sections: ComputeViewSections): SidebarView {
@@ -24,6 +26,7 @@ export function computeView(sections: ComputeViewSections): SidebarView {
       loop: sections.loop,
       agents: sections.agents,
       jobs: sections.jobs,
+      lsp: sections.lsp,
       configBanner: sections.config.kind === "invalid" ? { kind: "invalid" } : { kind: "none" },
     }
   }
@@ -32,7 +35,7 @@ export function computeView(sections: ComputeViewSections): SidebarView {
     return { kind: "broken", messages: sections.config.messages }
   }
 
-  return { kind: "idle", roster: sections.roster }
+  return { kind: "idle", roster: sections.roster, lsp: sections.lsp }
 }
 
 export function viewKey(view: SidebarView): string {
@@ -43,12 +46,13 @@ export function viewKey(view: SidebarView): string {
         loopKeyParts(view.loop),
         agentsKeyParts(view.agents),
         jobsKeyParts(view.jobs),
+        lspKeyParts(view.lsp),
         ["configBanner", view.configBanner.kind],
       ])
     case "broken":
       return stableKey(["broken", [...view.messages]])
     case "idle":
-      return stableKey(["idle", rosterKeyParts(view.roster)])
+      return stableKey(["idle", rosterKeyParts(view.roster), lspKeyParts(view.lsp)])
     default:
       return assertNever(view)
   }
@@ -107,6 +111,17 @@ function loopKeyParts(loop: LoopState): readonly unknown[] {
       return ["loop", "live", liveLoopKeyParts(loop)]
     default:
       return assertNever(loop)
+  }
+}
+
+function lspKeyParts(lsp: LspState): readonly unknown[] {
+  switch (lsp.kind) {
+    case "none":
+      return ["lsp", "none"]
+    case "list":
+      return ["lsp", "list", lsp.clients.map((client) => [client.serverId, client.root, client.state, client.refCount])]
+    default:
+      return assertNever(lsp)
   }
 }
 

--- a/packages/omo-opencode/src/features/tui-sidebar/constants.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/constants.ts
@@ -1,5 +1,5 @@
 export const MIRROR_DIR_NAME = "tui-state"
-export const MIRROR_SCHEMA_VERSION = 1
+export const MIRROR_SCHEMA_VERSION = 2
 export const STALE_MS = 6_000
 export const LOOP_FRESH_MS = 120_000
 export const POLL_INTERVAL_MS = 1_000
@@ -7,4 +7,8 @@ export const HEARTBEAT_MS = 2_000
 export const WRITE_DEBOUNCE_MS = 250
 export const MAX_AGENTS = 12
 export const MAX_JOBS = 12
+export const MAX_LSP_CLIENTS = 12
+export const LSP_STATUS_STALE_MS = 15_000
+export const LSP_STATUS_SCHEMA_VERSION = 1
+export const LSP_STATUS_FILE_NAME = "status.json"
 export const LABEL_MAX = 24

--- a/packages/omo-opencode/src/features/tui-sidebar/derivers.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/derivers.test.ts
@@ -5,11 +5,12 @@ import {
   deriveConfig,
   deriveJobBoard,
   deriveLoop,
+  deriveLsp,
   deriveRoster,
 } from "./derivers"
-import { MAX_AGENTS, MAX_JOBS, MIRROR_SCHEMA_VERSION } from "./constants"
+import { MAX_AGENTS, MAX_JOBS, MAX_LSP_CLIENTS, MIRROR_SCHEMA_VERSION } from "./constants"
 import type { TuiRuntimeSnapshot } from "./snapshot-schema"
-import type { AgentRow, JobRow, LoopLive, RosterRow } from "./state-types"
+import type { AgentRow, JobRow, LoopLive, LspClientRow, RosterRow } from "./state-types"
 
 const liveLoop: LoopLive = {
   kind: "live",
@@ -26,6 +27,7 @@ function snapshot(input: {
   readonly activeAgents?: readonly AgentRow[]
   readonly jobBoard?: readonly JobRow[]
   readonly loop?: LoopLive | null
+  readonly lspClients?: readonly LspClientRow[]
 }): TuiRuntimeSnapshot {
   return {
     version: MIRROR_SCHEMA_VERSION,
@@ -34,6 +36,7 @@ function snapshot(input: {
     activeAgents: [...(input.activeAgents ?? [])],
     jobBoard: [...(input.jobBoard ?? [])],
     loop: input.loop ?? null,
+    lspClients: [...(input.lspClients ?? [])],
   }
 }
 
@@ -199,6 +202,26 @@ describe("tui sidebar section derivers", () => {
     // then
     expect(nullState).toEqual({ kind: "none" })
     expect(emptyState).toEqual({ kind: "none" })
+  })
+
+  it("#given no clients #when deriving LSP #then it returns none", () => {
+    expect(deriveLsp(null)).toEqual({ kind: "none" })
+    expect(deriveLsp(snapshot({}))).toEqual({ kind: "none" })
+  })
+
+  it("#given oversized unsorted clients #when deriving LSP #then it sorts by state and server and caps", () => {
+    const clients: LspClientRow[] = Array.from({ length: MAX_LSP_CLIENTS + 2 }, (_, index) => ({
+      serverId: `server-${String(index).padStart(2, "0")}`,
+      root: `/root/${index}`,
+      state: index % 3 === 0 ? "dead" : index % 3 === 1 ? "alive" : "initializing",
+      refCount: index,
+    }))
+    const state = deriveLsp(snapshot({ lspClients: clients }))
+    expect(state.kind).toBe("list")
+    if (state.kind === "list") {
+      expect(state.clients).toHaveLength(MAX_LSP_CLIENTS)
+      expect(state.clients[0]?.state).toBe("initializing")
+    }
   })
 
   it("#given a live loop with pass fail pending and blocked counts #when deriving loop #then it passes the live state through", () => {

--- a/packages/omo-opencode/src/features/tui-sidebar/derivers.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/derivers.ts
@@ -1,4 +1,4 @@
-import { MAX_AGENTS, MAX_JOBS } from "./constants"
+import { MAX_AGENTS, MAX_JOBS, MAX_LSP_CLIENTS } from "./constants"
 import type { TuiRuntimeSnapshot } from "./snapshot-schema"
 import type {
   AgentsState,
@@ -6,6 +6,8 @@ import type {
   JobBoardState,
   JobRow,
   LoopState,
+  LspState,
+  LspClientRow,
   RosterRow,
   RosterState,
 } from "./state-types"
@@ -68,6 +70,13 @@ export function deriveLoop(snap: TuiRuntimeSnapshot | null): LoopState {
   return snap?.loop ?? { kind: "none" }
 }
 
+export function deriveLsp(snap: TuiRuntimeSnapshot | null): LspState {
+  if (!snap || snap.lspClients.length === 0) {
+    return { kind: "none" }
+  }
+  return { kind: "list", clients: [...snap.lspClients].sort(compareLspClients).slice(0, MAX_LSP_CLIENTS) }
+}
+
 function compareRosterRows(left: RosterRow, right: RosterRow): number {
   return left.label.localeCompare(right.label)
 }
@@ -79,4 +88,20 @@ function compareJobs(left: JobRow, right: JobRow): number {
   }
 
   return left.title.localeCompare(right.title)
+}
+
+function compareLspClients(left: LspClientRow, right: LspClientRow): number {
+  const priority = lspPriority(left) - lspPriority(right)
+  return priority !== 0 ? priority : left.serverId.localeCompare(right.serverId)
+}
+
+function lspPriority(client: LspClientRow): number {
+  switch (client.state) {
+    case "initializing":
+      return 0
+    case "alive":
+      return 1
+    case "dead":
+      return 2
+  }
 }

--- a/packages/omo-opencode/src/features/tui-sidebar/lsp-status-reader.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/lsp-status-reader.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, spyOn } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import * as fs from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { LSP_STATUS_SCHEMA_VERSION } from "./constants"
+import { readLspDaemonStatus } from "./lsp-status-reader"
+
+function withBase(run: (baseDir: string) => void): void {
+  const baseDir = mkdtempSync(join(tmpdir(), "omo-lsp-status-reader-"))
+  try {
+    run(baseDir)
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true })
+  }
+}
+
+function writeStatus(baseDir: string, versionDir: string, payload: unknown): void {
+  const dir = join(baseDir, versionDir)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, "status.json"), JSON.stringify(payload))
+}
+
+function status(updatedAt: number, serverId: string) {
+  return {
+    version: LSP_STATUS_SCHEMA_VERSION,
+    updatedAt,
+    pid: 42354,
+    clients: [{ serverId, root: "/abs/path", alive: true, isInitializing: false, refCount: 1 }],
+  }
+}
+
+describe("readLspDaemonStatus", () => {
+  it("returns empty for missing, invalid, wrong-version, and stale status", () => {
+    expect(readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: "/path/that/does/not/exist" })).toEqual([])
+    withBase((baseDir) => {
+      writeStatus(baseDir, "v1", { invalid: true })
+      expect(readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: baseDir })).toEqual([])
+      writeFileSync(join(baseDir, "v1", "status.json"), "{")
+      expect(readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: baseDir })).toEqual([])
+      writeStatus(baseDir, "v1", { ...status(Date.now(), "typescript"), version: 2 })
+      expect(readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: baseDir })).toEqual([])
+      writeStatus(baseDir, "v1", status(Date.now() - 15_001, "typescript"))
+      expect(readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: baseDir })).toEqual([])
+    })
+  })
+
+  it("picks freshest and maps alive, initializing, and dead clients", () => {
+    withBase((baseDir) => {
+      writeStatus(baseDir, "v1", status(Date.now() - 1_000, "older"))
+      writeStatus(baseDir, "v2", {
+        ...status(Date.now(), "typescript"),
+        clients: [
+          { serverId: "typescript", root: "/ts", alive: true, isInitializing: true, refCount: 2 },
+          { serverId: "eslint", root: "/eslint", alive: true, isInitializing: false, refCount: 1 },
+          { serverId: "dead", root: "/dead", alive: false, isInitializing: false, refCount: 0 },
+        ],
+      })
+      expect(readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: baseDir })).toEqual([
+        { serverId: "typescript", root: "/ts", state: "initializing", refCount: 2 },
+        { serverId: "eslint", root: "/eslint", state: "alive", refCount: 1 },
+        { serverId: "dead", root: "/dead", state: "dead", refCount: 0 },
+      ])
+    })
+  })
+
+  it("honors absolute overrides and ignores relative overrides", () => {
+    withBase((baseDir) => {
+      writeStatus(baseDir, "v1", status(Date.now(), "absolute"))
+      expect(readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: baseDir })[0]?.serverId).toBe("absolute")
+      expect(readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: "relative/path" })).toEqual([])
+    })
+  })
+
+  it("rethrows non-Error filesystem failures", () => {
+    const readdirSyncSpy = spyOn(fs, "readdirSync").mockImplementation(() => {
+      throw "readdir failed"
+    })
+    try {
+      expect(() => readLspDaemonStatus({ OMO_LSP_DAEMON_DIR: "/tmp/lsp-daemon" })).toThrow("readdir failed")
+    } finally {
+      readdirSyncSpy.mockRestore()
+    }
+  })
+})

--- a/packages/omo-opencode/src/features/tui-sidebar/lsp-status-reader.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/lsp-status-reader.ts
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { isAbsolute, join } from "node:path"
+import { z } from "zod"
+
+import { LSP_STATUS_FILE_NAME, LSP_STATUS_SCHEMA_VERSION, LSP_STATUS_STALE_MS } from "./constants"
+import type { LspClientRow } from "./state-types"
+
+const LspDaemonClientSchema = z.object({
+  serverId: z.string(),
+  root: z.string(),
+  alive: z.boolean(),
+  isInitializing: z.boolean(),
+  refCount: z.number(),
+})
+
+const LspDaemonStatusSchema = z.object({
+  version: z.literal(LSP_STATUS_SCHEMA_VERSION),
+  updatedAt: z.number(),
+  pid: z.number(),
+  clients: z.array(LspDaemonClientSchema),
+})
+
+export function readLspDaemonStatus(env: NodeJS.ProcessEnv = process.env): readonly LspClientRow[] {
+  const override = env["OMO_LSP_DAEMON_DIR"]
+  const baseDir = override !== undefined && isAbsolute(override) ? override : join(homedir(), ".omo", "lsp-daemon")
+  try {
+    const entries = readdirSync(baseDir, { withFileTypes: true })
+    let freshest: z.infer<typeof LspDaemonStatusSchema> | null = null
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !entry.name.startsWith("v")) {
+        continue
+      }
+      try {
+        const raw = JSON.parse(readFileSync(join(baseDir, entry.name, LSP_STATUS_FILE_NAME), "utf8"))
+        const parsed = LspDaemonStatusSchema.safeParse(raw)
+        if (!parsed.success || Date.now() - parsed.data.updatedAt > LSP_STATUS_STALE_MS) {
+          continue
+        }
+        if (freshest === null || parsed.data.updatedAt > freshest.updatedAt) {
+          freshest = parsed.data
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          continue
+        }
+        throw error
+      }
+    }
+    return freshest?.clients.map((client) => ({
+      serverId: client.serverId,
+      root: client.root,
+      state: client.alive ? (client.isInitializing ? "initializing" : "alive") : "dead",
+      refCount: client.refCount,
+    })) ?? []
+  } catch (error) {
+    if (error instanceof Error) {
+      return []
+    }
+    throw error
+  }
+}

--- a/packages/omo-opencode/src/features/tui-sidebar/mirror-io.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/mirror-io.test.ts
@@ -32,6 +32,7 @@ function snapshotFor(projectDir: string, updatedAt: number): TuiRuntimeSnapshot 
       },
     ],
     loop: null,
+    lspClients: [],
   }
 }
 
@@ -127,7 +128,7 @@ describe("tui-sidebar mirror IPC", () => {
   it("#given a version mismatch #when reading #then it returns null", () => {
     // given
     const projectDir = makeTempDir("version")
-    writeRawMirror(projectDir, { ...snapshotFor(projectDir, Date.now()), version: 2 })
+    writeRawMirror(projectDir, { ...snapshotFor(projectDir, Date.now()), version: 1 })
 
     // when
     const snapshot = readMirror(projectDir)

--- a/packages/omo-opencode/src/features/tui-sidebar/mirror-manager.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/mirror-manager.ts
@@ -10,6 +10,7 @@ import type {
   TuiMirrorClient,
 } from "./snapshot-builder"
 import type { TuiRuntimeSnapshot } from "./snapshot-schema"
+import type { LspClientRow } from "./state-types"
 
 export type TuiStateMirrorInput = {
   readonly client: TuiMirrorClient
@@ -17,6 +18,7 @@ export type TuiStateMirrorInput = {
   readonly backgroundManager: TuiBackgroundSnapshotProvider
   readonly getStatuses?: () => Promise<SessionStatusMap>
   readonly sessionAgentResolver?: SessionAgentResolver
+  readonly lspStatusReader?: () => readonly LspClientRow[]
   readonly reportFlushError?: (error: Error) => void
 }
 

--- a/packages/omo-opencode/src/features/tui-sidebar/render-view.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/render-view.test.ts
@@ -31,6 +31,10 @@ const activeSections: ComputeViewSections = {
     blocked: 0,
     activeGoal: "g1",
   },
+  lsp: {
+    kind: "list",
+    clients: [{ serverId: "typescript", root: "/workspace/project", state: "alive", refCount: 1 }],
+  },
 }
 
 describe("tui sidebar renderView", () => {
@@ -51,6 +55,8 @@ describe("tui sidebar renderView", () => {
     expect(description).toContain("fail 1")
     expect(description).toContain("fixer")
     expect(description).toContain("explore repo")
+    expect(description.indexOf("Jobs")).toBeLessThan(description.indexOf("LSP"))
+    expect(description).toContain("typescript alive /workspace/project refs=1")
     expect(nodes[0]?.kind).toBe("box")
   })
 
@@ -77,6 +83,7 @@ describe("tui sidebar renderView", () => {
       agents: { kind: "none" },
       jobs: { kind: "none" },
       loop: { kind: "none" },
+      lsp: { kind: "none" },
     })
 
     // when
@@ -94,6 +101,7 @@ describe("tui sidebar renderView", () => {
     const view: SidebarView = {
       kind: "idle",
       roster: { kind: "rows", rows: [{ label: "sisyphus", model: "gpt-5.5" }] },
+      lsp: { kind: "none" },
     }
 
     // when
@@ -104,5 +112,18 @@ describe("tui sidebar renderView", () => {
     expect(description).toContain("sisyphus")
     expect(description).toContain("gpt-5.5")
     expect(nodes[0]?.kind).toBe("box")
+  })
+
+  it("#given idle LSP clients #when rendering #then it keeps Models first and appends LSP", () => {
+    const view: SidebarView = {
+      kind: "idle",
+      roster: { kind: "empty" },
+      lsp: { kind: "list", clients: [{ serverId: "eslint", root: "/workspace", state: "initializing", refCount: 2 }] },
+    }
+
+    const description = describeView(view)
+
+    expect(description.indexOf("No configured models")).toBeLessThan(description.indexOf("LSP"))
+    expect(description).toContain("eslint initializing /workspace refs=2")
   })
 })

--- a/packages/omo-opencode/src/features/tui-sidebar/render-view.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/render-view.ts
@@ -7,6 +7,8 @@ import type {
   ConfigBanner,
   JobBoardState,
   LoopState,
+  LspClientRow,
+  LspState,
   RosterState,
   SidebarView,
 } from "./state-types"
@@ -31,12 +33,13 @@ export function buildViewNodes(view: SidebarView, theme: ThemeLike): ViewNode[] 
           ...loopNodes(view.loop, theme),
           ...agentNodes(view.agents, theme),
           ...jobNodes(view.jobs, theme),
+          ...lspNodes(view.lsp, theme),
         ]),
       ]
     case "broken":
       return brokenNodes(view.messages, theme)
     case "idle":
-      return idleNodes(view.roster, theme)
+      return idleNodes(view.roster, view.lsp, theme)
     default:
       return assertNever(view)
   }
@@ -54,11 +57,12 @@ function linesForView(view: SidebarView): string[] {
         ...loopLines(view.loop),
         ...agentLines(view.agents),
         ...jobLines(view.jobs),
+        ...lspLines(view.lsp),
       ]
     case "broken":
       return ["config invalid - run doctor", ...view.messages]
     case "idle":
-      return rosterLines(view.roster)
+      return [...rosterLines(view.roster), ...lspLines(view.lsp)]
     default:
       return assertNever(view)
   }
@@ -184,6 +188,32 @@ function jobLines(jobs: JobBoardState): string[] {
   }
 }
 
+function lspNodes(lsp: LspState, theme: ThemeLike): ViewNode[] {
+  switch (lsp.kind) {
+    case "none":
+      return []
+    case "list":
+      return [section("LSP", theme, lsp.clients.map((client) => text({ fg: theme.text }, lspLine(client))))]
+    default:
+      return assertNever(lsp)
+  }
+}
+
+function lspLines(lsp: LspState): string[] {
+  switch (lsp.kind) {
+    case "none":
+      return []
+    case "list":
+      return ["LSP", ...lsp.clients.map(lspLine)]
+    default:
+      return assertNever(lsp)
+  }
+}
+
+function lspLine(client: LspClientRow): string {
+  return `${truncate(client.serverId)} ${client.state} ${truncate(client.root)} refs=${client.refCount}`
+}
+
 function brokenNodes(messages: readonly string[], theme: ThemeLike): ViewNode[] {
   return [
     section("Config", theme, [
@@ -193,8 +223,11 @@ function brokenNodes(messages: readonly string[], theme: ThemeLike): ViewNode[] 
   ]
 }
 
-function idleNodes(roster: RosterState, theme: ThemeLike): ViewNode[] {
-  return [section("Models", theme, rosterLines(roster).map((line) => text({ fg: theme.text }, line)))]
+function idleNodes(roster: RosterState, lsp: LspState, theme: ThemeLike): ViewNode[] {
+  return [
+    section("Models", theme, rosterLines(roster).map((line) => text({ fg: theme.text }, line))),
+    ...lspNodes(lsp, theme),
+  ]
 }
 
 function rosterLines(roster: RosterState): string[] {

--- a/packages/omo-opencode/src/features/tui-sidebar/snapshot-builder.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/snapshot-builder.test.ts
@@ -131,6 +131,7 @@ describe("buildTuiRuntimeSnapshot", () => {
         },
       ]),
       sessionAgentResolver: resolveTestSessionAgent,
+      lspStatusReader: () => [{ serverId: "typescript", root: "/tmp", state: "alive", refCount: 1 }],
     })
 
     // then
@@ -153,6 +154,7 @@ describe("buildTuiRuntimeSnapshot", () => {
       blocked: 0,
       activeGoal: null,
     })
+    expect(snapshot.lspClients).toEqual([{ serverId: "typescript", root: "/tmp", state: "alive", refCount: 1 }])
     expect(Date.now() - snapshot.updatedAt).toBeLessThan(LOOP_FRESH_MS)
   })
 

--- a/packages/omo-opencode/src/features/tui-sidebar/snapshot-builder.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/snapshot-builder.ts
@@ -2,9 +2,10 @@ import { getLastAgentFromSession } from "../../hooks/atlas/session-last-agent"
 import { normalizeSDKResponse } from "../../shared/normalize-sdk-response"
 import { MIRROR_SCHEMA_VERSION } from "./constants"
 import { readActiveLoop } from "./loop-reader"
+import { readLspDaemonStatus } from "./lsp-status-reader"
 import { canonicalProjectDir } from "./mirror-path"
 import type { TuiRuntimeSnapshot } from "./snapshot-schema"
-import type { AgentStatus, JobRow } from "./state-types"
+import type { AgentStatus, JobRow, LspClientRow } from "./state-types"
 import type { BackgroundTaskSnapshot } from "../background-agent/types"
 
 export type TuiMirrorClient = {
@@ -32,6 +33,7 @@ export type BuildTuiRuntimeSnapshotInput = {
   readonly backgroundManager: TuiBackgroundSnapshotProvider
   readonly getStatuses?: () => Promise<SessionStatusMap>
   readonly sessionAgentResolver?: SessionAgentResolver
+  readonly lspStatusReader?: () => readonly LspClientRow[]
 }
 
 type ActiveAgentStatus = Extract<AgentStatus, "busy" | "retry" | "running">
@@ -49,6 +51,7 @@ export async function buildTuiRuntimeSnapshot(
     activeAgents: await activeAgentsFromStatuses(statuses, input.client, input.sessionAgentResolver ?? getLastAgentFromSession),
     jobBoard: input.backgroundManager.getTasksSnapshot().map(toJobRow),
     loop: loop.kind === "live" ? redactLoopText(loop) : null,
+    lspClients: [...(input.lspStatusReader?.() ?? readLspDaemonStatus())],
   }
 }
 

--- a/packages/omo-opencode/src/features/tui-sidebar/snapshot-schema.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/snapshot-schema.test.ts
@@ -33,6 +33,7 @@ describe("TuiRuntimeSnapshotSchema", () => {
         blocked: 1,
         activeGoal: "Render sidebar",
       },
+      lspClients: [],
     }
 
     // when
@@ -47,12 +48,13 @@ describe("TuiRuntimeSnapshotSchema", () => {
   it("#given a version mismatch #when parsed #then it returns null", () => {
     // given
     const raw = {
-      version: 2,
+      version: 1,
       projectDir: "/tmp/project",
       updatedAt: 1,
       activeAgents: [],
       jobBoard: [],
       loop: null,
+      lspClients: [],
     }
 
     // when
@@ -70,6 +72,7 @@ describe("TuiRuntimeSnapshotSchema", () => {
       activeAgents: [],
       jobBoard: [],
       loop: null,
+      lspClients: [],
     }
 
     // when

--- a/packages/omo-opencode/src/features/tui-sidebar/snapshot-schema.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/snapshot-schema.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
 import { MIRROR_SCHEMA_VERSION } from "./constants"
-import type { AgentStatus, LoopLive } from "./state-types"
+import type { AgentStatus, LspClientState, LoopLive } from "./state-types"
 import type { BackgroundTaskStatus } from "../background-agent/types"
 
 const AGENT_STATUS_VALUES = [
@@ -24,6 +24,15 @@ const BACKGROUND_TASK_STATUS_VALUES = [
 const AgentRowSchema = z.object({
   name: z.string(),
   status: z.enum(AGENT_STATUS_VALUES),
+})
+
+const LSP_CLIENT_STATE_VALUES = ["initializing", "alive", "dead"] as const satisfies readonly LspClientState[]
+
+const LspClientRowSchema = z.object({
+  serverId: z.string(),
+  root: z.string(),
+  state: z.enum(LSP_CLIENT_STATE_VALUES),
+  refCount: z.number().int().nonnegative(),
 })
 
 const JobRowSchema = z.object({
@@ -51,6 +60,7 @@ export const TuiRuntimeSnapshotSchema = z.object({
   activeAgents: z.array(AgentRowSchema),
   jobBoard: z.array(JobRowSchema),
   loop: LoopLiveSchema.nullable(),
+  lspClients: z.array(LspClientRowSchema),
 })
 
 export type TuiRuntimeSnapshot = z.infer<typeof TuiRuntimeSnapshotSchema>

--- a/packages/omo-opencode/src/features/tui-sidebar/state-types.test.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/state-types.test.ts
@@ -7,6 +7,7 @@ import type {
   ConfigState,
   JobBoardState,
   LoopState,
+  LspState,
   RosterState,
   SidebarView,
 } from "./state-types"
@@ -66,6 +67,17 @@ function describeLoopState(state: LoopState): string {
   }
 }
 
+function describeLspState(state: LspState): string {
+  switch (state.kind) {
+    case "none":
+      return "none"
+    case "list":
+      return state.clients.map((client) => `${client.serverId}:${client.state}`).join(",")
+    default:
+      return assertNever(state)
+  }
+}
+
 function describeConfigBanner(banner: ConfigBanner): string {
   switch (banner.kind) {
     case "none":
@@ -84,12 +96,13 @@ function describeSidebarView(view: SidebarView): string {
         describeLoopState(view.loop),
         describeAgentsState(view.agents),
         describeJobBoardState(view.jobs),
+        describeLspState(view.lsp),
         describeConfigBanner(view.configBanner),
       ].join("|")
     case "broken":
       return view.messages.join("\n")
     case "idle":
-      return describeRosterState(view.roster)
+      return `${describeRosterState(view.roster)}|${describeLspState(view.lsp)}`
     default:
       return assertNever(view)
   }
@@ -126,6 +139,7 @@ describe("tui sidebar state types", () => {
         ],
       },
       configBanner: { kind: "invalid" },
+      lsp: { kind: "none" },
     }
     const broken: SidebarView = {
       kind: "broken",
@@ -134,6 +148,7 @@ describe("tui sidebar state types", () => {
     const idle: SidebarView = {
       kind: "idle",
       roster: { kind: "rows", rows: [{ label: "sisyphus", model: "gpt-5" }] },
+      lsp: { kind: "none" },
     }
 
     // when
@@ -141,9 +156,9 @@ describe("tui sidebar state types", () => {
 
     // then
     expect(descriptions).toEqual([
-      "1/2|sisyphus:busy|Summarize:completed|invalid",
+      "1/2|sisyphus:busy|Summarize:completed|none|invalid",
       "config invalid",
-      "sisyphus:gpt-5",
+      "sisyphus:gpt-5|none",
     ])
     expect(describeConfigState({ kind: "valid" })).toBe("valid")
     expect(describeConfigState({ kind: "invalid", messages: ["bad"] })).toBe("bad")

--- a/packages/omo-opencode/src/features/tui-sidebar/state-types.ts
+++ b/packages/omo-opencode/src/features/tui-sidebar/state-types.ts
@@ -14,6 +14,17 @@ export type JobRow = {
   readonly lastTool: string | null
 }
 
+export type LspClientState = "initializing" | "alive" | "dead"
+
+export type LspClientRow = {
+  readonly serverId: string
+  readonly root: string
+  readonly state: LspClientState
+  readonly refCount: number
+}
+
+export type LspState = { readonly kind: "none" } | { readonly kind: "list"; readonly clients: readonly LspClientRow[] }
+
 export type RosterRow = {
   readonly label: string
   readonly model: string
@@ -58,10 +69,11 @@ export type SidebarView =
       readonly loop: LoopState
       readonly agents: AgentsState
       readonly jobs: JobBoardState
+      readonly lsp: LspState
       readonly configBanner: ConfigBanner
     }
   | { readonly kind: "broken"; readonly messages: readonly string[] }
-  | { readonly kind: "idle"; readonly roster: RosterState }
+  | { readonly kind: "idle"; readonly roster: RosterState; readonly lsp: LspState }
 
 export function assertNever(value: never): never {
   throw new Error(`Unexpected variant: ${JSON.stringify(value)}`)

--- a/packages/omo-opencode/src/tui.ts
+++ b/packages/omo-opencode/src/tui.ts
@@ -3,7 +3,7 @@ import type { TuiPluginModule } from "@opencode-ai/plugin/tui"
 import { registerBtwSideTui } from "./features/btw-side"
 import { computeView, viewKey } from "./features/tui-sidebar/compute-view"
 import { POLL_INTERVAL_MS } from "./features/tui-sidebar/constants"
-import { deriveAgents, deriveConfig, deriveJobBoard, deriveLoop, deriveRoster } from "./features/tui-sidebar/derivers"
+import { deriveAgents, deriveConfig, deriveJobBoard, deriveLoop, deriveLsp, deriveRoster } from "./features/tui-sidebar/derivers"
 import type { ViewNode } from "./features/tui-sidebar/element-helpers"
 import { readMirror } from "./features/tui-sidebar/mirror-io"
 import { buildViewNodes } from "./features/tui-sidebar/render-view"
@@ -101,6 +101,7 @@ async function readView(directory: string): Promise<SidebarView> {
     agents: deriveAgents(mirror),
     jobs: deriveJobBoard(mirror),
     loop: deriveLoop(mirror),
+    lsp: deriveLsp(mirror),
   })
 }
 


### PR DESCRIPTION
## What

Adds an **LSP** section to the oh-my-openagent TUI sidebar that lists the language-server clients currently held by the oh-my-openagent LSP daemon (`serverId`, `root`, `alive`/`initializing`/`dead`, `refCount`).

OpenCode's built-in `internal:sidebar-lsp` panel only reads OpenCode's **own** LSP runtime (disabled by default), and has no API to inject external data — so users who run LSP through this plugin only ever saw `LSPs are disabled`. This makes the plugin's own LSP activity visible.

## How

The daemon and the plugin live in separate processes, so the data flows through a file — the same idiom as the existing sidebar snapshot mirror and `loop-reader.ts`:

- **`packages/lsp-daemon`**: new `status-mirror.ts` writes `<version-dir>/status.json` every 2s (atomic tmp+rename, mode 0600), projecting each `getLspManager().getSnapshot()` entry to exactly `{serverId, root, alive, isInitializing, refCount}`. Wired into `startDaemonServer` after self-probe and stopped on both `close()` and the idle-shutdown path. No new public exports, no daemon autostart, no socket work.
- **`packages/omo-opencode`**: new `lsp-status-reader.ts` picks the freshest `v*/status.json` within `LSP_STATUS_STALE_MS` (honouring an absolute `OMO_LSP_DAEMON_DIR`), and degrades to `[]` on any `Error`. `lspClients` rides the mirror snapshot (`MIRROR_SCHEMA_VERSION` 1 → 2) and becomes a new `LspState` section.

Design notes worth calling out:

- LSP is carried by **both** the `active` and `idle` views and is deliberately **not** part of `isActive()`. A warm daemon keeps clients alive for the reaper window, so counting LSP as activity would evict the idle Models roster for minutes after any LSP call.
- Alternatives rejected: OpenCode's native `/lsp` (doesn't reflect the plugin daemon) and importing/duplicating the daemon socket client (adds a non-workspace dependency and a spawn-per-flush footgun).

## Tests

- `packages/lsp-daemon`: `npm --prefix packages/lsp-daemon test` → **23 files / 170 tests pass**; `npm --prefix packages/lsp-daemon run typecheck` clean. New `test/status-mirror.test.ts` covers the exact JSON shape, tmp+rename atomicity, `stop()` cleanup, and recovery after a transient write error.
- `packages/omo-opencode`: `bun test packages/omo-opencode/src/features/tui-sidebar` → **67 pass / 0 fail**; `tsgo --noEmit -p packages/omo-opencode/tsconfig.json` clean. New `lsp-status-reader.test.ts` (plus updated fixtures) covers missing/stale/bad-version files, freshest-dir selection, state mapping, absolute vs non-absolute `OMO_LSP_DAEMON_DIR`, and non-`Error` rethrow.

## Notes

- `MIRROR_SCHEMA_VERSION` bumped to 2 per the module contract (readers drop non-matching versions).
- `packages/omo-opencode/src/features/tui-sidebar/AGENTS.md` updated.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an LSP section to the TUI sidebar that lists the language-server clients currently held by the plugin's own LSP daemon. The sidebar previously only read OpenCode's internal LSP runtime, so LSP run through this plugin always showed as disabled.

- `lsp-daemon` writes `status.json` every 2s with atomic tmp+rename; the sidebar picks the freshest valid status within 15s and degrades to no clients on missing or stale files.
- LSP shows in both the active and idle views but isn't counted as activity, so a warm daemon won't evict the idle models roster for the reaper window.
- `MIRROR_SCHEMA_VERSION` is bumped to 2, so older sidebar readers drop the new snapshot format.

<sup>Written for commit 3d42de86216dafeb4824babc0545d6fe382a8461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

