### PR TITLE
feat(omo-senpi): declare the plugin a system package so its skills and extensions leave the compact startup banner

### DIFF
--- a/packages/omo-senpi/plugin/package.json
+++ b/packages/omo-senpi/plugin/package.json
@@ -16,6 +16,7 @@
     "pi"
   ],
   "pi": {
+    "system": true,
     "extensions": [
       "./extensions/omo.js"
     ],

--- a/packages/omo-senpi/src/plugin-manifest.test.ts
+++ b/packages/omo-senpi/src/plugin-manifest.test.ts
@@ -56,6 +56,20 @@ describe("OMO Senpi plugin manifest", () => {
     expect(Reflect.has(pi, "hooks")).toBe(false)
   })
 
+  it("#given the plugin is the harness itself #when the engine resolves it from the command line #then the manifest declares a system package", () => {
+    const manifest = readJsonObject(pluginManifestPath)
+    const pi = manifest.pi
+
+    if (typeof pi !== "object" || pi === null || Array.isArray(pi)) {
+      throw new Error("plugin package.json pi manifest is not an object")
+    }
+
+    // senpi honors a boolean `system` flag only for command-line packages (the launcher passes
+    // `--extension <plugin>`), which files the plugin's extension and bundled skills under the
+    // `system` scope and keeps them out of the compact startup banner.
+    expect(Reflect.get(pi, "system")).toBe(true)
+  })
+
   it("#given the Senpi package is one generated runtime unit #when loaded #then npm dependency and workspace surfaces stay absent", () => {
     const manifest = readJsonObject(pluginManifestPath)
     const dependencies = manifest.dependencies


### PR DESCRIPTION
## Summary

Every omo-senpi session opened with the compact `[Skills]` / `[Extensions]` banner listing the plugin's own bundled skills and extension files next to the user's resources, because the engine loads the plugin as an ad-hoc `--extension <plugin>` path and had no way to tell harness payload from user input. code-yeongyu/senpi#1640 (PR code-yeongyu/senpi#1643) adds a `system` provenance scope that a command-line package opts into with `"pi": { "system": true }`. This PR declares the flag in the plugin manifest.

## Changes

- `packages/omo-senpi/plugin/package.json`: `"pi": { "system": true, ... }`.
- `packages/omo-senpi/src/plugin-manifest.test.ts`: pins the flag next to the existing extensions/skills assertions (RED before the manifest change: `Expected: true, Received: undefined`).

## QA & Evidence

- Real plugin (the installed `plugin/` payload copied to a scratch dir with only the flag added) loaded through the engine branch from source with a hermetic agent dir, one user skill and a mock model, rendered through xterm.js: compact banner shows `[Skills] my-skill` only and no `[Extensions]` section at all (every extension is system-provided); the OmO Native badge confirms the plugin loaded. Evidence held locally.
- Older-engine tolerance: the same flagged plugin under the currently pinned engine (senpi 2026.9.13) loads normally, no manifest diagnostic, banner unchanged (all plugin skills and `omo.js` still listed, as before this change). Evidence held locally.
- Tests on a second machine from the repo root: `bun test packages/omo-senpi/src/package-shape.test.ts packages/omo-senpi/src/plugin-manifest.test.ts packages/omo-senpi/src/bundle-purity.test.ts` -> 10 pass / 0 fail; `bun test script/verify-omo-ai-payload.test.ts script/build-omo-native.test.ts packages/omo-senpi/src/install` -> 39 pass / 0 fail; `tsgo --noEmit -p packages/omo-senpi/tsconfig.json` exit 0.

## Risks & Residuals

- No launcher or build change: the manifest field is inert on engines that predate it.
- Follow-up gated on the next engine pin bump (tracked in #8218): tag the memory component's `resources_discover` skills directory `{ path, scope: "user" }` so memory skills are labeled `user` rather than a temporary path; the object entry form crashes the current pinned engine (`input.trim is not a function`), so it must land with the pin.

## Related Issues

Fixes #8218
Depends on code-yeongyu/senpi#1643 for the visible effect.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declares `omo-senpi` as a system package so its bundled skills and extensions stop appearing in the compact startup `[Skills]` / `[Extensions]` banner next to user resources.

- Adds `"system": true` to the plugin manifest; the engine files command-line packages with this flag under the `system` scope.
- Adds a manifest test pinning the flag.
- The field is inert on the currently pinned engine, so this only changes behavior after the next engine pin bump.
- Fixes #8218.

<sup>Written for commit da3174cbae26554313d477637c0eba06e5717a7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

