### PR TITLE
fix(git-bash-mcp): let a Windows lock race defer temp cleanup instead of failing the test

### DIFF
--- a/packages/git-bash-mcp/src/runner.test.ts
+++ b/packages/git-bash-mcp/src/runner.test.ts
@@ -12,24 +12,35 @@ function createTemporaryDirectory(prefix: string): string {
   return directory;
 }
 
-afterEach(() => {
-  for (const directory of temporaryDirectories.splice(0)) {
-    // Windows can transiently report EBUSY while the OS releases the fake bash.exe image of
-    // the just-exited child.  Bun's rmSync does not retry on EBUSY, so we loop manually.
-    const MAX_ATTEMPTS = 10;
-    const DELAY_MS = 200;
-    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-      try {
-        rmSync(directory, { recursive: true, force: true });
-        break;
-      } catch (error: unknown) {
-        const code = error !== null && typeof error === "object" && "code" in error ? (error as { code: string }).code : "";
-        if (code !== "EBUSY" && code !== "EPERM" && code !== "ENOTEMPTY") throw error;
-        if (attempt + 1 >= MAX_ATTEMPTS) throw error;
-        Bun.sleepSync(DELAY_MS);
+/**
+ * Windows holds the just-exited fake `bash.exe` image open past the child's exit, so removing its
+ * directory reports EBUSY/EPERM/ENOTEMPTY for a while. Bun's `rmSync` ignores `maxRetries`, so the
+ * retry is manual. The assertions have already run by the time this executes, so once the retries are
+ * spent a still-locked directory is left to the OS temp reaper rather than failing a passing test;
+ * every other error still throws, and POSIX - where this race does not exist - stays strict.
+ */
+function removeTemporaryDirectory(directory: string): void {
+  const MAX_ATTEMPTS = 10;
+  const DELAY_MS = 200;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      rmSync(directory, { recursive: true, force: true });
+      return;
+    } catch (error: unknown) {
+      const code = error !== null && typeof error === "object" && "code" in error ? (error as { code: string }).code : "";
+      const lockRace = code === "EBUSY" || code === "EPERM" || code === "ENOTEMPTY";
+      if (!lockRace) throw error;
+      if (attempt + 1 >= MAX_ATTEMPTS) {
+        if (process.platform === "win32") return;
+        throw error;
       }
+      Bun.sleepSync(DELAY_MS);
     }
   }
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) removeTemporaryDirectory(directory);
 });
 
 describe("Git Bash runner", () => {


### PR DESCRIPTION
## Summary

The Windows shard goes red from a **teardown** error, not a failed assertion: `afterEach` removes the test's temp directory and Windows still holds the just-exited fake `bash.exe` image, so `rmSync` throws `EBUSY` after its 1-second retry window (added for #7709) runs out. Bun attributes the throw to the last test and the whole shard fails.

Fixes #8202

## Evidence

Run 34704399080, `test (windows-latest, 2/2)` — 5933 pass, 1 fail, and the failure is line 19 of the suite's own cleanup:

```
19 |     rmSync(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
         ^
error: EBUSY: resource busy or locked, rm 'C:\Users\RUNNER~1\AppData\Local\Temp\omo-git-bash-runner-nvThnS'
      at packages/git-bash-mcp/src/runner.test.ts:19:5
```

## Change

Cleanup keeps retrying, but a final `EBUSY`/`EPERM` **on win32 only** is treated as deferred cleanup (the OS reaps `%TEMP%`) instead of failing a test whose assertions already passed. Every other error still throws, and POSIX — where this race does not exist — keeps the strict behavior.

The narrow condition is deliberate: this must not become a blanket try/catch that hides a real cleanup bug.

## Verification

`bun test packages/git-bash-mcp/src/runner.test.ts` → 1 pass / 0 fail locally, and `tsc --noEmit` on the package is clean. The Windows behavior is exercised by this PR's own `test (windows-latest)` job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `git-bash-mcp` test teardown on Windows, where the OS briefly holds the just-exited fake `bash.exe` image and `rmSync` raises `EBUSY`/`EPERM`/`ENOTEMPTY` after its retry window, failing tests whose assertions already passed. Cleanup now defers deletion on win32 when the final error is one of those lock codes, letting the Windows temp reaper handle it; all other errors still throw and POSIX behavior is unchanged. Fixes #8202.

<sup>Written for commit 304571ec7c2eb36152654ed603a140bd1c448708. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Rebased onto the retry loop that landed meanwhile

While this was open, #8200 replaced the `maxRetries` call with a manual retry loop and documented why: **Bun's `rmSync` ignores `maxRetries`/`retryDelay`**, so the original 1-second window never actually retried at all.

This PR keeps that manual loop — it is the part that makes retrying real — and adds the piece that is still missing: after the retries are spent, a win32 lock race leaves the directory to the OS temp reaper instead of throwing out of `afterEach`. A longer retry window only moves the flake; it does not stop a passing test from going red when Windows holds the image past it.

Non-lock errors still throw, and on POSIX an exhausted retry still throws, so a genuine cleanup bug cannot hide here.
