### PR TITLE
fix(release): isolate LazyCodex versions and retry transient trust failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: true
       lazycodex_only:
-        description: "Publish only LazyCodex (lazycodex-ai npm + Codex marketplace + LazyCodex GitHub release) from the base head, without stamping or publishing omo packages. Requires an explicit version."
+        description: "Publish only LazyCodex from the base head, without stamping or publishing omo packages. Requires a reserved version such as 5.0.0-beta.62.lazycodex.1 or 5.0.0-lazycodex.1."
         required: false
         type: boolean
         default: false
@@ -170,6 +170,8 @@ jobs:
             exit 1
           fi
 
+      - uses: actions/checkout@v7
+
       - name: Verify trusted publisher for release packages
         env:
           REPO: code-yeongyu/oh-my-openagent
@@ -177,15 +179,6 @@ jobs:
           PUBLISH_LAZYCODEX: ${{ inputs.publish_lazycodex }}
           LAZYCODEX_ONLY: ${{ inputs.lazycodex_only }}
         run: |
-          OIDC_TOKEN=$(curl -sH "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" \
-            | jq -r '.value // empty')
-
-          if [ -z "${OIDC_TOKEN}" ]; then
-            echo "::error::Failed to acquire GitHub OIDC token"
-            exit 1
-          fi
-
           PLATFORMS=(darwin-arm64 darwin-x64 darwin-x64-baseline linux-x64 linux-x64-baseline linux-arm64 linux-x64-musl linux-x64-musl-baseline linux-arm64-musl windows-x64 windows-x64-baseline windows-arm64)
           if [ "${LAZYCODEX_ONLY}" = "true" ]; then
             ALL_PACKAGES=(lazycodex-ai)
@@ -200,45 +193,8 @@ jobs:
             done
           fi
 
-          FAILED=()
-          for pkg in "${ALL_PACKAGES[@]}"; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-              -X POST \
-              "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${pkg}" \
-              -H "Authorization: Bearer ${OIDC_TOKEN}" \
-              -H "Content-Type: application/json" \
-              -d '{}')
-
-            # npm returns 200 or 201 when trusted publisher is configured (token issued).
-            # 404 means the package has no trusted publisher mapping for this workflow.
-            if [ "${STATUS}" -ge 200 ] && [ "${STATUS}" -lt 300 ]; then
-              echo "OK   ${pkg}"
-            else
-              echo "FAIL ${pkg} (HTTP ${STATUS})"
-              FAILED+=("${pkg}")
-            fi
-          done
-
-          if [ ${#FAILED[@]} -gt 0 ]; then
-            {
-              echo
-              echo "::error::Trusted publisher not configured for ${#FAILED[@]} required package(s)."
-              echo "::error::For omo-ai setup and verification, see docs/reference/omo-ai-publishing.md."
-              echo "::error::Configure each below at the URL with these values:"
-              echo "::error::  Provider: GitHub Actions"
-              echo "::error::  Organization: code-yeongyu"
-              echo "::error::  Repository: ${REPO}"
-              echo "::error::  Workflow filename: ${WORKFLOW_FILE}"
-              echo
-              for pkg in "${FAILED[@]}"; do
-                echo "::error::  https://www.npmjs.com/package/${pkg}/access"
-              done
-            } >&2
-            exit 1
-          fi
-
-          echo
-          echo "All ${#ALL_PACKAGES[@]} packages have trusted publisher configured."
+          # Diagnostic/setup reference: docs/reference/omo-ai-publishing.md
+          node script/preflight-trust.mjs "${ALL_PACKAGES[@]}"
 
       - name: Write job summary
         if: always()
@@ -260,7 +216,7 @@ jobs:
             echo
             echo "### If this fails"
             echo
-            echo "Configure the missing npm trusted publisher or required sync secret before rerunning."
+            echo "Read the first failing package/status diagnostic. Transport, throttling, server errors and ambiguous 404s retry automatically; exhaustion reports the actual error. Only definitive authorization failures print publisher-configuration guidance. Check the sync secret separately if its prerequisite failed."
           } >> "$GITHUB_STEP_SUMMARY"
 
   release-metadata:
@@ -314,24 +270,10 @@ jobs:
             esac
           fi
 
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$ ]]; then
-            echo "::error::Invalid version: $VERSION"
-            exit 1
-          fi
-
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-          if [[ "$VERSION" == *"-"* ]]; then
-            DIST_TAG=$(printf '%s' "$VERSION" | cut -d'-' -f2 | cut -d'.' -f1)
-            if ! [[ "$DIST_TAG" =~ ^[a-z][a-z0-9-]*$ ]]; then
-              echo "::error::Invalid dist_tag: $DIST_TAG"
-              exit 1
-            fi
-            echo "dist_tag=${DIST_TAG:-next}" >> "$GITHUB_OUTPUT"
-          else
-            DIST_TAG=""
-            echo "dist_tag=" >> "$GITHUB_OUTPUT"
-          fi
+          # Reject cross-line namespace use before drafting release state or probing npm.
+          METADATA=$(node script/release-version.mjs "$VERSION")
+          printf '%s\n' "$METADATA" >> "$GITHUB_OUTPUT"
+          DIST_TAG=$(printf '%s\n' "$METADATA" | awk -F= '$1 == "dist_tag" { print $2 }')
 
           LAZYCODEX_COMPARE_TAG="${DIST_TAG:-latest}"
           PREVIOUS_LAZYCODEX_VERSION=$(npm view "lazycodex-ai@${LAZYCODEX_COMPARE_TAG}" version 2>/dev/null || true)

