### PR TITLE
test(omo-senpi): sweep the direct kibitzer prune calls with the fixture clock

### DIFF
--- a/packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts
+++ b/packages/omo-senpi/src/components/memory/kibitzer/observe.test.ts
@@ -316,6 +316,7 @@ describe("kibitzer sidecar retention", () => {
     const locks = f.context.identityPaths.locks
     // Age is measured against the fixture's pinned clock, the same clock the sweep reads; deriving it
     // from wall-clock time instead makes the test pass or fail depending on the day it runs.
+    const now = () => f.clock.now
     const eightDaysAgo = f.clock.now - 8 * DAY_MS
     expect(KIBITZER_SIDECAR_RETENTION_MS).toBe(7 * DAY_MS)
 
@@ -331,7 +332,7 @@ describe("kibitzer sidecar retention", () => {
     const foreign = await createLockRecord("recall-sidecar")
     await acquireLock(kibitzerSidecarOwnerLockPath(locks, "other-process-session"), foreign)
 
-    const first = await pruneKibitzerSidecars({ recallDir: recall, locksDir: locks, owned: new Set([basename(active)]) })
+    const first = await pruneKibitzerSidecars({ recallDir: recall, locksDir: locks, now, owned: new Set([basename(active)]) })
     expect(first.pruned).toEqual([basename(stale)])
     expect([...first.kept].sort()).toEqual([basename(active), basename(fresh), basename(otherProcess)].sort())
     expect(existsSync(stale)).toBe(false)
@@ -340,7 +341,7 @@ describe("kibitzer sidecar retention", () => {
 
     // The owner lock alone kept `other-process-session`: once its owner lets go, the aged directory is prunable.
     expect(await releaseLock(kibitzerSidecarOwnerLockPath(locks, "other-process-session"), foreign)).toBe(true)
-    const second = await pruneKibitzerSidecars({ recallDir: recall, locksDir: locks, owned: new Set([basename(active)]) })
+    const second = await pruneKibitzerSidecars({ recallDir: recall, locksDir: locks, now, owned: new Set([basename(active)]) })
     expect(second.pruned).toEqual([basename(otherProcess)])
     expect(existsSync(active)).toBe(true)
 


### PR DESCRIPTION
Follow-up to #8197 (fixes the remaining fuse in the same test).

#8197 dated the retention fixtures by the frozen fixture clock, but the two direct  calls in that test still use the default wall clock. The  directory is dated , so from **2026-09-18T12:00Z** the wall clock sees it as seven days idle and the first direct sweep prunes it, failing . Passing the fixture clock () to those calls makes every age comparison in the test use one clock.

Test-only; bun test v1.4.2 (744846f84) -> 7 pass / 0 fail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the fixture clock to the direct `pruneKibitzerSidecars` calls in the `omo-senpi` kibitzer retention test so every age check uses the same pinned time. Previously those calls used the default wall clock, which would make the test prune the "fresh" fixture and fail once the wall clock reached 2026-09-18T12:00Z. Test-only change; no runtime behavior affected.

<sup>Written for commit 09e388c93957983449bea1cec32143c7ba3142c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

