### PR TITLE
test(qa): fix Windows-only failure in the dependency-audit graph-command test

### DIFF
--- a/script/qa/dependency-audit-capture.test.ts
+++ b/script/qa/dependency-audit-capture.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { join } from "node:path"
 import * as comparison from "./dependency-audit/comparison"
 import "./dependency-audit/compare-cli.cases"
 import {
@@ -25,7 +26,7 @@ describe("dependency audit parsers", () => {
     // when
     const result = graphArguments(release, "/graph")
     // then
-    expect(result).toEqual(["build", "--target=bun", "--minify-whitespace", "entry.ts", "worker.ts", "--outdir", "/graph", "--metafile=/graph/meta.json"])
+    expect(result).toEqual(["build", "--target=bun", "--minify-whitespace", "entry.ts", "worker.ts", "--outdir", "/graph", `--metafile=${join("/graph", "meta.json")}`])
   })
   test("rejects malformed CLI input when a case can escape the output directory", () => {
     // given


### PR DESCRIPTION
## Summary
`test (windows-latest, 2/2)` has been red on `dev` since #8239: `graphArguments()` joins the metafile path with `node:path.join`, which is backslash-separated on Windows, while the test pinned `--metafile=/graph/meta.json`.

## Change
Test-only: the expectation now uses the same `join("/graph", "meta.json")` the implementation uses, so the assertion holds on every platform without changing the audit harness behavior (Bun accepts native separators for `--metafile` on Windows).

## Evidence
- Red: dev CI run 34755023672 (head 0f8b4b471), `dependency audit parsers > strips compile-only arguments when constructing the graph command` fails only on windows-latest with the separator diff quoted in #8244.
- Green: this PR's CI matrix (windows-latest 2/2 included) at the head below.

Fixes #8244


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows-only failure in the dependency-audit graph-command test by asserting the same platform-joined metafile path the implementation uses. The test previously hard-coded a POSIX-style `--metafile` path, so it failed on Windows where `node:path.join` returns backslash separators. This is a test-only change and does not affect audit harness behavior.

Fixes #8244.

<sup>Written for commit 32c3f04c9b8dc8b1e81af94e2739b130a7db5940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/oh-my-openagent/pull/8245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