--- a/.omo/evidence/20260913-release-root-causes/README.md
+++ b/.omo/evidence/20260913-release-root-causes/README.md
@@ -1,0 +1,32 @@
+# Release root-cause verification (#8209)
+
+## Scope and observations
+
+Only release automation changes; no harness runtime or installer behavior changes. No live npm writes, tag/release mutations, or changes to the running beta.62 workflow.
+
+- `bun test script/release-version.test.ts script/preflight-trust.test.ts`: initial RED missing new modules (`red.log`), followed by behavioral RED for namespace channel escape and explicit HTTP 404 misconfiguration (`red-classification.log`).
+- Related suite: `bun test script/release-version.test.ts script/preflight-trust.test.ts script/publish*test.ts script/omo-ai-publish-shape.test.ts script/ci-job-summary-workflow.test.ts`: **96 pass, 0 fail**, 18 files (`green.log`). Tests exercise namespace separation, actual metadata shell outputs and validation before registry calls, real local HTTP POST retries, transport/429/503 recovery, retry exhaustion, 400/401/403 fail-fast, explicit versus ambiguous 404, credential redaction, and existing release guards.
+- `bun run typecheck:script`: passed (`typecheck.log`). Node syntax checks passed for both new .mjs scripts; git diff whitespace check passed.
+- LSP: TypeScript files/declarations had no errors or warnings (Bun async matcher awaits produce type-only hints). release-version.mjs had no diagnostics; preflight-trust.mjs freshness requests timed out, so Node syntax validation and executable tests provide its validation. YAML LSP unavailable; workflow validator recorded separately. Markdown has no configured language server.
+
+## Manual real-surface QA
+
+`manual-qa.log` records the actual workflow's preflight shell executed under bash -e, invoking the shipped Node CLI. A local HTTP server issued dummy GitHub OIDC tokens and handled npm exchange requests. A Node preload redirected only the npm hostname to the local fixture; production script logic was unmodified.
+
+1. LazyCodex-only package selection requested only lazycodex-ai. First exchange returned HTTP 503, the production backoff retried, second returned HTTP 201, and the process exited 0.
+2. HTTP 403 exited 1 after exactly one exchange. The first diagnostic named lazycodex-ai and HTTP 403, followed by the setup URL. Neither dummy OIDC nor issued npm tokens appeared in output.
+3. The release-version CLI emitted the exact isolated version and beta channel.
+4. The local publish --prepare-only entrypoint rejected an isolated LazyCodex version before reads or writes.
+
+The HTTP fixture checked request path and Authorization header. Child exit and server lifecycle were awaited by exact events with bounded timeouts, not sleeps/polling. Unit backoff tests use an injected clock-free delay recorder.
+
+## Historical evidence
+
+- Run 34733540565 attempt 1, job 103660748115: 22 OK packages through oh-my-openagent-linux-arm64-musl, then curl exit 35. The next package in the workflow is oh-my-opencode-windows-x64. TLS connection failure is established; specific TLS text/npm HTTP status/body was discarded by curl -s plus bash -e and cannot be recovered. Setup guidance in the echoed script was not an executed failure report.
+- beta.57 run 34703151137: identical LazyCodex version collision.
+- beta.58 run 34703416398 / CI job 103579294045: kibitzer retention test clock mismatch at observe.test.ts:356, already fixed on dev using f.clock.now (prior investigation #8199).
+- beta.59 run 34704261620 cancelled; #8201 owner comment states dev advanced and prepared tree was stale/conflicting. Existing freshness protection worked.
+
+## Omitted / residual risk
+
+Raw remote job logs and credentials are not committed; local paths are redacted. No live trusted-publisher OIDC exchange is possible outside GitHub Actions, and no new release was dispatched. Persistent registry outages still fail closed after six attempts. Historical consumed ordinary versions remain immutable. CI/build/merge results are recorded on the PR and issue.

--- a/.omo/evidence/20260913-release-root-causes/green.log
+++ b/.omo/evidence/20260913-release-root-causes/green.log
@@ -1,0 +1,138 @@
+bun test v1.4.2 (744846f84)
+
+script/publish-lazycodex-version-stamp-workflow.test.ts:
+(pass) LazyCodex release version stamping workflow > stamps hook status messages with the release version before publishing lazycodex-ai [0.60ms]
+(pass) LazyCodex release version stamping workflow > stamps hook status messages with the release version before syncing the LazyCodex repository [2.59ms]
+
+script/publish-readiness-budget.test.ts:
+(pass) publish.yml post-publish-verify registry readiness > #given the registry needs ~5 minutes to expose the version #when readiness polls #then it keeps waiting instead of failing a successful publish [158.79ms]
+(pass) publish.yml post-publish-verify registry readiness > #given the registry never exposes the version #when the budget is exhausted #then it fails and names the publish-vs-propagation distinction [389.26ms]
+
+script/omo-ai-publish-shape.test.ts:
+(pass) omo-ai publish workflow shape > preserves an explicit prerelease version and derives its beta dist tag [0.26ms]
+(pass) omo-ai publish workflow shape > decides the Latest badge from the highest published semver, never from a pre-release flag [0.12ms]
+(pass) omo-ai publish workflow shape > maps every root release to a unique ordered prerelease [0.12ms]
+(pass) omo-ai publish workflow shape > checks out before asserting root bin ownership [0.07ms]
+(pass) omo-ai publish workflow shape > stamps omo-native in both release paths and stages its manifest [0.07ms]
+(pass) omo-ai publish workflow shape > builds and verifies the payload before stripping token auth [0.07ms]
+(pass) omo-ai publish workflow shape > publishes omo-ai through beta-only OIDC after every wrapper publish [0.07ms]
+(pass) omo-ai publish workflow shape > always runs readiness, dist-tag guard, and live verification [0.10ms]
+(pass) omo-ai publish workflow shape > keeps trusted publishing unconditional and delegates validated channel metadata [0.09ms]
+
+script/publish-workflow.test.ts:
+(pass) test workflows > use pure bun test for workflows [0.35ms]
+(pass) test workflows > builds publish-main from the prepared release SHA [0.11ms]
+(pass) test workflows > dispatches a source-pinned publish run before provenance-bearing release operations [0.17ms]
+(pass) test workflows > passes the omo-ai version to the platform publish workflow [0.11ms]
+(pass) test workflows > attaches and verifies release-binary assets on every GitHub release [0.17ms]
+(pass) test workflows > exercise root checks across linux macos and windows [0.08ms]
+(pass) test workflows > runs codex compatibility checks on every supported os without serializing build [0.12ms]
+(pass) test workflows > runs Codex compatibility tests with Node available for the self-built MCP runtimes [0.08ms]
+(pass) test workflows > builds bundled MCP runtimes before Codex compatibility tests [0.16ms]
+(pass) test workflows > runs Git Bash installer regressions in Codex compatibility checks [0.07ms]
+(pass) test workflows > tracks the nested Codex plugin lockfile used by npm ci [16.55ms]
+(pass) test workflows > pins every workflow Bun setup to the tested runtime [8.87ms]
+
+script/release-version.test.ts:
+(pass) the actual metadata step validates before npm reads and forwards channel outputs [200.29ms]
+(pass) LazyCodex-only numbers cannot consume the next omo number [0.21ms]
+(pass) stable-base LazyCodex releases never advance latest; omo channel mapping stays unchanged [0.08ms]
+(pass) reserved identifier cannot escape the namespace through malformed versions [0.13ms]
+
+script/published-install-smoke.test.ts:
+(pass) published install smoke > #given an installed plugin without the composed ultrawork skill #when artifacts are checked #then the missing path is reported [0.60ms]
+(pass) published install smoke > #given a fully installed plugin #when artifacts are checked #then nothing is reported [0.60ms]
+(pass) published install smoke > #given both payload sources #when smoke args are parsed #then the package spec and tarball path are separated [0.09ms]
+(pass) published install smoke > #given specs carrying shell metacharacters #when they are checked #then none is accepted for packing [0.10ms]
+(pass) published install smoke > #given plain dist-tag and exact-version specs #when they are checked #then both are accepted [0.08ms]
+
+script/publish-resume-idempotency.test.ts:
+(pass) publish resume idempotency > keeps every resumability guard in the real publish workflow [0.26ms]
+(pass) publish resume idempotency > reports the exact guard removed by an in-memory mutation [0.19ms]
+(pass) publish resume idempotency > reports the stale-stamp refusal when the head-equality guard is neutralised [0.18ms]
+
+script/ci-job-summary-workflow.test.ts:
+(pass) GitHub workflow job summaries > #given a new step-based workflow job #when workflow coverage is checked #then the job is discovered automatically [0.18ms]
+(pass) GitHub workflow job summaries > #given repository workflows #when inspected #then every step-based job writes a concise Markdown summary [1.45ms]
+(pass) GitHub workflow job summaries > #given a privileged publish summary #when it renders dispatch inputs #then raw inputs are passed through env [0.13ms]
+(pass) GitHub workflow job summaries > #given summary inputs #when the shared writer runs #then it emits the Markdown contract GitHub renders [19.67ms]
+
+script/preflight-trust.test.ts:
+(pass) the real HTTP adapter retries the same POST with its authorization and body intact [6.59ms]
+(pass) TLS failures, rate limits and server errors recover automatically with bounded backoff [0.27ms]
+(pass) ambiguous 404 propagation retries rather than claiming missing configuration [0.13ms]
+(pass) definitive HTTP 400 fails fast with package/status and configuration guidance [0.12ms]
+(pass) definitive HTTP 401 fails fast with package/status and configuration guidance [0.08ms]
+(pass) definitive HTTP 403 fails fast with package/status and configuration guidance [0.07ms]
+(pass) exhaustion surfaces actual npm status/body without misleading configuration guidance [0.12ms]
+(pass) an explicit missing publisher mapping fails fast even on HTTP 404 [0.09ms]
+(pass) error diagnostics redact credential fields and JWTs [0.09ms]
+(pass) unknown HTTP failures fail closed and Retry-After is capped [0.11ms]
+
+script/publish-lazycodex-smoke-budget.test.ts:
+(pass) publish.yml post-publish-verify LazyCodex smoke readiness > #given the registry needs ~5 minutes to expose the version #when the smoke polls #then it reaches the package instead of giving up [263.76ms]
+(pass) publish.yml post-publish-verify LazyCodex smoke readiness > #given the registry never exposes the version #when the budget is exhausted #then it fails and names propagation, not the package [710.37ms]
+
+script/publish-post-verify-workflow.test.ts:
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when publish-main is inspected #then it no longer carries the post-publish verification steps [1.34ms]
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when the workflow is parsed #then post-publish-verify owns every one of those steps [0.08ms]
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when post-publish-verify is wired #then it runs after the release job [0.07ms]
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when the release job is wired #then it never waits on post-publish-verify [0.06ms]
+(pass) publish post-publish verification > #given registry propagation must not hold the release hostage > #when post-publish-verify completes #then it writes a job summary like every other publish job [0.06ms]
+(pass) publish post-publish verification > #given pre-publish gating must stay intact > #when publish-main is inspected #then it still refuses to publish without platform packages [0.07ms]
+
+script/publish-gate-reuse-workflow.test.ts:
+(pass) publish gate reuse > waits for a successful CI push workflow run on the exact prepared SHA [0.20ms]
+(pass) publish gate reuse > removes release-local test jobs and gates publication on CI reuse [0.27ms]
+(pass) publish gate reuse > uses a workflow-capable token and retries release PR writes [0.14ms]
+(pass) publish gate reuse > scopes the release PAT away from repo-controlled generation [0.15ms]
+(pass) publish gate reuse > keeps every publication surface pinned to a prepared release SHA [0.15ms]
+
+script/publish-lazycodex-channel-workflow.test.ts:
+(pass) LazyCodex publish channels > every channel that publishes lazycodex-ai also syncs the marketplace and cuts the LazyCodex release [0.11ms]
+(pass) LazyCodex publish channels > lazycodex_only is a dispatch input that reaches the provenance-safe child under its own tag namespace [0.08ms]
+(pass) LazyCodex publish channels > lazycodex_only publishes the base head without stamping and refuses a version either release path already used [0.08ms]
+(pass) LazyCodex publish channels > lazycodex_only skips every omo publish, release, and verification surface [0.09ms]
+(pass) LazyCodex publish channels > publish-time plugin builds stamp the manifests an unstamped tree would otherwise leave behind [0.08ms]
+
+script/publish-release-platform-workflow.test.ts:
+(pass) release and platform publish workflows > publishes platform packages before installable wrappers [0.15ms]
+(pass) release and platform publish workflows > fails when a required platform artifact is missing [0.11ms]
+(pass) release and platform publish workflows > publishes openagent platform packages even when legacy opencode publish is unavailable [0.09ms]
+(pass) release and platform publish workflows > keeps the platform publish workflow step syntax valid around version updates [0.09ms]
+(pass) release and platform publish workflows > publishes platform launchers without Bun compile [0.09ms]
+(pass) release and platform publish workflows > regenerates and commits release lockfiles only in the prepared source state [0.13ms]
+(pass) release and platform publish workflows > validates an existing release tag before redispatching its prepared source [0.11ms]
+(pass) release and platform publish workflows > enumerates windows-arm64 consistently across every platform-list surface [0.33ms]
+(pass) release and platform publish workflows > matches the canonical platform set in optionalDependencies and on-disk platform packages [0.21ms]
+(pass) release binary asset lane in the platform publish workflow > plumbs omo_ai_version into the release-binary build [0.12ms]
+(pass) release binary asset lane in the platform publish workflow > gates release-binary steps on a release-asset probe, not the npm publish skip [0.11ms]
+(pass) release binary asset lane in the platform publish workflow > smokes every release binary leg on its matching runner class [0.11ms]
+(pass) release binary asset lane in the platform publish workflow > smokes arm64 linux binaries on a native arm64 runner with no fallback [0.09ms]
+(pass) release binary asset lane in the platform publish workflow > leaves npm publishing, runner routing, and matrix fail-fast untouched [0.10ms]
+
+script/publish-lazycodex-workflow.test.ts:
+(pass) LazyCodex publish workflow > publishes a LazyCodex GitHub release only when the marketplace payload changed [0.24ms]
+(pass) LazyCodex publish workflow > skips the LazyCodex GitHub release when the previous payload is unchanged [0.12ms]
+(pass) LazyCodex publish workflow > can skip LazyCodex npm alias publishing when npm holds the package name [0.11ms]
+(pass) LazyCodex publish workflow > publishes lazycodex as a Node installer without Bun-backed runtime dependencies [0.35ms]
+(pass) LazyCodex publish workflow > smoke tests the published LazyCodex alias after npm publish [0.15ms]
+(pass) LazyCodex publish workflow > builds the Codex plugin components in publish-main before any package that ships the plugin tree [0.11ms]
+
+script/publish-release-bundle-rebuild.test.ts:
+(pass) test workflows > retries release-state PR reads and writes on transient GitHub API errors [0.10ms]
+(pass) test workflows > rebuilds version-stamped Senpi bundles into the release commit [0.09ms]
+
+script/publish-stale-stamp-reuse.test.ts:
+(pass) publish.yml prepare-release-state reuse decision > #given a stale 'release: vX' commit behind the base head #when prepare runs for vX #then it refuses instead of handing the stale SHA to the publish child [460.45ms]
+(pass) publish.yml prepare-release-state reuse decision > #given the 'release: vX' commit IS the base head #when prepare runs for vX #then it reuses that SHA without pushing [420.20ms]
+
+script/publish-lazycodex-sync-workflow.test.ts:
+(pass) LazyCodex marketplace sync workflow > builds bundled MCP dists before the release marketplace sync builds the Codex plugin [0.20ms]
+(pass) LazyCodex marketplace sync workflow > uses the vendored LSP tools package directly during release marketplace sync [0.14ms]
+(pass) LazyCodex marketplace sync workflow > stages generated LazyCodex repository workflow changes [0.11ms]
+
+ 96 pass
+ 0 fail
+ 611 expect() calls
+Ran 96 tests across 18 files. [4.98s]

--- a/.omo/evidence/20260913-release-root-causes/manual-qa.log
+++ b/.omo/evidence/20260913-release-root-causes/manual-qa.log
@@ -1,0 +1,20 @@
+{"mode":"recover","code":0,"exchanges":2,"acquisitions":1,"output":"lazycodex-ai HTTP 503: {\"error\":\"registry unavailable\"} (attempt 1/6)\nOK lazycodex-ai\n"}
+{"mode":"misconfigured","code":1,"exchanges":1,"acquisitions":2,"output":"lazycodex-ai HTTP 403: {\"error\":\"publisher mismatch\"} (attempt 1/6)\nConfigure https://www.npmjs.com/package/lazycodex-ai/access - Provider: GitHub Actions; Organization: code-yeongyu; Repository: oh-my-openagent; Workflow filename: publish.yml. See docs/reference/omo-ai-publishing.md.\n::error::lazycodex-ai HTTP 403: {\"error\":\"publisher mismatch\"} (attempt 1/6)\n"}
+PASS: real workflow shell + Node CLI + local HTTP OIDC/exchange: retry recovery and fail-fast configuration; no live registry writes or credentials.
+version=5.0.0-beta.62.lazycodex.1
+dist_tag=beta
+=== Publishing oh-my-opencode (multi-package) ===
+
+10 |   if (lazycodexOnly) {
+11 |     if (!reserved || !/^(?:[0-9A-Za-z]+\.)*lazycodex\.[1-9]\d*$/.test(match[4] ?? "") || identifiers.filter((part) => part === "lazycodex").length !== 1) {
+12 |       throw new Error("LazyCodex-only version must end in lazycodex.N (N >= 1), e.g. 5.0.0-beta.62.lazycodex.1 or 5.0.0-lazycodex.1")
+13 |     }
+14 |   } else if (reserved) {
+15 |     throw new Error("The lazycodex prerelease identifier is reserved for LazyCodex-only releases")
+                   ^
+error: The lazycodex prerelease identifier is reserved for LazyCodex-only releases
+      at resolveReleaseVersion (<worktree>/script/release-version.mjs:15:15)
+      at main (<worktree>/script/publish.ts:406:24)
+      at <worktree>/script/publish.ts:440:1
+
+Bun v1.4.2 (macOS arm64)

--- a/.omo/evidence/20260913-release-root-causes/red-classification.log
+++ b/.omo/evidence/20260913-release-root-causes/red-classification.log
@@ -1,0 +1,51 @@
+bun test v1.4.2 (744846f84)
+
+script/release-version.test.ts:
+(pass) LazyCodex-only numbers cannot consume the next omo number [0.51ms]
+(pass) stable-base LazyCodex releases never advance latest; omo channel mapping stays unchanged [0.23ms]
+14 |   expect(resolveReleaseVersion("5.0.0-rc.2.lazycodex.3", true).distTag).toBe("rc")
+15 | })
+16 | 
+17 | test("reserved identifier cannot escape the namespace through malformed versions", () => {
+18 |   for (const version of ["5.0.0", "5.0.0-beta.1", "5.0.0-beta.1.lazycodex", "5.0.0-beta.1.lazycodex.0", "5.0.0-beta.1.lazycodex.01", "5.0.0-beta.lazycodex.1.extra", "05.0.0-lazycodex.1", "5.0.0-beta.01.lazycodex.1", "5.0.0-latest.lazycodex.1"]) {
+19 |     expect(() => resolveReleaseVersion(version, true)).toThrow()
+                                                            ^
+error: expect(received).toThrow()
+
+Received function did not throw
+Received value: {
+  version: "5.0.0-latest.lazycodex.1",
+  distTag: "latest",
+}
+
+      at <anonymous> (<worktree>/script/release-version.test.ts:19:56)
+(fail) reserved identifier cannot escape the namespace through malformed versions [2.93ms]
+
+script/preflight-trust.test.ts:
+(pass) TLS failures, rate limits and server errors recover automatically with bounded backoff [4.06ms]
+(pass) ambiguous 404 propagation retries rather than claiming missing configuration [0.25ms]
+(pass) definitive HTTP 400 fails fast with package/status and configuration guidance [0.16ms]
+(pass) definitive HTTP 401 fails fast with package/status and configuration guidance [0.08ms]
+(pass) definitive HTTP 403 fails fast with package/status and configuration guidance [0.08ms]
+(pass) exhaustion surfaces actual npm status/body without misleading configuration guidance [0.16ms]
+58 |   expect(f.logs.join("\n")).not.toContain("/access")
+59 | })
+60 | 
+61 | test("an explicit missing publisher mapping fails fast even on HTTP 404", async () => {
+62 |   const f = fixture([new Response('{"error":"No trusted publisher configured"}', { status: 404 })])
+63 |   await expect(verifyPublisher("lazycodex-ai", "token", f.options)).rejects.toThrow("lazycodex-ai HTTP 404")
+                                                                                 ^
+error: expect(received).toThrow(expected)
+
+Expected substring: "lazycodex-ai HTTP 404"
+Received message: "lazycodex-ai transport Error: Unexpected request (attempt 6/6)"
+
+      at <anonymous> (<worktree>/script/preflight-trust.test.ts:63:77)
+(fail) an explicit missing publisher mapping fails fast even on HTTP 404 [0.20ms]
+(pass) error diagnostics redact credential fields and JWTs [0.10ms]
+(pass) unknown HTTP failures fail closed and Retry-After is capped [0.13ms]
+
+ 10 pass
+ 2 fail
+ 48 expect() calls
+Ran 12 tests across 2 files. [1.61s]

--- a/.omo/evidence/20260913-release-root-causes/red.log
+++ b/.omo/evidence/20260913-release-root-causes/red.log
@@ -1,0 +1,22 @@
+bun test v1.4.2 (744846f84)
+
+script/release-version.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+error: Cannot find module './release-version.mjs' from '<worktree>/script/release-version.test.ts'
+-------------------------------
+
+
+script/preflight-trust.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+error: Cannot find module './preflight-trust.mjs' from '<worktree>/script/preflight-trust.test.ts'
+-------------------------------
+
+
+ 0 pass
+ 2 fail
+ 2 errors
+Ran 2 tests across 2 files. [1.53s]

--- a/.omo/evidence/20260913-release-root-causes/typecheck.log
+++ b/.omo/evidence/20260913-release-root-causes/typecheck.log
@@ -1,0 +1,1 @@
+$ tsgo --noEmit -p script/tsconfig.json

--- a/docs/reference/lazycodex-npm-reservation.md
+++ b/docs/reference/lazycodex-npm-reservation.md
@@ -6,6 +6,23 @@
 
 The `publish.yml` trusted-publisher preflight is a hard gate for every selected release package, including `lazycodex-ai`. Missing trusted publishing fails preflight and blocks the release.
 
+## LazyCodex-only version namespace
+
+Dispatch `publish.yml` with `lazycodex_only=true`, `publish_lazycodex=true`, and an explicit version based on the current omo release, with a reserved `lazycodex.N` prerelease suffix (positive counter):
+
+- Current omo `5.0.0-beta.62`: use `5.0.0-beta.62.lazycodex.1`, then `.2`, etc. These publish `lazycodex-ai` to **beta**. The next omo release remains `5.0.0-beta.63`.
+- Stable base `5.0.0`: use `5.0.0-lazycodex.1`. These are prereleases on the **lazycodex** dist-tag, not `latest`; install with `lazycodex-ai@lazycodex` or the exact version.
+
+The source tag remains `lazycodex-v<version>`. No omo manifests, npm packages or release tags are changed. Normal omo releases reject the reserved `lazycodex` identifier; LazyCodex-only releases reject normal omo versions. Validation runs in release metadata before release-state drafting, and the local omo publish/preparation script enforces the same reservation. Historical tag/npm collision guards remain for immutable payloads and old releases. Existing consumed plain versions cannot be reclaimed.
+
+Full releases keep their existing channel semantics: LazyCodex follows the root prerelease channel (or `latest` for stable releases); `omo-ai` keeps its ordered version mapping and always publishes to `beta`. No prerelease may explicitly use the `latest` channel.
+
+## Preflight diagnostics and retry budget
+
+Each OIDC request/token exchange has a 30-second timeout and at most six attempts. Transport/TLS errors, HTTP 408, HTTP 429, HTTP 5xx, and ambiguous HTTP 404 responses retry after 1, 2, 4, 8 and 16 seconds. Numeric `Retry-After` can extend a delay, capped at 30 seconds. Every failed attempt starts its diagnostic with the package (or GitHub OIDC) and actual HTTP status or transport error code, followed by redacted error detail.
+
+HTTP 400/401/403, or a 404 explicitly reporting an absent/mismatched trusted publisher, fail immediately; package exchange failures in this class print the setup URL and workflow identity. Unknown non-transient HTTP statuses fail closed without setup guidance. Ambiguous 404 exhaustion and transient exhaustion report the actual error, not a claim that publishing is unconfigured. Persistent outages still fail closed after the bounded budget. Successful exchange credentials are discarded and never logged.
+
 Before publishing `lazycodex-ai`, configure GitHub Actions trusted publishing at:
 https://www.npmjs.com/package/lazycodex-ai/access
 Set Provider to GitHub Actions, Organization to `code-yeongyu`, Repository to `oh-my-openagent`, and Workflow filename to `publish.yml`.

--- a/script/omo-ai-publish-shape.test.ts
+++ b/script/omo-ai-publish-shape.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test"
 import { readFileSync } from "node:fs"
+import { resolveReleaseVersion } from "./release-version.mjs"
 
 const workflowPath = new URL("../.github/workflows/publish.yml", import.meta.url)
 // Windows checks YAML out with CRLF, and the byte-pinned markers below are written with LF, so
@@ -28,18 +29,6 @@ interface Workflow {
   jobs?: Record<string, Job>
 }
 
-const DIST_TAG_FIXTURE = `          if [[ "$VERSION" == *"-"* ]]; then
-            DIST_TAG=$(printf '%s' "$VERSION" | cut -d'-' -f2 | cut -d'.' -f1)
-            if ! [[ "$DIST_TAG" =~ ^[a-z][a-z0-9-]*$ ]]; then
-              echo "::error::Invalid dist_tag: $DIST_TAG"
-              exit 1
-            fi
-            echo "dist_tag=\${DIST_TAG:-next}" >> "$GITHUB_OUTPUT"
-          else
-            DIST_TAG=""
-            echo "dist_tag=" >> "$GITHUB_OUTPUT"
-          fi`
-
 function job(name: string): Job {
   const value = workflow.jobs?.[name]
   if (!value) throw new Error(`missing job: ${name}`)
@@ -63,14 +52,6 @@ function mapOmoAiVersion(rootVersion: string): string {
     : `${rootVersion.slice(0, prereleaseIndex)}-0.${rootVersion.slice(prereleaseIndex + 1)}`
 }
 
-function extractDistTagBlock(text: string): string {
-  const start = text.indexOf('          if [[ "$VERSION" == *"-"* ]]; then')
-  const endMarker = '          fi\n\n          LAZYCODEX_COMPARE_TAG='
-  const end = text.indexOf(endMarker, start)
-  if (start < 0 || end < 0) throw new Error("missing DIST_TAG derivation block")
-  return text.slice(start, end + "          fi".length)
-}
-
 describe("omo-ai publish workflow shape", () => {
   test("preserves an explicit prerelease version and derives its beta dist tag", () => {
     // given
@@ -82,8 +63,8 @@ describe("omo-ai publish workflow shape", () => {
 
     // then
     expect(explicitVersionPrecedesBump).toBe(true)
-    expect(versionRun).toContain(String.raw`^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?$`)
-    expect(versionRun).toContain('DIST_TAG=$(printf \'%s\' "$VERSION" | cut -d\'-\' -f2 | cut -d\'.\' -f1)')
+    expect(versionRun).toContain('METADATA=$(node script/release-version.mjs "$VERSION")')
+    expect(resolveReleaseVersion("5.0.0-beta.62", false)).toEqual({ version: "5.0.0-beta.62", distTag: "beta" })
   })
 
   test("decides the Latest badge from the highest published semver, never from a pre-release flag", () => {
@@ -216,11 +197,15 @@ describe("omo-ai publish workflow shape", () => {
     expect(liveRun).toContain("ETARGET")
   })
 
-  test("keeps trusted publishing unconditional and DIST_TAG derivation byte-pinned", () => {
+  test("keeps trusted publishing unconditional and delegates validated channel metadata", () => {
     const preflightRun = namedStep("preflight-trust", "Verify trusted publisher for release packages").run ?? ""
 
     expect(preflightRun).toContain("ALL_PACKAGES=(oh-my-opencode oh-my-openagent omo-ai)")
     expect(preflightRun).toContain("docs/reference/omo-ai-publishing.md")
-    expect(extractDistTagBlock(workflowText)).toBe(DIST_TAG_FIXTURE)
+    expect(preflightRun).toContain('node script/preflight-trust.mjs "${ALL_PACKAGES[@]}"')
+    const versionRun = namedStep("release-metadata", "Calculate version").run ?? ""
+    expect(versionRun).toContain("DIST_TAG=$(printf '%s\\n' \"$METADATA\" | awk -F= '$1 == \"dist_tag\" { print $2 }')")
+    expect(resolveReleaseVersion("5.0.0", false).distTag).toBe("")
+    expect(resolveReleaseVersion("5.0.0-rc.1", false).distTag).toBe("rc")
   })
 })

--- a/script/preflight-trust.d.mts
+++ b/script/preflight-trust.d.mts
@@ -1,0 +1,8 @@
+export interface RetryOptions {
+  request?: (url: string | URL, init: RequestInit) => Promise<Response>
+  sleep?: (milliseconds: number) => Promise<unknown>
+  log?: (line: string) => void
+}
+export function requestWithRetry(label: string, url: string | URL, init: RequestInit, options?: RetryOptions): Promise<Response>
+export function verifyPublisher(pkg: string, token: string, options?: RetryOptions): Promise<void>
+export function main(packages: string[], env?: NodeJS.ProcessEnv): Promise<void>

--- a/script/preflight-trust.mjs
+++ b/script/preflight-trust.mjs
@@ -1,0 +1,85 @@
+import { setTimeout } from "node:timers/promises"
+import { pathToFileURL } from "node:url"
+
+const ATTEMPTS = 6
+const MAX_DELAY_MS = 30_000
+const CONFIG_STATUSES = new Set([400, 401, 403])
+
+// npm exchanges return credentials on success. Only failure bodies are diagnostic,
+// and credential-shaped values must never reach Actions annotations.
+function safeDetail(text) {
+  return text.replace(/"(?:token|access_token|id_token|value)"\s*:\s*"[^"]*"/gi, '"credential":"[redacted]"')
+    .replace(/\b(?:npm_[A-Za-z0-9]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/g, "[redacted]")
+    .replace(/[\r\n\x00-\x1f]/g, " ").slice(0, 2000)
+}
+
+export async function requestWithRetry(label, url, init, { request = fetch, sleep = setTimeout, log = console.error } = {}) {
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    let response
+    let detail
+    let status
+    let transient
+    let configuration = false
+    try {
+      response = await request(url, { ...init, redirect: "error", signal: AbortSignal.timeout(30_000) })
+      if (response.ok) return response
+      status = `HTTP ${response.status}`
+      detail = safeDetail(await response.text())
+      configuration = CONFIG_STATUSES.has(response.status) || (response.status === 404 && /no trusted publisher|trusted publisher[^\n]*(?:not found|not configured|mismatch)/i.test(detail))
+      transient = !configuration && ([408, 404, 429].includes(response.status) || response.status >= 500)
+    } catch (error) {
+      status = `transport ${error.cause?.code ?? error.code ?? error.name}`
+      detail = safeDetail(error.cause?.message ?? error.message)
+      transient = true
+    }
+    const diagnostic = `${label} ${status}: ${detail} (attempt ${attempt}/${ATTEMPTS})`
+    log(diagnostic)
+    if (!transient || attempt === ATTEMPTS) {
+      const error = new Error(diagnostic)
+      error.configuration = configuration
+      throw error
+    }
+    const retryAfter = Number(response?.headers.get("retry-after")) * 1000
+    const backoff = 1000 * 2 ** (attempt - 1)
+    await sleep(Math.min(MAX_DELAY_MS, Math.max(backoff, Number.isFinite(retryAfter) ? retryAfter : 0)))
+  }
+}
+
+export async function verifyPublisher(pkg, token, options = {}) {
+  const log = options.log ?? console.error
+  try {
+    const response = await requestWithRetry(pkg, `https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/${encodeURIComponent(pkg)}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: "{}",
+    }, options)
+    // Discard issued credentials without logging or storing them.
+    await response.body?.cancel()
+    log(`OK ${pkg}`)
+  } catch (error) {
+    if (error.configuration) {
+      log(`Configure https://www.npmjs.com/package/${pkg}/access - Provider: GitHub Actions; Organization: code-yeongyu; Repository: oh-my-openagent; Workflow filename: publish.yml. See docs/reference/omo-ai-publishing.md.`)
+    }
+    throw error
+  }
+}
+
+export async function main(packages, env = process.env) {
+  if (!packages.length) throw new Error("No release packages selected")
+  if (!env.ACTIONS_ID_TOKEN_REQUEST_URL || !env.ACTIONS_ID_TOKEN_REQUEST_TOKEN) throw new Error("GitHub OIDC request credentials are missing")
+  const url = new URL(env.ACTIONS_ID_TOKEN_REQUEST_URL)
+  url.searchParams.set("audience", "npm:registry.npmjs.org")
+  const response = await requestWithRetry("GitHub OIDC", url, {
+    headers: { Authorization: `bearer ${env.ACTIONS_ID_TOKEN_REQUEST_TOKEN}` },
+  })
+  const { value } = await response.json()
+  if (typeof value !== "string" || !value) throw new Error("GitHub OIDC HTTP 200: response has no token")
+  for (const pkg of packages) await verifyPublisher(pkg, value)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`::error::${error.message}`)
+    process.exitCode = 1
+  })
+}

--- a/script/preflight-trust.test.ts
+++ b/script/preflight-trust.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test"
+import { verifyPublisher, requestWithRetry } from "./preflight-trust.mjs"
+import { createServer } from "node:http"
+import { once } from "node:events"
+
+test("the real HTTP adapter retries the same POST with its authorization and body intact", async () => {
+  const requests: Array<{ method?: string; authorization?: string; body: string }> = []
+  const server = createServer(async (request, response) => {
+    const chunks = []
+    for await (const chunk of request) chunks.push(chunk)
+    requests.push({ method: request.method, authorization: request.headers.authorization, body: Buffer.concat(chunks).toString() })
+    response.writeHead(requests.length === 1 ? 503 : 201, { "Content-Type": "application/json" })
+    response.end(requests.length === 1 ? '{"error":"propagating"}' : '{"token":"issued-secret"}')
+  })
+  const listening = once(server, "listening", { signal: AbortSignal.timeout(5000) })
+  server.listen(0, "127.0.0.1")
+  await listening
+  try {
+    const address = server.address()
+    if (!address || typeof address === "string") throw new Error("Missing TCP address")
+    const waits: number[] = []
+    const response = await requestWithRetry("lazycodex-ai", `http://127.0.0.1:${address.port}/exchange`, {
+      method: "POST", headers: { Authorization: "Bearer fixture-token" }, body: "{}",
+    }, { sleep: async (ms: number) => { waits.push(ms) }, log: () => {} })
+    expect(response.status).toBe(201)
+    await response.body?.cancel()
+    expect(requests).toEqual(Array.from({ length: 2 }, () => ({ method: "POST", authorization: "Bearer fixture-token", body: "{}" })))
+    expect(waits).toEqual([1000])
+  } finally {
+    const closed = once(server, "close", { signal: AbortSignal.timeout(5000) })
+    server.close()
+    server.closeAllConnections()
+    await closed
+  }
+})
+
+function fixture(responses: Array<Response | Error>) {
+  const waits: number[] = []
+  const logs: string[] = []
+  let calls = 0
+  return {
+    waits, logs,
+    get calls() { return calls },
+    options: {
+      request: async () => {
+        const value = responses[calls++]
+        if (value instanceof Error) throw value
+        if (!value) throw new Error("Unexpected request")
+        return value
+      },
+      sleep: async (ms: number) => { waits.push(ms) },
+      log: (line: string) => { logs.push(line) },
+    },
+  }
+}
+
+test("TLS failures, rate limits and server errors recover automatically with bounded backoff", async () => {
+  const f = fixture([Object.assign(new Error("TLS handshake failed"), { code: "ECONNRESET" }), new Response("rate limited", { status: 429 }), new Response("unavailable", { status: 503 }), new Response('{"token":"secret"}', { status: 201 })])
+  await verifyPublisher("oh-my-opencode-windows-x64", "oidc-secret", f.options)
+  expect(f.calls).toBe(4)
+  expect(f.waits).toEqual([1000, 2000, 4000])
+  expect(f.logs[0]).toContain("oh-my-opencode-windows-x64")
+  expect(f.logs[0]).toContain("ECONNRESET")
+  expect(f.logs.join("\n")).not.toContain("secret")
+})
+
+test("ambiguous 404 propagation retries rather than claiming missing configuration", async () => {
+  const f = fixture([new Response("not found", { status: 404 }), new Response("{}", { status: 200 })])
+  await verifyPublisher("lazycodex-ai", "token", f.options)
+  expect(f.calls).toBe(2)
+})
+
+for (const status of [400, 401, 403]) {
+  test(`definitive HTTP ${status} fails fast with package/status and configuration guidance`, async () => {
+    const f = fixture([new Response('{"error":"publisher mismatch"}', { status })])
+    await expect(verifyPublisher("omo-ai", "token", f.options)).rejects.toThrow(`omo-ai HTTP ${status}`)
+    expect(f.calls).toBe(1)
+    expect(f.waits).toEqual([])
+    expect(f.logs[0]).toContain(`omo-ai HTTP ${status}`)
+    expect(f.logs.join("\n")).toContain("https://www.npmjs.com/package/omo-ai/access")
+  })
+}
+
+test("exhaustion surfaces actual npm status/body without misleading configuration guidance", async () => {
+  const f = fixture(Array.from({ length: 6 }, () => new Response('{"error":"registry unavailable"}', { status: 503 })))
+  await expect(verifyPublisher("lazycodex-ai", "token", f.options)).rejects.toThrow("lazycodex-ai HTTP 503")
+  expect(f.calls).toBe(6)
+  expect(f.waits).toEqual([1000, 2000, 4000, 8000, 16000])
+  expect(f.logs[0]).toContain("lazycodex-ai HTTP 503")
+  expect(f.logs.join("\n")).toContain("registry unavailable")
+  expect(f.logs.join("\n")).not.toContain("/access")
+})
+
+test("an explicit missing publisher mapping fails fast even on HTTP 404", async () => {
+  const f = fixture([new Response('{"error":"No trusted publisher configured"}', { status: 404 })])
+  await expect(verifyPublisher("lazycodex-ai", "token", f.options)).rejects.toThrow("lazycodex-ai HTTP 404")
+  expect(f.calls).toBe(1)
+  expect(f.logs.join("\n")).toContain("/access")
+})
+
+test("error diagnostics redact credential fields and JWTs", async () => {
+  const f = fixture([new Response('{"error":"denied","token":"private-token","value":"private-oidc"}', { status: 403 })])
+  await expect(verifyPublisher("omo-ai", "token", f.options)).rejects.toThrow("HTTP 403")
+  expect(f.logs.join("\n")).not.toContain("private-")
+})
+
+test("unknown HTTP failures fail closed and Retry-After is capped", async () => {
+  const f = fixture([new Response("busy", { status: 429, headers: { "retry-after": "99999" } }), new Response("bad redirect", { status: 302 })])
+  await expect(requestWithRetry("npm", "https://registry.npmjs.org", {}, f.options)).rejects.toThrow("HTTP 302")
+  expect(f.waits).toEqual([30000])
+})

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -4,6 +4,7 @@ import { $ } from "bun"
 import { existsSync } from "node:fs"
 import { join } from "node:path"
 import { resolveLatestFlag } from "./release-latest-flag"
+import { resolveReleaseVersion } from "./release-version.mjs"
 
 const PACKAGE_NAME = "oh-my-opencode"
 const bump = process.env.BUMP as "major" | "minor" | "patch" | undefined
@@ -401,6 +402,8 @@ async function checkVersionExists(version: string): Promise<boolean> {
 }
 
 async function main() {
+  // The local preparation/publish entrypoint must respect the same reserved namespace.
+  if (versionOverride) resolveReleaseVersion(versionOverride, false)
   const previous = await fetchPreviousVersion()
   const newVersion = versionOverride || (bump ? bumpVersion(previous, bump) : bumpVersion(previous, "patch"))
   console.log(`New version: ${newVersion}\n`)

--- a/script/release-version.d.mts
+++ b/script/release-version.d.mts
@@ -1,0 +1,1 @@
+export function resolveReleaseVersion(version: string, lazycodexOnly: boolean): { version: string; distTag: string }

--- a/script/release-version.mjs
+++ b/script/release-version.mjs
@@ -1,0 +1,31 @@
+import { pathToFileURL } from "node:url"
+
+/** Validate the version before any release-state drafting or registry writes. */
+export function resolveReleaseVersion(version, lazycodexOnly) {
+  const match = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*))?$/.exec(version)
+  if (!match) throw new Error(`Invalid version: ${version}`)
+  const identifiers = match[4]?.split(".") ?? []
+  if (identifiers.some((part) => /^0\d+$/.test(part))) throw new Error(`Invalid numeric prerelease identifier: ${version}`)
+  const reserved = identifiers.includes("lazycodex")
+  if (lazycodexOnly) {
+    if (!reserved || !/^(?:[0-9A-Za-z]+\.)*lazycodex\.[1-9]\d*$/.test(match[4] ?? "") || identifiers.filter((part) => part === "lazycodex").length !== 1) {
+      throw new Error("LazyCodex-only version must end in lazycodex.N (N >= 1), e.g. 5.0.0-beta.62.lazycodex.1 or 5.0.0-lazycodex.1")
+    }
+  } else if (reserved) {
+    throw new Error("The lazycodex prerelease identifier is reserved for LazyCodex-only releases")
+  }
+  const distTag = identifiers[0] ?? ""
+  if (distTag === "latest") throw new Error("Prereleases must not publish to latest")
+  if (distTag && !/^[a-z][a-z0-9-]*$/.test(distTag)) throw new Error(`Invalid dist_tag: ${distTag}`)
+  return { version, distTag }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const result = resolveReleaseVersion(process.argv[2], process.env.LAZYCODEX_ONLY === "true")
+    console.log(`version=${result.version}\ndist_tag=${result.distTag}`)
+  } catch (error) {
+    console.error(`::error::${error.message}`)
+    process.exitCode = 1
+  }
+}

--- a/script/release-version.test.ts
+++ b/script/release-version.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import { resolveReleaseVersion } from "./release-version.mjs"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+test("the actual metadata step validates before npm reads and forwards channel outputs", () => {
+  const root = fileURLToPath(new URL("../", import.meta.url))
+  const workflow = Bun.YAML.parse(readFileSync(join(root, ".github/workflows/publish.yml"), "utf8")) as { jobs: Record<string, { steps: Array<{ name?: string; run?: string }> }> }
+  const run = workflow.jobs["release-metadata"].steps.find((step) => step.name === "Calculate version")?.run
+  if (!run) throw new Error("Missing metadata entrypoint")
+  const dir = mkdtempSync(join(tmpdir(), "release-version-"))
+  try {
+    for (const [version, only, tag, valid] of [
+      ["5.0.0-beta.63", "true", "beta", false],
+      ["5.0.0-beta.62.lazycodex.1", "false", "beta", false],
+      ["5.0.0-beta.62.lazycodex.1", "true", "beta", true],
+      ["5.0.0-lazycodex.1", "true", "lazycodex", true],
+      ["5.0.0-beta.63", "false", "beta", true],
+    ] as const) {
+      const output = join(dir, "output")
+      const calls = join(dir, "calls")
+      writeFileSync(output, "")
+      writeFileSync(calls, "")
+      const result = spawnSync("bash", ["-e", "-c", `npm() { printf '%s\\n' "$*" >> "$CALLS"; printf '5.0.0-beta.60\\n'; }\n${run}`], {
+        cwd: root, encoding: "utf8", timeout: 10_000,
+        env: { ...process.env, RAW_VERSION: version, LAZYCODEX_ONLY: only, PUBLISH_LAZYCODEX: "true", GITHUB_OUTPUT: output, CALLS: calls },
+      })
+      expect(result.status, result.stderr).toBe(valid ? 0 : 1)
+      const metadata = readFileSync(output, "utf8")
+      if (valid) {
+        expect(metadata).toContain(`version=${version}\n`)
+        expect(metadata).toContain(`dist_tag=${tag}\n`)
+        expect(readFileSync(calls, "utf8")).toBe(`view lazycodex-ai@${tag} version\n`)
+      } else {
+        expect(metadata).toBe("")
+        expect(readFileSync(calls, "utf8")).toBe("")
+      }
+    }
+  } finally { rmSync(dir, { recursive: true, force: true }) }
+})
+
+test("LazyCodex-only numbers cannot consume the next omo number", () => {
+  expect(resolveReleaseVersion("5.0.0-beta.62.lazycodex.1", true)).toEqual({ version: "5.0.0-beta.62.lazycodex.1", distTag: "beta" })
+  expect(resolveReleaseVersion("5.0.0-beta.63", false)).toEqual({ version: "5.0.0-beta.63", distTag: "beta" })
+  expect(() => resolveReleaseVersion("5.0.0-beta.63", true)).toThrow()
+  expect(() => resolveReleaseVersion("5.0.0-beta.62.lazycodex.1", false)).toThrow()
+})
+
+test("stable-base LazyCodex releases never advance latest; omo channel mapping stays unchanged", () => {
+  expect(resolveReleaseVersion("5.0.0-lazycodex.1", true).distTag).toBe("lazycodex")
+  expect(resolveReleaseVersion("5.0.0", false).distTag).toBe("")
+  expect(resolveReleaseVersion("5.0.0-rc.2.lazycodex.3", true).distTag).toBe("rc")
+})
+
+test("reserved identifier cannot escape the namespace through malformed versions", () => {
+  for (const version of ["5.0.0", "5.0.0-beta.1", "5.0.0-beta.1.lazycodex", "5.0.0-beta.1.lazycodex.0", "5.0.0-beta.1.lazycodex.01", "5.0.0-beta.lazycodex.1.extra", "05.0.0-lazycodex.1", "5.0.0-beta.01.lazycodex.1", "5.0.0-latest.lazycodex.1"]) {
+    expect(() => resolveReleaseVersion(version, true)).toThrow()
+  }
+  for (const version of ["5.0.0-lazycodex.1", "5.0.0-beta.lazycodex.1", "5.0.0-lazycodex"]) {
+    expect(() => resolveReleaseVersion(version, false)).toThrow()
+  }
+})


### PR DESCRIPTION
## Summary

Fixes #8209.

Reserve `lazycodex.N` prerelease identifiers for LazyCodex-only releases so they cannot consume the next omo number. For example, omo beta.62 can have LazyCodex-only `5.0.0-beta.62.lazycodex.1` on the beta channel while the next omo release remains beta.63. Stable-base `5.0.0-lazycodex.1` uses the lazycodex channel, never latest. Both the workflow metadata entry and local omo preparation reject cross-line namespace use before drafting anything; historical immutable-payload guards stay intact. The omo-ai version mapping and beta-only publish are unchanged.

Replace the silent curl exchange loop with a bounded Node preflight. Six attempts, 30-second request timeout, exponential delays of 1/2/4/8/16 seconds; numeric Retry-After can extend delays up to 30 seconds. Transport/TLS, 408, 429, 5xx and ambiguous 404 retry. HTTP 400/401/403 and an explicit absent/mismatched publisher 404 fail immediately with setup guidance. Other failures/exhaustion surface actual status/error, not misleading setup guidance. Each failed attempt starts with package/status; credential responses are never logged.

## Actual incident findings

Run 34733540565 attempt 1 checked 22 packages successfully, then curl exited **35** on the next package, **oh-my-opencode-windows-x64**. This was a TLS connection failure, not a demonstrated npm mapping failure. Silent curl plus bash -e discarded the specific TLS error/HTTP response. The setup guidance visible in the log was echoed script source, not executed guidance.

Beta.57 shared the version collision. Beta.58 hit a separate kibitzer fixture-clock bug already fixed on dev (#8199 investigation). Beta.59 was cancelled because dev advanced and #8201's prepared tree became stale; freshness protection worked.

## Verification

- RED: missing new modules, then behavioral failures for reserved-channel escape and explicit 404 classification.
- GREEN: **96 tests passed, 0 failed**, covering new logic plus 18 related release/workflow test files.
- `bun run typecheck:script`, `node --check` on both helpers, `actionlint .github/workflows/publish.yml`, and `git diff --check` passed.
- Real workflow shell + Node CLI + local HTTP OIDC/npm fixture: 503 recovered automatically after one retry; 403 failed after one exchange with package/status on the first line and no credential leakage. Actual metadata shell tests prove invalid versions stop before npm reads and valid versions forward the right dist-tag.
- Local omo `--prepare-only` rejects the reserved namespace before writes.
- Evidence: `.omo/evidence/20260913-release-root-causes/README.md` and adjacent sanitized logs.
- Full build and PR CI are being tracked before merge. No live tags, releases, npm packages, or running beta.62 release were modified.

## Residual limits

Persistent outages still fail closed after the bounded budget. Already-consumed historical versions cannot be reclaimed. Live GitHub OIDC publication is deliberately not triggered for verification; the next release uses the merged workflow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8209. This change only touches release automation: LazyCodex-only releases no longer consume the next omo number, and the release preflight no longer turns transient npm failures into misleading configuration errors.

**Version isolation**
- LazyCodex-only versions must end in a reserved `lazycodex.N` suffix, such as `5.0.0-beta.62.lazycodex.1` or `5.0.0-lazycodex.1`.
- The release metadata step and local `omo --prepare-only` reject cross-namespace versions before drafting or writing.
- LazyCodex-only releases from a stable base use the `lazycodex` dist-tag, never `latest`; `omo-ai` version mapping and beta-only publish are unchanged.
- Already-consumed historical versions remain immutable, and no live tags, packages, or the running beta.62 release were modified.

**Preflight retry**
- The silent curl loop is replaced with a bounded Node preflight: six attempts, a 30-second request timeout, and exponential backoff with `Retry-After` capped at 30 seconds.
- Transport/TLS errors, HTTP 408/429/5xx, and ambiguous 404s retry; HTTP 400/401/403 and explicit missing-publisher 404s fail fast with setup guidance.
- The beta.62 failure was a curl exit 35 on `oh-my-opencode-windows-x64`, not a missing npm publisher mapping.
- Exhaustion and non-configuration failures report the actual package, status, and redacted error; credentials are discarded and never logged.
- Persistent outages still fail closed after the bounded retry budget.

<sup>Written for commit 96bad90c4957209df562e0699278cdaa248381d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

