### PR TITLE
test(omo-senpi): derive the kibitzer retention fixture from the frozen clock

### DIFF
--- a/packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts
+++ b/packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts
@@ -314,13 +314,16 @@ describe("kibitzer sidecar retention", () => {
     const f = await fixture()
     const recall = f.context.identityPaths.recall
     const locks = f.context.identityPaths.locks
-    const eightDaysAgo = Date.now() - 8 * DAY_MS
+    // Every timestamp derives from the fixture clock: the sweep reads it through `now`, so a real-clock
+    // backdate would silently stop being "idle" once the wall clock outran the frozen fixture time.
+    const now = () => f.clock.now
+    const eightDaysAgo = f.clock.now - 8 * DAY_MS
     expect(KIBITZER_SIDECAR_RETENTION_MS).toBe(7 * DAY_MS)
 
     const stale = await sidecarDirWithTranscript(f.context, "stale-session", eightDaysAgo)
     const active = await sidecarDirWithTranscript(f.context, "active-session", eightDaysAgo)
     const otherProcess = await sidecarDirWithTranscript(f.context, "other-process-session", eightDaysAgo)
-    const fresh = await sidecarDirWithTranscript(f.context, "fresh-session", Date.now())
+    const fresh = await sidecarDirWithTranscript(f.context, "fresh-session", f.clock.now)
     const tombstone = join(recall, "sidecars", ".prune-leftover")
     await mkdir(tombstone, { recursive: true })
     await writeFile(join(tombstone, "child.jsonl"), "{}\n")
@@ -329,7 +332,7 @@ describe("kibitzer sidecar retention", () => {
     const foreign = await createLockRecord("recall-sidecar")
     await acquireLock(kibitzerSidecarOwnerLockPath(locks, "other-process-session"), foreign)
 
-    const first = await pruneKibitzerSidecars({ recallDir: recall, locksDir: locks, owned: new Set([basename(active)]) })
+    const first = await pruneKibitzerSidecars({ recallDir: recall, locksDir: locks, now, owned: new Set([basename(active)]) })
     expect(first.pruned).toEqual([basename(stale)])
     expect([...first.kept].sort()).toEqual([basename(active), basename(fresh), basename(otherProcess)].sort())
     expect(existsSync(stale)).toBe(false)
@@ -338,7 +341,7 @@ describe("kibitzer sidecar retention", () => {
 
     // The owner lock alone kept `other-process-session`: once its owner lets go, the aged directory is prunable.
     expect(await releaseLock(kibitzerSidecarOwnerLockPath(locks, "other-process-session"), foreign)).toBe(true)
-    const second = await pruneKibitzerSidecars({ recallDir: recall, locksDir: locks, owned: new Set([basename(active)]) })
+    const second = await pruneKibitzerSidecars({ recallDir: recall, locksDir: locks, now, owned: new Set([basename(active)]) })
     expect(second.pruned).toEqual([basename(otherProcess)])
     expect(existsSync(active)).toBe(true)
 


### PR DESCRIPTION
## Summary

Every CI run on `dev` has failed `packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts` > "kibitzer sidecar retention" since **2026-09-12T12:00:00Z**, blocking the beta.58 release-state PR (#8195, closed).

## Root cause

The test backdated its sidecar directories from the **real** clock (`Date.now() - 8 * DAY_MS`) while the observability under test sweeps with the **fixture** clock frozen at `Date.UTC(2026, 8, 11, 12, 0, 0)`. The sweep's idle check is `fixtureNow - newestMtime >= 7d`; once the wall clock passed 2026-09-12T12:00Z that difference dropped below seven days, the shutdown sweep kept the aged `active-session` directory, and `expect(existsSync(active)).toBe(false)` failed - on every OS, on every branch, deterministically from that instant.

## Fix

Every timestamp in the test derives from the fixture clock (`f.clock.now`), and the two direct `pruneKibitzerSidecars` calls receive the same `now`, so the assertion no longer depends on when the suite runs. No production code changed.

## Evidence

- RED: CI run 34703492129 (`senpi-compatibility` ubuntu + macos) and a local run before the edit: `Expected: false / Received: true` at `observe.test.ts:356`; the identical failure appears on #8194 and #8184 CI after 12:00Z.
- GREEN: `bun test packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts` -> 7 pass / 0 fail after the edit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the kibitzer sidecar retention test so it no longer fails based on when CI runs. The test backdated sidecar directories using `Date.now()`, but the sweep uses a fixture clock frozen at `2026-09-11T12:00Z`; once the wall clock passed `2026-09-12T12:00Z`, the `active-session` directory looked less than seven days idle and was kept, failing the assertion. All test timestamps now derive from `f.clock.now`, and the direct `pruneKibitzerSidecars` calls receive that same clock. No production code changed.

<sup>Written for commit 8670cfc66f813b9346e8eb7e0991731ae05c9de6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

